### PR TITLE
corpus: add checksum2-bmv2 (manual — runtime failure)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -199,5 +199,6 @@ corpus_test_suite(
     tags = ["manual"],
     tests = [
         "bvec-hdr-bmv2",
+        "checksum2-bmv2",
     ],
 )


### PR DESCRIPTION
Runtime failure: `unknown runtime error`

Generated with [Claude Code](https://claude.com/claude-code)