### PR TITLE
Populate LIMITATIONS.md, add pre-PR doc checklist to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,17 @@ expression inside `Simulator.handleLoadPipeline()`.
 Proto changes affect both the p4c backend (C++) and the simulator (Kotlin).
 Update both sides and make sure the relevant STF tests still pass.
 
+## Before submitting a PR
+
+Consider whether your change affects any documentation:
+
+- **[LIMITATIONS.md](LIMITATIONS.md)** — did you add a shortcut, discover a
+  gap, or resolve an existing limitation?
+- **[REFACTORING.md](REFACTORING.md)** — did you notice tech debt worth
+  tracking, or complete an item already listed?
+- **[ROADMAP.md](ROADMAP.md)** — does your change move a track forward or
+  change priorities?
+
 ## Worktrees
 
 **Always work in a dedicated git worktree. Never make changes directly in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,8 +127,6 @@ Consider whether your change affects any documentation:
   gap, or resolve an existing limitation?
 - **[REFACTORING.md](REFACTORING.md)** — did you notice tech debt worth
   tracking, or complete an item already listed?
-- **[ROADMAP.md](ROADMAP.md)** — does your change move a track forward or
-  change priorities?
 
 ## Worktrees
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -9,3 +9,56 @@ lost in commit messages or forgotten entirely.
 
 Agents: when you take a shortcut or skip a corner case, add it here. No
 guilt — just write it down so someone can find it later.
+
+## Architecture support
+
+- **v1model only.** PSA, PNA, and TNA are not implemented. The architecture
+  interface (`Architecture.kt`) is designed for pluggability, but only
+  `V1ModelArchitecture.kt` exists today. 25 corpus tests are blocked on PSA.
+
+## Externs
+
+- **`mark_to_drop` is the only extern function.** All other v1model externs
+  — `hash`, `verify_checksum`, `update_checksum`, `verify`, `random`,
+  `digest`, `log_msg` — are unimplemented and will crash with
+  `"unhandled extern call"`. Blocks ~6 corpus tests (verify/checksum).
+- **No register, counter, or meter support.** Extern object methods
+  (`register.read`/`.write`, `counter.count`, etc.) are not implemented.
+  Blocks ~3 corpus tests.
+
+## Simulator
+
+- **No const table entries.** Tables with `const entries` in P4 source are
+  not populated at pipeline load time. The IR carries the entries, but
+  `Simulator.handleLoadPipeline()` ignores them. Blocks ~8 corpus tests.
+- **`ReadEntries` is a stub.** The `ReadEntriesRequest` handler returns an
+  empty response (`Simulator.kt:143`).
+- **No clone, resubmit, or recirculate.** `V1ModelArchitecture` defines the
+  stage pipeline but does not implement packet cloning, resubmission, or
+  recirculation. Packets are processed in a single ingress→egress pass.
+- **No multicast.** Multicast group replication is not implemented.
+
+## Header types
+
+- **Header union gaps.** Basic union support landed, but one-valid-at-a-time
+  semantics (P4 spec §8.20) are not fully enforced. Header stacks of unions
+  are not supported. Blocks ~10 corpus tests.
+- **Header stack `push_front`/`pop_front` not implemented.** Array indexing
+  and field access work, but the stack manipulation primitives do not.
+  Blocks ~1 corpus test.
+
+## p4c backend
+
+- **No `lookahead` or `advance`.** The backend does not emit IR for parser
+  `lookahead<T>()` or `packet.advance()`. This is a backend limitation, not
+  a simulator one. Blocks 6 corpus tests.
+- **Integer literals without explicit bit type** are not always handled
+  correctly. Blocks ~2 corpus tests.
+
+## Testing
+
+- **STF parser edge cases.** Some STF syntax variants (large hex literals,
+  unusual formatting) cause `NumberFormatException`. Blocks ~2 corpus tests.
+- **Payload mismatches.** ~5 corpus tests produce correct control flow but
+  emit packets with wrong payload bytes. Root causes vary and are not yet
+  triaged individually.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -28,9 +28,6 @@ guilt — just write it down so someone can find it later.
 
 ## Simulator
 
-- **No const table entries.** Tables with `const entries` in P4 source are
-  not populated at pipeline load time. The IR carries the entries, but
-  `Simulator.handleLoadPipeline()` ignores them. Blocks ~8 corpus tests.
 - **`ReadEntries` is a stub.** The `ReadEntriesRequest` handler returns an
   empty response (`Simulator.kt:143`).
 - **No clone, resubmit, or recirculate.** `V1ModelArchitecture` defines the


### PR DESCRIPTION
## Summary

- **LIMITATIONS.md**: Populate with known gaps — missing externs, v1model-only
  architecture, header union issues, backend limitations, testing edge cases.
  Organized by component so agents (and humans) can see at a glance what's
  known-missing.
- **AGENTS.md**: Add "Before submitting a PR" section prompting agents to
  consider updating LIMITATIONS.md and REFACTORING.md as part of their
  workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)