### PR TITLE
Document ~/.bazelrc settings for parallel worktree builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,28 @@ changing `ir.proto` or `simulator.proto`:
 4. Make sure the relevant STF tests still pass.
 
 Never remove or renumber existing fields; add new ones instead.
+
+## Local development
+
+When running multiple agents in parallel (each in its own worktree), Bazel can
+saturate all CPU cores and cause heavy swapping because each worktree gets its
+own output base — recompiling p4c and Z3 from scratch every time.
+
+Add the following to your **`~/.bazelrc`** (not the repo `.bazelrc`) to fix
+this:
+
+```
+# Shared disk cache across worktrees — avoids recompiling p4c/Z3 in every
+# worktree. Grows without bounds; wipe with: rm -rf ~/.cache/bazel-disk
+build --disk_cache=~/.cache/bazel-disk
+
+# Cap resources to keep the machine responsive when multiple agents build in
+# parallel. Tune to your machine (these values suit a MacBook Air M-series).
+build --local_cpu_resources=4
+build --local_ram_resources=8192
+```
+
+These settings are intentionally **not** checked into the repo `.bazelrc`:
+- `--disk_cache` has no garbage collection. If CI ever picked it up, the cache
+  would balloon.
+- Resource limits are machine-specific — CI runners have different specs.


### PR DESCRIPTION
## Summary

- Running multiple Claude agents in parallel (each in its own worktree) causes 100% CPU and 15GB swap on a MacBook Air because each worktree gets its own Bazel output base, recompiling p4c and Z3 from scratch every time.
- Adds a "Local development" section to `AGENTS.md` documenting recommended `~/.bazelrc` settings: a shared disk cache (`--disk_cache`) and resource caps (`--local_cpu_resources`, `--local_ram_resources`).
- Settings are intentionally user-local (`~/.bazelrc`) rather than checked into the repo to avoid CI side effects (unbounded cache growth, machine-specific resource limits).

## Test plan

- [ ] `bazel test //...` passes (documentation-only change)
- [ ] Add settings to `~/.bazelrc`, rebuild in a fresh worktree, confirm p4c/Z3 compilation is skipped (disk cache hits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)