### PR TITLE
corpus: add gauntlet_optional-bmv2 (manual — unsupported architecture 'top')

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -216,3 +216,13 @@ corpus_test_suite(
         "gauntlet_invalid_hdr_short_circuit-bmv2",
     ],
 )
+
+# Tests blocked on unsupported non-v1model/non-PSA architectures.
+# These fail at p4c-4ward compile time.
+corpus_test_suite(
+    name = "unsupported_arch_stf_corpus_test",
+    tags = ["manual"],
+    tests = [
+        "gauntlet_optional-bmv2",
+    ],
+)


### PR DESCRIPTION
Compile failure: unsupported architecture 'top'.

Generated with [Claude Code](https://claude.com/claude-code)