### PR TITLE
Add --repo_env for Clang toolchain auto-detection

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,9 +6,12 @@ common --noenable_workspace
 build --java_runtime_version=remotejdk_21
 build --tool_java_runtime_version=remotejdk_21
 
-# Force Clang for all builds, matching p4c upstream. This also ensures
-# clang-tidy (a Clang tool) shares the same header search paths as the
-# compiler, avoiding system-header-not-found errors in the Bazel sandbox.
+# Force Clang for all builds, matching p4c upstream. repo_env influences
+# Bazel's C++ toolchain auto-detection (cc_autoconf), ensuring include paths
+# are Clang-native. This also fixes clang-tidy, which inherits these paths
+# via the compilation database.
+build --repo_env=CC=clang
+build --repo_env=CXX=clang++
 build --action_env=CC=clang
 build --action_env=CXX=clang++
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,11 @@ WarningsAsErrors: "*"
 # p4c and other third-party headers pulled in via @p4c//.
 HeaderFilterRegex: "^p4c_backend/.*"
 
+# Bazel's sandbox + GCC toolchain on Linux doesn't expose /usr/include to
+# clang-tidy, so GCC's C++ stdlib.h can't #include_next the C stdlib.h.
+ExtraArgsBefore:
+  - '-isystem/usr/include'
+
 CheckOptions:
   # Naming conventions.  The p4c backend is a p4c plugin and inherits p4c's
   # camelBack naming for functions, variables, and members.  Namespaces follow

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,11 +27,6 @@ WarningsAsErrors: "*"
 # p4c and other third-party headers pulled in via @p4c//.
 HeaderFilterRegex: "^p4c_backend/.*"
 
-# Bazel's sandbox + GCC toolchain on Linux doesn't expose /usr/include to
-# clang-tidy, so GCC's C++ stdlib.h can't #include_next the C stdlib.h.
-ExtraArgsBefore:
-  - '-isystem/usr/include'
-
 CheckOptions:
   # Naming conventions.  The p4c backend is a p4c plugin and inherits p4c's
   # camelBack naming for functions, variables, and members.  Namespaces follow


### PR DESCRIPTION
## Summary

Follow-up to #14. The `--action_env=CC=clang` added there sets Clang for
build actions, but Bazel's `cc_autoconf` repository rule (which determines
include paths for the C++ toolchain) reads `CC` from `--repo_env` instead.

Without `--repo_env`, the auto-detected toolchain still uses GCC include
paths, causing clang-tidy to fail on `#include_next <stdlib.h>` because
GCC's C++ `stdlib.h` wrapper can't find the C `stdlib.h` under Clang's
header search paths.

## Test plan

- [ ] CI lint job passes (clang-tidy no longer errors on system headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)