### PR TITLE
Batch 90 corpus tests into a single JVM

### DIFF
--- a/e2e_tests/corpus.bzl
+++ b/e2e_tests/corpus.bzl
@@ -1,71 +1,64 @@
-"""Starlark macro for p4c corpus STF tests.
+"""Starlark macro for batched p4c corpus STF tests.
 
 Usage in e2e_tests/corpus/BUILD.bazel:
 
-    load("//e2e_tests:corpus.bzl", "p4_stf_test")
+    load("//e2e_tests:corpus.bzl", "corpus_test_suite")
 
-    p4_stf_test(name = "opassign1-bmv2")
+    corpus_test_suite(
+        name = "corpus_test",
+        tests = ["opassign1-bmv2", "flag_lost-bmv2", ...],
+    )
 
 This creates:
-  - a genrule that compiles <name>.p4 → <name>.txtpb using p4c-4ward
-  - a genrule that copies <name>.stf from @p4c into this package (so the test
-    runner can locate it via TEST_TARGET without needing to know the canonical
-    @p4c runfiles path)
-  - a kt_jvm_test that runs CorpusStfTest against that txtpb + <name>.stf
+  - per-test genrules that compile <name>.p4 → <name>.txtpb using p4c-4ward
+  - per-test genrules that copy <name>.stf from @p4c into this package
+  - a single kt_jvm_test that runs all tests in one JVM via @Parameterized
 """
 
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
-def p4_stf_test(name, p4_src = None, stf_src = None, tags = []):
-    """Compiles a p4c corpus P4 file and runs its STF test against 4ward.
+def corpus_test_suite(name, tests, tags = []):
+    """Compiles p4c corpus P4 files and runs all STF tests in a single JVM.
 
     Args:
-        name:    base name; also used to derive default p4_src/stf_src filenames.
-        p4_src:  P4 source file (default: @p4c//testdata/p4_16_samples:<name>.p4).
-        stf_src: STF test file (default: @p4c//testdata/p4_16_samples:<name>.stf).
-        tags:    Bazel tags forwarded to the kt_jvm_test (e.g. ["manual"] to
-                 exclude from //... until the required feature is implemented).
+        name:  name of the batched kt_jvm_test target.
+        tests: list of test base names (e.g. "opassign1-bmv2").
+        tags:  Bazel tags forwarded to the kt_jvm_test.
     """
-    if p4_src == None:
-        p4_src = "@p4c//testdata/p4_16_samples:" + name + ".p4"
-    if stf_src == None:
-        stf_src = "@p4c//testdata/p4_16_samples:" + name + ".stf"
+    data = ["//simulator"]
 
-    pb_name = name + "_pb"
-    stf_name = name + "_stf"
+    for test in tests:
+        p4_src = "@p4c//testdata/p4_16_samples:" + test + ".p4"
+        stf_src = "@p4c//testdata/p4_16_samples:" + test + ".stf"
 
-    native.genrule(
-        name = pb_name,
-        srcs = [p4_src],
-        outs = [name + ".txtpb"],
-        cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-        tools = [
-            "//p4c_backend:p4c-4ward",
-            "@p4c//:core_p4",
-            "@p4c//:p4include",
-        ],
-    )
+        native.genrule(
+            name = test + "_pb",
+            srcs = [p4_src],
+            outs = [test + ".txtpb"],
+            cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
+            tools = [
+                "//p4c_backend:p4c-4ward",
+                "@p4c//:core_p4",
+                "@p4c//:p4include",
+            ],
+        )
 
-    # Copy the STF file from @p4c into this package so the test runner can
-    # locate it via TEST_TARGET (at _main/<pkg>/<name>.stf) without needing to
-    # know @p4c's canonical Bzlmod runfiles path.
-    native.genrule(
-        name = stf_name,
-        srcs = [stf_src],
-        outs = [name + ".stf"],
-        cmd = "cp $< $@",
-    )
+        native.genrule(
+            name = test + "_stf",
+            srcs = [stf_src],
+            outs = [test + ".stf"],
+            cmd = "cp $< $@",
+        )
+
+        data.append(":" + test + "_pb")
+        data.append(":" + test + "_stf")
 
     kt_jvm_test(
-        name = name + "_test",
+        name = name,
         srcs = ["CorpusStfTest.kt"],
         test_class = "fourward.e2e.corpus.CorpusStfTest",
         tags = tags,
-        data = [
-            ":" + stf_name,
-            ":" + pb_name,
-            "//simulator",
-        ],
+        data = data,
         deps = [
             "//e2e_tests/stf:stf_runner",
             "@maven//:junit_junit",

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -1,184 +1,101 @@
-load("//e2e_tests:corpus.bzl", "p4_stf_test")
-
-# p4c corpus STF tests. Each entry compiles the P4 source with p4c-4ward and
-# runs the corresponding STF test against the simulator.
-
-p4_stf_test(name = "flag_lost-bmv2")
-
-p4_stf_test(name = "gauntlet_action_mux-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_1-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_2-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_3-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_4-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_5-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_6-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_7-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_8-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_9-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_10-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_11-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_13-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_14-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_15-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_16-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_17-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_18-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_19-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_20-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_21-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_22-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_combination_23-bmv2")
-
-p4_stf_test(name = "gauntlet_hdr_assign_1-bmv2")
-
-p4_stf_test(name = "opassign1-bmv2")
-
-p4_stf_test(name = "gauntlet_action_return-bmv2")
-
-p4_stf_test(name = "gauntlet_arithref_cast-bmv2")
-
-p4_stf_test(name = "gauntlet_complex_initialization-bmv2")
-
-p4_stf_test(name = "gauntlet_copy_out-bmv2")
-
-p4_stf_test(name = "gauntlet_enum_assign-bmv2")
-
-p4_stf_test(name = "gauntlet_exit_after_valid-bmv2")
-
-p4_stf_test(name = "gauntlet_function_if_hdr_return-bmv2")
-
-p4_stf_test(name = "gauntlet_function_return-bmv2")
-
-p4_stf_test(name = "gauntlet_function_return_cast-bmv2")
-
-p4_stf_test(name = "gauntlet_hdr_function_cast-bmv2")
-
-p4_stf_test(name = "gauntlet_hdr_in_value-bmv2")
-
-p4_stf_test(name = "gauntlet_hdr_init-bmv2")
-
-p4_stf_test(name = "gauntlet_hdr_int_initializer-bmv2")
-
-p4_stf_test(name = "gauntlet_hdr_out_in_action-bmv2")
-
-p4_stf_test(name = "gauntlet_hdr_set_valid-bmv2")
-
-p4_stf_test(name = "gauntlet_indirect_hdr_assign_1-bmv2")
-
-p4_stf_test(name = "gauntlet_indirect_hdr_assign_2-bmv2")
-
-p4_stf_test(name = "gauntlet_instance_overwrite-bmv2")
-
-p4_stf_test(name = "gauntlet_int_casting-bmv2")
-
-p4_stf_test(name = "gauntlet_int_slice-bmv2")
-
-p4_stf_test(name = "gauntlet_invalid_hdr_assign-bmv2")
-
-p4_stf_test(name = "gauntlet_list_as_in_argument-bmv2")
-
-p4_stf_test(name = "gauntlet_mux_hdr-bmv2")
-
-p4_stf_test(name = "gauntlet_mux_typecasting-bmv2")
-
-p4_stf_test(name = "gauntlet_mux_validity-bmv2")
-
-p4_stf_test(name = "gauntlet_nested_ifs_in_function-bmv2")
-
-p4_stf_test(name = "gauntlet_nested_slice-bmv2")
-
-p4_stf_test(name = "gauntlet_nested_switch-bmv2")
-
-p4_stf_test(name = "gauntlet_nested_table_calls-bmv2")
-
-p4_stf_test(name = "gauntlet_return_truncate-bmv2")
-
-p4_stf_test(name = "gauntlet_set_valid_in_function-bmv2")
-
-p4_stf_test(name = "gauntlet_short_circuit-bmv2")
-
-p4_stf_test(name = "gauntlet_side_effect_order_1-bmv2")
-
-p4_stf_test(name = "gauntlet_side_effect_order_2-bmv2")
-
-p4_stf_test(name = "gauntlet_side_effect_order_3-bmv2")
-
-p4_stf_test(name = "gauntlet_side_effect_order_4-bmv2")
-
-p4_stf_test(name = "gauntlet_side_effect_order_5-bmv2")
-
-p4_stf_test(name = "gauntlet_side_effects_in_mux-bmv2")
-
-p4_stf_test(name = "gauntlet_switch_exclusivity-bmv2")
-
-p4_stf_test(name = "gauntlet_switch_nested_table_apply-bmv2")
-
-p4_stf_test(name = "gauntlet_switch_shadowing-bmv2")
-
-p4_stf_test(name = "gauntlet_table_call_in_expression-bmv2")
-
-p4_stf_test(name = "gauntlet_typedef_cast-bmv2")
-
-p4_stf_test(name = "gauntlet_uninitialized_bool_struct-bmv2")
-
-p4_stf_test(name = "issue2147-bmv2")
-
-p4_stf_test(name = "issue2153-bmv2")
-
-p4_stf_test(name = "issue2170-bmv2")
-
-p4_stf_test(name = "issue2176-bmv2")
-
-p4_stf_test(name = "issue2205-1-bmv2")
-
-p4_stf_test(name = "issue2205-bmv2")
-
-p4_stf_test(name = "issue2221-bmv2")
-
-p4_stf_test(name = "issue2225-bmv2")
-
-p4_stf_test(name = "issue2287-bmv2")
-
-p4_stf_test(name = "issue2343-bmv2")
-
-p4_stf_test(name = "issue2375-1-bmv2")
-
-p4_stf_test(name = "issue2375-bmv2")
-
-p4_stf_test(name = "issue2383-bmv2")
-
-p4_stf_test(name = "issue2392-bmv2")
-
-p4_stf_test(name = "issue2488-bmv2")
-
-p4_stf_test(name = "issue2498-bmv2")
-
-p4_stf_test(name = "issue2614-bmv2")
-
-p4_stf_test(name = "issue3488-bmv2")
-
-p4_stf_test(name = "issue635-bmv2")
-
-p4_stf_test(name = "issue983-bmv2")
+load("//e2e_tests:corpus.bzl", "corpus_test_suite")
+
+# p4c corpus STF tests. Each P4 source is compiled with p4c-4ward and its STF
+# test is run against the simulator. All tests share a single JVM to avoid the
+# overhead of 90 separate JVM startups.
+
+corpus_test_suite(
+    name = "p4c_stf_corpus_test",
+    tests = [
+        "flag_lost-bmv2",
+        "gauntlet_action_mux-bmv2",
+        "gauntlet_action_return-bmv2",
+        "gauntlet_arithref_cast-bmv2",
+        "gauntlet_complex_initialization-bmv2",
+        "gauntlet_copy_out-bmv2",
+        "gauntlet_enum_assign-bmv2",
+        "gauntlet_exit_after_valid-bmv2",
+        "gauntlet_exit_combination_1-bmv2",
+        "gauntlet_exit_combination_10-bmv2",
+        "gauntlet_exit_combination_11-bmv2",
+        "gauntlet_exit_combination_13-bmv2",
+        "gauntlet_exit_combination_14-bmv2",
+        "gauntlet_exit_combination_15-bmv2",
+        "gauntlet_exit_combination_16-bmv2",
+        "gauntlet_exit_combination_17-bmv2",
+        "gauntlet_exit_combination_18-bmv2",
+        "gauntlet_exit_combination_19-bmv2",
+        "gauntlet_exit_combination_2-bmv2",
+        "gauntlet_exit_combination_20-bmv2",
+        "gauntlet_exit_combination_21-bmv2",
+        "gauntlet_exit_combination_22-bmv2",
+        "gauntlet_exit_combination_23-bmv2",
+        "gauntlet_exit_combination_3-bmv2",
+        "gauntlet_exit_combination_4-bmv2",
+        "gauntlet_exit_combination_5-bmv2",
+        "gauntlet_exit_combination_6-bmv2",
+        "gauntlet_exit_combination_7-bmv2",
+        "gauntlet_exit_combination_8-bmv2",
+        "gauntlet_exit_combination_9-bmv2",
+        "gauntlet_function_if_hdr_return-bmv2",
+        "gauntlet_function_return-bmv2",
+        "gauntlet_function_return_cast-bmv2",
+        "gauntlet_hdr_assign_1-bmv2",
+        "gauntlet_hdr_function_cast-bmv2",
+        "gauntlet_hdr_in_value-bmv2",
+        "gauntlet_hdr_init-bmv2",
+        "gauntlet_hdr_int_initializer-bmv2",
+        "gauntlet_hdr_out_in_action-bmv2",
+        "gauntlet_hdr_set_valid-bmv2",
+        "gauntlet_indirect_hdr_assign_1-bmv2",
+        "gauntlet_indirect_hdr_assign_2-bmv2",
+        "gauntlet_instance_overwrite-bmv2",
+        "gauntlet_int_casting-bmv2",
+        "gauntlet_int_slice-bmv2",
+        "gauntlet_invalid_hdr_assign-bmv2",
+        "gauntlet_list_as_in_argument-bmv2",
+        "gauntlet_mux_hdr-bmv2",
+        "gauntlet_mux_typecasting-bmv2",
+        "gauntlet_mux_validity-bmv2",
+        "gauntlet_nested_ifs_in_function-bmv2",
+        "gauntlet_nested_slice-bmv2",
+        "gauntlet_nested_switch-bmv2",
+        "gauntlet_nested_table_calls-bmv2",
+        "gauntlet_return_truncate-bmv2",
+        "gauntlet_set_valid_in_function-bmv2",
+        "gauntlet_short_circuit-bmv2",
+        "gauntlet_side_effect_order_1-bmv2",
+        "gauntlet_side_effect_order_2-bmv2",
+        "gauntlet_side_effect_order_3-bmv2",
+        "gauntlet_side_effect_order_4-bmv2",
+        "gauntlet_side_effect_order_5-bmv2",
+        "gauntlet_side_effects_in_mux-bmv2",
+        "gauntlet_switch_exclusivity-bmv2",
+        "gauntlet_switch_nested_table_apply-bmv2",
+        "gauntlet_switch_shadowing-bmv2",
+        "gauntlet_table_call_in_expression-bmv2",
+        "gauntlet_typedef_cast-bmv2",
+        "gauntlet_uninitialized_bool_struct-bmv2",
+        "issue2147-bmv2",
+        "issue2153-bmv2",
+        "issue2170-bmv2",
+        "issue2176-bmv2",
+        "issue2205-1-bmv2",
+        "issue2205-bmv2",
+        "issue2221-bmv2",
+        "issue2225-bmv2",
+        "issue2287-bmv2",
+        "issue2343-bmv2",
+        "issue2375-1-bmv2",
+        "issue2375-bmv2",
+        "issue2383-bmv2",
+        "issue2392-bmv2",
+        "issue2488-bmv2",
+        "issue2498-bmv2",
+        "issue2614-bmv2",
+        "issue3488-bmv2",
+        "issue635-bmv2",
+        "issue983-bmv2",
+        "opassign1-bmv2",
+    ],
+)

--- a/e2e_tests/corpus/CorpusStfTest.kt
+++ b/e2e_tests/corpus/CorpusStfTest.kt
@@ -15,22 +15,43 @@
 package fourward.e2e.corpus
 
 import fourward.e2e.TestResult
-import fourward.e2e.runStfTestFromEnv
+import fourward.e2e.runStfTest
+import java.nio.file.Files
+import java.nio.file.Paths
 import org.junit.Assert.fail
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
 /**
- * Generic test class for p4c corpus STF tests.
+ * Parameterized test that runs all p4c corpus STF tests in a single JVM.
  *
- * The compiled pipeline config and STF file paths are injected via the environment variables
- * FOURWARD_TXTPB and FOURWARD_STF (rlocation paths set by the p4_stf_test Bazel macro). A single
- * instance of this class is reused for every corpus test target.
+ * Test names are discovered at runtime from the .stf files present in the runfiles directory. Each
+ * test launches a fresh simulator subprocess (the simulator resets state on each LoadPipeline), so
+ * tests remain isolated despite sharing a JVM.
  */
-class CorpusStfTest {
+@RunWith(Parameterized::class)
+class CorpusStfTest(private val testName: String) {
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "{0}")
+    fun testCases(): List<Array<String>> {
+      val r = System.getenv("JAVA_RUNFILES") ?: "."
+      val corpusDir = Paths.get(r, "_main/e2e_tests/corpus")
+      return Files.list(corpusDir).use { stream ->
+        stream
+          .filter { it.toString().endsWith(".stf") }
+          .map { arrayOf(it.fileName.toString().removeSuffix(".stf")) }
+          .sorted(Comparator.comparing { it[0] })
+          .toList()
+      }
+    }
+  }
 
   @Test
-  fun `corpus stf test`() {
-    val result = runStfTestFromEnv()
+  fun test() {
+    val result = runStfTest(testName, "e2e_tests/corpus")
     if (result is TestResult.Failure) fail(result.message)
   }
 }

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -209,33 +209,12 @@ sealed class TestResult {
 /**
  * Runs the STF test named [testName] using the standard Bazel runfiles layout.
  *
- * Looks for `_main/simulator/simulator`, `_main/e2e_tests/<testName>/<testName>.txtpb`, and
- * `_main/e2e_tests/<testName>/<testName>.stf` under `JAVA_RUNFILES`.
+ * Looks for `_main/simulator/simulator`, `_main/<pkg>/<testName>.txtpb`, and
+ * `_main/<pkg>/<testName>.stf` under `JAVA_RUNFILES`. The [pkg] defaults to `e2e_tests/<testName>`
+ * (matching the per-test package layout of the regular e2e tests).
  */
-fun runStfTest(testName: String): TestResult {
+fun runStfTest(testName: String, pkg: String = "e2e_tests/$testName"): TestResult {
   val r = System.getenv("JAVA_RUNFILES") ?: "."
-  return runStf(
-    r,
-    Paths.get(r, "_main/e2e_tests/$testName/$testName.txtpb"),
-    Paths.get(r, "_main/e2e_tests/$testName/$testName.stf"),
-  )
-}
-
-/**
- * Runs an STF test whose identity is derived from Bazel's `TEST_TARGET` environment variable.
- *
- * Bazel sets `TEST_TARGET` to the fully qualified label of the running test, e.g.
- * `//e2e_tests/corpus:opassign1-bmv2_test`. This function strips the `_test` suffix to obtain the
- * test name, then looks up `<name>.txtpb` and `<name>.stf` in the same package under
- * `JAVA_RUNFILES/_main/`. Used by [fourward.e2e.corpus.CorpusStfTest] via the `p4_stf_test` Bazel
- * macro.
- */
-fun runStfTestFromEnv(): TestResult {
-  val r = System.getenv("JAVA_RUNFILES") ?: "."
-  val target = System.getenv("TEST_TARGET") ?: error("TEST_TARGET not set")
-  // "//e2e_tests/corpus:opassign1-bmv2_test" → pkg = "e2e_tests/corpus", name = "opassign1-bmv2"
-  val pkg = target.removePrefix("//").substringBefore(":")
-  val testName = target.substringAfterLast(":").removeSuffix("_test")
   return runStf(
     r,
     Paths.get(r, "_main/$pkg/$testName.txtpb"),


### PR DESCRIPTION
## Summary

- Replaces 90 separate `kt_jvm_test` targets with a single `@Parameterized` JUnit test that runs all corpus STF tests in one JVM
- Eliminates 89 redundant JVM startups (~1s each), saving ~40-50s of test execution time
- Per-test isolation is preserved: each test still spawns a fresh simulator subprocess

## Changes

- `corpus.bzl`: new `corpus_test_suite` macro — keeps individual genrules (one p4c-4ward compilation per P4 file) but creates a single `kt_jvm_test`
- `CorpusStfTest.kt`: rewrote as `@Parameterized` test that discovers `.stf` files from runfiles at runtime
- `Runner.kt`: simplified `runStfTest` with optional `pkg` parameter; removed env-var-based `runStfTestFromEnv`
- `corpus/BUILD.bazel`: single `corpus_test_suite()` call replaces 90 `p4_stf_test()` calls

## Test plan

- [ ] `bazel test //...` passes (all 90 corpus tests + other e2e tests)
- [ ] Individual test failures are still reported with meaningful names (via `@Parameters(name = "{0}")`)
- [ ] CI wall-clock time is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)