### PR TITLE
Add delta coverage stats to HTML report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,29 @@ jobs:
           path: ~/.cache/bazel
           key: bazel-coverage-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
 
+      - name: Compute diff coverage
+        run: |
+          gh pr diff "${PR_NUM}" > /tmp/pr.diff
+          ./diff-coverage.sh /tmp/pr.diff coverage.lcov >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Inject coverage summary into HTML report
+        run: |
+          if [[ "${TOTAL_LF}" -gt 0 ]]; then
+            PCT=$(( 100 * TOTAL_LH / TOTAL_LF ))
+            ABS="Absolute: ${TOTAL_LH}/${TOTAL_LF} (${PCT}%)"
+          else
+            ABS="Absolute: no data collected"
+          fi
+          if [[ "${DIFF_PCT}" -ge 0 ]]; then
+            DELTA="Delta: ${DIFF_LH}/${DIFF_LF} (${DIFF_PCT}%)"
+          else
+            DELTA="Delta: no coverable lines changed"
+          fi
+          BANNER="<div style=\"background:#f0f4f8;border:1px solid #d0d7de;border-radius:6px;padding:12px 16px;margin:10px;font-family:sans-serif;font-size:14px\"><strong>Coverage summary</strong> — ${ABS} · ${DELTA}</div>"
+          sed -i "s|<body>|<body>${BANNER}|" coverage-report/index.html
+
       - name: Publish HTML report to GitHub Pages
         run: |
           git fetch --depth=1 origin gh-pages
@@ -169,13 +192,6 @@ jobs:
               commit -m "Coverage report for PR #${PR_NUM}" --allow-empty
           # Retry once on conflict (concurrent PR pushes).
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
-
-      - name: Compute diff coverage
-        run: |
-          gh pr diff "${PR_NUM}" > /tmp/pr.diff
-          ./diff-coverage.sh /tmp/pr.diff coverage.lcov >> "$GITHUB_ENV"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment coverage on PR
         run: |


### PR DESCRIPTION
## Summary

- The gh-pages coverage report only showed genhtml's built-in absolute coverage rate. Delta coverage (fraction of changed lines that are covered) was only visible in the PR bot comment.
- Reorders CI steps so diff-coverage runs before publishing, then injects a summary banner into genhtml's `index.html` showing both absolute and delta stats.

## Test plan

- [ ] Open this PR and let CI run the coverage job
- [ ] Check the gh-pages report: a "Coverage summary" banner should appear at the top with absolute and delta stats
- [ ] Verify the bot comment still posts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)