### PR TITLE
corpus: add equality-bmv2 (manual — runtime failure)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -201,5 +201,6 @@ corpus_test_suite(
         "bvec-hdr-bmv2",
         "checksum2-bmv2",
         "checksum3-bmv2",
+        "equality-bmv2",
     ],
 )


### PR DESCRIPTION
Runtime failure: `unknown runtime error`

Generated with [Claude Code](https://claude.com/claude-code)