### PR TITLE
corpus: add gauntlet_index_5-bmv2 (manual — runtime failure)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -207,5 +207,6 @@ corpus_test_suite(
         "gauntlet_index_1-bmv2",
         "gauntlet_index_2-bmv2",
         "gauntlet_index_4-bmv2",
+        "gauntlet_index_5-bmv2",
     ],
 )


### PR DESCRIPTION
Runtime failure: `unknown runtime error`

Generated with [Claude Code](https://claude.com/claude-code)