### PR TITLE
Fix CI: disable buf lint, speed up formatting + clang-tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,23 @@ jobs:
           echo "Please run \`format.sh\` to apply the changes."
           exit 1
 
-      - name: Proto lint
-        uses: bufbuild/buf-action@v1
-        with:
-          lint: true
-          breaking: true
-          breaking_against: |
-            ${{ github.event_name == 'pull_request' && format(
-              'https://github.com/{0}.git#branch={1}',
-              github.repository, github.base_ref
-            ) || '' }}
+      # TODO(buf-edition-2024): Re-enable once buf supports protobuf edition 2024.
+      # As of buf 1.66.0 (latest), `buf build` hard-fails with:
+      #   edition "2024" not yet fully supported; latest supported edition "2023"
+      # Additionally, format.sh creates bazel-* symlinks that buf follows into
+      # external dependency trees, causing duplicate-symbol errors.  When
+      # re-enabling, add `rm -f bazel-*` before the buf step.
+      #
+      # - name: Proto lint
+      #   uses: bufbuild/buf-action@v1
+      #   with:
+      #     lint: true
+      #     breaking: true
+      #     breaking_against: |
+      #       ${{ github.event_name == 'pull_request' && format(
+      #         'https://github.com/{0}.git#branch={1}',
+      #         github.repository, github.base_ref
+      #       ) || '' }}
 
 
   clang-tidy:


### PR DESCRIPTION
## Summary

- **Disable buf lint** until buf supports protobuf edition 2024 (latest buf 1.66.0 hard-fails). Protos are still validated by Bazel's protoc. Left a TODO with re-enablement instructions.
- **Merge format-and-lint + clang-tidy** into a single `lint` job. The old format-and-lint job had no Bazel cache, so `format.sh` rebuilt buildifier and ktfmt from scratch every run (~90s). The merged job shares the ubuntu-24.04 Bazel cache with build-and-test.
- **Skip clang-tidy on PRs with no C++ changes.** Most PRs only touch Kotlin or proto files — no need to spend 5 min parsing p4c's header graph. Pushes to main always run the full lint.

Expected impact:
- Non-C++ PRs: ~7.5 min → ~1 min (format check only, cached Bazel)
- C++ PRs / main pushes: ~7.5 min → ~6 min (shared cache, single job)

## Test plan

- [ ] Verify the `lint` job passes on this PR (no C++ changes → clang-tidy skipped)
- [ ] Verify build-and-test jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)