### PR TITLE
Add -isystem/usr/include to .clang-tidy for Bazel sandbox

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,11 @@ WarningsAsErrors: "*"
 # p4c and other third-party headers pulled in via @p4c//.
 HeaderFilterRegex: "^p4c_backend/.*"
 
+# Bazel's sandbox + GCC toolchain on Linux doesn't expose /usr/include to
+# clang-tidy, so GCC's C++ stdlib.h can't #include_next the C stdlib.h.
+ExtraArgsBefore:
+  - '-isystem/usr/include'
+
 CheckOptions:
   # Naming conventions.  The p4c backend is a p4c plugin and inherits p4c's
   # camelBack naming for functions, variables, and members.  Namespaces follow

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,11 +27,6 @@ WarningsAsErrors: "*"
 # p4c and other third-party headers pulled in via @p4c//.
 HeaderFilterRegex: "^p4c_backend/.*"
 
-# Bazel's sandbox + GCC toolchain on Linux doesn't expose /usr/include to
-# clang-tidy, so GCC's C++ stdlib.h can't #include_next the C stdlib.h.
-ExtraArgsBefore:
-  - '-isystem/usr/include'
-
 CheckOptions:
   # Naming conventions.  The p4c backend is a p4c plugin and inherits p4c's
   # camelBack naming for functions, variables, and members.  Namespaces follow

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,12 @@ WarningsAsErrors: "*"
 # p4c and other third-party headers pulled in via @p4c//.
 HeaderFilterRegex: "^p4c_backend/.*"
 
+# clang-tidy's include search path inside Bazel's sandbox is missing
+# /usr/include, so C headers like stdlib.h aren't found. Adding it
+# explicitly is harmless on macOS (nonexistent -isystem dirs are ignored).
+ExtraArgsBefore:
+  - '-isystem/usr/include'
+
 CheckOptions:
   # Naming conventions.  The p4c backend is a p4c plugin and inherits p4c's
   # camelBack naming for functions, variables, and members.  Namespaces follow


### PR DESCRIPTION
## Summary

Follow-up to #19. clang-tidy's include search path inside Bazel's sandbox
doesn't include `/usr/include`, so C standard headers (`stdlib.h`) aren't
found when included from C++ headers (`cstdlib`). Adding the path via
`ExtraArgsBefore` fixes the lookup. Harmless on macOS where nonexistent
`-isystem` dirs are silently ignored.

## Test plan

- [ ] CI lint passes (clang-tidy finds system headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)