### PR TITLE
Replace Codecov with GitHub Pages coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
     name: Coverage
     runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      PR_NUM: ${{ github.event.pull_request.number }}
     steps:
       - uses: actions/checkout@v6
 
@@ -105,14 +110,51 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/bazel
-          key: bazel-ubuntu-24.04-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
-          restore-keys: bazel-ubuntu-24.04-
+          key: bazel-coverage-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
+          restore-keys: bazel-coverage-
+
+      - name: Install lcov
+        run: sudo apt install -y lcov
 
       - name: Run coverage
-        run: ./coverage.sh
+        run: ./coverage.sh --html
 
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.lcov
-          fail_ci_if_error: false
+      - name: Publish HTML report to GitHub Pages
+        run: |
+          git fetch --depth=1 origin gh-pages
+          git worktree add /tmp/gh-pages gh-pages
+          mkdir -p "/tmp/gh-pages/pr/${PR_NUM}"
+          cp -r coverage-report/* "/tmp/gh-pages/pr/${PR_NUM}/"
+          cd /tmp/gh-pages
+          git add "pr/${PR_NUM}"
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -m "Coverage report for PR #${PR_NUM}" --allow-empty
+          # Retry once on conflict (concurrent PR pushes).
+          git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
+
+      - name: Comment coverage on PR
+        run: |
+          MARKER="<!-- coverage-report -->"
+          TOTAL_LH=$(awk -F: '/^LH:/{s+=$2} END{print s+0}' coverage.lcov)
+          TOTAL_LF=$(awk -F: '/^LF:/{s+=$2} END{print s+0}' coverage.lcov)
+          REPO_NAME="${{ github.event.repository.name }}"
+          if [[ "${TOTAL_LF}" -gt 0 ]]; then
+            PCT=$(( 100 * TOTAL_LH / TOTAL_LF ))
+            REPORT_URL="https://${{ github.repository_owner }}.github.io/${REPO_NAME}/pr/${PR_NUM}/"
+            BODY="${MARKER}"$'\n'"**Coverage**: ${TOTAL_LH}/${TOTAL_LF} lines (${PCT}%) — [full report](${REPORT_URL})"
+          else
+            BODY="${MARKER}"$'\n'"**Coverage**: no data collected"
+          fi
+          # Update existing comment or create a new one.
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUM}/comments" \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
+            | head -1)
+          if [[ -n "${EXISTING}" ]]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+              -X PATCH -f body="${BODY}"
+          else
+            gh pr comment "${PR_NUM}" --body "${BODY}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ bazel build //...          # build everything
 bazel test //...           # run all tests
 ./format.sh                # auto-format all files (clang-format + buildifier + ktfmt)
 ./lint.sh                  # lint all files (clang-tidy for C++, detekt for Kotlin)
+./coverage.sh              # collect code coverage (LCOV + optional HTML report)
 ./dev.sh help              # show all developer commands
 ```
 
@@ -39,6 +40,15 @@ bazel run @hedron_compile_commands//:refresh_all
 ```
 
 All builds are hermetic. Do not install dependencies outside of Bazel.
+
+## CI
+
+CI runs on every push and PR via GitHub Actions (`.github/workflows/ci.yml`):
+formatting, clang-tidy, build+test (Ubuntu + macOS), and coverage.
+
+On PRs, a coverage report is published to GitHub Pages and linked from a bot
+comment. Reports are browsable at
+`https://smolkaj.github.io/4ward/pr/<number>/`.
 
 ## Key design invariants — do not break these
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Run `./dev.sh help` for a summary of available developer commands.
 5. Open a **draft** PR explaining what you changed and why.
 
 Don't worry about getting it perfect on the first try — that's what review is
-for.
+for. CI will post a coverage report on your PR automatically.
 
 ## Style
 


### PR DESCRIPTION
## Summary

Replace Codecov with a self-hosted coverage pipeline that publishes browsable
HTML reports to GitHub Pages and posts a summary comment on every PR.

- **HTML reports**: `./coverage.sh --html` generates a genhtml report; CI
  pushes it to the `gh-pages` branch under `pr/<number>/`, browsable at
  `https://smolkaj.github.io/4ward/pr/<number>/`.
- **PR comment**: A bot comment shows line coverage stats and links to the
  full report. Subsequent pushes update the same comment (idempotent via HTML
  marker).
- **Separate coverage cache**: Own Bazel cache key (`bazel-coverage-`) to
  avoid write contention with build-and-test.
- **Drop redundant build step**: `bazel test` already builds its deps, so the
  separate `bazel build` step in build-and-test was removed.
- **Docs**: Added `./coverage.sh` to AGENTS.md build commands and a CI section
  documenting the coverage pipeline and GitHub Pages URLs.

## Test plan

- [ ] CI passes (lint, build+test, coverage)
- [ ] Coverage comment appears on this PR with line stats and report link
- [ ] HTML report is browsable at the GitHub Pages URL


🤖 Generated with [Claude Code](https://claude.com/claude-code)