### PR TITLE
corpus: add invalid-hdr-warnings3-bmv2 (manual — unknown table name)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -218,6 +218,7 @@ corpus_test_suite(
         "gauntlet_variable_shadowing-bmv2",
         "header-bool-bmv2",
         "header-stack-ops-bmv2",
+        "invalid-hdr-warnings3-bmv2",
     ],
 )
 


### PR DESCRIPTION
Fails with `unknown table: ` (empty name).

Generated with [Claude Code](https://claude.com/claude-code)