### PR TITLE
STATUS.md: note that the log is append-only

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,7 @@
 # 4ward — Status
 
 > Append-only log. Add new entries at the bottom; do not edit past entries.
+> See [ROADMAP.md](ROADMAP.md) for the big picture.
 
 ## 2026-03-03
 


### PR DESCRIPTION
## Summary

Documentation housekeeping based on a holistic review of all project docs.

- **STATUS.md**: Add blockquote noting it's an append-only log, with cross-reference to ROADMAP.md.
- **REFACTORING.md**: Move `docs/refactoring.md` to root (eliminates one-file directory, matches naming convention). Absorb three items from ROADMAP.md that were only listed there (CI hygiene, buf lint, upstream backend).
- **LIMITATIONS.md**: New living document for tracking intentional shortcuts and known gaps. Agents note trade-offs here so they don't get lost. Cross-referenced from AGENTS.md.
- **ROADMAP.md**: Deduplicate Track 2 — replace inline bullet list with pointer to REFACTORING.md.
- **CONTRIBUTING.md**: Fix placeholder clone URL (`yourorg` → `smolkaj`).
- **README.md**: Replace stale status checklist with links to ROADMAP.md and STATUS.md. Add documentation index table listing all project docs. Note pre-1.0 status and willingness to aggressively refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)