### PR TITLE
bazelrc: preserve analysis cache across clang-tidy runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,9 +26,11 @@ build --host_cxxopt=-std=c++20
 test --test_output=errors
 
 # clang-tidy: run via `bazel build //p4c_backend/... --config=clang-tidy`.
+# The config flag is set unconditionally so switching to --config=clang-tidy
+# does not change it and Bazel can reuse its analysis cache.
+build --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --output_groups=report
-build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 
 # Coverage: instrument the simulator library. Run via `bazel coverage //...`.
 coverage --combined_report=lcov


### PR DESCRIPTION
## Problem

Every `bazel build --config=clang-tidy` run prints:

```
WARNING: Build option --@@bazel_clang_tidy+//:clang_tidy_config has changed,
discarding analysis cache (this can be expensive)
```

This happens because `--@bazel_clang_tidy//:clang_tidy_config` was only set
under `build:clang-tidy`. Switching from a plain `bazel build` to
`--config=clang-tidy` changed the flag from unset to set, forcing a full
analysis cache discard on every lint run.

## Fix

Move the config flag to the unconditional `build` stanza. It just points at
the config target and is harmless when clang-tidy is not active. With it
always set, `--config=clang-tidy` only adds the aspect and output group —
neither of which invalidates the analysis cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)