### PR TITLE
Document pre-existing refactoring debt from p4testgen integration

### DIFF
--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -53,3 +53,46 @@ The module extension has read access to the p4c source tree (via
 `git_override`) and can enumerate files with
 `mctx.path(Label("@p4c//:MODULE.bazel")).dirname`. The generated repo replaces
 `e2e_tests/corpus/BUILD.bazel` entirely.
+
+---
+
+## Extract shared `p4_compile` genrule macro
+
+**Files**: new `e2e_tests/p4_compile.bzl`, all callers
+
+**Problem**: The p4c-4ward compilation genrule is copy-pasted across 8
+locations (`corpus.bzl`, `p4testgen.bzl`, and 6 hand-written `BUILD.bazel`
+files). Each copy has the same `cmd`, `tools`, and `outs` pattern.
+
+**Fix**: Extract a shared Starlark function in `e2e_tests/p4_compile.bzl`:
+
+```python
+def p4_compile(name, p4_src, tags = []):
+    native.genrule(
+        name = name + "_pb",
+        srcs = [p4_src],
+        outs = [name + ".txtpb"],
+        cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
+        tools = [
+            "//p4c_backend:p4c-4ward",
+            "@p4c//:core_p4",
+            "@p4c//:p4include",
+        ],
+        tags = tags,
+    )
+```
+
+Then `corpus.bzl`, `p4testgen.bzl`, and the standalone `BUILD.bazel` files
+all call `p4_compile(name, p4_src)` instead of inlining the genrule.
+
+---
+
+## Make `matchesMasked` internal for test reuse
+
+**Files**: `e2e_tests/stf/Runner.kt`, `e2e_tests/stf/StfParserTest.kt`
+
+**Problem**: `matchesMasked` is `private` in `Runner.kt`, so
+`StfParserTest.kt` has an identical copy to test the logic independently.
+
+**Fix**: Change visibility from `private` to `internal` so the test can
+import the production implementation directly.


### PR DESCRIPTION
## Summary

- Adds two refactoring backlog items to `docs/refactoring.md` discovered
  during the p4testgen integration (#36):
  - **Extract shared `p4_compile` genrule macro** — the p4c-4ward compilation
    genrule is copy-pasted across 8 locations
  - **Make `matchesMasked` internal** — duplicated between Runner.kt and
    StfParserTest.kt because the production version is `private`


🤖 Generated with [Claude Code](https://claude.com/claude-code)