### PR TITLE
corpus: add gauntlet_variable_shadowing-bmv2 (manual — unknown table)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -215,6 +215,7 @@ corpus_test_suite(
         "gauntlet_index_8-bmv2",
         "gauntlet_index_9-bmv2",
         "gauntlet_invalid_hdr_short_circuit-bmv2",
+        "gauntlet_variable_shadowing-bmv2",
     ],
 )
 


### PR DESCRIPTION
Fails with `unknown table: c_t`.

Generated with [Claude Code](https://claude.com/claude-code)