### PR TITLE
Add BuildBuddy remote cache for CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,3 +41,5 @@ build:ci --remote_download_toplevel
 build:ci --remote_upload_local_results
 build:ci --remote_timeout=3s
 build:ci --remote_cache_compression
+build:ci --bes_results_url=https://4ward.buildbuddy.io/invocation/
+build:ci --bes_backend=grpcs://4ward.buildbuddy.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
             echo "build --config=ci" >> ~/.bazelrc
-            echo "build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
+            echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
           fi
 
       # Restore-only: the build-and-test job owns the authoritative cache for
@@ -93,7 +93,7 @@ jobs:
         run: |
           if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
             echo "build --config=ci" >> ~/.bazelrc
-            echo "build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
+            echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
           fi
 
       - name: Restore Bazel cache
@@ -149,7 +149,7 @@ jobs:
         run: |
           if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
             echo "build --config=ci" >> ~/.bazelrc
-            echo "build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
+            echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
           fi
 
       - name: Restore Bazel cache


### PR DESCRIPTION
## Summary

- Adds a Bazel remote cache (BuildBuddy free tier) layered on top of the
  existing GitHub Actions cache
- Per-action caching shared across all jobs and branches — builds only
  re-execute actions whose inputs actually changed
- Gated on the `BUILDBUDDY_API_KEY` repo secret; degrades gracefully
  (runs exactly as before) when the secret is absent

## Transfer minimization

- `--remote_download_toplevel` — only download final outputs, not
  intermediate .o/.class files
- `--remote_cache_compression` — zstd, ~60-70% less bytes on the wire
- `--remote_timeout=3s` — fail fast on BuildBuddy issues, fall back to
  the GHA local cache (which stays as-is)

## Setup

The `BUILDBUDDY_API_KEY` repository secret is already configured.

## Test plan

- [ ] Verify CI passes on this PR (remote cache populates on first run)
- [ ] Check a follow-up PR for cache hit rates (BuildBuddy dashboard or
      Bazel log output)
- [ ] Confirm fork PRs still work (secret absent → no remote cache, no
      errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)