### PR TITLE
corpus: add gauntlet_index_8-bmv2 (manual — header stack field access)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -210,5 +210,6 @@ corpus_test_suite(
         "gauntlet_index_5-bmv2",
         "gauntlet_index_6-bmv2",
         "gauntlet_index_7-bmv2",
+        "gauntlet_index_8-bmv2",
     ],
 )


### PR DESCRIPTION
Blocked on header stack field access: `field access on non-aggregate value: HeaderStackVal`.

Generated with [Claude Code](https://claude.com/claude-code)