### PR TITLE
docs: trace trees — exhaustive exploration of non-deterministic paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -133,6 +133,40 @@ We also have:
 - **BMv2 diff testing** (maybe, someday): run the same inputs through BMv2 and
   4ward and compare outputs.
 
+## Trace trees (future)
+
+Today, 4ward returns a single execution trace per packet — a linear sequence of
+events. But P4 programs can have non-deterministic choice points, most notably
+**action selectors** where the selected group member depends on a hash that is
+opaque to the programmer. Other sources include action profiles, packet
+replication (clone, multicast), and random externs.
+
+The key insight: even when these choices are technically deterministic (governed
+by a hash algorithm or controller configuration), it's often more useful to
+reason about them as non-deterministic — "what *could* happen to my packet?"
+rather than "what happens with this specific hash seed?"
+
+4ward will support a mode where, instead of picking one path, the simulator
+forks at every non-deterministic choice point and returns a **trace tree**: a
+tree of events where each fork node is labeled with the choice being made, and
+the subtrees represent the possible continuations. Since execution paths share
+a common prefix (parsing and early pipeline stages are typically deterministic),
+the tree is much more compact than a flat list of traces.
+
+**Control mechanisms:**
+
+- A simulator flag (e.g. `--nondeterministic-selectors`) to treat all action
+  selectors as non-deterministic — fork at every selector instead of evaluating
+  the hash.
+- P4 annotations for fine-grained control: mark specific selectors as
+  non-deterministic (or deterministic) regardless of the global flag.
+
+**Why this matters:**
+
+No other P4 tool gives you this. BMv2 picks one path. Hardware picks one path.
+4ward can show you *all* paths — making it a powerful tool for testing,
+verification, and understanding complex P4 programs.
+
 ## P4Runtime (future)
 
 Not yet! We're deliberately building the simulator first and getting it solid

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ branch — delivered as a structured trace you can actually read.
 |---|---|---|---|
 | Runs P4 programs | sure | sure | **yep** |
 | Execution trace | text | nope | **proto/JSON** |
+| All possible traces | nope | nope | **trace trees!** |
 | Architecture-generic | nope | nope | **yes!** |
 | P4Runtime | sure | sure | **yep** |
 | Simple, readable codebase | ehh | ehh | **yes!** |
@@ -88,6 +89,35 @@ Given a simple IPv4 forwarding program, 4ward produces traces like this:
 ```
 
 No printf debugging. No Wireshark. No guessing. Just the trace.
+
+## Not just one trace — all of them
+
+P4 programs have non-deterministic choice points. Action selectors pick a group
+member based on an opaque hash. Action profiles let the controller choose
+between multiple actions. Multicast replicates packets to different ports.
+
+Other tools pick one path and show you what happened. 4ward will show you what
+*could* happen — all possible executions, returned as a **trace tree**:
+
+```
+                    ┌─ parse ─ table lookup ─┐
+                    │                        │
+         packet ────┤       (shared prefix)  ├─── action_selector ─┐
+                    │                        │                     │
+                    └────────────────────────┘        ┌────────────┼────────────┐
+                                                      │            │            │
+                                                  member_0     member_1     member_2
+                                                      │            │            │
+                                                   trace …     trace …     trace …
+```
+
+Since execution paths share a common prefix, the tree is compact — shared work
+is represented once, and each fork node is labeled with the choice being made.
+A flag like `--nondeterministic-selectors` tells the simulator to fork at every
+action selector; P4 annotations give fine-grained per-selector control.
+
+This is 4ward's killer feature: the tool you reach for when you need to
+understand not just what your program *did*, but everything it *can* do.
 
 ## Project structure
 


### PR DESCRIPTION
## Summary

Document a planned killer feature: **trace trees**. Instead of returning a
single execution trace per packet, 4ward will fork at non-deterministic choice
points and return a tree of all possible executions.

## Motivation

P4 programs have non-deterministic choice points — most notably action
selectors, where the selected group member depends on an opaque hash. Even
when technically deterministic, it's often more useful to model these as
non-deterministic to answer "what *could* happen?" rather than "what happens
with this specific hash seed?"

No other P4 tool provides this. BMv2 picks one path. Hardware picks one path.
4ward can show you all of them.

## Design

- A simulator flag (e.g. `--nondeterministic-selectors`) treats all action
  selectors as non-deterministic
- P4 annotations for fine-grained per-selector control
- Output is a trace tree: shared prefixes are represented once, fork nodes
  labeled with the choice, subtrees for each possible continuation