### PR TITLE
corpus: add final 9 tests (all manual — various failures)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -263,6 +263,15 @@ corpus_test_suite(
         "table-entries-range-bmv2",  # expected packet but got none (const entries)
         "table-entries-ser-enum-bmv2",  # expected packet but got none (const entries)
         "table-entries-ternary-bmv2",  # expected packet but got none (const entries)
+        "ternary2-bmv2",  # NumberFormatException: "val:0x7f"
+        "test-parserinvalidargument-error-bmv2",  # payload mismatch
+        "union-bmv2",  # field access on non-aggregate value: UnitVal
+        "union-valid-bmv2",  # field access on non-aggregate value: UnitVal
+        "union1-bmv2",  # field access on non-aggregate value: UnitVal
+        "union2-bmv2",  # field access on non-aggregate value: UnitVal
+        "union3-bmv2",  # field access on non-aggregate value: UnitVal
+        "v1model-const-entries-bmv2",  # payload mismatch
+        "v1model-special-ops-bmv2",  # NumberFormatException: "new_ipv4_"
     ],
 )
 


### PR DESCRIPTION
Last batch of uncategorized tests. All 9 fail:
- ternary2-bmv2: NumberFormatException: "val:0x7f"
- test-parserinvalidargument-error-bmv2: payload mismatch
- union-{,valid,1,2,3}-bmv2: field access on non-aggregate value: UnitVal
- v1model-const-entries-bmv2: payload mismatch
- v1model-special-ops-bmv2: NumberFormatException: "new_ipv4_"

This completes the corpus expansion — every p4c STF test is now tracked.