### PR TITLE
corpus: add gauntlet_index_2-bmv2 (manual — runtime failure)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -205,5 +205,6 @@ corpus_test_suite(
         "checksum3-bmv2",
         "equality-bmv2",
         "gauntlet_index_1-bmv2",
+        "gauntlet_index_2-bmv2",
     ],
 )


### PR DESCRIPTION
Runtime failure: `unknown runtime error`

Generated with [Claude Code](https://claude.com/claude-code)