### PR TITLE
Fix Bazel cache path on macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-26]
+    env:
+      BAZEL_CACHE: ${{ contains(matrix.os, 'macos') && '~/Library/Caches/bazel' || '~/.cache/bazel' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -79,7 +81,7 @@ jobs:
       - name: Restore Bazel cache
         uses: actions/cache/restore@v5
         with:
-          path: ~/.cache/bazel
+          path: ${{ env.BAZEL_CACHE }}
           key: bazel-${{ matrix.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
             bazel-${{ matrix.os }}-
@@ -107,7 +109,7 @@ jobs:
         uses: actions/cache/save@v5
         if: always() && (github.ref_name == 'main' || env.DURATION > 300)
         with:
-          path: ~/.cache/bazel
+          path: ${{ env.BAZEL_CACHE }}
           key: bazel-${{ matrix.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
 
 


### PR DESCRIPTION
## Summary
- macOS stores Bazel cache in `~/Library/Caches/bazel`, not `~/.cache/bazel`
- Adds a conditional `BAZEL_CACHE` env var to the build-and-test job that picks the right path per OS
- Fixes the "Path(s) specified in the action for caching do(es) not exist" warning on macos-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)