### PR TITLE
corpus: add checksum3-bmv2 (manual — runtime failure)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -200,5 +200,6 @@ corpus_test_suite(
     tests = [
         "bvec-hdr-bmv2",
         "checksum2-bmv2",
+        "checksum3-bmv2",
     ],
 )


### PR DESCRIPTION
Runtime failure: `unknown runtime error`

Generated with [Claude Code](https://claude.com/claude-code)