### PR TITLE
Replace TLA acronyms with readable labels in coverage reports

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -319,6 +319,21 @@ GENHTML_ARGS=(--quiet)
 if command -v genhtml >/dev/null 2>&1; then
   rm -rf "${REPORT_DIR}"
   genhtml "${PERSISTENT}" --output-directory "${REPORT_DIR}" "${GENHTML_ARGS[@]}"
+
+  # Replace cryptic TLA abbreviations with readable labels in the generated
+  # HTML. Only matches text between > and < so CSS classes are preserved.
+  # Uses -i.bak + delete for BSD/GNU sed portability (BSD requires an
+  # argument to -i; GNU treats a separate '' as a filename).
+  find "${REPORT_DIR}" -name '*.html' -exec sed -i.bak \
+      -e 's/>CBC</>Covered</g'           -e 's/>GBC</>Newly covered</g' \
+      -e 's/>UBC</>Not covered</g'       -e 's/>LBC</>Coverage lost</g' \
+      -e 's/>GNC</>New \&amp; covered</g'    -e 's/>UNC</>New \&amp; not covered</g' \
+      -e 's/>EUB</>Excluded (not covered)</g' -e 's/>ECB</>Excluded (covered)</g' \
+      -e 's/>DUB</>Deleted (not covered)</g'  -e 's/>DCB</>Deleted (covered)</g' \
+      -e 's/>UIC</>Included (not covered)</g' -e 's/>GIC</>Included (covered)</g' \
+      {} +
+  find "${REPORT_DIR}" -name '*.bak' -delete
+
   echo "HTML report:  ${REPORT_DIR}/index.html"
 elif "${WANT_HTML}"; then
   echo "Error: genhtml not found (install lcov: brew install lcov)" >&2


### PR DESCRIPTION
## Summary

- genhtml (LCOV 2.0) uses cryptic three-letter acronyms (UBC, CBC, GNC, etc.)
  as column headers and line annotations in its HTML output. These are
  meaningless to most readers and there's no built-in option to rename them.
- Adds a `sed` post-processing pass after `genhtml` that replaces all 12 TLA
  codes with human-readable labels (e.g. "Not covered", "New & covered").
- Only replaces text between `>` and `<` so CSS class names like `tlaUBC` and
  color-coding are preserved.
- Uses `sed -i.bak` + cleanup for BSD/GNU portability (CI runs on Linux).

## Test plan

- [ ] Run `./coverage.sh --html` and inspect column headers in `coverage-report/index.html`
- [ ] Verify source file views show readable line annotations
- [ ] Confirm CSS classes and color-coding are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)