### PR TITLE
docs: call out spec compliance as a design goal, link to P4 spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,15 @@ and confirm no other tests regress: `bazel test //...`.
 
 ## P4 language notes
 
+4ward is a spec-compliant reference implementation. The authoritative source
+for language semantics is the
+[P4₁₆ Language Specification (v1.2.5)](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html).
+**When in doubt, consult the spec.** If the spec is ambiguous, follow p4c's
+behaviour and document the ambiguity with a comment citing the relevant spec
+section.
+
+Key points:
+
 - P4_16 is the target language. P4_14 is not supported.
 - The IR is emitted after p4c's midend, so it reflects a simplified program:
   no generics, no abstract types, no P4_14 constructs.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,6 +6,19 @@ components, how they talk to each other, and why we made the choices we did.
 If you just want to use 4ward, the [README](README.md) is all you need. If you
 want to hack on it, keep reading.
 
+## Design goal: spec-compliant reference implementation
+
+4ward's primary goal is to be a faithful implementation of the
+[P4₁₆ language specification](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html).
+Every language feature should behave exactly as the spec describes. When the
+spec is ambiguous, we follow p4c's reference compiler behaviour and document
+the ambiguity. When the spec is clear, we follow it — even if BMv2 or other
+implementations do something different.
+
+This means correctness always wins over convenience, performance, or
+compatibility with non-standard behaviour. The simulator is meant to be the
+implementation you trust when you need to know what a P4 program *should* do.
+
 ## The big picture
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,53 @@
 # 4ward — Claude Instructions
 
-See [AGENTS.md](AGENTS.md) for the full agent guide. This file adds
+See [AGENTS.md](AGENTS.md) for the general agent guide. This file adds
 Claude-specific notes.
 
-- Reference the STF test being fixed in commit messages where applicable.
-- Comments on subtle P4 spec requirements should include spec section numbers.
+## Commit messages
+
+Focus on *why* the change is being made and what problem it solves. Avoid
+restating what the diff already shows. Reference the STF test being fixed where
+applicable.
+
+## Code comments
+
+Write self-explanatory code. Add a comment when the code deviates from the
+obvious approach, works around a non-obvious constraint, or implements a
+subtle P4 spec requirement. Include spec references (section numbers, GitHub
+issues) where helpful. Do not add comments that merely restate the code.
+
+## Pull requests
+
+Open PRs in draft mode (`gh pr create --draft`). Rebase onto `origin/main`
+before submitting. The description should explain motivation and approach,
+not list every changed line.
+
+## Worktrees
+
+Always work in a dedicated worktree. Never make changes directly in the main
+tree. Rebase and squash when merging back.
+
+## P4 spec compliance
+
+4ward is a spec-compliant reference implementation. When implementing a
+feature or resolving an ambiguity, consult the
+[P4₁₆ Language Specification (v1.2.5)](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html).
+Cite spec section numbers in comments on non-obvious semantics.
+
+## Tool use
+
+- Prefer `bazel build //...` and `bazel test //...` to direct invocations of
+  `kotlinc`, `g++`, etc. The build is hermetic.
+- Use `ibazel build //...` for any work that spans multiple edit/build cycles.
+  Run it in the background at the start of a task so build errors surface
+  immediately rather than after a full rebuild.
+- Use `./format.sh` to format files, not manual edits.
+- Use `./lint.sh` to lint all code (clang-tidy for C++, detekt for Kotlin).
+  Fix all warnings before marking a task complete.
+- Do not install anything with `apt`, `brew`, or `pip`; declare dependencies
+  in `MODULE.bazel` instead.
+
+## Testing discipline
+
+Do not mark a task complete unless `bazel test //...` passes. A test that was
+green before your change must still be green after it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,13 @@ We follow the Google style guides and let the formatters handle the details:
 simulator, so treat field numbers like promises: never remove or renumber them.
 Add new fields instead.
 
-## On performance
+## On correctness
+
+4ward is a spec-compliant reference implementation: it should behave exactly as
+the [P4₁₆ spec](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html)
+describes. When you're unsure about a language detail, check the spec. If the
+spec is ambiguous, follow p4c's behaviour and document the ambiguity in a
+comment citing the relevant section.
 
 4ward is proudly not fast. It's correct, it's observable, and it's readable.
 Please don't send PRs that trade any of those for speed — if you want a fast P4

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ branch — delivered as a structured trace you can actually read.
 | P4Runtime | sure | sure | **yep** |
 | Simple, readable codebase | ehh | ehh | **yes!** |
 
-4ward optimises for **correctness and observability**, not performance. It's a
-development and testing tool — think of it as a debugger that speaks P4, not a
-production data plane.
+4ward is a **spec-compliant reference implementation** of the
+[P4₁₆ language](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html),
+optimised for **correctness and observability** rather than performance. Think of
+it as a debugger that speaks P4, not a production data plane.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

4ward is a spec-compliant reference implementation of P4₁₆, but the
documentation didn't say that explicitly or provide a link to the spec.

This PR adds that framing to all key docs — README, ARCHITECTURE, AGENTS,
CLAUDE, and CONTRIBUTING — so both humans and agents know to consult the
[P4₁₆ spec (v1.2.5)](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html)
when resolving ambiguities.

## Changes

- **README**: Updated tagline from "development and testing tool" to
  "spec-compliant reference implementation"
- **ARCHITECTURE**: New "Design goal" section establishing spec compliance as
  the primary objective
- **AGENTS**: Added spec link and "when in doubt, consult the spec" directive
  to the P4 language notes section
- **CLAUDE**: Added "P4 spec compliance" section with spec link; expanded from
  bullet points to full sections matching upstream CLAUDE.md conventions
- **CONTRIBUTING**: New "On correctness" section before the existing performance
  note