### PR TITLE
Add incremental (diff) coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,16 @@ jobs:
           # Retry once on conflict (concurrent PR pushes).
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
 
+      - name: Compute diff coverage
+        run: |
+          gh pr diff "${PR_NUM}" > /tmp/pr.diff
+          ./diff-coverage.sh /tmp/pr.diff coverage.lcov >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Comment coverage on PR
         run: |
           MARKER="<!-- coverage-report -->"
-          TOTAL_LH=$(awk -F: '/^LH:/{s+=$2} END{print s+0}' coverage.lcov)
-          TOTAL_LF=$(awk -F: '/^LF:/{s+=$2} END{print s+0}' coverage.lcov)
           REPO_NAME="${{ github.event.repository.name }}"
           if [[ "${TOTAL_LF}" -gt 0 ]]; then
             PCT=$(( 100 * TOTAL_LH / TOTAL_LF ))
@@ -141,6 +146,11 @@ jobs:
             BODY="${MARKER}"$'\n'"**Coverage**: ${TOTAL_LH}/${TOTAL_LF} lines (${PCT}%) — [full report](${REPORT_URL})"
           else
             BODY="${MARKER}"$'\n'"**Coverage**: no data collected"
+          fi
+          if [[ "${DIFF_PCT}" -ge 0 ]]; then
+            BODY="${BODY}"$'\n'"**Diff coverage**: ${DIFF_LH}/${DIFF_LF} changed lines (${DIFF_PCT}%)"
+          else
+            BODY="${BODY}"$'\n'"**Diff coverage**: no coverable lines changed"
           fi
           # Update existing comment or create a new one.
           EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUM}/comments" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ bazel test //...           # run all tests
 ./format.sh                # auto-format all files (clang-format + buildifier + ktfmt)
 ./lint.sh                  # lint all files (clang-tidy for C++, detekt for Kotlin)
 ./coverage.sh              # collect code coverage (LCOV + optional HTML report)
+./diff-coverage.sh         # incremental coverage from a diff + LCOV file
 ./dev.sh help              # show all developer commands
 ```
 
@@ -40,8 +41,8 @@ CI runs on every push and PR via GitHub Actions (`.github/workflows/ci.yml`):
 formatting, clang-tidy, build+test (Ubuntu + macOS), and coverage.
 
 On PRs, a coverage report is published to GitHub Pages and linked from a bot
-comment. Reports are browsable at
-`https://smolkaj.github.io/4ward/pr/<number>/`.
+comment that shows both absolute and incremental (diff) coverage. Reports are
+browsable at `https://smolkaj.github.io/4ward/pr/<number>/`.
 
 ## Key design invariants — do not break these
 

--- a/dev.sh
+++ b/dev.sh
@@ -15,6 +15,7 @@ Commands:
   fmt             Auto-format all files
   lint            Run all linters
   coverage        Run tests with coverage, open report
+  diff-coverage   Compute incremental coverage from a diff + LCOV file
   help            Show this help
 EOF
 }
@@ -40,13 +41,18 @@ cmd_coverage() {
   exec "${REPO_ROOT}/coverage.sh" "$@"
 }
 
+cmd_diff_coverage() {
+  exec "${REPO_ROOT}/diff-coverage.sh" "$@"
+}
+
 # Dispatch.
 case "${1:-help}" in
   build)        shift; cmd_build "$@" ;;
   test)         shift; cmd_test "$@" ;;
   fmt|format)   shift; cmd_fmt "$@" ;;
   lint)         shift; cmd_lint "$@" ;;
-  coverage|cov) shift; cmd_coverage "$@" ;;
+  coverage|cov)  shift; cmd_coverage "$@" ;;
+  diff-coverage) shift; cmd_diff_coverage "$@" ;;
   help|--help|-h) cmd_help ;;
   *)
     echo "Unknown command: $1" >&2

--- a/diff-coverage.sh
+++ b/diff-coverage.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Computes incremental (diff) coverage: the fraction of added/modified lines
+# that are covered by tests.
+#
+# Usage: ./diff-coverage.sh <diff-file> <lcov-file>
+#
+# Output (stdout, one per line):
+#   TOTAL_LH=<total covered lines>
+#   TOTAL_LF=<total coverable lines>
+#   DIFF_LH=<covered changed lines>
+#   DIFF_LF=<coverable changed lines>
+#   DIFF_PCT=<percentage, or -1 if no coverable lines changed>
+#
+# The diff must be in unified format (e.g. `git diff` or `gh pr diff`).
+# The LCOV file is the one produced by coverage.sh.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <diff-file> <lcov-file>" >&2
+  exit 1
+fi
+
+DIFF_FILE="$1"
+LCOV_FILE="$2"
+
+if [[ ! -f "${DIFF_FILE}" ]]; then
+  echo "Error: diff file not found: ${DIFF_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${LCOV_FILE}" ]]; then
+  echo "Error: LCOV file not found: ${LCOV_FILE}" >&2
+  exit 1
+fi
+
+# Single awk invocation, two-file pass:
+#   File 1 (diff): build set of (file, line) pairs for added lines.
+#   File 2 (LCOV): check which of those lines have coverage data.
+awk '
+  # ── Pass 1: unified diff ──────────────────────────────────────────────
+  FILENAME == ARGV[1] {
+    # New file header.
+    if (/^\+\+\+ /) {
+      # +++ /dev/null means a deleted file — ignore.
+      if ($2 == "/dev/null") { diff_file = ""; next }
+      # Strip the "b/" prefix.
+      diff_file = $2
+      sub(/^b\//, "", diff_file)
+      next
+    }
+    # Hunk header: @@ -old,oldN +new,newN @@  —  $3 is "+L" or "+L,N".
+    if (/^@@ /) {
+      split($3, a, ",")
+      sub(/\+/, "", a[1])
+      diff_line = a[1] + 0
+      next
+    }
+    # Inside a hunk: added lines get recorded.
+    if (diff_file != "" && /^\+/) {
+      added[diff_file, diff_line] = 1
+      diff_line++
+      next
+    }
+    # Context lines increment the counter; deleted lines do not.
+    if (diff_file != "" && /^-/) next
+    if (diff_file != "") diff_line++
+    next
+  }
+
+  # ── Pass 2: LCOV ─────────────────────────────────────────────────────
+  FILENAME == ARGV[2] {
+    if (/^SF:/) {
+      lcov_file = substr($0, 4)
+      next
+    }
+    if (/^DA:/) {
+      # DA:<line>,<count>[,...]
+      split(substr($0, 4), da, ",")
+      line = da[1] + 0
+      count = da[2] + 0
+      total_lf++
+      if (count > 0) total_lh++
+      if ((lcov_file, line) in added) {
+        diff_lf++
+        if (count > 0) diff_lh++
+      }
+      next
+    }
+    next
+  }
+
+  END {
+    if (diff_lf > 0) {
+      pct = int(100 * diff_lh / diff_lf)
+    } else {
+      pct = -1
+    }
+    printf "TOTAL_LH=%d\n", total_lh + 0
+    printf "TOTAL_LF=%d\n", total_lf + 0
+    printf "DIFF_LH=%d\n", diff_lh + 0
+    printf "DIFF_LF=%d\n", diff_lf + 0
+    printf "DIFF_PCT=%d\n", pct
+  }
+' "${DIFF_FILE}" "${LCOV_FILE}"


### PR DESCRIPTION
## Summary

- PR authors care most about whether *their* changes are covered. This adds diff coverage — the fraction of added/modified lines that are covered — to the CI coverage comment alongside the existing absolute coverage.
- A new `diff-coverage.sh` script cross-references a unified diff against LCOV data using a single portable awk invocation (no gawk dependency). It also emits total coverage stats, which lets the CI comment step drop its redundant LCOV re-parsing.
- Exposed via `./dev.sh diff-coverage` for local use.
- Documents the new script and CI behavior in `AGENTS.md`.

## Test plan

- [x] Verified locally with synthetic fixtures: normal diff (60%), deleted file (no coverable lines), comment-only changes (no coverable lines), single-line hunk (100%)
- [x] `./format.sh` clean
- [ ] CI run on this PR exercises the new step end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)