### PR TITLE
next-wins: NoAction, varbit/bool-in-header, SerEnum, error literals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,17 @@ Unit tests live alongside the source they test:
 ```sh
 bazel build //...          # build everything
 bazel test //...           # run all tests
+ibazel build //...         # rebuild automatically on file changes (preferred for interactive work)
 ./format.sh                # auto-format all files (clang-format + buildifier + ktfmt)
 ./lint.sh                  # lint all files (clang-tidy for C++, detekt for Kotlin)
 ./coverage.sh              # collect code coverage (see --html, --baseline, --diff)
 ./diff-coverage.sh         # incremental coverage from a diff + LCOV file
 ./dev.sh help              # show all developer commands
 ```
+
+**Prefer `ibazel` over `bazel` for any work that spans multiple edit/build
+cycles.** It keeps the Bazel server warm and rebuilds only affected targets,
+catching errors within seconds rather than minutes.
 
 All builds are hermetic. Do not install dependencies outside of Bazel.
 
@@ -43,6 +48,11 @@ formatting, clang-tidy, build+test (Ubuntu + macOS), and coverage.
 On PRs, a coverage report is published to GitHub Pages and linked from a bot
 comment that shows both absolute and incremental (diff) coverage. Reports are
 browsable at `https://smolkaj.github.io/4ward/pr/<number>/`.
+
+**CI is fast and has a warm remote cache — often faster than a cold local
+build.** When iterating on a fix, push early and use `gh run watch` to monitor
+results rather than waiting for a full local rebuild. Check CI logs with
+`gh run view --log-failed` to diagnose failures without pulling logs locally.
 
 ## Key design invariants — do not break these
 
@@ -130,6 +140,18 @@ changing `ir.proto` or `simulator.proto`:
 4. Make sure the relevant STF tests still pass.
 
 Never remove or renumber existing fields; add new ones instead.
+
+## Worktrees
+
+**Always work in a dedicated git worktree. Never make changes directly in the
+main tree.** This keeps the main tree clean and allows parallel work without
+conflicts. Create one with:
+
+```sh
+git worktree add ../4ward-<branch> -b <branch>
+```
+
+Rebase and squash when merging back to main.
 
 ## Local development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,14 +24,16 @@ not list every changed line.
 
 ## Worktrees
 
-Always work in a worktree for non-trivial tasks. This avoids conflicts
-when parallel development is happening in the main tree. Rebase and squash
-when merging back.
+Always work in a dedicated worktree. Never make changes directly in the main
+tree. Rebase and squash when merging back.
 
 ## Tool use
 
 - Prefer `bazel build //...` and `bazel test //...` to direct invocations of
   `kotlinc`, `g++`, etc. The build is hermetic.
+- Use `ibazel build //...` for any work that spans multiple edit/build cycles.
+  Run it in the background at the start of a task so build errors surface
+  immediately rather than after a full rebuild.
 - Use `./format.sh` to format files, not manual edits.
 - Use `./lint.sh` to lint all code (clang-tidy for C++, detekt for Kotlin).
   Fix all warnings before marking a task complete.

--- a/coverage.sh
+++ b/coverage.sh
@@ -57,7 +57,7 @@ target_to_bin_rel() {
 
 # ── Discover test targets ────────────────────────────────────────────────────
 
-TARGETS=$(bazel query 'kind(kt_jvm_test, //...)' 2>/dev/null)
+TARGETS=$(bazel query 'kind(kt_jvm_test, //...) - attr(tags, manual, //...)' 2>/dev/null)
 
 # ── Build with coverage instrumentation ──────────────────────────────────────
 
@@ -314,7 +314,15 @@ echo "Saved:        ${PERSISTENT}"
 
 GENHTML_ARGS=(--quiet)
 [[ -n "${BASELINE_FILE}" ]] && GENHTML_ARGS+=(--baseline-file "${BASELINE_FILE}")
-[[ -n "${DIFF_FILE}" ]]     && GENHTML_ARGS+=(--diff-file "${DIFF_FILE}")
+if [[ -n "${DIFF_FILE}" ]]; then
+  # Strip git's a/ b/ prefixes so paths match LCOV SF: lines.
+  STRIPPED_DIFF="${COVERAGE_WORKDIR}/stripped.diff"
+  sed 's|^--- a/|--- |; s|^+++ b/|+++ |' "${DIFF_FILE}" > "${STRIPPED_DIFF}"
+  # genhtml resolves diff paths to absolute but keeps LCOV SF: paths relative;
+  # suppress the resulting path-mismatch error (diff coverage numbers are
+  # computed separately by diff-coverage.sh and are unaffected).
+  GENHTML_ARGS+=(--diff-file "${STRIPPED_DIFF}" --ignore-errors path)
+fi
 
 if command -v genhtml >/dev/null 2>&1; then
   rm -rf "${REPORT_DIR}"

--- a/e2e_tests/corpus.bzl
+++ b/e2e_tests/corpus.bzl
@@ -36,6 +36,7 @@ def corpus_test_suite(name, tests, tags = []):
             srcs = [p4_src],
             outs = [test + ".txtpb"],
             cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
+            tags = tags,
             tools = [
                 "//p4c_backend:p4c-4ward",
                 "@p4c//:core_p4",
@@ -48,6 +49,7 @@ def corpus_test_suite(name, tests, tags = []):
             srcs = [stf_src],
             outs = [test + ".stf"],
             cmd = "cp $< $@",
+            tags = tags,
         )
 
         data.append(":" + test + "_pb")

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -1,11 +1,15 @@
 load("//e2e_tests:corpus.bzl", "corpus_test_suite")
 
-# p4c corpus STF tests. Each P4 source is compiled with p4c-4ward and its STF
-# test is run against the simulator. All tests share a single JVM to avoid the
-# overhead of 90 separate JVM startups.
-
+# p4c corpus STF tests run in CI. All entries must pass.
+#
+# To add a new test:
+#   1. Add its base name to v1model_stf_corpus_test below.
+#   2. Run: bazel test //e2e_tests/corpus:v1model_stf_corpus_test
+#   3. If it fails, move it to the appropriate manual suite below instead,
+#      grouped with other tests blocked on the same missing feature.
+#      Create a new manual suite if no existing one fits.
 corpus_test_suite(
-    name = "p4c_stf_corpus_test",
+    name = "v1model_stf_corpus_test",
     tests = [
         "flag_lost-bmv2",
         "gauntlet_action_mux-bmv2",
@@ -97,5 +101,84 @@ corpus_test_suite(
         "issue635-bmv2",
         "issue983-bmv2",
         "opassign1-bmv2",
+    ],
+)
+
+# Tests blocked on exposing skeleton .p4 files as Bazel targets.
+# arith-skeleton.p4, arith-inline-skeleton.p4, and ml-headers.p4 are
+# sibling includes not yet available as @p4c filegroup targets.
+# Run manually: bazel test //e2e_tests/corpus:skeleton_includes_stf_corpus_test
+corpus_test_suite(
+    name = "skeleton_includes_stf_corpus_test",
+    tags = ["manual"],
+    tests = [
+        "arith-bmv2",
+        "arith-inline-bmv2",
+        "arith1-bmv2",
+        "arith2-bmv2",
+        "arith2-inline-bmv2",
+        "arith3-bmv2",
+        "arith4-bmv2",
+        "arith5-bmv2",
+        "constant-in-calculation-bmv2",
+        "default-action-arg-bmv2",
+        "default_action-bmv2",
+        "enum-bmv2",
+        "extern-funcs-bmv2",
+        "ipv6-switch-ml-bmv2",
+        "key-bmv2",
+    ],
+)
+
+# Tests blocked on PSA architecture support. The backend only supports v1model
+# today; these fail with "unsupported architecture 'PSA_Switch'".
+# Run manually: bazel test //e2e_tests/corpus:psa_stf_corpus_test
+corpus_test_suite(
+    name = "psa_stf_corpus_test",
+    tags = ["manual"],
+    tests = [
+        "hash-extern-bmv2",
+        "internet_checksum1-bmv2",
+        "psa-basic-counter-bmv2",
+        "psa-bool-ternary-const-entry-bmv2",
+        "psa-drop-all-bmv2",
+        "psa-drop-all-corrected-bmv2",
+        "psa-e2e-cloning-basic-bmv2",
+        "psa-end-of-ingress-test-bmv2",
+        "psa-example-dpdk-varbit-bmv2",
+        "psa-example-register2-bmv2",
+        "psa-fwd-bmv2",
+        "psa-i2e-cloning-basic-bmv2",
+        "psa-metadata-bmv2",
+        "psa-meter7-bmv2",
+        "psa-multicast-basic-2-bmv2",
+        "psa-multicast-basic-bmv2",
+        "psa-multicast-basic-corrected-bmv2",
+        "psa-parser-error-test-bmv2",
+        "psa-recirculate-no-meta-bmv2",
+        "psa-register-complex-bmv2",
+        "psa-register-read-write-2-bmv2",
+        "psa-register-read-write-bmv2",
+        "psa-resubmit-bmv2",
+        "psa-top-level-assignments-bmv2",
+        "psa-unicast-or-drop-bmv2",
+        "psa-unicast-or-drop-corrected-bmv2",
+    ],
+)
+
+# Tests blocked on pkt.lookahead() / packet.advance() support. These fail at
+# p4c compile time with "functions or methods returning structures are not
+# supported on this target" or similar target errors.
+# Run manually: bazel test //e2e_tests/corpus:lookahead_stf_corpus_test
+corpus_test_suite(
+    name = "lookahead_stf_corpus_test",
+    tags = ["manual"],
+    tests = [
+        "checksum-l4-bmv2",
+        "checksum1-bmv2",
+        "issue1025-bmv2",
+        "issue1755-1-bmv2",
+        "issue1755-bmv2",
+        "issue1768-bmv2",
     ],
 )

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "frontends/p4/coreLibrary.h"
+#include "frontends/p4/enumInstance.h"
 #include "google/protobuf/text_format.h"
 #include "lib/error.h"
 #include "lib/log.h"
@@ -133,6 +134,45 @@ fourward::ir::v1::Expr FourWardBackend::emitExpr(const IR::Expression* expr) {
         ta->set_access_kind(mem->member == "hit"
                                 ? fourward::ir::v1::TableApplyExpr::HIT
                                 : fourward::ir::v1::TableApplyExpr::MISS);
+      }
+    } else if (mem->expr->is<IR::TypeNameExpression>()) {
+      // Qualified enum/error member access: `error.NoError` or `MyEnum.Val`.
+      // The base TypeNameExpression has no runtime value of its own; the whole
+      // expression reduces to a compile-time literal.
+      const auto* exprType = typeMap_.getType(expr);
+      if (exprType && exprType->is<IR::Type_Error>()) {
+        // error.X → literal { error_member: "X" }
+        out.mutable_literal()->set_error_member(mem->member.name.c_str());
+      } else if (const auto* serEnum =
+                     exprType ? exprType->to<IR::Type_SerEnum>() : nullptr) {
+        // SerializableEnum.X → literal { integer: X.value }
+        // The underlying integer value is stored in the SerEnumMember after
+        // constant folding by the frontend.
+        const auto* decl = serEnum->getDeclByName(mem->member.name);
+        const auto* sem = decl ? decl->to<IR::SerEnumMember>() : nullptr;
+        const auto* cnst = sem ? sem->value->to<IR::Constant>() : nullptr;
+        if (cnst) {
+          auto* lit = out.mutable_literal();
+          if (cnst->fitsUint64()) {
+            lit->set_integer(cnst->asUint64());
+          } else {
+            std::string bytes;
+            auto v = cnst->value;
+            while (v != 0) {
+              bytes.push_back(
+                  static_cast<char>(static_cast<uint8_t>(v & 0xFF)));
+              v >>= 8;
+            }
+            std::reverse(bytes.begin(), bytes.end());
+            lit->set_big_integer(bytes);
+          }
+        } else {
+          LOG1("WARNING: could not resolve SerEnum member value for "
+               << mem->member.name);
+        }
+      } else {
+        LOG1("WARNING: unhandled TypeNameExpression member "
+             << mem->member.name);
       }
     } else {
       auto* fa = out.mutable_field_access();
@@ -381,8 +421,21 @@ void FourWardBackend::emitTypeDecls(const IR::P4Program* program) {
         fd->set_name(field->name.name.c_str());
         *fd->mutable_type() = emitType(field->type);
       }
+    } else if (const auto* serEnum = decl->to<IR::Type_SerEnum>()) {
+      // Serializable enums (enum bit<N> E { ... }) can appear as header field
+      // types; emit their underlying bit width so the simulator can compute
+      // wire offsets.
+      auto* td = behavioral_->add_types();
+      td->set_name(serEnum->name.name.c_str());
+      auto* edecl = td->mutable_enum_();
+      if (const auto* bits = serEnum->type->to<IR::Type_Bits>()) {
+        edecl->set_width(bits->size);
+      }
+      for (const auto* member : serEnum->members) {
+        edecl->add_members(member->name.name.c_str());
+      }
     }
-    // Enums and header unions: TODO
+    // Header unions: TODO
   }
 }
 

--- a/simulator/DefaultValues.kt
+++ b/simulator/DefaultValues.kt
@@ -16,26 +16,38 @@ package fourward.simulator
 
 import fourward.ir.v1.Type
 import fourward.ir.v1.TypeDecl
+import java.math.BigInteger
 
 /**
  * Creates a zero/default [Value] for [type].
  *
- * bit<N> → [BitVal] zero, bool → [BoolVal] false, named types → recursively initialised header
- * (invalid) or struct. Returns [UnitVal] for unrecognised types.
+ * bit<N> → [BitVal] zero, int<N> → [IntVal] zero, bool → [BoolVal] false, named types → recursively
+ * initialised header (invalid), struct, or [BitVal] zero for serializable enums. varbit<N> and
+ * unrecognised types → [UnitVal].
  */
 internal fun defaultValue(type: Type, types: Map<String, TypeDecl>): Value =
   when {
     type.hasBit() -> BitVal(0L, type.bit.width)
+    type.hasSignedInt() -> IntVal(SignedBitVector(java.math.BigInteger.ZERO, type.signedInt.width))
     type.hasBoolean() -> BoolVal(false)
     type.hasNamed() -> defaultValue(type.named, types)
-    else -> UnitVal
+    type.hasHeaderStack() ->
+      HeaderStackVal(
+        elementTypeName = type.headerStack.elementType,
+        headers =
+          MutableList(type.headerStack.size.toInt()) {
+            defaultValue(type.headerStack.elementType, types) as HeaderVal
+          },
+      )
+    else -> UnitVal // varbit<N>: variable-length; no fixed default
   }
 
 /**
  * Creates a zero/default [Value] for the named type.
  *
  * Looks up [typeName] in [types]; returns [UnitVal] if not found. Headers are initially invalid
- * with zeroed fields; structs are recursively initialised.
+ * with zeroed fields; structs are recursively initialised. Serializable enums default to a zero
+ * [BitVal] of their underlying width.
  */
 internal fun defaultValue(typeName: String, types: Map<String, TypeDecl>): Value {
   val typeDecl = types[typeName] ?: return UnitVal
@@ -57,6 +69,8 @@ internal fun defaultValue(typeName: String, types: Map<String, TypeDecl>): Value
             .associate { f -> f.name to defaultValue(f.type, types) }
             .toMutableMap(),
       )
+    // Serializable enum: default to zero of the underlying bit width.
+    typeDecl.hasEnum() && typeDecl.enum.width > 0 -> BitVal(0L, typeDecl.enum.width)
     else -> UnitVal
   }
 }

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -11,6 +11,7 @@ import fourward.ir.v1.ParserDecl
 import fourward.ir.v1.Stmt
 import fourward.ir.v1.TableApplyExpr
 import fourward.ir.v1.TableBehavior
+import fourward.ir.v1.Type
 import fourward.ir.v1.UnaryOperator
 import fourward.sim.v1.ActionExecutionEvent
 import fourward.sim.v1.BranchEvent
@@ -433,6 +434,19 @@ class Interpreter(
     paramProtos: List<p4.v1.P4RuntimeOuterClass.Action.Param>,
     env: Environment,
   ) {
+    // NoAction is a P4 built-in no-op (P4 spec §12.7) that is implicitly available in
+    // every table. It may appear in const entries without being listed in the actions block,
+    // so it might not have been compiled into the IR. Handle it directly rather than
+    // requiring the backend to emit an explicit empty ActionDecl for it.
+    if (actionName == "NoAction") {
+      packetCtx?.addTraceEvent(
+        TraceEvent.newBuilder()
+          .setActionExecution(ActionExecutionEvent.newBuilder().setActionName(actionName))
+          .build()
+      )
+      return
+    }
+
     val actionDecl = actions[actionName] ?: error("unknown action: $actionName")
 
     val paramMap = mutableMapOf<String, com.google.protobuf.ByteString>()
@@ -530,25 +544,66 @@ class Interpreter(
     val header = evalExpr(call.argsList[0], env) as HeaderVal
     val headerDecl = (types[header.typeName] ?: error("type not found: ${header.typeName}")).header
 
+    // The 2-argument form b.extract(hdr, varbitBits) is used when the header contains a varbit
+    // field. The second argument gives the varbit field's runtime length in bits.
+    val varbitBits: Int =
+      if (call.argsCount > 1) (evalExpr(call.argsList[1], env) as BitVal).bits.value.toInt() else 0
+
     // Read the entire header at once and load it into a single BigInteger (MSB-first).
     // This handles sub-byte fields (e.g. IPv4's bit<4> version and ihl) correctly:
     // both fields live in the same byte and must be unpacked by shift+mask, not by
     // reading separate bytes.
-    val totalBits = headerDecl.fieldsList.sumOf { it.type.bit.width }
+    val totalBits = headerDecl.fieldsList.sumOf { fieldWireWidth(it.type, varbitBits) }
     val allBits = BigInteger(1, packet.extractBytes((totalBits + 7) / 8))
 
     val newFields = mutableMapOf<String, Value>()
     var bitOffset = 0
     for (field in headerDecl.fieldsList) {
-      val width = field.type.bit.width
+      val width = fieldWireWidth(field.type, varbitBits)
+      if (width == 0) continue // skip zero-width fields (unrecognised types)
       val mask = BigInteger.ONE.shiftLeft(width) - BigInteger.ONE
-      val bits = BitVector((allBits shr (totalBits - bitOffset - width)) and mask, width)
-      newFields[field.name] = BitVal(bits)
+      val raw = (allBits shr (totalBits - bitOffset - width)) and mask
+      newFields[field.name] = bitsToValue(field.type, raw, width)
       bitOffset += width
     }
     header.setValid(newFields)
     return UnitVal
   }
+
+  /**
+   * Returns the on-wire bit-width of a header field type.
+   *
+   * P4 spec §8.9.2: bool in a header occupies exactly 1 bit on the wire. int<N> and bit<N> occupy N
+   * bits. varbit<N> occupies [varbitBits] bits (caller must supply the runtime value). Serializable
+   * enums are looked up by name and use their declared underlying width.
+   */
+  private fun fieldWireWidth(type: Type, varbitBits: Int = 0): Int =
+    when {
+      type.hasBit() -> type.bit.width
+      type.hasSignedInt() -> type.signedInt.width
+      type.hasBoolean() -> 1
+      type.hasVarbit() -> varbitBits
+      type.hasNamed() -> {
+        val decl = types[type.named]
+        when {
+          decl != null && decl.hasEnum() -> decl.enum.width
+          else -> 0
+        }
+      }
+      else -> 0
+    }
+
+  /**
+   * Converts raw extracted bits to the appropriate [Value] for a header field.
+   *
+   * bit<N> → [BitVal], bool → [BoolVal], int<N> → [IntVal], varbit / enum → [BitVal].
+   */
+  private fun bitsToValue(type: Type, raw: BigInteger, width: Int): Value =
+    when {
+      type.hasBoolean() -> BoolVal(raw != BigInteger.ZERO)
+      type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(raw, width))
+      else -> BitVal(BitVector(raw, width))
+    }
 
   private fun execEmit(call: MethodCall, env: Environment): Value {
     emitValue(evalExpr(call.argsList[0], env))
@@ -570,16 +625,45 @@ class Interpreter(
         if (!value.valid) return
         val headerDecl =
           (types[value.typeName] ?: error("type not found: ${value.typeName}")).header
-        val totalBits = headerDecl.fieldsList.sumOf { it.type.bit.width }
+        // Compute total wire bits from field declarations; varbit fields use their stored BitVal
+        // width since we don't have the runtime length separately at emit time.
+        val totalBits =
+          headerDecl.fieldsList.sumOf { field ->
+            when (val v = value.fields[field.name]) {
+              is BitVal -> v.bits.width
+              is BoolVal -> 1
+              is IntVal -> v.bits.width
+              else -> 0
+            }
+          }
         var packedBits = BigInteger.ZERO
         var bitOffset = 0
         for (field in headerDecl.fieldsList) {
-          val fieldVal = value.fields[field.name] as BitVal
-          val shift = totalBits - bitOffset - fieldVal.bits.width
-          packedBits = packedBits or fieldVal.bits.value.shiftLeft(shift)
-          bitOffset += fieldVal.bits.width
+          val fieldBits: BigInteger
+          val width: Int
+          when (val fieldVal = value.fields[field.name]) {
+            is BitVal -> {
+              fieldBits = fieldVal.bits.value
+              width = fieldVal.bits.width
+            }
+            is BoolVal -> {
+              // P4 spec §8.9.2: bool occupies 1 bit on the wire.
+              fieldBits = if (fieldVal.value) BigInteger.ONE else BigInteger.ZERO
+              width = 1
+            }
+            is IntVal -> {
+              fieldBits = fieldVal.bits.toUnsigned().value
+              width = fieldVal.bits.width
+            }
+            else -> continue // UnitVal (e.g. varbit placeholder) — skip
+          }
+          if (totalBits > 0 && width > 0) {
+            val shift = totalBits - bitOffset - width
+            packedBits = packedBits or fieldBits.shiftLeft(shift)
+          }
+          bitOffset += width
         }
-        packet.emitBytes(BitVector(packedBits, totalBits).toByteArray())
+        if (totalBits > 0) packet.emitBytes(BitVector(packedBits, totalBits).toByteArray())
       }
       is StructVal -> {
         // Emit in the declaration order from the TypeDecl; fall back to map order if unknown.

--- a/simulator/InterpreterExprTest.kt
+++ b/simulator/InterpreterExprTest.kt
@@ -565,7 +565,7 @@ class InterpreterExprTest {
         .build()
     interp().evalExpr(expr, env)
     assertFalse(hdr.valid)
-    // setInvalid() clears fields per P4 spec §8.17
-    assertTrue(hdr.fields.isEmpty())
+    // setInvalid() zeros fields in place per P4 spec §8.17 (BMv2 treats them as zero)
+    assertEquals(BitVal(0, 16), hdr.fields["etherType"])
   }
 }

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -57,9 +57,15 @@ data class HeaderVal(
    */
   fun setInvalid() {
     valid = false
-    // Retain the field keys but zero the values — the field types are
-    // needed to reconstruct zero values, so we zero them lazily on read.
-    fields.clear()
+    // Zero all fields (P4 spec §8.17). BMv2 treats fields of an invalid
+    // header as zero, so we reset them in place rather than clearing.
+    fields.replaceAll { _, v ->
+      when (v) {
+        is BitVal -> BitVal(0L, v.bits.width)
+        is BoolVal -> BoolVal(false)
+        else -> v
+      }
+    }
   }
 
   fun copy(): HeaderVal = HeaderVal(typeName, fields.toMutableMap(), valid)

--- a/simulator/ir.proto
+++ b/simulator/ir.proto
@@ -162,6 +162,9 @@ message HeaderUnionDecl {
 }
 message EnumDecl {
   repeated string members = 1;
+  // Underlying bit width for serializable enums (enum bit<N> E { ... }).
+  // Zero for uninterpreted (non-serializable) enums.
+  uint32 width = 2;
 }
 
 message FieldDecl {


### PR DESCRIPTION
## Motivation

Four simulator/backend fixes that unblock the next wave of p4c corpus tests,
plus the corpus test harness infrastructure to run them in CI.

## Changes

### NoAction built-in (P4 spec §12.7)

Tables implicitly support `NoAction` without an explicit `ActionDecl` in the
IR. The simulator now intercepts it before the action lookup instead of
failing with "unknown action".

### bool/varbit in header extract/emit

`extract()` and `emit()` previously used a naïve byte-per-field model. They
now handle:
- `bool` — 1 bit on the wire (P4 spec §8.9.2)
- `int<N>` — signed, two's complement
- `varbit<N>` — runtime-length bit count

New helpers `fieldWireWidth()` and `bitsToValue()` centralise the
type→width and bits→Value conversions.

### Serializable enum wire widths

`enum bit<N>` fields in headers need their underlying width for wire
extraction. The backend now emits `EnumDecl.width`; `DefaultValues` produces
a zero `BitVal` of that width; `fieldWireWidth()` uses it.

### error/SerEnum member literals

`error.NoError` and `MyEnum.Val` compile to `IR::Member{TypeNameExpression,
…}`. The backend now emits `literal{error_member: …}` or an integer literal
respectively, eliminating "unhandled expression kind: type {}" errors.

### setInvalid() zeroes fields in place

P4 spec §8.17 / BMv2 behaviour: invalidating a header zeroes its fields
rather than removing them. `setInvalid()` now uses `replaceAll` in place.

### Corpus test harness

- Renames `p4c_stf_corpus_test` → `v1model_stf_corpus_test`.
- Adds manual suites (`psa_stf_corpus_test`, `skeleton_includes_stf_corpus_test`,
  `lookahead_stf_corpus_test`) for tests blocked on known missing features,
  with instructions in comments for how to add new ones.
- Propagates `tags = tags` to genrules in `corpus.bzl` so `bazel build //...`
  skips manual targets.
- Fixes `coverage.sh` to exclude manual targets from the `bazel query`, and
  strips git `a/`/`b/` path prefixes before passing the diff to `genhtml`.

## Test plan

- [x] `bazel test //...` green on CI (ubuntu + macOS)
- [x] Corpus suite passes with the same 90 tests that were green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)