### PR TITLE
Use genhtml's native differential coverage for PR reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,11 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request'
     permissions:
       contents: write
       pull-requests: write
     env:
-      PR_NUM: ${{ github.event.pull_request.number }}
+      PR_NUM: ${{ github.event.pull_request.number || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -165,10 +164,32 @@ jobs:
         run: echo "START_TIME=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Install lcov
+        if: github.event_name == 'pull_request'
         run: sudo apt install -y lcov
 
+      - name: Download baseline coverage
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --depth=1 origin gh-pages || exit 0
+          git show origin/gh-pages:main/coverage.lcov > /tmp/baseline.lcov 2>/dev/null \
+            || rm -f /tmp/baseline.lcov
+
+      - name: Generate PR diff
+        if: github.event_name == 'pull_request'
+        run: gh pr diff "${PR_NUM}" > /tmp/pr.diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run coverage
-        run: ./coverage.sh --html
+        run: |
+          ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            ARGS+=(--html)
+            if [[ -s /tmp/baseline.lcov && -s /tmp/pr.diff ]]; then
+              ARGS+=(--baseline /tmp/baseline.lcov --diff /tmp/pr.diff)
+            fi
+          fi
+          ./coverage.sh "${ARGS[@]}"
 
       - name: Calculate build duration
         if: always()
@@ -185,32 +206,27 @@ jobs:
           path: ~/.cache/bazel
           key: bazel-coverage-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}-${{ github.run_id }}
 
-      - name: Compute diff coverage
+      - name: Publish baseline LCOV
+        if: github.event_name == 'push'
         run: |
-          gh pr diff "${PR_NUM}" > /tmp/pr.diff
-          ./diff-coverage.sh /tmp/pr.diff coverage.lcov >> "$GITHUB_ENV"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git fetch --depth=1 origin gh-pages || exit 0
+          git worktree add /tmp/gh-pages gh-pages
+          mkdir -p /tmp/gh-pages/main
+          cp coverage.lcov /tmp/gh-pages/main/
+          cd /tmp/gh-pages
+          git add main/coverage.lcov
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -m "Baseline coverage for $(git -C "$GITHUB_WORKSPACE" rev-parse --short HEAD)" --allow-empty
+          git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
 
-      - name: Inject coverage summary into HTML report
-        run: |
-          if [[ "${TOTAL_LF}" -gt 0 ]]; then
-            PCT=$(( 100 * TOTAL_LH / TOTAL_LF ))
-            ABS="Absolute: ${TOTAL_LH}/${TOTAL_LF} (${PCT}%)"
-          else
-            ABS="Absolute: no data collected"
-          fi
-          if [[ "${DIFF_PCT}" -ge 0 ]]; then
-            DELTA="Delta: ${DIFF_LH}/${DIFF_LF} (${DIFF_PCT}%)"
-          else
-            DELTA="Delta: no coverable lines changed"
-          fi
-          BANNER="<div style=\"background:#f0f4f8;border:1px solid #d0d7de;border-radius:6px;padding:12px 16px;margin:10px;font-family:sans-serif;font-size:14px\"><strong>Coverage summary</strong> — ${ABS} · ${DELTA}</div>"
-          sed -i "s|<body>|<body>${BANNER}|" coverage-report/index.html
+      - name: Compute diff coverage
+        if: github.event_name == 'pull_request'
+        run: ./diff-coverage.sh /tmp/pr.diff coverage.lcov >> "$GITHUB_ENV"
 
       - name: Publish HTML report to GitHub Pages
+        if: github.event_name == 'pull_request'
         run: |
-          git fetch --depth=1 origin gh-pages
           git worktree add /tmp/gh-pages gh-pages
           mkdir -p "/tmp/gh-pages/pr/${PR_NUM}"
           cp -r coverage-report/* "/tmp/gh-pages/pr/${PR_NUM}/"
@@ -223,6 +239,7 @@ jobs:
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
 
       - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
         run: |
           MARKER="<!-- coverage-report -->"
           REPO_NAME="${{ github.event.repository.name }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ bazel build //...          # build everything
 bazel test //...           # run all tests
 ./format.sh                # auto-format all files (clang-format + buildifier + ktfmt)
 ./lint.sh                  # lint all files (clang-tidy for C++, detekt for Kotlin)
-./coverage.sh              # collect code coverage (LCOV + optional HTML report)
+./coverage.sh              # collect code coverage (see --html, --baseline, --diff)
 ./diff-coverage.sh         # incremental coverage from a diff + LCOV file
 ./dev.sh help              # show all developer commands
 ```

--- a/coverage.sh
+++ b/coverage.sh
@@ -2,8 +2,14 @@
 # Collects Kotlin code coverage for the simulator library.
 #
 # Usage:
-#   ./coverage.sh              # run all tests, produce LCOV + optional HTML
-#   ./coverage.sh --html       # same, but require genhtml for HTML output
+#   ./coverage.sh                                # run tests, produce LCOV
+#   ./coverage.sh --html                         # also generate HTML report
+#   ./coverage.sh --html --baseline B --diff D   # HTML with differential coverage
+#
+# Options:
+#   --html              Generate an HTML report (requires genhtml / lcov).
+#   --baseline <file>   Baseline LCOV for differential coverage (genhtml --baseline-file).
+#   --diff <file>       Unified diff for differential coverage (genhtml --diff-file).
 #
 # Bazel 9's built-in `bazel coverage` pipeline doesn't produce LCOV data for
 # kt_jvm_test targets.  Two independent bugs conspire:
@@ -25,6 +31,18 @@
 #     that bypasses the broken path filtering.
 
 set -euo pipefail
+
+WANT_HTML=false
+BASELINE_FILE=""
+DIFF_FILE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --html)     WANT_HTML=true; shift ;;
+    --baseline) BASELINE_FILE="${2:?--baseline requires a file argument}"; shift 2 ;;
+    --diff)     DIFF_FILE="${2:?--diff requires a file argument}"; shift 2 ;;
+    *)          echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
 
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 REPORT_DIR="${REPO_ROOT}/coverage-report"
@@ -294,11 +312,15 @@ echo "Saved:        ${PERSISTENT}"
 
 # ── HTML report (optional) ───────────────────────────────────────────────────
 
+GENHTML_ARGS=(--quiet)
+[[ -n "${BASELINE_FILE}" ]] && GENHTML_ARGS+=(--baseline-file "${BASELINE_FILE}")
+[[ -n "${DIFF_FILE}" ]]     && GENHTML_ARGS+=(--diff-file "${DIFF_FILE}")
+
 if command -v genhtml >/dev/null 2>&1; then
   rm -rf "${REPORT_DIR}"
-  genhtml "${PERSISTENT}" --output-directory "${REPORT_DIR}" --quiet
+  genhtml "${PERSISTENT}" --output-directory "${REPORT_DIR}" "${GENHTML_ARGS[@]}"
   echo "HTML report:  ${REPORT_DIR}/index.html"
-elif [[ "${1:-}" == "--html" ]]; then
+elif "${WANT_HTML}"; then
   echo "Error: genhtml not found (install lcov: brew install lcov)" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Publishes a baseline `coverage.lcov` to gh-pages on every push to `main`
- On PRs, downloads the baseline and passes it (along with the PR diff) to
  `genhtml --baseline-file --diff-file`, enabling LCOV 2.0's native
  differential coverage display (TLA categories: GNC, UNC, CBC, etc.)
- Removes the hand-rolled `sed` banner in favor of genhtml's built-in
  per-file TLA breakdowns and color-coded source views
- Adds `--baseline` and `--diff` flags to `coverage.sh` for local use

Graceful degradation: if no baseline exists yet (first PR before a main push),
the report falls back to a standard non-differential view.

## Test plan

- [ ] Push a commit to main → verify `gh-pages/main/coverage.lcov` exists
- [ ] Open a PR → verify the HTML report shows TLA categories (colored
      line backgrounds, per-file breakdown)
- [ ] PR bot comment still shows aggregate diff coverage numbers
- [ ] `./coverage.sh` and `./coverage.sh --html` still work locally unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)