### PR TITLE
simulator: fix default action resolution and int<N> support (132 → 139 passing)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -16,7 +16,14 @@ corpus_test_suite(
         "@p4c//testdata/p4_16_samples:ml-headers.p4",
     ],
     tests = [
+        "arith-bmv2",
+        "arith-inline-bmv2",
+        "arith1-bmv2",
+        "arith2-bmv2",
         "arith2-inline-bmv2",
+        "arith3-bmv2",
+        "arith4-bmv2",
+        "arith5-bmv2",
         "array-copy-bmv2",
         "equality-varbit-bmv2",
         "flag_lost-bmv2",
@@ -164,20 +171,13 @@ corpus_test_suite(
     ],
     tags = ["manual"],
     tests = [
-        "arith-bmv2",  # payload mismatch (arithmetic)
-        "arith-inline-bmv2",  # payload mismatch (arithmetic)
-        "arith1-bmv2",  # payload mismatch (arithmetic)
-        "arith2-bmv2",  # payload mismatch (arithmetic)
-        "arith3-bmv2",  # payload mismatch (arithmetic)
-        "arith4-bmv2",  # payload mismatch (arithmetic)
-        "arith5-bmv2",  # payload mismatch (arithmetic)
         "constant-in-calculation-bmv2",  # unhandled extern call: hash
-        "default-action-arg-bmv2",  # payload mismatch (arithmetic)
-        "default_action-bmv2",  # payload mismatch (arithmetic)
+        "default-action-arg-bmv2",  # UnitVal as action param default
+        "default_action-bmv2",  # UnitVal as action param default
         "enum-bmv2",  # unhandled expression kind (enum)
         "extern-funcs-bmv2",  # unhandled extern call: extern_func
-        "ipv6-switch-ml-bmv2",  # unhandled expression kind (enum)
-        "key-bmv2",  # unknown table: c.t (short table name)
+        "ipv6-switch-ml-bmv2",  # unknown match field (STF runner)
+        "key-bmv2",  # unknown table: c.t (STF runner dotted name)
     ],
 )
 

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -384,8 +384,7 @@ class Interpreter(
     if (left is IntVal && (op.op == BinaryOperator.SHL || op.op == BinaryOperator.SHR)) {
       val amount = intValue(right)
       return if (op.op == BinaryOperator.SHL) {
-        val shifted = left.bits.toUnsigned().shl(amount)
-        IntVal(SignedBitVector.fromUnsignedBits(shifted.value, left.bits.width))
+        IntVal(left.bits.toUnsigned().shl(amount).toSigned())
       } else {
         // Arithmetic right shift: shift the signed value, then re-wrap.
         val shifted = left.bits.value.shiftRight(amount)
@@ -431,10 +430,7 @@ class Interpreter(
   ): Value =
     when (left) {
       is BitVal -> BitVal(f(left.bits, (right as BitVal).bits))
-      is IntVal -> {
-        val result = f(left.bits.toUnsigned(), (right as IntVal).bits.toUnsigned())
-        IntVal(SignedBitVector.fromUnsignedBits(result.value, left.bits.width))
-      }
+      is IntVal -> IntVal(f(left.bits.toUnsigned(), (right as IntVal).bits.toUnsigned()).toSigned())
       else -> error("expected fixed-width integer operands, got: $left, $right")
     }
 

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -393,86 +393,58 @@ class Interpreter(
       }
     }
 
-    // int<N> operands: use signed comparison for relational ops, unsigned bits for arithmetic.
-    if (left is IntVal && right is IntVal) {
-      return when (op.op) {
-        BinaryOperator.ADD ->
-          IntVal(
-            SignedBitVector.fromUnsignedBits(
-              (left.bits.toUnsigned() + right.bits.toUnsigned()).value,
-              left.bits.width,
-            )
-          )
-        BinaryOperator.SUB ->
-          IntVal(
-            SignedBitVector.fromUnsignedBits(
-              (left.bits.toUnsigned() - right.bits.toUnsigned()).value,
-              left.bits.width,
-            )
-          )
-        BinaryOperator.MUL ->
-          IntVal(
-            SignedBitVector.fromUnsignedBits(
-              (left.bits.toUnsigned() * right.bits.toUnsigned()).value,
-              left.bits.width,
-            )
-          )
-        BinaryOperator.EQ -> BoolVal(left.bits.value == right.bits.value)
-        BinaryOperator.NEQ -> BoolVal(left.bits.value != right.bits.value)
-        // P4 spec §8.5: relational operators on int<N> use signed comparison.
-        BinaryOperator.LT -> BoolVal(left.bits.value < right.bits.value)
-        BinaryOperator.GT -> BoolVal(left.bits.value > right.bits.value)
-        BinaryOperator.LE -> BoolVal(left.bits.value <= right.bits.value)
-        BinaryOperator.GE -> BoolVal(left.bits.value >= right.bits.value)
-        BinaryOperator.BIT_AND ->
-          IntVal(
-            SignedBitVector.fromUnsignedBits(
-              (left.bits.toUnsigned() and right.bits.toUnsigned()).value,
-              left.bits.width,
-            )
-          )
-        BinaryOperator.BIT_OR ->
-          IntVal(
-            SignedBitVector.fromUnsignedBits(
-              (left.bits.toUnsigned() or right.bits.toUnsigned()).value,
-              left.bits.width,
-            )
-          )
-        BinaryOperator.BIT_XOR ->
-          IntVal(
-            SignedBitVector.fromUnsignedBits(
-              (left.bits.toUnsigned() xor right.bits.toUnsigned()).value,
-              left.bits.width,
-            )
-          )
-        else -> error("unhandled binary operator on int<N>: ${op.op}")
-      }
-    }
-
     return when (op.op) {
-      BinaryOperator.ADD -> BitVal((left as BitVal).bits + (right as BitVal).bits)
-      BinaryOperator.SUB -> BitVal((left as BitVal).bits - (right as BitVal).bits)
-      BinaryOperator.MUL -> BitVal((left as BitVal).bits * (right as BitVal).bits)
+      // Arithmetic and bitwise ops work on unsigned bits; liftBitwise rewraps as
+      // the original signedness (BitVal or IntVal).
+      BinaryOperator.ADD -> liftBitwise(left, right) { a, b -> a + b }
+      BinaryOperator.SUB -> liftBitwise(left, right) { a, b -> a - b }
+      BinaryOperator.MUL -> liftBitwise(left, right) { a, b -> a * b }
+      BinaryOperator.BIT_AND -> liftBitwise(left, right) { a, b -> a and b }
+      BinaryOperator.BIT_OR -> liftBitwise(left, right) { a, b -> a or b }
+      BinaryOperator.BIT_XOR -> liftBitwise(left, right) { a, b -> a xor b }
+      // bit<N>-only operations (no int<N> equivalent in P4 spec).
       BinaryOperator.DIV -> BitVal((left as BitVal).bits / (right as BitVal).bits)
       BinaryOperator.MOD -> BitVal((left as BitVal).bits % (right as BitVal).bits)
       BinaryOperator.ADD_SAT -> BitVal((left as BitVal).bits.addSat((right as BitVal).bits))
       BinaryOperator.SUB_SAT -> BitVal((left as BitVal).bits.subSat((right as BitVal).bits))
-      BinaryOperator.BIT_AND -> BitVal((left as BitVal).bits and (right as BitVal).bits)
-      BinaryOperator.BIT_OR -> BitVal((left as BitVal).bits or (right as BitVal).bits)
-      BinaryOperator.BIT_XOR -> BitVal((left as BitVal).bits xor (right as BitVal).bits)
-      BinaryOperator.SHL -> BitVal((left as BitVal).bits.shl((right as BitVal).bits.value.toInt()))
-      BinaryOperator.SHR -> BitVal((left as BitVal).bits.shr((right as BitVal).bits.value.toInt()))
+      BinaryOperator.SHL -> BitVal((left as BitVal).bits.shl(intValue(right)))
+      BinaryOperator.SHR -> BitVal((left as BitVal).bits.shr(intValue(right)))
+      // Equality uses data-class structural equality (works for both bit<N> and int<N>).
       BinaryOperator.EQ -> BoolVal(left == right)
       BinaryOperator.NEQ -> BoolVal(left != right)
-      BinaryOperator.LT -> BoolVal((left as BitVal).bits < (right as BitVal).bits)
-      BinaryOperator.GT -> BoolVal((left as BitVal).bits > (right as BitVal).bits)
-      BinaryOperator.LE -> BoolVal((left as BitVal).bits <= (right as BitVal).bits)
-      BinaryOperator.GE -> BoolVal((left as BitVal).bits >= (right as BitVal).bits)
+      // P4 spec §8.5: relational operators use signed comparison for int<N>.
+      BinaryOperator.LT -> liftCompare(left, right) { it < 0 }
+      BinaryOperator.GT -> liftCompare(left, right) { it > 0 }
+      BinaryOperator.LE -> liftCompare(left, right) { it <= 0 }
+      BinaryOperator.GE -> liftCompare(left, right) { it >= 0 }
       BinaryOperator.AND -> BoolVal((left as BoolVal).value && (right as BoolVal).value)
       BinaryOperator.OR -> BoolVal((left as BoolVal).value || (right as BoolVal).value)
       else -> error("unhandled binary operator: ${op.op}")
     }
   }
+
+  /** Apply a [BitVector] operation to two fixed-width values, preserving signedness. */
+  private inline fun liftBitwise(
+    left: Value,
+    right: Value,
+    f: (BitVector, BitVector) -> BitVector,
+  ): Value =
+    when (left) {
+      is BitVal -> BitVal(f(left.bits, (right as BitVal).bits))
+      is IntVal -> {
+        val result = f(left.bits.toUnsigned(), (right as IntVal).bits.toUnsigned())
+        IntVal(SignedBitVector.fromUnsignedBits(result.value, left.bits.width))
+      }
+      else -> error("expected fixed-width integer operands, got: $left, $right")
+    }
+
+  /** Compare two fixed-width values, dispatching to signed or unsigned comparison. */
+  private inline fun liftCompare(left: Value, right: Value, pred: (Int) -> Boolean): BoolVal =
+    when (left) {
+      is BitVal -> BoolVal(pred(left.bits.compareTo((right as BitVal).bits)))
+      is IntVal -> BoolVal(pred(left.bits.value.compareTo((right as IntVal).bits.value)))
+      else -> error("expected fixed-width integer operands for comparison")
+    }
 
   /** Extract a small integer from a [BitVal], [IntVal], or [InfIntVal]. */
   private fun intValue(v: Value): Int =

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -336,13 +336,31 @@ class Interpreter(
       }
       cast.targetType.hasSignedInt() -> {
         val targetWidth = cast.targetType.signedInt.width
-        val sourceBits =
-          when (inner) {
-            is BitVal -> inner.bits.value
-            is InfIntVal -> inner.value
-            else -> error("cannot cast $inner to int<$targetWidth>")
+        when (inner) {
+          // int<N> → int<M>: preserve the signed value (sign-extends or truncates).
+          is IntVal -> {
+            val truncated =
+              SignedBitVector.fromUnsignedBits(
+                inner.bits.value.mod(java.math.BigInteger.TWO.pow(targetWidth)),
+                targetWidth,
+              )
+            // If widening, sign-extend by using the original signed value directly.
+            if (targetWidth >= inner.bits.width) {
+              IntVal(SignedBitVector(inner.bits.value, targetWidth))
+            } else {
+              IntVal(truncated)
+            }
           }
-        IntVal(SignedBitVector.fromUnsignedBits(sourceBits, targetWidth))
+          else -> {
+            val sourceBits =
+              when (inner) {
+                is BitVal -> inner.bits.value
+                is InfIntVal -> inner.value
+                else -> error("cannot cast $inner to int<$targetWidth>")
+              }
+            IntVal(SignedBitVector.fromUnsignedBits(sourceBits, targetWidth))
+          }
+        }
       }
       cast.targetType.boolean -> {
         val v =
@@ -360,6 +378,77 @@ class Interpreter(
   private fun evalBinaryOp(op: fourward.ir.v1.BinaryOp, env: Environment): Value {
     // P4 spec §8.1: compile-time integers adopt the width of the other operand.
     val (left, right) = coerceInfInts(evalExpr(op.left, env), evalExpr(op.right, env))
+
+    // P4 spec §8.5: shift amount is always unsigned, so left may be IntVal while right is BitVal.
+    // SHR on int<N> is arithmetic (sign-extending); SHL is logical.
+    if (left is IntVal && (op.op == BinaryOperator.SHL || op.op == BinaryOperator.SHR)) {
+      val amount = intValue(right)
+      return if (op.op == BinaryOperator.SHL) {
+        val shifted = left.bits.toUnsigned().shl(amount)
+        IntVal(SignedBitVector.fromUnsignedBits(shifted.value, left.bits.width))
+      } else {
+        // Arithmetic right shift: shift the signed value, then re-wrap.
+        val shifted = left.bits.value.shiftRight(amount)
+        IntVal(SignedBitVector(shifted, left.bits.width))
+      }
+    }
+
+    // int<N> operands: use signed comparison for relational ops, unsigned bits for arithmetic.
+    if (left is IntVal && right is IntVal) {
+      return when (op.op) {
+        BinaryOperator.ADD ->
+          IntVal(
+            SignedBitVector.fromUnsignedBits(
+              (left.bits.toUnsigned() + right.bits.toUnsigned()).value,
+              left.bits.width,
+            )
+          )
+        BinaryOperator.SUB ->
+          IntVal(
+            SignedBitVector.fromUnsignedBits(
+              (left.bits.toUnsigned() - right.bits.toUnsigned()).value,
+              left.bits.width,
+            )
+          )
+        BinaryOperator.MUL ->
+          IntVal(
+            SignedBitVector.fromUnsignedBits(
+              (left.bits.toUnsigned() * right.bits.toUnsigned()).value,
+              left.bits.width,
+            )
+          )
+        BinaryOperator.EQ -> BoolVal(left.bits.value == right.bits.value)
+        BinaryOperator.NEQ -> BoolVal(left.bits.value != right.bits.value)
+        // P4 spec §8.5: relational operators on int<N> use signed comparison.
+        BinaryOperator.LT -> BoolVal(left.bits.value < right.bits.value)
+        BinaryOperator.GT -> BoolVal(left.bits.value > right.bits.value)
+        BinaryOperator.LE -> BoolVal(left.bits.value <= right.bits.value)
+        BinaryOperator.GE -> BoolVal(left.bits.value >= right.bits.value)
+        BinaryOperator.BIT_AND ->
+          IntVal(
+            SignedBitVector.fromUnsignedBits(
+              (left.bits.toUnsigned() and right.bits.toUnsigned()).value,
+              left.bits.width,
+            )
+          )
+        BinaryOperator.BIT_OR ->
+          IntVal(
+            SignedBitVector.fromUnsignedBits(
+              (left.bits.toUnsigned() or right.bits.toUnsigned()).value,
+              left.bits.width,
+            )
+          )
+        BinaryOperator.BIT_XOR ->
+          IntVal(
+            SignedBitVector.fromUnsignedBits(
+              (left.bits.toUnsigned() xor right.bits.toUnsigned()).value,
+              left.bits.width,
+            )
+          )
+        else -> error("unhandled binary operator on int<N>: ${op.op}")
+      }
+    }
+
     return when (op.op) {
       BinaryOperator.ADD -> BitVal((left as BitVal).bits + (right as BitVal).bits)
       BinaryOperator.SUB -> BitVal((left as BitVal).bits - (right as BitVal).bits)
@@ -385,10 +474,11 @@ class Interpreter(
     }
   }
 
-  /** Extract a small integer from a [BitVal] or [InfIntVal]. */
+  /** Extract a small integer from a [BitVal], [IntVal], or [InfIntVal]. */
   private fun intValue(v: Value): Int =
     when (v) {
       is BitVal -> v.bits.value.toInt()
+      is IntVal -> v.bits.value.toInt()
       is InfIntVal -> v.value.toInt()
       else -> error("expected integer value: $v")
     }
@@ -398,6 +488,21 @@ class Interpreter(
     when {
       left is InfIntVal && right is BitVal -> left.toBitVal(right.bits.width) to right
       right is InfIntVal && left is BitVal -> left to right.toBitVal((left as BitVal).bits.width)
+      left is InfIntVal && right is IntVal ->
+        IntVal(
+          SignedBitVector.fromUnsignedBits(
+            left.value.mod(java.math.BigInteger.TWO.pow(right.bits.width)),
+            right.bits.width,
+          )
+        ) to right
+      right is InfIntVal && left is IntVal ->
+        left to
+          IntVal(
+            SignedBitVector.fromUnsignedBits(
+              right.value.mod(java.math.BigInteger.TWO.pow(left.bits.width)),
+              left.bits.width,
+            )
+          )
       else -> left to right
     }
 

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -44,21 +44,37 @@ class Simulator {
     val config = req.config
     pipeline = config
 
-    // Use aliases (short names) so they match the originalName-based keys the behavioral IR uses.
+    // The behavioral IR uses its own table/action names (TableBehavior.name,
+    // ActionDecl.name/current_name), which may differ from p4info aliases
+    // (e.g. inlined controls: behavioral "c_t" vs p4info alias "t").
+    // Resolve p4info IDs to behavioral names so the TableStore uses the same
+    // keys as the interpreter.
+    val behavioralTables = config.behavioral.tablesList.map { it.name }
+    val behavioralActions =
+      (config.behavioral.actionsList +
+          config.behavioral.controlsList.flatMap { it.localActionsList })
+        .flatMap { action -> listOfNotNull(action.name, action.currentName.ifEmpty { null }) }
+
+    fun resolveName(alias: String, candidates: List<String>): String =
+      candidates.find { it == alias } ?: candidates.find { it.endsWith("_$alias") } ?: alias
+
     val tableNameById =
-      config.p4Info.tablesList.associate {
-        it.preamble.id to it.preamble.alias.ifEmpty { it.preamble.name }
+      config.p4Info.tablesList.associate { table ->
+        val alias = table.preamble.alias.ifEmpty { table.preamble.name }
+        table.preamble.id to resolveName(alias, behavioralTables)
       }
     val actionNameById =
-      config.p4Info.actionsList.associate {
-        it.preamble.id to it.preamble.alias.ifEmpty { it.preamble.name }
+      config.p4Info.actionsList.associate { action ->
+        val alias = action.preamble.alias.ifEmpty { action.preamble.name }
+        action.preamble.id to resolveName(alias, behavioralActions)
       }
     tableStore.loadMappings(tableNameById, actionNameById)
 
     for (table in config.p4Info.tablesList) {
       if (table.constDefaultActionId != 0) {
+        val tableName = tableNameById[table.preamble.id] ?: continue
         val actionName = actionNameById[table.constDefaultActionId] ?: "NoAction"
-        tableStore.setDefaultAction(table.preamble.name, actionName)
+        tableStore.setDefaultAction(tableName, actionName)
       }
     }
 


### PR DESCRIPTION
## Summary

Three bugs fixed, then refactored for clarity:

1. **Default action table name mismatch**: the simulator registered default
   actions under p4info aliases (e.g. `"t"`) but the interpreter looks up
   tables by behavioral IR names (e.g. `"c_t"` for inlined controls). Now
   resolves p4info IDs to behavioral names using a suffix-matching lookup.

2. **int\<N\> binary operations**: `evalBinaryOp` assumed all operands were
   `BitVal`, crashing on `IntVal` (signed integers). Added signed comparison,
   arithmetic, shift, and bitwise support for `int<N>` types. `SHR` on
   `int<N>` is arithmetic (sign-extending) per P4 spec §8.5.

3. **int\<N\> casts**: casting between signed integer widths now sign-extends
   (widening) or truncates (narrowing) correctly.

4. **Refactor `evalBinaryOp`**: extracted `liftBitwise` and `liftCompare`
   inline helpers to unify the duplicated IntVal/BitVal paths. Net −32 lines.

### Promoted tests (132 → 139)

`arith-bmv2`, `arith-inline-bmv2`, `arith1-bmv2`, `arith2-bmv2`,
`arith3-bmv2`, `arith4-bmv2`, `arith5-bmv2`

## Test plan

- [x] `bazel test //...` — all 23 tests pass, no regressions
- [x] `./format.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)