### PR TITLE
corpus: add header-stack-ops-bmv2 (manual — unhandled extern verify)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -217,6 +217,7 @@ corpus_test_suite(
         "gauntlet_invalid_hdr_short_circuit-bmv2",
         "gauntlet_variable_shadowing-bmv2",
         "header-bool-bmv2",
+        "header-stack-ops-bmv2",
     ],
 )
 


### PR DESCRIPTION
Generated with [Claude Code](https://claude.com/claude-code)