### PR TITLE
corpus: add 8 table-entries tests (all manual — const entries)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -255,6 +255,14 @@ corpus_test_suite(
         "saturated-bmv2",  # payload mismatch
         "stack_complex-bmv2",  # field access on non-aggregate value: HeaderStackVal
         "subparser-with-header-stack-bmv2",  # unhandled extern call: verify
+        "table-entries-exact-bmv2",  # expected packet but got none (const entries)
+        "table-entries-exact-ternary-bmv2",  # expected packet but got none (const entries)
+        "table-entries-lpm-bmv2",  # expected packet but got none (const entries)
+        "table-entries-optional-bmv2",  # expected packet but got none (const entries)
+        "table-entries-priority-bmv2",  # expected packet but got none (const entries)
+        "table-entries-range-bmv2",  # expected packet but got none (const entries)
+        "table-entries-ser-enum-bmv2",  # expected packet but got none (const entries)
+        "table-entries-ternary-bmv2",  # expected packet but got none (const entries)
     ],
 )
 


### PR DESCRIPTION
All 8 table-entries-*-bmv2 tests fail with "expected packet but got none", likely blocked on const table entries support.