### PR TITLE
Remove obsolete buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,3 +1,0 @@
-version: v2
-modules:
-  - path: simulator


### PR DESCRIPTION
## Summary

Removes `buf.yaml`, which was added to scope `buf lint` to `simulator/`
but became obsolete when #4 disabled the buf CI step entirely.

This is cleanup from a larger set of lint infrastructure fixes that
were merged directly to main:

- **`lint.sh`**: removed `.h` files from find (silently ignored by
  `run-clang-tidy`), dropped `set -e` so both linters always run,
  parallelized clang-tidy and detekt execution
- **`.clang-tidy`**: disabled `modernize-use-constraints` to fix
  clang-tidy-18 crash on Boost multiprecision headers

## Test plan

- [ ] CI passes (only a file deletion, no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)