### PR TITLE
Publish mainline HTML coverage report on gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,13 +164,14 @@ jobs:
         run: echo "START_TIME=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Install lcov
-        if: github.event_name == 'pull_request'
         run: sudo apt install -y lcov
+
+      - name: Fetch gh-pages
+        run: git fetch --depth=1 origin gh-pages || true
 
       - name: Download baseline coverage
         if: github.event_name == 'pull_request'
         run: |
-          git fetch --depth=1 origin gh-pages || exit 0
           git show origin/gh-pages:main/coverage.lcov > /tmp/baseline.lcov 2>/dev/null \
             || rm -f /tmp/baseline.lcov
 
@@ -182,12 +183,9 @@ jobs:
 
       - name: Run coverage
         run: |
-          ARGS=()
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            ARGS+=(--html)
-            if [[ -s /tmp/baseline.lcov && -s /tmp/pr.diff ]]; then
-              ARGS+=(--baseline /tmp/baseline.lcov --diff /tmp/pr.diff)
-            fi
+          ARGS=(--html)
+          if [[ -s /tmp/baseline.lcov && -s /tmp/pr.diff ]]; then
+            ARGS+=(--baseline /tmp/baseline.lcov --diff /tmp/pr.diff)
           fi
           ./coverage.sh "${ARGS[@]}"
 
@@ -206,18 +204,18 @@ jobs:
           path: ~/.cache/bazel
           key: bazel-coverage-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}-${{ github.run_id }}
 
-      - name: Publish baseline LCOV
+      - name: Publish mainline report
         if: github.event_name == 'push'
         run: |
-          git fetch --depth=1 origin gh-pages || exit 0
           git worktree add /tmp/gh-pages gh-pages
           mkdir -p /tmp/gh-pages/main
           cp coverage.lcov /tmp/gh-pages/main/
+          cp -r coverage-report/* /tmp/gh-pages/main/
           cd /tmp/gh-pages
-          git add main/coverage.lcov
-          git -c user.name="github-actions[bot]" \
-              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-              commit -m "Baseline coverage for $(git -C "$GITHUB_WORKSPACE" rev-parse --short HEAD)" --allow-empty
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add main/
+          git commit -m "Coverage report for $(git -C "$GITHUB_WORKSPACE" rev-parse --short HEAD)" --allow-empty
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
 
       - name: Compute diff coverage
@@ -231,10 +229,10 @@ jobs:
           mkdir -p "/tmp/gh-pages/pr/${PR_NUM}"
           cp -r coverage-report/* "/tmp/gh-pages/pr/${PR_NUM}/"
           cd /tmp/gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "pr/${PR_NUM}"
-          git -c user.name="github-actions[bot]" \
-              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-              commit -m "Coverage report for PR #${PR_NUM}" --allow-empty
+          git commit -m "Coverage report for PR #${PR_NUM}" --allow-empty
           # Retry once on conflict (concurrent PR pushes).
           git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
 


### PR DESCRIPTION
## Summary

- The coverage CI job now generates and publishes an HTML report on every push
  to main (at `gh-pages/main/`), not just the LCOV baseline. This makes the
  mainline coverage report browsable alongside the per-PR reports.
- The gh-pages index page now links to the mainline report at the top.
- Fixes a bug where the push-retry fallback (`git pull --rebase`) failed because
  the committer identity was only passed via `git -c` on the commit command,
  which doesn't carry over to rebase. Both publish steps now use `git config`
  in the worktree instead.
- Minor cleanup: the gh-pages fetch is now a single unconditional step rather
  than being duplicated/implicit across the baseline download and mainline
  publish steps.

## Test plan

- [ ] Push to main triggers coverage job and publishes HTML report under `gh-pages/main/`
- [ ] Index page at https://smolkaj.github.io/4ward/ shows "Mainline" link
- [ ] PR coverage continues to work (HTML report + comment)
- [ ] Push-retry fallback works when gh-pages has concurrent updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)