### PR TITLE
trace trees: TraceTree proto + golden test harness + 7 failing tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,12 @@ Find the relevant failing test, implement the missing feature in `simulator/`,
 and confirm no other tests regress: `bazel test //...`.
 
 If you take a shortcut or skip a corner case to make progress, note it in
-[LIMITATIONS.md](LIMITATIONS.md) so it doesn't get forgotten.
+[LIMITATIONS.md](LIMITATIONS.md) so it doesn't get forgotten, and leave a
+`TODO(<scope>)` comment at the site — e.g. `TODO(PR 3): update names to match
+actual simulator output`. The scope should identify the task, PR, or issue that
+will resolve it. This applies to any code that is intentionally incomplete:
+shortcuts, known limitations, placeholder/approximate data, stub
+implementations.
 
 ## P4 language notes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,33 +137,23 @@ We also have:
 - **BMv2 diff testing** (maybe, someday): run the same inputs through BMv2 and
   4ward and compare outputs.
 
-## Trace trees (future)
+## Trace trees
 
-Today, 4ward returns a single execution trace per packet — a linear sequence of
-events. But P4 programs can have non-deterministic choice points, most notably
-**action selectors** where the selected group member depends on a hash that is
-opaque to the programmer. Other sources include action profiles, packet
-replication (clone, multicast), and random externs.
+4ward's output format is a **trace tree** (`TraceTree` in `simulator.proto`) —
+a recursive structure where each node contains a sequence of events and an
+optional fork. At non-deterministic choice points (action selectors, clone,
+multicast), execution forks into branches, one per possible outcome. A program
+with no non-determinism produces a zero-fork tree that is structurally
+equivalent to a flat trace — there is no separate "flat trace" format.
 
-The key insight: even when these choices are technically deterministic (governed
-by a hash algorithm or controller configuration), it's often more useful to
-reason about them as non-deterministic — "what *could* happen to my packet?"
-rather than "what happens with this specific hash seed?"
+The key insight: even when choices like action selector hashing are technically
+deterministic, it's often more useful to reason about them as
+non-deterministic — "what *could* happen to my packet?" rather than "what
+happens with this specific hash seed?"
 
-4ward will support a mode where, instead of picking one path, the simulator
-forks at every non-deterministic choice point and returns a **trace tree**: a
-tree of events where each fork node is labeled with the choice being made, and
-the subtrees represent the possible continuations. Since execution paths share
-a common prefix (parsing and early pipeline stages are typically deterministic),
-the tree is much more compact than a flat list of traces.
-
-**Control mechanisms:**
-
-- A simulator flag (e.g. `--nondeterministic-selectors`) to treat all action
-  selectors as non-deterministic — fork at every selector instead of evaluating
-  the hash.
-- P4 annotations for fine-grained control: mark specific selectors as
-  non-deterministic (or deterministic) regardless of the global flag.
+**Status:** The `TraceTree` proto schema is defined and the simulator produces
+zero-fork trees. Forking (action selectors, clone, multicast) is under active
+development — see [ROADMAP.md](ROADMAP.md) Track 3.
 
 **Why this matters:**
 

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -128,6 +128,28 @@ Blocked on buf support for proto edition 2024.
 
 ---
 
+## Trace tree golden files: approximate → exact
+
+**Files**: `e2e_tests/trace_tree/*.golden.txtpb`
+
+**Problem**: The golden trace tree files written in PR 1 are approximations —
+they don't match actual simulator output. Specific issues:
+
+- **Name mismatches**: golden files use qualified names
+  (`MyIngress.routing`) but the simulator uses p4info aliases (`routing`).
+- **Missing `matched_entry`**: the `table_lookup` event includes the full
+  `TableEntry` proto on hit, omitted in the golden files.
+- **Empty clone/multicast subtrees**: fork branches for clone and multicast
+  have no events, making the assertion structurally weak.
+- **Placeholder selector labels and params**: action selector member names
+  and parameter values are guesses.
+
+**Fix**: As each feature is implemented (PRs 2–4), capture the actual
+simulator output and update the corresponding golden files to match exactly.
+Mark each golden file done by removing its TODO comment.
+
+---
+
 ## Upstream p4c backend
 
 Land the 4ward backend in the p4c repository. Blocked on upstream review.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,17 +111,17 @@ action selectors are orthogonal to the remaining v1model gaps — no need to
 wait.
 
 Work breakdown:
-1. **Testing harness**: golden tests that snapshot trace tree output (proto
-   text or JSON) for small P4 programs with action selectors. The golden file
-   is the spec.
-2. **Design**: proto schema for tree-structured traces, forking semantics,
-   output format.
-3. **Implement**: interpreter changes to fork execution, trace tree
-   construction, flag and annotation support.
-4. **Polish**: trace tree visualization, diffing tools, documentation.
+1. **Proto + golden tests**: `TraceTree` schema, golden test harness, 7
+   failing tests covering all fork types.
+2. **Zero-fork tree**: simulator produces `TraceTree` instead of flat `Trace`.
+   Existing tests pass unchanged; `no_fork` golden test passes.
+3. **Action selector forking**: IR support, deep copy, `TraceTreeBuilder`,
+   interpreter forks at selector tables. 3 golden tests pass.
+4. **Clone + multicast forking**: fork at clone/multicast points. 3 golden
+   tests pass.
 
-**Done when:** `--nondeterministic-selectors` produces correct trace trees for
-programs with action selectors and action profiles.
+**Done when:** all 7 golden trace tree tests pass and all existing corpus tests
+still pass.
 
 ### Track 4: P4Runtime server
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -188,3 +188,22 @@ Next highest-impact items:
    enforcement; issue561-4–7 need `HeaderStackVal` to accept union elements
 3. **verify/verify_checksum externs** (6 tests) — implement the extern calls
 4. **Register read/write + counter** (3 tests) — implement extern methods
+
+## 2026-03-04 (evening)
+
+**Track 3 kickoff: trace tree proto + golden tests** (PR #101).
+
+### What landed
+
+- **`TraceTree` proto schema** — replaced flat `Trace` with recursive
+  `TraceTree` (events + optional `ForkNode`). `ForkReason` enum covers action
+  selectors, clone, and multicast. Zero-fork tree is structurally equivalent to
+  the old flat trace, so all 142 existing tests pass unchanged.
+- **7 golden trace tree tests** — TDD-style: all written up front, all expected
+  to fail. Tagged `manual` so they don't break CI. Cover: zero-fork, 3
+  selector variants, clone, clone+selector, multicast.
+- **`SimulatorClient`** — extracted shared simulator subprocess protocol from
+  `StfRunner` so both STF tests and golden tests use the same wire protocol
+  client.
+- **TODO convention** — added to `AGENTS.md`: leave `TODO(<scope>)` comments on
+  any intentionally incomplete code (shortcuts, placeholders, limitations).

--- a/coverage.sh
+++ b/coverage.sh
@@ -318,10 +318,11 @@ if [[ -n "${DIFF_FILE}" ]]; then
   # Strip git's a/ b/ prefixes so paths match LCOV SF: lines.
   STRIPPED_DIFF="${COVERAGE_WORKDIR}/stripped.diff"
   sed 's|^--- a/|--- |; s|^+++ b/|+++ |' "${DIFF_FILE}" > "${STRIPPED_DIFF}"
-  # genhtml resolves diff paths to absolute but keeps LCOV SF: paths relative;
-  # suppress the resulting path-mismatch error (diff coverage numbers are
-  # computed separately by diff-coverage.sh and are unaffected).
-  GENHTML_ARGS+=(--diff-file "${STRIPPED_DIFF}" --ignore-errors path)
+  # genhtml resolves diff paths to absolute but keeps LCOV SF: paths relative
+  # (path), and line-number shifts between baseline and current cause unmapped
+  # TLA categories (unmapped). Suppress both — diff coverage numbers are
+  # computed separately by diff-coverage.sh and are unaffected.
+  GENHTML_ARGS+=(--diff-file "${STRIPPED_DIFF}" --ignore-errors path,unmapped)
 fi
 
 if command -v genhtml >/dev/null 2>&1; then

--- a/e2e_tests/stf/BUILD.bazel
+++ b/e2e_tests/stf/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
 kt_jvm_library(
     name = "stf_runner",
-    srcs = ["Runner.kt"],
+    srcs = [
+        "Runner.kt",
+        "SimulatorClient.kt",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//simulator:ir_java_proto",

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -63,7 +63,7 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
 
       // Install table entries.
       for (directive in stf.tableEntries) {
-        val writeReq = resolveTableEntry(directive, config.p4Info)
+        val writeReq = resolveStfTableEntry(directive, config.p4Info)
         sendRequest(output, SimRequest.newBuilder().setWriteEntry(writeReq).build())
         val writeResp = readResponse(input)
         if (writeResp.hasError()) {
@@ -121,114 +121,6 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
     } finally {
       process.destroy()
     }
-  }
-
-  private fun resolveTableEntry(
-    directive: StfTableDirective,
-    p4info: P4InfoOuterClass.P4Info,
-  ): WriteEntryRequest {
-    val table =
-      p4info.tablesList.find {
-        it.preamble.alias == directive.tableName || it.preamble.name == directive.tableName
-      }
-        // BMv2 STF files may use partially-qualified names like "c.t" for
-        // "ingress.c.t". Fall back to suffix matching.
-        ?: p4info.tablesList.find { it.preamble.name.endsWith(".${directive.tableName}") }
-        ?: error("unknown table: ${directive.tableName}")
-
-    val action =
-      p4info.actionsList.find {
-        it.preamble.alias == directive.actionName || it.preamble.name == directive.actionName
-      }
-        ?: p4info.actionsList.find { it.preamble.name.endsWith(".${directive.actionName}") }
-        ?: error("unknown action: ${directive.actionName}")
-
-    val paramsList =
-      action.paramsList.mapIndexed { i, paramInfo ->
-        // Named params (e.g. "val:0x7f") are resolved by name; unnamed by position.
-        val raw =
-          directive.actionParams.find { it.extractParamName() == paramInfo.name }
-            ?: directive.actionParams.getOrNull(i)
-            ?: error("missing param ${paramInfo.name} for action ${directive.actionName}")
-        P4RuntimeOuterClass.Action.Param.newBuilder()
-          .setParamId(paramInfo.id)
-          .setValue(encodeValue(raw.stripNamedParamPrefix(), paramInfo.bitwidth))
-          .build()
-      }
-
-    val tableEntry =
-      P4RuntimeOuterClass.TableEntry.newBuilder()
-        .setTableId(table.preamble.id)
-        .setAction(
-          P4RuntimeOuterClass.TableAction.newBuilder()
-            .setAction(
-              P4RuntimeOuterClass.Action.newBuilder()
-                .setActionId(action.preamble.id)
-                .addAllParams(paramsList)
-            )
-        )
-
-    val updateType =
-      when (directive) {
-        is StfAddEntry -> {
-          tableEntry.addAllMatch(
-            directive.matches.map { m -> resolveMatchField(m, table, directive.tableName) }
-          )
-          if (directive.priority != null) tableEntry.setPriority(directive.priority)
-          P4RuntimeOuterClass.Update.Type.INSERT
-        }
-        is StfSetDefault -> {
-          tableEntry.setIsDefaultAction(true)
-          P4RuntimeOuterClass.Update.Type.MODIFY
-        }
-      }
-
-    return WriteEntryRequest.newBuilder()
-      .setUpdate(
-        P4RuntimeOuterClass.Update.newBuilder()
-          .setType(updateType)
-          .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(tableEntry))
-      )
-      .build()
-  }
-
-  private fun resolveMatchField(
-    m: StfMatchField,
-    table: P4InfoOuterClass.Table,
-    tableName: String,
-  ): P4RuntimeOuterClass.FieldMatch {
-    // BMv2 STF files strip the outermost struct prefix from field names
-    // (e.g. p4info "hdrs.data.f1" → STF "data.f1") and use $N for array
-    // indices (p4info "extra[0].h" → STF "extra$0.h").
-    val stfNorm = m.fieldName.replace(ARRAY_INDEX_REGEX, "[$1]")
-    val mf =
-      table.matchFieldsList.find { it.name == m.fieldName || it.name == stfNorm }
-        ?: table.matchFieldsList.find {
-          val suffix = it.name.substringAfter(".")
-          suffix == m.fieldName || suffix == stfNorm
-        }
-        ?: error("unknown match field '${m.fieldName}' in table '$tableName'")
-    val fmBuilder = P4RuntimeOuterClass.FieldMatch.newBuilder().setFieldId(mf.id)
-    when (m.kind) {
-      MatchKind.EXACT ->
-        fmBuilder.setExact(
-          P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
-            .setValue(encodeValue(m.value, mf.bitwidth))
-        )
-      MatchKind.LPM ->
-        fmBuilder.setLpm(
-          P4RuntimeOuterClass.FieldMatch.LPM.newBuilder()
-            .setValue(encodeValue(m.value, mf.bitwidth))
-            .setPrefixLen(m.prefixLen!!)
-        )
-      MatchKind.TERNARY ->
-        fmBuilder.setTernary(
-          P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
-            .setValue(encodeValue(m.value, mf.bitwidth))
-            .setMask(encodeValue(m.mask!!, mf.bitwidth))
-        )
-    }
-    return fmBuilder.build()
   }
 
   private fun sendRequest(output: DataOutputStream, request: SimRequest) {
@@ -422,6 +314,119 @@ data class StfFile(
       return name to params
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Table entry resolution
+// ---------------------------------------------------------------------------
+
+/** Resolves an STF table directive against the p4info to produce a [WriteEntryRequest]. */
+fun resolveStfTableEntry(
+  directive: StfTableDirective,
+  p4info: P4InfoOuterClass.P4Info,
+): WriteEntryRequest {
+  val table =
+    p4info.tablesList.find {
+      it.preamble.alias == directive.tableName || it.preamble.name == directive.tableName
+    }
+      // BMv2 STF files may use partially-qualified names like "c.t" for
+      // "ingress.c.t". Fall back to suffix matching.
+      ?: p4info.tablesList.find { it.preamble.name.endsWith(".${directive.tableName}") }
+      ?: error("unknown table: ${directive.tableName}")
+
+  val action =
+    p4info.actionsList.find {
+      it.preamble.alias == directive.actionName || it.preamble.name == directive.actionName
+    }
+      ?: p4info.actionsList.find { it.preamble.name.endsWith(".${directive.actionName}") }
+      ?: error("unknown action: ${directive.actionName}")
+
+  val paramsList =
+    action.paramsList.mapIndexed { i, paramInfo ->
+      // Named params (e.g. "val:0x7f") are resolved by name; unnamed by position.
+      val raw =
+        directive.actionParams.find { it.extractParamName() == paramInfo.name }
+          ?: directive.actionParams.getOrNull(i)
+          ?: error("missing param ${paramInfo.name} for action ${directive.actionName}")
+      P4RuntimeOuterClass.Action.Param.newBuilder()
+        .setParamId(paramInfo.id)
+        .setValue(encodeValue(raw.stripNamedParamPrefix(), paramInfo.bitwidth))
+        .build()
+    }
+
+  val tableEntry =
+    P4RuntimeOuterClass.TableEntry.newBuilder()
+      .setTableId(table.preamble.id)
+      .setAction(
+        P4RuntimeOuterClass.TableAction.newBuilder()
+          .setAction(
+            P4RuntimeOuterClass.Action.newBuilder()
+              .setActionId(action.preamble.id)
+              .addAllParams(paramsList)
+          )
+      )
+
+  val updateType =
+    when (directive) {
+      is StfAddEntry -> {
+        tableEntry.addAllMatch(
+          directive.matches.map { m -> resolveStfMatchField(m, table, directive.tableName) }
+        )
+        if (directive.priority != null) tableEntry.setPriority(directive.priority)
+        P4RuntimeOuterClass.Update.Type.INSERT
+      }
+      is StfSetDefault -> {
+        tableEntry.setIsDefaultAction(true)
+        P4RuntimeOuterClass.Update.Type.MODIFY
+      }
+    }
+
+  return WriteEntryRequest.newBuilder()
+    .setUpdate(
+      P4RuntimeOuterClass.Update.newBuilder()
+        .setType(updateType)
+        .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(tableEntry))
+    )
+    .build()
+}
+
+private fun resolveStfMatchField(
+  m: StfMatchField,
+  table: P4InfoOuterClass.Table,
+  tableName: String,
+): P4RuntimeOuterClass.FieldMatch {
+  // BMv2 STF files strip the outermost struct prefix from field names
+  // (e.g. p4info "hdrs.data.f1" → STF "data.f1") and use $N for array
+  // indices (p4info "extra[0].h" → STF "extra$0.h").
+  val stfNorm = m.fieldName.replace(ARRAY_INDEX_REGEX, "[$1]")
+  val mf =
+    table.matchFieldsList.find { it.name == m.fieldName || it.name == stfNorm }
+      ?: table.matchFieldsList.find {
+        val suffix = it.name.substringAfter(".")
+        suffix == m.fieldName || suffix == stfNorm
+      }
+      ?: error("unknown match field '${m.fieldName}' in table '$tableName'")
+  val fmBuilder = P4RuntimeOuterClass.FieldMatch.newBuilder().setFieldId(mf.id)
+  when (m.kind) {
+    MatchKind.EXACT ->
+      fmBuilder.setExact(
+        P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+          .setValue(encodeValue(m.value, mf.bitwidth))
+      )
+    MatchKind.LPM ->
+      fmBuilder.setLpm(
+        P4RuntimeOuterClass.FieldMatch.LPM.newBuilder()
+          .setValue(encodeValue(m.value, mf.bitwidth))
+          .setPrefixLen(m.prefixLen!!)
+      )
+    MatchKind.TERNARY ->
+      fmBuilder.setTernary(
+        P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
+          .setValue(encodeValue(m.value, mf.bitwidth))
+          .setMask(encodeValue(m.mask!!, mf.bitwidth))
+      )
+  }
+  return fmBuilder.build()
 }
 
 // ---------------------------------------------------------------------------

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -2,13 +2,7 @@ package fourward.e2e
 
 import com.google.protobuf.ByteString
 import fourward.ir.v1.PipelineConfig
-import fourward.sim.v1.LoadPipelineRequest
-import fourward.sim.v1.ProcessPacketRequest
-import fourward.sim.v1.SimRequest
-import fourward.sim.v1.SimResponse
 import fourward.sim.v1.WriteEntryRequest
-import java.io.DataInputStream
-import java.io.DataOutputStream
 import java.math.BigInteger
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -33,9 +27,13 @@ private val ARRAY_INDEX_REGEX = Regex("\\$(\\d+)")
  * 5. Reports pass/fail.
  */
 class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPath: Path) {
-  // The run function is a single sequential protocol: load pipeline → install entries →
-  // send packets → compare. Splitting it would require passing mutable state between
-  // helper functions, making the protocol harder to follow.
+
+  /**
+   * Runs an STF test: loads the pipeline, installs entries, sends packets, and compares output.
+   *
+   * Cross-port ordering is ignored; within the same port, outputs are matched FIFO (first output on
+   * that port satisfies the first expect for that port). This matches BMv2's STF semantics.
+   */
   @Suppress("NestedBlockDepth")
   fun run(stfPath: Path): TestResult {
     val stf = StfFile.parse(stfPath)
@@ -43,54 +41,25 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
     com.google.protobuf.TextFormat.merge(pipelineConfigPath.toFile().readText(), builder)
     val config = builder.build()
 
-    val process = ProcessBuilder(simulatorBinary.toString()).redirectErrorStream(false).start()
-
-    val input = DataInputStream(process.inputStream.buffered())
-    val output = DataOutputStream(process.outputStream.buffered())
-
-    try {
-      // Load the pipeline.
-      sendRequest(
-        output,
-        SimRequest.newBuilder()
-          .setLoadPipeline(LoadPipelineRequest.newBuilder().setConfig(config))
-          .build(),
-      )
-      val loadResp = readResponse(input)
+    SimulatorClient(simulatorBinary).use { sim ->
+      val loadResp = sim.loadPipeline(config)
       if (loadResp.hasError()) {
         return TestResult.Failure("LoadPipeline failed: ${loadResp.error.message}")
       }
 
-      // Install table entries.
       for (directive in stf.tableEntries) {
-        val writeReq = resolveStfTableEntry(directive, config.p4Info)
-        sendRequest(output, SimRequest.newBuilder().setWriteEntry(writeReq).build())
-        val writeResp = readResponse(input)
+        val writeResp = sim.writeEntry(resolveStfTableEntry(directive, config.p4Info))
         if (writeResp.hasError()) {
           return TestResult.Failure("WriteEntry failed: ${writeResp.error.message}")
         }
       }
 
-      // Send all packets and collect outputs, then match expects by port.
-      // Cross-port ordering is ignored; within the same port, outputs are
-      // matched FIFO (first output on that port satisfies the first expect
-      // for that port). This matches BMv2's STF semantics.
       val failures = mutableListOf<String>()
       data class Output(val port: Int, val payload: ByteArray)
       val outputQueue = mutableListOf<Output>()
 
       for (packet in stf.packets) {
-        sendRequest(
-          output,
-          SimRequest.newBuilder()
-            .setProcessPacket(
-              ProcessPacketRequest.newBuilder()
-                .setIngressPort(packet.ingressPort)
-                .setPayload(com.google.protobuf.ByteString.copyFrom(packet.payload))
-            )
-            .build(),
-        )
-        val resp = readResponse(input)
+        val resp = sim.processPacket(packet.ingressPort, packet.payload)
         if (resp.hasError()) {
           failures += "ProcessPacket failed: ${resp.error.message}"
           continue
@@ -100,7 +69,6 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
         }
       }
 
-      // Match expects against the output queue in order.
       for (expected in stf.expects) {
         val idx = outputQueue.indexOfFirst { it.port == expected.port }
         if (idx < 0) {
@@ -118,23 +86,7 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
 
       return if (failures.isEmpty()) TestResult.Pass
       else TestResult.Failure(failures.joinToString("\n"))
-    } finally {
-      process.destroy()
     }
-  }
-
-  private fun sendRequest(output: DataOutputStream, request: SimRequest) {
-    val bytes = request.toByteArray()
-    output.writeInt(bytes.size)
-    output.write(bytes)
-    output.flush()
-  }
-
-  private fun readResponse(input: DataInputStream): SimResponse {
-    val length = input.readInt()
-    val bytes = ByteArray(length)
-    input.readFully(bytes)
-    return SimResponse.parseFrom(bytes)
   }
 }
 

--- a/e2e_tests/stf/SimulatorClient.kt
+++ b/e2e_tests/stf/SimulatorClient.kt
@@ -1,0 +1,66 @@
+package fourward.e2e
+
+import fourward.ir.v1.PipelineConfig
+import fourward.sim.v1.LoadPipelineRequest
+import fourward.sim.v1.ProcessPacketRequest
+import fourward.sim.v1.SimRequest
+import fourward.sim.v1.SimResponse
+import fourward.sim.v1.WriteEntryRequest
+import java.io.Closeable
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.nio.file.Path
+
+/**
+ * Client for the 4ward simulator subprocess protocol.
+ *
+ * Manages the simulator process lifecycle and provides typed methods for each request kind.
+ * Implements [Closeable] so it can be used in `use {}` blocks.
+ *
+ * The wire protocol is length-delimited protobuf over stdin/stdout: a 4-byte big-endian length
+ * prefix followed by a serialized [SimRequest] or [SimResponse].
+ */
+class SimulatorClient(simulatorBinary: Path) : Closeable {
+
+  private val process: Process =
+    ProcessBuilder(simulatorBinary.toString()).redirectErrorStream(false).start()
+
+  private val input = DataInputStream(process.inputStream.buffered())
+  private val output = DataOutputStream(process.outputStream.buffered())
+
+  fun loadPipeline(config: PipelineConfig): SimResponse =
+    call(
+      SimRequest.newBuilder()
+        .setLoadPipeline(LoadPipelineRequest.newBuilder().setConfig(config))
+        .build()
+    )
+
+  fun writeEntry(writeReq: WriteEntryRequest): SimResponse =
+    call(SimRequest.newBuilder().setWriteEntry(writeReq).build())
+
+  fun processPacket(ingressPort: Int, payload: ByteArray): SimResponse =
+    call(
+      SimRequest.newBuilder()
+        .setProcessPacket(
+          ProcessPacketRequest.newBuilder()
+            .setIngressPort(ingressPort)
+            .setPayload(com.google.protobuf.ByteString.copyFrom(payload))
+        )
+        .build()
+    )
+
+  private fun call(request: SimRequest): SimResponse {
+    val bytes = request.toByteArray()
+    output.writeInt(bytes.size)
+    output.write(bytes)
+    output.flush()
+    val length = input.readInt()
+    val respBytes = ByteArray(length)
+    input.readFully(respBytes)
+    return SimResponse.parseFrom(respBytes)
+  }
+
+  override fun close() {
+    process.destroy()
+  }
+}

--- a/e2e_tests/stf/SimulatorClient.kt
+++ b/e2e_tests/stf/SimulatorClient.kt
@@ -23,7 +23,9 @@ import java.nio.file.Path
 class SimulatorClient(simulatorBinary: Path) : Closeable {
 
   private val process: Process =
-    ProcessBuilder(simulatorBinary.toString()).redirectErrorStream(false).start()
+    ProcessBuilder(simulatorBinary.toString())
+      .redirectError(ProcessBuilder.Redirect.INHERIT)
+      .start()
 
   private val input = DataInputStream(process.inputStream.buffered())
   private val output = DataOutputStream(process.outputStream.buffered())
@@ -61,6 +63,8 @@ class SimulatorClient(simulatorBinary: Path) : Closeable {
   }
 
   override fun close() {
+    output.close()
     process.destroy()
+    input.close()
   }
 }

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+# =============================================================================
+# Trace tree golden tests (Track 3)
+#
+# Each test compiles a P4 program, sends a packet, and compares the resulting
+# TraceTree against a golden .txtpb file.  All tests are expected to fail
+# until the corresponding feature is implemented.  They are tagged "manual"
+# so they don't break CI.
+# =============================================================================
+
+_P4_PROGRAMS = [
+    "no_fork",
+    "action_selector_3",
+    "action_selector_miss",
+    "action_selector_nested",
+    "clone_ingress_egress",
+    "clone_plus_selector",
+    "multicast",
+]
+
+[genrule(
+    name = "%s_pb" % name,
+    srcs = ["%s.p4" % name],
+    outs = ["%s.txtpb" % name],
+    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
+    tools = [
+        "//p4c_backend:p4c-4ward",
+        "@p4c//:core_p4",
+        "@p4c//:p4include",
+    ],
+) for name in _P4_PROGRAMS]
+
+kt_jvm_test(
+    name = "golden_trace_tree_test",
+    srcs = ["GoldenTraceTreeTest.kt"],
+    data = ["%s.stf" % n for n in _P4_PROGRAMS] +
+           ["%s.golden.txtpb" % n for n in _P4_PROGRAMS] +
+           [":%s_pb" % n for n in _P4_PROGRAMS] +
+           ["//simulator"],
+    tags = ["manual"],
+    test_class = "fourward.e2e.tracetree.GoldenTraceTreeTest",
+    deps = [
+        "//e2e_tests/stf:stf_runner",
+        "//simulator:ir_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_java_proto",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:junit_junit",
+    ],
+)

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -36,8 +36,9 @@ kt_jvm_test(
     srcs = ["GoldenTraceTreeTest.kt"],
     data = ["%s.stf" % n for n in _P4_PROGRAMS] +
            ["%s.golden.txtpb" % n for n in _P4_PROGRAMS] +
-           [":%s_pb" % n for n in _P4_PROGRAMS] +
-           ["//simulator"],
+           [":%s_pb" % n for n in _P4_PROGRAMS] + [
+        "//simulator",
+    ],
     tags = ["manual"],
     test_class = "fourward.e2e.tracetree.GoldenTraceTreeTest",
     deps = [

--- a/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
+++ b/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
@@ -8,7 +8,6 @@ import fourward.ir.v1.PipelineConfig
 import fourward.sim.v1.TraceTree
 import java.nio.file.Path
 import java.nio.file.Paths
-import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -54,13 +53,13 @@ class GoldenTraceTreeTest(private val testName: String) {
 
     val expected = loadGoldenTraceTree(goldenPath)
     val actual = captureTraceTree(r, configPath, stfPath)
-    assertEquals(
-      "Trace tree mismatch for $testName.\n" +
-        "Expected:\n${TextFormat.printer().printToString(expected)}\n" +
-        "Actual:\n${TextFormat.printer().printToString(actual)}",
-      expected,
-      actual,
-    )
+    if (expected != actual) {
+      fail(
+        "Trace tree mismatch for $testName.\n" +
+          "Expected:\n${TextFormat.printer().printToString(expected)}\n" +
+          "Actual:\n${TextFormat.printer().printToString(actual)}"
+      )
+    }
   }
 
   private fun loadGoldenTraceTree(path: Path): TraceTree {

--- a/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
+++ b/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
@@ -1,0 +1,151 @@
+package fourward.e2e.tracetree
+
+import com.google.protobuf.TextFormat
+import fourward.e2e.TestResult
+import fourward.e2e.resolveStfTableEntry
+import fourward.e2e.runStf
+import fourward.ir.v1.PipelineConfig
+import fourward.sim.v1.LoadPipelineRequest
+import fourward.sim.v1.ProcessPacketRequest
+import fourward.sim.v1.SimRequest
+import fourward.sim.v1.SimResponse
+import fourward.sim.v1.TraceTree
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.nio.file.Path
+import java.nio.file.Paths
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+/**
+ * Parameterized golden test for trace trees.
+ *
+ * Each test case consists of:
+ * - A compiled PipelineConfig (.txtpb)
+ * - An STF file (.stf) with optional table entries and at least one packet directive
+ * - An expected TraceTree (.golden.txtpb)
+ *
+ * The test sends the first packet through the simulator and compares the
+ * resulting TraceTree against the golden file.  This is the TDD harness for
+ * Track 3 (trace trees): all tests are written up front and expected to fail
+ * until the corresponding feature is implemented.
+ */
+@RunWith(Parameterized::class)
+class GoldenTraceTreeTest(private val testName: String) {
+
+  companion object {
+    private const val PKG = "e2e_tests/trace_tree"
+
+    @JvmStatic
+    @Parameters(name = "{0}")
+    fun testCases(): List<Array<String>> {
+      val r = System.getenv("JAVA_RUNFILES") ?: "."
+      val dir = Paths.get(r, "_main/$PKG").toFile()
+      return dir
+        .listFiles { f -> f.name.endsWith(".golden.txtpb") }
+        ?.map { arrayOf(it.name.removeSuffix(".golden.txtpb")) }
+        ?.sortedBy { it[0] }
+        ?: emptyList()
+    }
+  }
+
+  @Test
+  fun `trace tree matches golden file`() {
+    val r = System.getenv("JAVA_RUNFILES") ?: "."
+    val configPath = Paths.get(r, "_main/$PKG/$testName.txtpb")
+    val stfPath = Paths.get(r, "_main/$PKG/$testName.stf")
+    val goldenPath = Paths.get(r, "_main/$PKG/$testName.golden.txtpb")
+
+    val expected = loadGoldenTraceTree(goldenPath)
+    val actual = captureTraceTree(r, configPath, stfPath)
+    assertEquals(
+      "Trace tree mismatch for $testName.\n" +
+        "Expected:\n${TextFormat.printer().printToString(expected)}\n" +
+        "Actual:\n${TextFormat.printer().printToString(actual)}",
+      expected,
+      actual,
+    )
+  }
+
+  private fun loadGoldenTraceTree(path: Path): TraceTree {
+    val builder = TraceTree.newBuilder()
+    TextFormat.merge(path.toFile().readText(), builder)
+    return builder.build()
+  }
+
+  /**
+   * Launches the simulator, loads the pipeline, installs table entries from the STF file, sends the
+   * first packet, and returns the TraceTree from the response.
+   */
+  private fun captureTraceTree(runfiles: String, configPath: Path, stfPath: Path): TraceTree {
+    val config = loadConfig(configPath)
+    val stf = fourward.e2e.StfFile.parse(stfPath)
+
+    val simPath = Paths.get(runfiles, "_main/simulator/simulator")
+    val process = ProcessBuilder(simPath.toString()).redirectErrorStream(false).start()
+    val input = DataInputStream(process.inputStream.buffered())
+    val output = DataOutputStream(process.outputStream.buffered())
+
+    try {
+      // Load pipeline.
+      sendRequest(
+        output,
+        SimRequest.newBuilder()
+          .setLoadPipeline(LoadPipelineRequest.newBuilder().setConfig(config))
+          .build(),
+      )
+      val loadResp = readResponse(input)
+      if (loadResp.hasError()) fail("LoadPipeline failed: ${loadResp.error.message}")
+
+      // Install table entries.
+      for (directive in stf.tableEntries) {
+        val writeReq = resolveStfTableEntry(directive, config.p4Info)
+        sendRequest(output, SimRequest.newBuilder().setWriteEntry(writeReq).build())
+        val writeResp = readResponse(input)
+        if (writeResp.hasError()) fail("WriteEntry failed: ${writeResp.error.message}")
+      }
+
+      // Send the first packet.
+      val packet = stf.packets.first()
+      sendRequest(
+        output,
+        SimRequest.newBuilder()
+          .setProcessPacket(
+            ProcessPacketRequest.newBuilder()
+              .setIngressPort(packet.ingressPort)
+              .setPayload(com.google.protobuf.ByteString.copyFrom(packet.payload))
+          )
+          .build(),
+      )
+      val resp = readResponse(input)
+      if (resp.hasError()) fail("ProcessPacket failed: ${resp.error.message}")
+      return resp.processPacket.trace
+    } finally {
+      process.destroy()
+    }
+  }
+
+  private fun loadConfig(path: Path): PipelineConfig {
+    val builder = PipelineConfig.newBuilder()
+    TextFormat.merge(path.toFile().readText(), builder)
+    return builder.build()
+  }
+
+  private fun sendRequest(output: DataOutputStream, request: SimRequest) {
+    val bytes = request.toByteArray()
+    output.writeInt(bytes.size)
+    output.write(bytes)
+    output.flush()
+  }
+
+  private fun readResponse(input: DataInputStream): SimResponse {
+    val length = input.readInt()
+    val bytes = ByteArray(length)
+    input.readFully(bytes)
+    return SimResponse.parseFrom(bytes)
+  }
+}

--- a/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
+++ b/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
@@ -1,17 +1,11 @@
 package fourward.e2e.tracetree
 
 import com.google.protobuf.TextFormat
-import fourward.e2e.TestResult
+import fourward.e2e.SimulatorClient
+import fourward.e2e.StfFile
 import fourward.e2e.resolveStfTableEntry
-import fourward.e2e.runStf
 import fourward.ir.v1.PipelineConfig
-import fourward.sim.v1.LoadPipelineRequest
-import fourward.sim.v1.ProcessPacketRequest
-import fourward.sim.v1.SimRequest
-import fourward.sim.v1.SimResponse
 import fourward.sim.v1.TraceTree
-import java.io.DataInputStream
-import java.io.DataOutputStream
 import java.nio.file.Path
 import java.nio.file.Paths
 import org.junit.Assert.assertEquals
@@ -26,13 +20,12 @@ import org.junit.runners.Parameterized.Parameters
  *
  * Each test case consists of:
  * - A compiled PipelineConfig (.txtpb)
- * - An STF file (.stf) with optional table entries and at least one packet directive
+ * - An STF file (.stf) with optional table entries and at least one packet
  * - An expected TraceTree (.golden.txtpb)
  *
- * The test sends the first packet through the simulator and compares the
- * resulting TraceTree against the golden file.  This is the TDD harness for
- * Track 3 (trace trees): all tests are written up front and expected to fail
- * until the corresponding feature is implemented.
+ * The test sends the first packet through the simulator and compares the resulting TraceTree
+ * against the golden file. This is the TDD harness for Track 3 (trace trees): all tests are written
+ * up front and expected to fail until the corresponding feature is implemented.
  */
 @RunWith(Parameterized::class)
 class GoldenTraceTreeTest(private val testName: String) {
@@ -48,8 +41,7 @@ class GoldenTraceTreeTest(private val testName: String) {
       return dir
         .listFiles { f -> f.name.endsWith(".golden.txtpb") }
         ?.map { arrayOf(it.name.removeSuffix(".golden.txtpb")) }
-        ?.sortedBy { it[0] }
-        ?: emptyList()
+        ?.sortedBy { it[0] } ?: emptyList()
     }
   }
 
@@ -83,49 +75,22 @@ class GoldenTraceTreeTest(private val testName: String) {
    */
   private fun captureTraceTree(runfiles: String, configPath: Path, stfPath: Path): TraceTree {
     val config = loadConfig(configPath)
-    val stf = fourward.e2e.StfFile.parse(stfPath)
-
+    val stf = StfFile.parse(stfPath)
     val simPath = Paths.get(runfiles, "_main/simulator/simulator")
-    val process = ProcessBuilder(simPath.toString()).redirectErrorStream(false).start()
-    val input = DataInputStream(process.inputStream.buffered())
-    val output = DataOutputStream(process.outputStream.buffered())
 
-    try {
-      // Load pipeline.
-      sendRequest(
-        output,
-        SimRequest.newBuilder()
-          .setLoadPipeline(LoadPipelineRequest.newBuilder().setConfig(config))
-          .build(),
-      )
-      val loadResp = readResponse(input)
+    SimulatorClient(simPath).use { sim ->
+      val loadResp = sim.loadPipeline(config)
       if (loadResp.hasError()) fail("LoadPipeline failed: ${loadResp.error.message}")
 
-      // Install table entries.
       for (directive in stf.tableEntries) {
-        val writeReq = resolveStfTableEntry(directive, config.p4Info)
-        sendRequest(output, SimRequest.newBuilder().setWriteEntry(writeReq).build())
-        val writeResp = readResponse(input)
+        val writeResp = sim.writeEntry(resolveStfTableEntry(directive, config.p4Info))
         if (writeResp.hasError()) fail("WriteEntry failed: ${writeResp.error.message}")
       }
 
-      // Send the first packet.
       val packet = stf.packets.first()
-      sendRequest(
-        output,
-        SimRequest.newBuilder()
-          .setProcessPacket(
-            ProcessPacketRequest.newBuilder()
-              .setIngressPort(packet.ingressPort)
-              .setPayload(com.google.protobuf.ByteString.copyFrom(packet.payload))
-          )
-          .build(),
-      )
-      val resp = readResponse(input)
+      val resp = sim.processPacket(packet.ingressPort, packet.payload)
       if (resp.hasError()) fail("ProcessPacket failed: ${resp.error.message}")
       return resp.processPacket.trace
-    } finally {
-      process.destroy()
     }
   }
 
@@ -133,19 +98,5 @@ class GoldenTraceTreeTest(private val testName: String) {
     val builder = PipelineConfig.newBuilder()
     TextFormat.merge(path.toFile().readText(), builder)
     return builder.build()
-  }
-
-  private fun sendRequest(output: DataOutputStream, request: SimRequest) {
-    val bytes = request.toByteArray()
-    output.writeInt(bytes.size)
-    output.write(bytes)
-    output.flush()
-  }
-
-  private fun readResponse(input: DataInputStream): SimResponse {
-    val length = input.readInt()
-    val bytes = ByteArray(length)
-    input.readFully(bytes)
-    return SimResponse.parseFrom(bytes)
   }
 }

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -1,0 +1,52 @@
+# Expected trace tree for action_selector_3: fork with 3 branches.
+# Parser events are shared (prefix); the fork occurs at the selector table.
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  table_lookup {
+    table_name: "MyIngress.ecmp"
+    hit: true
+    action_name: "MyIngress.set_port"
+  }
+}
+fork {
+  reason: ACTION_SELECTOR
+  branches {
+    label: "member_0"
+    subtree {
+      events {
+        action_execution {
+          action_name: "MyIngress.set_port"
+          params { key: "port" value: "\000\001" }
+        }
+      }
+    }
+  }
+  branches {
+    label: "member_1"
+    subtree {
+      events {
+        action_execution {
+          action_name: "MyIngress.set_port"
+          params { key: "port" value: "\000\002" }
+        }
+      }
+    }
+  }
+  branches {
+    label: "member_2"
+    subtree {
+      events {
+        action_execution {
+          action_name: "MyIngress.set_port"
+          params { key: "port" value: "\000\003" }
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -1,5 +1,8 @@
 # Expected trace tree for action_selector_3: fork with 3 branches.
 # Parser events are shared (prefix); the fork occurs at the selector table.
+#
+# TODO(PR 3): update with actual member labels/params once action selector
+# forking is implemented. Current labels and param values are placeholders.
 events {
   parser_transition {
     parser_name: "MyParser"

--- a/e2e_tests/trace_tree/action_selector_3.p4
+++ b/e2e_tests/trace_tree/action_selector_3.p4
@@ -1,0 +1,60 @@
+/* action_selector_3.p4 — basic action selector with 3 group members.
+ *
+ * An exact-match table uses an action selector implementation.  When a lookup
+ * hits a group entry, the simulator should fork into 3 branches (one per
+ * member) to explore all possible forwarding outcomes.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    action set_port(bit<9> port) { smeta.egress_spec = port; }
+    action drop() { mark_to_drop(smeta); }
+
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) ecmp_selector;
+
+    table ecmp {
+        key = {
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { set_port; drop; }
+        implementation = ecmp_selector;
+        default_action = drop();
+    }
+
+    apply { ecmp.apply(); }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/action_selector_3.stf
+++ b/e2e_tests/trace_tree/action_selector_3.stf
@@ -1,0 +1,5 @@
+# action_selector_3.stf — 3 members in the ECMP group.
+# Table entries and action profile members will be installed via P4Runtime
+# once the simulator supports action profiles.  For now, just send a packet.
+
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -1,0 +1,32 @@
+# Expected trace tree for action_selector_miss: zero-fork tree on miss.
+# The selector table misses, so the default action (drop) runs directly
+# with no forking.
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  table_lookup {
+    table_name: "MyIngress.ecmp"
+    action_name: "MyIngress.drop"
+  }
+}
+events {
+  action_execution {
+    action_name: "MyIngress.drop"
+  }
+}
+events {
+  extern_call {
+    extern_instance_name: "mark_to_drop"
+    method: "__call__"
+  }
+}
+events {
+  drop {
+    reason: MARK_TO_DROP
+  }
+}

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -1,6 +1,9 @@
 # Expected trace tree for action_selector_miss: zero-fork tree on miss.
 # The selector table misses, so the default action (drop) runs directly
 # with no forking.
+#
+# TODO(PR 3): update to match actual simulator output for a selector table
+# miss. Event sequence and names are approximate.
 events {
   parser_transition {
     parser_name: "MyParser"

--- a/e2e_tests/trace_tree/action_selector_miss.p4
+++ b/e2e_tests/trace_tree/action_selector_miss.p4
@@ -1,0 +1,60 @@
+/* action_selector_miss.p4 — selector table: fork only on hit, not on miss.
+ *
+ * When the lookup misses, the default action runs without forking.
+ * When it hits a group entry, the simulator forks into N branches.
+ * This test verifies that misses produce a zero-fork subtree.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    action set_port(bit<9> port) { smeta.egress_spec = port; }
+    action drop() { mark_to_drop(smeta); }
+
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) ecmp_selector;
+
+    table ecmp {
+        key = {
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { set_port; drop; }
+        implementation = ecmp_selector;
+        default_action = drop();
+    }
+
+    apply { ecmp.apply(); }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/action_selector_miss.stf
+++ b/e2e_tests/trace_tree/action_selector_miss.stf
@@ -1,0 +1,4 @@
+# action_selector_miss.stf — no table entries installed, so lookup misses.
+# The default action (drop) should run without forking.
+
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -1,5 +1,8 @@
 # Expected trace tree for action_selector_nested: depth-2 fork tree.
 # stage1 forks into 2 branches; within each, stage2 forks into 2 branches.
+#
+# TODO(PR 3): update with actual member labels/params once action selector
+# forking is implemented. Current structure and values are placeholders.
 events {
   parser_transition {
     parser_name: "MyParser"

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -1,0 +1,105 @@
+# Expected trace tree for action_selector_nested: depth-2 fork tree.
+# stage1 forks into 2 branches; within each, stage2 forks into 2 branches.
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  table_lookup {
+    table_name: "MyIngress.stage1"
+    hit: true
+    action_name: "MyIngress.set_tag"
+  }
+}
+fork {
+  reason: ACTION_SELECTOR
+  branches {
+    label: "member_0"
+    subtree {
+      events {
+        action_execution {
+          action_name: "MyIngress.set_tag"
+          params { key: "tag" value: "\001" }
+        }
+      }
+      events {
+        table_lookup {
+          table_name: "MyIngress.stage2"
+          hit: true
+          action_name: "MyIngress.set_port"
+        }
+      }
+      fork {
+        reason: ACTION_SELECTOR
+        branches {
+          label: "member_0"
+          subtree {
+            events {
+              action_execution {
+                action_name: "MyIngress.set_port"
+                params { key: "port" value: "\000\001" }
+              }
+            }
+          }
+        }
+        branches {
+          label: "member_1"
+          subtree {
+            events {
+              action_execution {
+                action_name: "MyIngress.set_port"
+                params { key: "port" value: "\000\002" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  branches {
+    label: "member_1"
+    subtree {
+      events {
+        action_execution {
+          action_name: "MyIngress.set_tag"
+          params { key: "tag" value: "\002" }
+        }
+      }
+      events {
+        table_lookup {
+          table_name: "MyIngress.stage2"
+          hit: true
+          action_name: "MyIngress.set_port"
+        }
+      }
+      fork {
+        reason: ACTION_SELECTOR
+        branches {
+          label: "member_0"
+          subtree {
+            events {
+              action_execution {
+                action_name: "MyIngress.set_port"
+                params { key: "port" value: "\000\001" }
+              }
+            }
+          }
+        }
+        branches {
+          label: "member_1"
+          subtree {
+            events {
+              action_execution {
+                action_name: "MyIngress.set_port"
+                params { key: "port" value: "\000\002" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/action_selector_nested.p4
+++ b/e2e_tests/trace_tree/action_selector_nested.p4
@@ -1,0 +1,75 @@
+/* action_selector_nested.p4 — two selector tables producing nested forks.
+ *
+ * The ingress applies two tables sequentially, each with an action selector.
+ * This should produce a trace tree of depth 2: the first table forks, and
+ * within each branch the second table forks again.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t { bit<8> tag; }
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    action set_port(bit<9> port) { smeta.egress_spec = port; }
+    action set_tag(bit<8> tag) { meta.tag = tag; }
+    action drop() { mark_to_drop(smeta); }
+
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) sel1;
+    action_selector(HashAlgorithm.crc32, 32w1024, 32w14) sel2;
+
+    table stage1 {
+        key = {
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { set_tag; drop; }
+        implementation = sel1;
+        default_action = drop();
+    }
+
+    table stage2 {
+        key = {
+            hdr.ethernet.etherType : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { set_port; drop; }
+        implementation = sel2;
+        default_action = drop();
+    }
+
+    apply {
+        stage1.apply();
+        stage2.apply();
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/action_selector_nested.stf
+++ b/e2e_tests/trace_tree/action_selector_nested.stf
@@ -1,0 +1,3 @@
+# action_selector_nested.stf — two selector tables, nested forks.
+
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -1,0 +1,30 @@
+# Expected trace tree for clone_ingress_egress: fork at clone3 point.
+# Parser events are shared; after clone3, the tree forks into "original"
+# and "clone" branches.
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  clone {
+    session_id: 100
+  }
+}
+fork {
+  reason: CLONE
+  branches {
+    label: "original"
+    subtree {
+      # Original packet continues to egress on port 1.
+    }
+  }
+  branches {
+    label: "clone"
+    subtree {
+      # Cloned packet enters the egress pipeline.
+    }
+  }
+}

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -1,6 +1,9 @@
-# Expected trace tree for clone_ingress_egress: fork at clone3 point.
-# Parser events are shared; after clone3, the tree forks into "original"
+# Expected trace tree for clone_ingress_egress: fork at clone point.
+# Parser events are shared; after clone, the tree forks into "original"
 # and "clone" branches.
+#
+# TODO(PR 4): populate subtrees with actual egress pipeline events.
+# Currently empty — a weak assertion that only checks the fork structure.
 events {
   parser_transition {
     parser_name: "MyParser"

--- a/e2e_tests/trace_tree/clone_ingress_egress.p4
+++ b/e2e_tests/trace_tree/clone_ingress_egress.p4
@@ -1,0 +1,47 @@
+/* clone_ingress_egress.p4 — clone(CloneType.I2E) fork test.
+ *
+ * During ingress, the program clones the packet from ingress to egress.
+ * The trace tree should fork at the clone point: one branch for the
+ * original packet continuing through egress, one for the clone.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply {
+        smeta.egress_spec = 1;
+        clone(CloneType.I2E, 32w100);
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/clone_ingress_egress.stf
+++ b/e2e_tests/trace_tree/clone_ingress_egress.stf
@@ -1,0 +1,3 @@
+# clone_ingress_egress.stf — clone3 from ingress to egress.
+
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -1,0 +1,61 @@
+# Expected trace tree for clone_plus_selector: clone fork + selector fork.
+# First fork at clone3; within the "original" branch, a second fork at the
+# selector table.
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  clone {
+    session_id: 100
+  }
+}
+fork {
+  reason: CLONE
+  branches {
+    label: "original"
+    subtree {
+      events {
+        table_lookup {
+          table_name: "MyIngress.ecmp"
+          hit: true
+          action_name: "MyIngress.set_port"
+        }
+      }
+      fork {
+        reason: ACTION_SELECTOR
+        branches {
+          label: "member_0"
+          subtree {
+            events {
+              action_execution {
+                action_name: "MyIngress.set_port"
+                params { key: "port" value: "\000\001" }
+              }
+            }
+          }
+        }
+        branches {
+          label: "member_1"
+          subtree {
+            events {
+              action_execution {
+                action_name: "MyIngress.set_port"
+                params { key: "port" value: "\000\002" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  branches {
+    label: "clone"
+    subtree {
+      # Cloned packet enters the egress pipeline.
+    }
+  }
+}

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -1,6 +1,9 @@
 # Expected trace tree for clone_plus_selector: clone fork + selector fork.
-# First fork at clone3; within the "original" branch, a second fork at the
+# First fork at clone; within the "original" branch, a second fork at the
 # selector table.
+#
+# TODO(PR 4): populate clone subtree with actual egress pipeline events.
+# TODO(PR 3): update selector member labels/params once implemented.
 events {
   parser_transition {
     parser_name: "MyParser"

--- a/e2e_tests/trace_tree/clone_plus_selector.p4
+++ b/e2e_tests/trace_tree/clone_plus_selector.p4
@@ -1,0 +1,64 @@
+/* clone_plus_selector.p4 — both clone3 and action selector in the same
+ * pipeline, producing mixed fork types.
+ *
+ * Ingress: clone3, then apply a selector table.
+ * The trace tree should fork at the clone point, and within the "original"
+ * branch, fork again at the selector table.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    action set_port(bit<9> port) { smeta.egress_spec = port; }
+    action drop() { mark_to_drop(smeta); }
+
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) ecmp_selector;
+
+    table ecmp {
+        key = {
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { set_port; drop; }
+        implementation = ecmp_selector;
+        default_action = drop();
+    }
+
+    apply {
+        clone(CloneType.I2E, 32w100);
+        ecmp.apply();
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/clone_plus_selector.stf
+++ b/e2e_tests/trace_tree/clone_plus_selector.stf
@@ -1,0 +1,3 @@
+# clone_plus_selector.stf — clone3 + action selector.
+
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -1,6 +1,9 @@
 # Expected trace tree for multicast: fork per replica.
 # Parser + ingress events are shared; the tree forks when the architecture
 # dispatches the packet to each replica in the multicast group.
+#
+# TODO(PR 4): populate subtrees with actual per-replica egress events.
+# Currently empty — labels and replica structure are placeholders.
 events {
   parser_transition {
     parser_name: "MyParser"

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -1,0 +1,31 @@
+# Expected trace tree for multicast: fork per replica.
+# Parser + ingress events are shared; the tree forks when the architecture
+# dispatches the packet to each replica in the multicast group.
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+fork {
+  reason: MULTICAST
+  branches {
+    label: "replica_0_port_1"
+    subtree {
+      # Replica 0 enters egress on port 1.
+    }
+  }
+  branches {
+    label: "replica_0_port_2"
+    subtree {
+      # Replica 0 enters egress on port 2.
+    }
+  }
+  branches {
+    label: "replica_0_port_3"
+    subtree {
+      # Replica 0 enters egress on port 3.
+    }
+  }
+}

--- a/e2e_tests/trace_tree/multicast.p4
+++ b/e2e_tests/trace_tree/multicast.p4
@@ -1,0 +1,45 @@
+/* multicast.p4 — multicast group fork test.
+ *
+ * During ingress, the program sets the multicast group ID. The architecture
+ * should fork the trace tree with one branch per replica in the group.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply {
+        smeta.mcast_grp = 1;
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/multicast.stf
+++ b/e2e_tests/trace_tree/multicast.stf
@@ -1,0 +1,5 @@
+# multicast.stf — multicast group with 3 replicas.
+# Multicast group configuration will be installed via P4Runtime
+# once the simulator supports multicast groups.
+
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/no_fork.golden.txtpb
+++ b/e2e_tests/trace_tree/no_fork.golden.txtpb
@@ -1,5 +1,10 @@
 # Expected trace tree for no_fork: zero-fork tree (no ForkNode).
 # Parser transition + table hit + action execution — nothing else.
+#
+# TODO(PR 2): update to match actual simulator output. Known diffs:
+# - table/action names use p4info aliases ("routing", "forward"), not
+#   qualified names ("MyIngress.routing", "MyIngress.forward")
+# - table_lookup.matched_entry is populated on hit (omitted here)
 events {
   parser_transition {
     parser_name: "MyParser"

--- a/e2e_tests/trace_tree/no_fork.golden.txtpb
+++ b/e2e_tests/trace_tree/no_fork.golden.txtpb
@@ -1,0 +1,22 @@
+# Expected trace tree for no_fork: zero-fork tree (no ForkNode).
+# Parser transition + table hit + action execution — nothing else.
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  table_lookup {
+    table_name: "MyIngress.routing"
+    hit: true
+    action_name: "MyIngress.forward"
+  }
+}
+events {
+  action_execution {
+    action_name: "MyIngress.forward"
+    params { key: "port" value: "\000\001" }
+  }
+}

--- a/e2e_tests/trace_tree/no_fork.p4
+++ b/e2e_tests/trace_tree/no_fork.p4
@@ -1,0 +1,52 @@
+/* no_fork.p4 — simplest trace tree test: no non-determinism.
+ *
+ * Parses an Ethernet header, applies an exact-match table to set the egress
+ * port, and re-emits.  The resulting trace tree should be a zero-fork tree
+ * (no ForkNode) with parser + table lookup + action execution events.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    action forward(bit<9> port) { smeta.egress_spec = port; }
+
+    table routing {
+        key = { hdr.ethernet.dstAddr : exact; }
+        actions = { forward; }
+        default_action = forward(0);
+    }
+
+    apply { routing.apply(); }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/no_fork.stf
+++ b/e2e_tests/trace_tree/no_fork.stf
@@ -1,0 +1,6 @@
+# no_fork.stf — send one packet, expect it on port 1 via table entry.
+
+add routing hdr.ethernet.dstAddr:0xFFFFFFFFFFFF forward(1)
+
+packet 0 FFFFFFFFFFFF 000000000001 0800
+expect 1 FFFFFFFFFFFF 000000000001 0800

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -38,9 +38,12 @@ interface Architecture {
 /**
  * The result of running a packet through the pipeline.
  *
- * [outputPackets] are the packets to emit (port, payload). [trace] is the combined execution trace
- * across all pipeline stages.
+ * [outputPackets] are the packets to emit (port, payload). [trace] is the execution trace tree
+ * across all pipeline stages, with forks at non-deterministic choice points.
  */
-data class PipelineResult(val outputPackets: List<OutputPacket>, val trace: fourward.sim.v1.Trace)
+data class PipelineResult(
+  val outputPackets: List<OutputPacket>,
+  val trace: fourward.sim.v1.TraceTree,
+)
 
 data class OutputPacket(val port: UInt, val payload: ByteArray)

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -1,7 +1,7 @@
 package fourward.simulator
 
-import fourward.sim.v1.Trace
 import fourward.sim.v1.TraceEvent
+import fourward.sim.v1.TraceTree
 import java.io.ByteArrayOutputStream
 
 /**
@@ -101,7 +101,7 @@ class PacketContext(payload: ByteArray) {
     traceEvents.add(event)
   }
 
-  fun buildTrace(): Trace = Trace.newBuilder().addAllEvents(traceEvents).build()
+  fun buildTrace(): TraceTree = TraceTree.newBuilder().addAllEvents(traceEvents).build()
 }
 
 /**

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -345,19 +345,18 @@ class Interpreter(
         val targetWidth = cast.targetType.signedInt.width
         when (inner) {
           // int<N> → int<M>: preserve the signed value (sign-extends or truncates).
-          is IntVal -> {
-            val truncated =
-              SignedBitVector.fromUnsignedBits(
-                inner.bits.value.mod(java.math.BigInteger.TWO.pow(targetWidth)),
-                targetWidth,
-              )
-            // If widening, sign-extend by using the original signed value directly.
+          // int<N> → int<M>: sign-extend if widening, truncate if narrowing.
+          is IntVal ->
             if (targetWidth >= inner.bits.width) {
               IntVal(SignedBitVector(inner.bits.value, targetWidth))
             } else {
-              IntVal(truncated)
+              IntVal(
+                SignedBitVector.fromUnsignedBits(
+                  inner.bits.value.mod(java.math.BigInteger.TWO.pow(targetWidth)),
+                  targetWidth,
+                )
+              )
             }
-          }
           else -> {
             val sourceBits =
               when (inner) {
@@ -462,22 +461,9 @@ class Interpreter(
   private fun coerceInfInts(left: Value, right: Value): Pair<Value, Value> =
     when {
       left is InfIntVal && right is BitVal -> left.toBitVal(right.bits.width) to right
-      right is InfIntVal && left is BitVal -> left to right.toBitVal((left as BitVal).bits.width)
-      left is InfIntVal && right is IntVal ->
-        IntVal(
-          SignedBitVector.fromUnsignedBits(
-            left.value.mod(java.math.BigInteger.TWO.pow(right.bits.width)),
-            right.bits.width,
-          )
-        ) to right
-      right is InfIntVal && left is IntVal ->
-        left to
-          IntVal(
-            SignedBitVector.fromUnsignedBits(
-              right.value.mod(java.math.BigInteger.TWO.pow(left.bits.width)),
-              left.bits.width,
-            )
-          )
+      right is InfIntVal && left is BitVal -> left to right.toBitVal(left.bits.width)
+      left is InfIntVal && right is IntVal -> left.toIntVal(right.bits.width) to right
+      right is InfIntVal && left is IntVal -> left to right.toIntVal(left.bits.width)
       else -> left to right
     }
 

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -25,9 +25,13 @@ data class BitVal(val bits: BitVector) : Value() {
  * adopt the width of the other operand when used in a binary operation.
  */
 data class InfIntVal(val value: java.math.BigInteger) : Value() {
-  /** Coerce to a fixed-width [BitVal]. */
+  /** Coerce to a fixed-width unsigned [BitVal]. */
   fun toBitVal(width: Int): BitVal =
     BitVal(BitVector(value.mod(java.math.BigInteger.TWO.pow(width)), width))
+
+  /** Coerce to a fixed-width signed [IntVal]. */
+  fun toIntVal(width: Int): IntVal =
+    IntVal(SignedBitVector.fromUnsignedBits(value.mod(java.math.BigInteger.TWO.pow(width)), width))
 }
 
 /** An int<N> value (two's complement). */

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -65,10 +65,15 @@ message ProcessPacketRequest {
 }
 
 // The primary output of the simulator: output packets (what a real device would
-// emit) plus a complete execution trace (what 4ward uniquely provides).
+// emit) plus a complete execution trace tree (what 4ward uniquely provides).
+//
+// At non-deterministic choice points (action selectors, clone, multicast) the
+// tree forks into branches — one per possible outcome.  A program with no
+// non-determinism produces a zero-fork tree that is structurally equivalent to
+// a flat trace.
 message ProcessPacketResponse {
   repeated OutputPacket output_packets = 1;
-  Trace trace = 2;
+  TraceTree trace = 2;
 }
 
 message OutputPacket {
@@ -77,14 +82,43 @@ message OutputPacket {
 }
 
 // =============================================================================
-// Execution trace
+// Execution trace tree
 //
 // A complete record of every decision the simulator made while processing a
-// packet. Events are ordered chronologically.
+// packet.  Events within a node are ordered chronologically.  At
+// non-deterministic choice points the tree forks: each branch represents one
+// possible outcome and contains its own subtree of events.
+//
+// A zero-fork tree (fork absent) is structurally equivalent to a flat trace.
 // =============================================================================
 
-message Trace {
+// Recursive trace structure: a sequence of events followed by an optional fork.
+// Shared prefix events (e.g. the parser trace before a selector fork) live in
+// the parent node; per-branch events live in the fork's subtrees.
+message TraceTree {
   repeated TraceEvent events = 1;
+  ForkNode fork = 2;  // absent when there is no non-determinism
+}
+
+// A non-deterministic choice point where execution forks into multiple
+// possible paths.
+message ForkNode {
+  ForkReason reason = 1;
+  repeated ForkBranch branches = 2;
+}
+
+// One branch of a fork.  The label describes this particular outcome (e.g. the
+// action selector member name or "clone"/"original").
+message ForkBranch {
+  string label = 1;
+  TraceTree subtree = 2;
+}
+
+enum ForkReason {
+  FORK_REASON_UNSPECIFIED = 0;
+  ACTION_SELECTOR = 1;
+  CLONE = 2;
+  MULTICAST = 3;
 }
 
 message TraceEvent {


### PR DESCRIPTION
## Summary

PR 1 of the trace tree track (Track 3). Lays the foundation for 4ward's killer
feature: at non-deterministic choice points (action selectors, clone,
multicast), fork execution and return a tree of all possible traces instead of
a single path.

This PR defines the `TraceTree` proto schema, writes all 7 golden tests up
front (TDD-style), and mechanically updates existing code. All 7 golden tests
fail — subsequent PRs implement features until they pass.

- **Proto**: replace `Trace` with `TraceTree` (events + optional `ForkNode`).
  A zero-fork tree is structurally equivalent to the old flat trace, so all
  132 existing tests pass unchanged.
- **Golden tests** (all tagged `manual`, expected to fail):
  - `no_fork` — zero-fork tree matches flat trace
  - `action_selector_3` — basic forking at selector (3 members)
  - `action_selector_nested` — nested forks (tree depth > 1)
  - `action_selector_miss` — fork only on hit, not on miss
  - `clone_ingress_egress` — fork at clone point
  - `clone_plus_selector` — mixed clone + selector forks
  - `multicast` — fork per replica
- **SimulatorClient**: extracted shared simulator wire protocol from `StfRunner`
  so both `StfRunner` and `GoldenTraceTreeTest` use the same subprocess
  management and length-delimited proto codec.
- **TODO convention**: golden files carry `TODO(PR N)` comments documenting
  known gaps (approximate names, missing `matched_entry`, empty subtrees).
  Added this as a project convention in `AGENTS.md`.

## Test plan

- [x] `bazel test //...` passes (all existing tests, golden tests excluded via `manual` tag)
- [x] `bazel test //e2e_tests/trace_tree:golden_trace_tree_test` runs all 7
      tests, all 7 fail with trace tree mismatch (expected)
- [x] Lint clean (`./lint.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)