### PR TITLE
Simulator refactoring: separate PacketContext from Environment

### DIFF
--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -69,7 +69,7 @@ class Environment(payload: ByteArray) {
    * found.
    */
   fun lookup(name: String): Value? {
-    for (scope in scopes.reversed()) {
+    for (scope in scopes.asReversed()) {
       scope[name]?.let {
         return it
       }
@@ -82,7 +82,7 @@ class Environment(payload: ByteArray) {
    * first match. Throws if the variable is not found.
    */
   fun update(name: String, value: Value) {
-    for (scope in scopes.reversed()) {
+    for (scope in scopes.asReversed()) {
       if (name in scope) {
         scope[name] = value
         return

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -5,45 +5,15 @@ import fourward.sim.v1.TraceEvent
 import java.io.ByteArrayOutputStream
 
 /**
- * The execution environment for a single packet traversal.
+ * Variable scope stack for a single packet traversal.
  *
- * [Environment] holds all mutable state during packet processing:
- * - Variable bindings (headers, metadata, local variables), organised as a stack of scopes to
- *   handle nested control blocks.
- * - The packet buffer (bytes not yet extracted by the parser).
- * - The execution trace being built up event by event.
+ * Holds variable bindings (headers, metadata, local variables) organised as a stack of scopes to
+ * handle nested control blocks. A new Environment is created for each [ProcessPacketRequest] and
+ * discarded afterwards.
  *
- * A new Environment is created for each [ProcessPacketRequest] and discarded afterwards. Table
- * state and extern instances live in [Simulator], not here.
+ * Packet-level state (input buffer, output buffer, execution trace) lives in [PacketContext].
  */
-class Environment(payload: ByteArray) {
-
-  // -------------------------------------------------------------------------
-  // Packet buffer
-  // -------------------------------------------------------------------------
-
-  /** Remaining bytes in the input packet, consumed by parser extract(). */
-  private val buffer: PacketBuffer = PacketBuffer(payload)
-
-  /** Output packet bytes, written by deparser emit(). */
-  private val outputBuffer = ByteArrayOutputStream()
-
-  fun extractBytes(count: Int): ByteArray = buffer.read(count)
-
-  fun emitBytes(bytes: ByteArray) {
-    outputBuffer.write(bytes)
-  }
-
-  fun outputPayload(): ByteArray = outputBuffer.toByteArray()
-
-  fun remainingInputBytes(): Int = buffer.remaining()
-
-  /** Returns all bytes not yet consumed by the parser (the un-parsed packet body). */
-  fun drainRemainingInput(): ByteArray = buffer.readAll()
-
-  // -------------------------------------------------------------------------
-  // Variable bindings
-  // -------------------------------------------------------------------------
+class Environment {
 
   private val scopes: ArrayDeque<MutableMap<String, Value>> = ArrayDeque()
 
@@ -90,6 +60,38 @@ class Environment(payload: ByteArray) {
     }
     error("undefined variable: $name")
   }
+}
+
+/**
+ * Packet-level state for a single [ProcessPacketRequest].
+ *
+ * Holds the input packet buffer, the output (emit) buffer, and the execution trace. Created once
+ * per packet in the architecture's [processPacket] and threaded through the interpreter.
+ */
+class PacketContext(payload: ByteArray) {
+
+  // -------------------------------------------------------------------------
+  // Packet buffer
+  // -------------------------------------------------------------------------
+
+  /** Remaining bytes in the input packet, consumed by parser extract(). */
+  private val buffer: PacketBuffer = PacketBuffer(payload)
+
+  /** Output packet bytes, written by deparser emit(). */
+  private val outputBuffer = ByteArrayOutputStream()
+
+  fun extractBytes(count: Int): ByteArray = buffer.read(count)
+
+  fun emitBytes(bytes: ByteArray) {
+    outputBuffer.write(bytes)
+  }
+
+  fun outputPayload(): ByteArray = outputBuffer.toByteArray()
+
+  fun remainingInputBytes(): Int = buffer.remaining()
+
+  /** Returns all bytes not yet consumed by the parser (the un-parsed packet body). */
+  fun drainRemainingInput(): ByteArray = buffer.readAll()
 
   // -------------------------------------------------------------------------
   // Trace

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -88,8 +88,6 @@ class PacketContext(payload: ByteArray) {
 
   fun outputPayload(): ByteArray = outputBuffer.toByteArray()
 
-  fun remainingInputBytes(): Int = buffer.remaining()
-
   /** Returns all bytes not yet consumed by the parser (the un-parsed packet body). */
   fun drainRemainingInput(): ByteArray = buffer.readAll()
 

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -20,7 +20,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
-/** Unit tests for [Environment]: variable scoping, packet buffer, and output buffer. */
+/** Unit tests for [Environment] (variable scoping) and [PacketContext] (packet buffer, output). */
 class EnvironmentTest {
 
   // ---------------------------------------------------------------------------
@@ -29,20 +29,20 @@ class EnvironmentTest {
 
   @Test
   fun `lookup returns null for undefined name`() {
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     assertNull(env.lookup("x"))
   }
 
   @Test
   fun `define and lookup in same scope`() {
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     env.define("x", BitVal(7, 8))
     assertEquals(BitVal(7, 8), env.lookup("x"))
   }
 
   @Test
   fun `inner scope shadows outer binding`() {
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     env.define("x", BitVal(1, 8))
     env.pushScope()
     env.define("x", BitVal(99, 8))
@@ -53,7 +53,7 @@ class EnvironmentTest {
 
   @Test
   fun `inner scope variable is not visible after popScope`() {
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     env.pushScope()
     env.define("inner", BitVal(5, 8))
     env.popScope()
@@ -62,7 +62,7 @@ class EnvironmentTest {
 
   @Test
   fun `update modifies variable in the nearest enclosing scope`() {
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     env.define("x", BitVal(1, 8))
     env.pushScope()
     env.update("x", BitVal(2, 8))
@@ -73,7 +73,7 @@ class EnvironmentTest {
 
   @Test
   fun `update throws for undefined variable`() {
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     assertThrows(IllegalStateException::class.java) { env.update("missing", BitVal(0, 8)) }
   }
 
@@ -83,28 +83,28 @@ class EnvironmentTest {
 
   @Test
   fun `extractBytes reads exactly N bytes from the front of the packet`() {
-    val env = Environment(byteArrayOf(0x01, 0x02, 0x03, 0x04))
-    assertArrayEquals(byteArrayOf(0x01, 0x02), env.extractBytes(2))
+    val pktCtx = PacketContext(byteArrayOf(0x01, 0x02, 0x03, 0x04))
+    assertArrayEquals(byteArrayOf(0x01, 0x02), pktCtx.extractBytes(2))
   }
 
   @Test
   fun `extractBytes advances the cursor so the next call gets the next bytes`() {
-    val env = Environment(byteArrayOf(0x01, 0x02, 0x03, 0x04))
-    env.extractBytes(2)
-    assertArrayEquals(byteArrayOf(0x03, 0x04), env.extractBytes(2))
+    val pktCtx = PacketContext(byteArrayOf(0x01, 0x02, 0x03, 0x04))
+    pktCtx.extractBytes(2)
+    assertArrayEquals(byteArrayOf(0x03, 0x04), pktCtx.extractBytes(2))
   }
 
   @Test
   fun `drainRemainingInput returns bytes not yet extracted`() {
-    val env = Environment(byteArrayOf(0x01, 0x02, 0x03, 0x04))
-    env.extractBytes(1)
-    assertArrayEquals(byteArrayOf(0x02, 0x03, 0x04), env.drainRemainingInput())
+    val pktCtx = PacketContext(byteArrayOf(0x01, 0x02, 0x03, 0x04))
+    pktCtx.extractBytes(1)
+    assertArrayEquals(byteArrayOf(0x02, 0x03, 0x04), pktCtx.drainRemainingInput())
   }
 
   @Test
   fun `extractBytes throws when fewer bytes remain than requested`() {
-    val env = Environment(byteArrayOf(0x01))
-    assertThrows(PacketTooShortException::class.java) { env.extractBytes(2) }
+    val pktCtx = PacketContext(byteArrayOf(0x01))
+    assertThrows(PacketTooShortException::class.java) { pktCtx.extractBytes(2) }
   }
 
   // ---------------------------------------------------------------------------
@@ -113,22 +113,22 @@ class EnvironmentTest {
 
   @Test
   fun `outputPayload is empty before any emitBytes call`() {
-    val env = Environment(byteArrayOf())
-    assertArrayEquals(byteArrayOf(), env.outputPayload())
+    val pktCtx = PacketContext(byteArrayOf())
+    assertArrayEquals(byteArrayOf(), pktCtx.outputPayload())
   }
 
   @Test
   fun `emitBytes appends bytes to the output buffer`() {
-    val env = Environment(byteArrayOf())
-    env.emitBytes(byteArrayOf(0x08, 0x00))
-    assertArrayEquals(byteArrayOf(0x08, 0x00), env.outputPayload())
+    val pktCtx = PacketContext(byteArrayOf())
+    pktCtx.emitBytes(byteArrayOf(0x08, 0x00))
+    assertArrayEquals(byteArrayOf(0x08, 0x00), pktCtx.outputPayload())
   }
 
   @Test
   fun `multiple emitBytes calls concatenate in order`() {
-    val env = Environment(byteArrayOf())
-    env.emitBytes(byteArrayOf(0x01, 0x02))
-    env.emitBytes(byteArrayOf(0x03, 0x04))
-    assertArrayEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04), env.outputPayload())
+    val pktCtx = PacketContext(byteArrayOf())
+    pktCtx.emitBytes(byteArrayOf(0x01, 0x02))
+    pktCtx.emitBytes(byteArrayOf(0x03, 0x04))
+    assertArrayEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04), pktCtx.outputPayload())
   }
 }

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -60,6 +60,10 @@ class Interpreter(
 
   private val tables: Map<String, TableBehavior> = config.tablesList.associateBy { it.name }
 
+  /** Non-null packet context; throws a clear error if packet I/O is attempted without one. */
+  private val packet: PacketContext
+    get() = packetCtx ?: error("packet I/O requires a PacketContext")
+
   private val types = config.typesList.associateBy { it.name }
 
   // -------------------------------------------------------------------------
@@ -485,7 +489,8 @@ class Interpreter(
       // mark_to_drop(standard_metadata): sets egress_spec to the v1model drop port (511).
       "mark_to_drop" -> {
         val smeta = evalExpr(call.argsList[0], env) as StructVal
-        smeta.fields["egress_spec"] = BitVal(V1ModelArchitecture.DROP_PORT.toLong(), PORT_BITS)
+        smeta.fields["egress_spec"] =
+          BitVal(V1ModelArchitecture.DROP_PORT.toLong(), V1ModelArchitecture.PORT_BITS)
         UnitVal
       }
       else -> error("unhandled extern call: $funcName")
@@ -506,7 +511,7 @@ class Interpreter(
     // both fields live in the same byte and must be unpacked by shift+mask, not by
     // reading separate bytes.
     val totalBits = headerDecl.fieldsList.sumOf { it.type.bit.width }
-    val allBits = BigInteger(1, packetCtx!!.extractBytes((totalBits + 7) / 8))
+    val allBits = BigInteger(1, packet.extractBytes((totalBits + 7) / 8))
 
     val newFields = mutableMapOf<String, Value>()
     var bitOffset = 0
@@ -550,11 +555,7 @@ class Interpreter(
           packedBits = packedBits or fieldVal.bits.value.shiftLeft(shift)
           bitOffset += fieldVal.bits.width
         }
-        val totalBytes = (totalBits + 7) / 8
-        val raw = packedBits.toByteArray()
-        packetCtx!!.emitBytes(
-          ByteArray(totalBytes) { i -> raw.getOrElse(raw.size - totalBytes + i) { 0 } }
-        )
+        packet.emitBytes(BitVector(packedBits, totalBits).toByteArray())
       }
       is StructVal -> {
         // Emit in the declaration order from the TypeDecl; fall back to map order if unknown.
@@ -616,9 +617,6 @@ class Interpreter(
     }
   }
 }
-
-// Drop port for v1model mark_to_drop(): egress_spec is set to 511 (0x1FF).
-private const val PORT_BITS = 9
 
 /**
  * Thrown by an `exit` statement; unwinds the call stack to the top of the current pipeline stage.

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -21,15 +21,19 @@ import java.math.BigInteger
 /**
  * The core P4 interpreter.
  *
- * Walks the proto IR tree for a single packet traversal. All mutable packet-local state lives in
- * the [Environment]; program-global state (table entries, extern instances) lives in [TableStore]
- * and is passed in.
+ * Walks the proto IR tree for a single packet traversal. Variable scopes live in [Environment];
+ * packet-level state (input buffer, output buffer, trace) lives in [PacketContext]; program-global
+ * state (table entries, extern instances) lives in [TableStore].
  *
  * The interpreter is deliberately simple: it pattern-matches on proto oneof fields and dispatches
  * to focused methods. There is no bytecode compilation or optimisation — correctness and
  * readability are the goals.
  */
-class Interpreter(private val config: P4BehavioralConfig, private val tableStore: TableStore) {
+class Interpreter(
+  private val config: P4BehavioralConfig,
+  private val tableStore: TableStore,
+  private val packetCtx: PacketContext? = null,
+) {
   private val parsers: Map<String, ParserDecl> = config.parsersList.associateBy { it.name }
 
   private val controls: Map<String, ControlDecl> = config.controlsList.associateBy { it.name }
@@ -84,7 +88,7 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
           else -> state.transition.nextState
         }
 
-      env.addTraceEvent(
+      packetCtx?.addTraceEvent(
         TraceEvent.newBuilder()
           .setParserTransition(
             ParserTransitionEvent.newBuilder()
@@ -103,7 +107,7 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
     val keyValues = select.keysList.map { evalExpr(it, env) }
     // Keyset expressions in parser select are always compile-time constants; a single
     // empty environment is correct for all of them.
-    val constEnv = Environment(byteArrayOf())
+    val constEnv = Environment()
     for (case in select.casesList) {
       if (keyValues.zip(case.keysetsList).all { (v, k) -> matchesKeyset(v, k, constEnv) }) {
         return case.nextState
@@ -186,7 +190,7 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
 
     // The control name is not directly available in the Stmt proto; we use
     // a placeholder here. A richer trace could include source location info.
-    env.addTraceEvent(
+    packetCtx?.addTraceEvent(
       TraceEvent.newBuilder().setBranch(BranchEvent.newBuilder().setTaken(condition)).build()
     )
 
@@ -380,7 +384,7 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
 
     val (hit, entry, actionName) = tableStore.lookup(tableName, keyValues)
 
-    env.addTraceEvent(
+    packetCtx?.addTraceEvent(
       TraceEvent.newBuilder()
         .setTableLookup(
           TableLookupEvent.newBuilder()
@@ -420,7 +424,7 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
         env.define(paramDecl.name, value)
       }
 
-      env.addTraceEvent(
+      packetCtx?.addTraceEvent(
         TraceEvent.newBuilder()
           .setActionExecution(
             ActionExecutionEvent.newBuilder()
@@ -502,7 +506,7 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
     // both fields live in the same byte and must be unpacked by shift+mask, not by
     // reading separate bytes.
     val totalBits = headerDecl.fieldsList.sumOf { it.type.bit.width }
-    val allBits = BigInteger(1, env.extractBytes((totalBits + 7) / 8))
+    val allBits = BigInteger(1, packetCtx!!.extractBytes((totalBits + 7) / 8))
 
     val newFields = mutableMapOf<String, Value>()
     var bitOffset = 0
@@ -518,7 +522,7 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
   }
 
   private fun execEmit(call: MethodCall, env: Environment): Value {
-    emitValue(evalExpr(call.argsList[0], env), env)
+    emitValue(evalExpr(call.argsList[0], env))
     return UnitVal
   }
 
@@ -531,7 +535,7 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
    * This handles both `pkt.emit(hdr.ethernet)` (single header) and `pkt.emit(hdr)` where `hdr` is a
    * struct containing multiple headers, as required by the P4 deparser model.
    */
-  private fun emitValue(value: Value, env: Environment) {
+  private fun emitValue(value: Value) {
     when (value) {
       is HeaderVal -> {
         if (!value.valid) return
@@ -548,17 +552,19 @@ class Interpreter(private val config: P4BehavioralConfig, private val tableStore
         }
         val totalBytes = (totalBits + 7) / 8
         val raw = packedBits.toByteArray()
-        env.emitBytes(ByteArray(totalBytes) { i -> raw.getOrElse(raw.size - totalBytes + i) { 0 } })
+        packetCtx!!.emitBytes(
+          ByteArray(totalBytes) { i -> raw.getOrElse(raw.size - totalBytes + i) { 0 } }
+        )
       }
       is StructVal -> {
         // Emit in the declaration order from the TypeDecl; fall back to map order if unknown.
         val structDecl = types[value.typeName]?.struct
         if (structDecl != null) {
           for (field in structDecl.fieldsList) {
-            emitValue(value.fields[field.name] ?: continue, env)
+            emitValue(value.fields[field.name] ?: continue)
           }
         } else {
-          for (fieldVal in value.fields.values) emitValue(fieldVal, env)
+          for (fieldVal in value.fields.values) emitValue(fieldVal)
         }
       }
       else -> {} // BoolVal, BitVal outside a header, UnitVal — not emittable

--- a/simulator/InterpreterControlTest.kt
+++ b/simulator/InterpreterControlTest.kt
@@ -34,7 +34,7 @@ import org.junit.Test
 class InterpreterControlTest {
 
   private val emptyEnv
-    get() = Environment(byteArrayOf())
+    get() = Environment()
 
   // ---------------------------------------------------------------------------
   // Expr / Stmt builder helpers

--- a/simulator/InterpreterExprTest.kt
+++ b/simulator/InterpreterExprTest.kt
@@ -31,7 +31,7 @@ class InterpreterExprTest {
   private val emptyConfig = P4BehavioralConfig.getDefaultInstance()
 
   private val emptyEnv
-    get() = Environment(byteArrayOf())
+    get() = Environment()
 
   private fun interp() = Interpreter(emptyConfig, TableStore())
 

--- a/simulator/InterpreterInlineActionTest.kt
+++ b/simulator/InterpreterInlineActionTest.kt
@@ -38,7 +38,7 @@ import org.junit.Test
 class InterpreterInlineActionTest {
 
   private val emptyEnv
-    get() = Environment(byteArrayOf())
+    get() = Environment()
 
   private fun bitType(width: Int): Type =
     Type.newBuilder().setBit(BitType.newBuilder().setWidth(width)).build()

--- a/simulator/InterpreterPacketTest.kt
+++ b/simulator/InterpreterPacketTest.kt
@@ -71,10 +71,10 @@ class InterpreterPacketTest {
       )
       .build()
 
-  private fun interp(vararg types: TypeDecl): Interpreter {
+  private fun interp(packetCtx: PacketContext, vararg types: TypeDecl): Interpreter {
     val config =
       P4BehavioralConfig.newBuilder().also { cfg -> types.forEach { cfg.addTypes(it) } }.build()
-    return Interpreter(config, TableStore())
+    return Interpreter(config, TableStore(), packetCtx)
   }
 
   // ---------------------------------------------------------------------------
@@ -84,11 +84,12 @@ class InterpreterPacketTest {
   @Test
   fun `extract byte-aligned 16-bit field`() {
     val type = headerType("h_t", "etherType" to 16)
-    val env = Environment(byteArrayOf(0x08, 0x00))
+    val pktCtx = PacketContext(byteArrayOf(0x08, 0x00))
+    val env = Environment()
     val header = HeaderVal(typeName = "h_t", valid = false)
     env.define("hdr", header)
 
-    interp(type).evalExpr(packetCall("extract", "hdr"), env)
+    interp(pktCtx, type).evalExpr(packetCall("extract", "hdr"), env)
 
     assertTrue(header.valid)
     assertEquals(BitVal(0x0800, 16), header.fields["etherType"])
@@ -98,11 +99,12 @@ class InterpreterPacketTest {
   fun `extract two sub-byte fields from a shared byte`() {
     // 0x45: upper nibble = version=4, lower nibble = ihl=5
     val type = headerType("h_t", "version" to 4, "ihl" to 4)
-    val env = Environment(byteArrayOf(0x45))
+    val pktCtx = PacketContext(byteArrayOf(0x45))
+    val env = Environment()
     val header = HeaderVal(typeName = "h_t", valid = false)
     env.define("hdr", header)
 
-    interp(type).evalExpr(packetCall("extract", "hdr"), env)
+    interp(pktCtx, type).evalExpr(packetCall("extract", "hdr"), env)
 
     assertTrue(header.valid)
     assertEquals(BitVal(4, 4), header.fields["version"])
@@ -113,11 +115,12 @@ class InterpreterPacketTest {
   fun `extract mixed-width fields spanning four bytes`() {
     // bit<4>(4) + bit<4>(5) + bit<8>(0) + bit<16>(0x0800) = 0x45 0x00 0x08 0x00
     val type = headerType("h_t", "version" to 4, "ihl" to 4, "tos" to 8, "len" to 16)
-    val env = Environment(byteArrayOf(0x45, 0x00, 0x08, 0x00))
+    val pktCtx = PacketContext(byteArrayOf(0x45, 0x00, 0x08, 0x00))
+    val env = Environment()
     val header = HeaderVal(typeName = "h_t", valid = false)
     env.define("hdr", header)
 
-    interp(type).evalExpr(packetCall("extract", "hdr"), env)
+    interp(pktCtx, type).evalExpr(packetCall("extract", "hdr"), env)
 
     assertEquals(BitVal(4, 4), header.fields["version"])
     assertEquals(BitVal(5, 4), header.fields["ihl"])
@@ -129,13 +132,14 @@ class InterpreterPacketTest {
   fun `extract advances the packet buffer cursor`() {
     // Two sequential extracts: first grabs bytes [0x08, 0x00], second gets [0x01, 0x00].
     val type = headerType("h_t", "f" to 16)
-    val env = Environment(byteArrayOf(0x08, 0x00, 0x01, 0x00))
+    val pktCtx = PacketContext(byteArrayOf(0x08, 0x00, 0x01, 0x00))
+    val env = Environment()
     val h1 = HeaderVal(typeName = "h_t", valid = false)
     val h2 = HeaderVal(typeName = "h_t", valid = false)
     env.define("h1", h1)
     env.define("h2", h2)
 
-    val interp = interp(type)
+    val interp = interp(pktCtx, type)
     interp.evalExpr(packetCall("extract", "h1"), env)
     interp.evalExpr(packetCall("extract", "h2"), env)
 
@@ -150,7 +154,8 @@ class InterpreterPacketTest {
   @Test
   fun `emit valid 16-bit header produces correct bytes`() {
     val type = headerType("h_t", "etherType" to 16)
-    val env = Environment(byteArrayOf())
+    val pktCtx = PacketContext(byteArrayOf())
+    val env = Environment()
     val header =
       HeaderVal(
         typeName = "h_t",
@@ -159,28 +164,30 @@ class InterpreterPacketTest {
       )
     env.define("hdr", header)
 
-    interp(type).evalExpr(packetCall("emit", "hdr"), env)
+    interp(pktCtx, type).evalExpr(packetCall("emit", "hdr"), env)
 
-    assertArrayEquals(byteArrayOf(0x08, 0x00), env.outputPayload())
+    assertArrayEquals(byteArrayOf(0x08, 0x00), pktCtx.outputPayload())
   }
 
   @Test
   fun `emit invalid header produces no bytes`() {
     val type = headerType("h_t", "etherType" to 16)
-    val env = Environment(byteArrayOf())
+    val pktCtx = PacketContext(byteArrayOf())
+    val env = Environment()
     val header = HeaderVal(typeName = "h_t", valid = false)
     env.define("hdr", header)
 
-    interp(type).evalExpr(packetCall("emit", "hdr"), env)
+    interp(pktCtx, type).evalExpr(packetCall("emit", "hdr"), env)
 
-    assertArrayEquals(byteArrayOf(), env.outputPayload())
+    assertArrayEquals(byteArrayOf(), pktCtx.outputPayload())
   }
 
   @Test
   fun `emit packs sub-byte fields into a single byte`() {
     // version=4, ihl=5 → both in the same byte → 0x45
     val type = headerType("h_t", "version" to 4, "ihl" to 4)
-    val env = Environment(byteArrayOf())
+    val pktCtx = PacketContext(byteArrayOf())
+    val env = Environment()
     val header =
       HeaderVal(
         typeName = "h_t",
@@ -189,23 +196,24 @@ class InterpreterPacketTest {
       )
     env.define("hdr", header)
 
-    interp(type).evalExpr(packetCall("emit", "hdr"), env)
+    interp(pktCtx, type).evalExpr(packetCall("emit", "hdr"), env)
 
-    assertArrayEquals(byteArrayOf(0x45), env.outputPayload())
+    assertArrayEquals(byteArrayOf(0x45), pktCtx.outputPayload())
   }
 
   @Test
   fun `extract then emit round-trips the original bytes`() {
     val type = headerType("h_t", "version" to 4, "ihl" to 4, "tos" to 8, "len" to 16)
     val input = byteArrayOf(0x45, 0x00, 0x08, 0x00)
-    val env = Environment(input)
+    val pktCtx = PacketContext(input)
+    val env = Environment()
     val header = HeaderVal(typeName = "h_t", valid = false)
     env.define("hdr", header)
 
-    val interp = interp(type)
+    val interp = interp(pktCtx, type)
     interp.evalExpr(packetCall("extract", "hdr"), env)
     interp.evalExpr(packetCall("emit", "hdr"), env)
 
-    assertArrayEquals(input, env.outputPayload())
+    assertArrayEquals(input, pktCtx.outputPayload())
   }
 }

--- a/simulator/InterpreterParserTest.kt
+++ b/simulator/InterpreterParserTest.kt
@@ -69,7 +69,7 @@ class InterpreterParserTest {
 
   @Test
   fun `single-state parser executes stmts and halts at accept`() {
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     env.define("x", BitVal(0, 8))
 
     interp(state("start", "accept", assign("x", bit(1, 8)))).runParser("MyParser", env)
@@ -80,7 +80,7 @@ class InterpreterParserTest {
   @Test
   fun `two-state parser traverses states in order`() {
     // start(x=1) → middle(x=2) → accept: both states must run.
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     env.define("x", BitVal(0, 8))
 
     interp(
@@ -95,7 +95,7 @@ class InterpreterParserTest {
   @Test
   fun `three-state chain visits all states`() {
     // start(x=1) → s1(x=2) → s2(x=3) → accept
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     env.define("x", BitVal(0, 8))
 
     interp(
@@ -111,7 +111,7 @@ class InterpreterParserTest {
   @Test
   fun `parser stops at reject without error`() {
     // reject is a terminal state, not an exception — the pipeline drops the packet separately.
-    val env = Environment(byteArrayOf())
+    val env = Environment()
     interp(state("start", "reject")).runParser("MyParser", env)
   }
 }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -143,7 +143,7 @@ class V1ModelArchitecture : Architecture {
     private const val V1MODEL_USER_PARAM_COUNT = 3
 
     // Bit widths for standard_metadata_t fields, as defined in v1model.p4.
-    private const val PORT_BITS = 9
+    const val PORT_BITS = 9
     private const val INT32_BITS = 32
     private const val FLAG_BITS = 1
   }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -26,8 +26,9 @@ class V1ModelArchitecture : Architecture {
     config: P4BehavioralConfig,
     tableStore: TableStore,
   ): PipelineResult {
-    val interpreter = Interpreter(config, tableStore)
-    val env = Environment(payload)
+    val packetCtx = PacketContext(payload)
+    val interpreter = Interpreter(config, tableStore, packetCtx)
+    val env = Environment()
 
     val typesByName = config.typesList.associateBy { it.name }
 
@@ -94,10 +95,10 @@ class V1ModelArchitecture : Architecture {
       try {
         interpreter.runParser(parserStage.blockName, env)
       } catch (e: ExitException) {
-        return PipelineResult(emptyList(), env.buildTrace())
+        return PipelineResult(emptyList(), packetCtx.buildTrace())
       } catch (e: PacketTooShortException) {
         // In v1model/BMv2, a PacketTooShort parser error causes the packet to be dropped.
-        return PipelineResult(emptyList(), env.buildTrace())
+        return PipelineResult(emptyList(), packetCtx.buildTrace())
       }
     }
 
@@ -117,7 +118,7 @@ class V1ModelArchitecture : Architecture {
 
     // Port 511 is the v1model drop port (mark_to_drop sets egress_spec = 511).
     if (egressSpec == DROP_PORT) {
-      return PipelineResult(emptyList(), env.buildTrace())
+      return PipelineResult(emptyList(), packetCtx.buildTrace())
     }
 
     // --- Deparser ---
@@ -128,9 +129,9 @@ class V1ModelArchitecture : Architecture {
     // Append any bytes the parser did not extract (the un-parsed packet body).
     // In P4, the deparser emits re-serialised headers; the remaining payload
     // is transparently forwarded after them.
-    val outputBytes = env.outputPayload() + env.drainRemainingInput()
+    val outputBytes = packetCtx.outputPayload() + packetCtx.drainRemainingInput()
     val output = OutputPacket(egressSpec.toUInt(), outputBytes)
-    return PipelineResult(listOf(output), env.buildTrace())
+    return PipelineResult(listOf(output), packetCtx.buildTrace())
   }
 
   companion object {


### PR DESCRIPTION
## Summary

- **`reversed()` → `asReversed()`**: Eliminates a list copy on every variable
  lookup/update — the hottest path in the interpreter.

- **Extract `PacketContext` from `Environment`**: Variable scopes and packet
  state (input buffer, output buffer, trace) had different lifetimes but lived
  in the same class. `Environment` is now a no-arg scope-only class;
  `PacketContext` holds per-packet state and is threaded through the
  `Interpreter` constructor. Tests that don't involve packets no longer need
  the awkward `Environment(byteArrayOf())`.

- **Cleanup**: Removed dead `remainingInputBytes()`, replaced bare `!!` with a
  domain-specific error, deduplicated byte-packing logic (now uses
  `BitVector.toByteArray()`), and consolidated the duplicate `PORT_BITS`
  constant.

Refactoring #2 from `docs/refactoring.md` (evalMethodCall dispatch) was
skipped — the grouping comments already exist and the one-liner handlers
don't benefit from extraction.

## Test plan

- [x] `bazel test //simulator/...` — all 8 unit tests pass
- [x] `bazel test //e2e_tests/...` — all 31 e2e tests pass
- [x] `./format.sh` clean
- [x] detekt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)