### PR TITLE
corpus: add bvec-hdr-bmv2 (manual — wrong output port/payload)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -192,3 +192,12 @@ corpus_test_suite(
         "array-copy-bmv2",
     ],
 )
+
+# Tests blocked on various unclassified missing features.
+corpus_test_suite(
+    name = "other_stf_corpus_test",
+    tags = ["manual"],
+    tests = [
+        "bvec-hdr-bmv2",
+    ],
+)


### PR DESCRIPTION
Expected packet on port 2 but got none; payload mismatches on port 0.

Generated with [Claude Code](https://claude.com/claude-code)