### PR TITLE
corpus: add header-bool-bmv2 (manual — field access on UnitVal)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -216,6 +216,7 @@ corpus_test_suite(
         "gauntlet_index_9-bmv2",
         "gauntlet_invalid_hdr_short_circuit-bmv2",
         "gauntlet_variable_shadowing-bmv2",
+        "header-bool-bmv2",
     ],
 )
 


### PR DESCRIPTION
Generated with [Claude Code](https://claude.com/claude-code)