### PR TITLE
corpus: skeleton includes support, promote arith2-inline-bmv2

### DIFF
--- a/e2e_tests/corpus.bzl
+++ b/e2e_tests/corpus.bzl
@@ -17,15 +17,25 @@ This creates:
 
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
-def corpus_test_suite(name, tests, tags = []):
+def corpus_test_suite(name, tests, tags = [], includes = []):
     """Compiles p4c corpus P4 files and runs all STF tests in a single JVM.
 
     Args:
-        name:  name of the batched kt_jvm_test target.
-        tests: list of test base names (e.g. "opassign1-bmv2").
-        tags:  Bazel tags forwarded to the kt_jvm_test.
+        name:     name of the batched kt_jvm_test target.
+        tests:    list of test base names (e.g. "opassign1-bmv2").
+        tags:     Bazel tags forwarded to the kt_jvm_test.
+        includes: extra P4 file labels needed as #include dependencies (e.g.
+                  skeleton headers). Their directory is added to the p4c
+                  include path.
     """
     data = ["//simulator"]
+
+    # Build -I flags for any extra includes.
+    if includes:
+        # All includes are assumed to be in the same directory; one -I suffices.
+        include_flag = " -I $$(dirname $(execpath " + includes[0] + "))"
+    else:
+        include_flag = ""
 
     for test in tests:
         p4_src = "@p4c//testdata/p4_16_samples:" + test + ".p4"
@@ -33,9 +43,9 @@ def corpus_test_suite(name, tests, tags = []):
 
         native.genrule(
             name = test + "_pb",
-            srcs = [p4_src],
+            srcs = [p4_src] + includes,
             outs = [test + ".txtpb"],
-            cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
+            cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flag + " -o $@ $(execpath " + p4_src + ")",
             tags = tags,
             tools = [
                 "//p4c_backend:p4c-4ward",

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -10,7 +10,13 @@ load("//e2e_tests:corpus.bzl", "corpus_test_suite")
 #      Create a new manual suite if no existing one fits.
 corpus_test_suite(
     name = "v1model_stf_corpus_test",
+    includes = [
+        "@p4c//testdata/p4_16_samples:arith-inline-skeleton.p4",
+        "@p4c//testdata/p4_16_samples:arith-skeleton.p4",
+        "@p4c//testdata/p4_16_samples:ml-headers.p4",
+    ],
     tests = [
+        "arith2-inline-bmv2",
         "array-copy-bmv2",
         "equality-varbit-bmv2",
         "flag_lost-bmv2",
@@ -138,29 +144,32 @@ corpus_test_suite(
     ],
 )
 
-# Tests blocked on exposing skeleton .p4 files as Bazel targets.
-# arith-skeleton.p4, arith-inline-skeleton.p4, and ml-headers.p4 are
-# sibling includes not yet available as @p4c filegroup targets.
-# Run manually: bazel test //e2e_tests/corpus:skeleton_includes_stf_corpus_test
+# Tests that need sibling skeleton .p4 files as #include dependencies.
+# These are compiled with an extra -I pointing at the testdata directory.
+# Blocked on various simulator gaps (payload mismatches, missing externs).
 corpus_test_suite(
     name = "skeleton_includes_stf_corpus_test",
+    includes = [
+        "@p4c//testdata/p4_16_samples:arith-inline-skeleton.p4",
+        "@p4c//testdata/p4_16_samples:arith-skeleton.p4",
+        "@p4c//testdata/p4_16_samples:ml-headers.p4",
+    ],
     tags = ["manual"],
     tests = [
-        "arith-bmv2",
-        "arith-inline-bmv2",
-        "arith1-bmv2",
-        "arith2-bmv2",
-        "arith2-inline-bmv2",
-        "arith3-bmv2",
-        "arith4-bmv2",
-        "arith5-bmv2",
-        "constant-in-calculation-bmv2",
-        "default-action-arg-bmv2",
-        "default_action-bmv2",
-        "enum-bmv2",
-        "extern-funcs-bmv2",
-        "ipv6-switch-ml-bmv2",
-        "key-bmv2",
+        "arith-bmv2",  # payload mismatch (arithmetic)
+        "arith-inline-bmv2",  # payload mismatch (arithmetic)
+        "arith1-bmv2",  # payload mismatch (arithmetic)
+        "arith2-bmv2",  # payload mismatch (arithmetic)
+        "arith3-bmv2",  # payload mismatch (arithmetic)
+        "arith4-bmv2",  # payload mismatch (arithmetic)
+        "arith5-bmv2",  # payload mismatch (arithmetic)
+        "constant-in-calculation-bmv2",  # unhandled extern call: hash
+        "default-action-arg-bmv2",  # payload mismatch (arithmetic)
+        "default_action-bmv2",  # payload mismatch (arithmetic)
+        "enum-bmv2",  # unhandled expression kind (enum)
+        "extern-funcs-bmv2",  # unhandled extern call: extern_func
+        "ipv6-switch-ml-bmv2",  # unhandled expression kind (enum)
+        "key-bmv2",  # unknown table: c.t (short table name)
     ],
 )
 


### PR DESCRIPTION
## Summary

Adds an `includes` parameter to `corpus_test_suite()` so tests that `#include`
sibling skeleton P4 files can compile. The skeleton files (`arith-skeleton.p4`,
`arith-inline-skeleton.p4`, `ml-headers.p4`) were already exported by `@p4c`
but never declared as genrule inputs — this was the only thing blocking 15
corpus tests from compiling.

Of the 15 newly-compilable tests:
- **1 passes** (`arith2-inline-bmv2`) → promoted to CI suite
- **14 fail** on pre-existing simulator gaps (arithmetic payload mismatches,
  missing externs like `hash`/`extern_func`, enum expression kinds, short
  table names) → annotated and kept as manual

## Test plan

- [x] `bazel test //...` — all 23 tests pass, no regressions
- [x] `./format.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)