### PR TITLE
Header union one-valid-at-a-time; promote 6 tests (142 → 148)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -140,6 +140,7 @@ corpus_test_suite(
         "issue510-bmv2",
         "issue561-1-bmv2",
         "issue561-2-bmv2",
+        "issue561-3-bmv2",
         "issue635-bmv2",
         "issue774-4-bmv2",
         "issue983-bmv2",
@@ -158,6 +159,11 @@ corpus_test_suite(
         "table-entries-range-bmv2",
         "table-entries-ser-enum-bmv2",
         "table-entries-ternary-bmv2",
+        "union-bmv2",
+        "union-valid-bmv2",
+        "union1-bmv2",
+        "union2-bmv2",
+        "union3-bmv2",
         "v1model-const-entries-bmv2",
     ],
 )
@@ -263,7 +269,6 @@ corpus_test_suite(
         "issue1824-bmv2",  # unhandled extern call: verify
         "issue1879-bmv2",  # undefined variable: inf_0 (inlined function locals)
         "issue3488-1-bmv2",  # expected packet on port 2 but got none
-        "issue561-3-bmv2",  # header union one-valid-at-a-time invariant
         "issue561-4-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-5-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-6-bmv2",  # header stack of unions (StructVal as stack element)
@@ -275,11 +280,6 @@ corpus_test_suite(
         "table-entries-priority-bmv2",  # BMv2 @priority uses lower-is-better; P4Runtime uses higher-is-better
         "ternary2-bmv2",  # payload mismatch
         "test-parserinvalidargument-error-bmv2",  # payload mismatch
-        "union-bmv2",  # field access on non-aggregate value: UnitVal
-        "union-valid-bmv2",  # field access on non-aggregate value: UnitVal
-        "union1-bmv2",  # field access on non-aggregate value: UnitVal
-        "union2-bmv2",  # field access on non-aggregate value: UnitVal
-        "union3-bmv2",  # field access on non-aggregate value: UnitVal
         "v1model-special-ops-bmv2",  # unhandled extern call: verify_checksum
     ],
 )

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -513,7 +513,16 @@ class Interpreter(
         }
       }
       "setValid" -> {
-        (evalExpr(call.target, env) as HeaderVal).valid = true
+        val target = evalExpr(call.target, env) as HeaderVal
+        // P4 spec §8.20: setting a union member valid invalidates all other members.
+        if (call.target.hasFieldAccess()) {
+          val parentType = call.target.fieldAccess.expr.type
+          if (parentType.hasNamed() && types[parentType.named]?.hasHeaderUnion() == true) {
+            val union = evalExpr(call.target.fieldAccess.expr, env) as StructVal
+            union.fields.values.forEach { if (it is HeaderVal && it !== target) it.setInvalid() }
+          }
+        }
+        target.valid = true
         UnitVal
       }
       "setInvalid" -> {
@@ -712,6 +721,15 @@ class Interpreter(
       val raw = (allBits shr (totalBits - bitOffset - width)) and mask
       newFields[field.name] = bitsToValue(field.type, raw, width)
       bitOffset += width
+    }
+    // P4 spec §8.20: extracting into a union member invalidates all other members.
+    val arg0 = call.argsList[0]
+    if (arg0.hasFieldAccess()) {
+      val parentType = arg0.fieldAccess.expr.type
+      if (parentType.hasNamed() && types[parentType.named]?.hasHeaderUnion() == true) {
+        val union = evalExpr(arg0.fieldAccess.expr, env) as StructVal
+        union.fields.values.forEach { if (it is HeaderVal && it !== header) it.setInvalid() }
+      }
     }
     header.setValid(newFields)
     return UnitVal

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -514,14 +514,7 @@ class Interpreter(
       }
       "setValid" -> {
         val target = evalExpr(call.target, env) as HeaderVal
-        // P4 spec §8.20: setting a union member valid invalidates all other members.
-        if (call.target.hasFieldAccess()) {
-          val parentType = call.target.fieldAccess.expr.type
-          if (parentType.hasNamed() && types[parentType.named]?.hasHeaderUnion() == true) {
-            val union = evalExpr(call.target.fieldAccess.expr, env) as StructVal
-            union.fields.values.forEach { if (it is HeaderVal && it !== target) it.setInvalid() }
-          }
-        }
+        invalidateUnionSiblings(call.target, target, env)
         target.valid = true
         UnitVal
       }
@@ -682,6 +675,15 @@ class Interpreter(
     }
   }
 
+  /** P4 spec §8.20: if [expr] is a field access into a header union, invalidate all siblings. */
+  private fun invalidateUnionSiblings(expr: Expr, target: HeaderVal, env: Environment) {
+    if (!expr.hasFieldAccess()) return
+    val parentType = expr.fieldAccess.expr.type
+    if (!parentType.hasNamed() || types[parentType.named]?.hasHeaderUnion() != true) return
+    val union = evalExpr(expr.fieldAccess.expr, env) as StructVal
+    union.fields.values.forEach { if (it is HeaderVal && it !== target) it.setInvalid() }
+  }
+
   // -------------------------------------------------------------------------
   // Packet extract / emit
   // -------------------------------------------------------------------------
@@ -722,15 +724,7 @@ class Interpreter(
       newFields[field.name] = bitsToValue(field.type, raw, width)
       bitOffset += width
     }
-    // P4 spec §8.20: extracting into a union member invalidates all other members.
-    val arg0 = call.argsList[0]
-    if (arg0.hasFieldAccess()) {
-      val parentType = arg0.fieldAccess.expr.type
-      if (parentType.hasNamed() && types[parentType.named]?.hasHeaderUnion() == true) {
-        val union = evalExpr(arg0.fieldAccess.expr, env) as StructVal
-        union.fields.values.forEach { if (it is HeaderVal && it !== header) it.setInvalid() }
-      }
-    }
+    invalidateUnionSiblings(call.argsList[0], header, env)
     header.setValid(newFields)
     return UnitVal
   }

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -675,13 +675,12 @@ class Interpreter(
     }
   }
 
-  /** P4 spec §8.20: if [expr] is a field access into a header union, invalidate all siblings. */
+  /** If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20). */
   private fun invalidateUnionSiblings(expr: Expr, target: HeaderVal, env: Environment) {
     if (!expr.hasFieldAccess()) return
     val parentType = expr.fieldAccess.expr.type
     if (!parentType.hasNamed() || types[parentType.named]?.hasHeaderUnion() != true) return
-    val union = evalExpr(expr.fieldAccess.expr, env) as StructVal
-    union.fields.values.forEach { if (it is HeaderVal && it !== target) it.setInvalid() }
+    (evalExpr(expr.fieldAccess.expr, env) as StructVal).invalidateUnionExcept(target)
   }
 
   // -------------------------------------------------------------------------

--- a/simulator/InterpreterExprTest.kt
+++ b/simulator/InterpreterExprTest.kt
@@ -583,6 +583,46 @@ class InterpreterExprTest {
     assertTrue(hdr.valid)
   }
 
+  @Test
+  fun `setValid on union member invalidates siblings`() {
+    val memberA = HeaderVal(typeName = "A_t", valid = true)
+    val memberB = HeaderVal(typeName = "B_t", valid = false)
+    val union = StructVal("U", mutableMapOf("a" to memberA, "b" to memberB))
+    val env = emptyEnv
+    env.define("u", union)
+
+    // Build: u.b.setValid()  with u typed as named "U"
+    val unionRef =
+      Expr.newBuilder()
+        .setNameRef(NameRef.newBuilder().setName("u"))
+        .setType(Type.newBuilder().setNamed("U"))
+        .build()
+    val memberAccess =
+      Expr.newBuilder()
+        .setFieldAccess(FieldAccess.newBuilder().setExpr(unionRef).setFieldName("b"))
+        .setType(Type.newBuilder().setNamed("B_t"))
+        .build()
+    val expr =
+      Expr.newBuilder()
+        .setMethodCall(MethodCall.newBuilder().setTarget(memberAccess).setMethod("setValid"))
+        .setType(boolType())
+        .build()
+
+    // Register "U" as a header_union type so invalidateUnionSiblings fires.
+    val config =
+      P4BehavioralConfig.newBuilder()
+        .addTypes(
+          fourward.ir.v1.TypeDecl.newBuilder()
+            .setName("U")
+            .setHeaderUnion(fourward.ir.v1.HeaderUnionDecl.getDefaultInstance())
+        )
+        .build()
+    Interpreter(config, TableStore()).evalExpr(expr, env)
+
+    assertTrue(memberB.valid)
+    assertFalse(memberA.valid)
+  }
+
   // ---------------------------------------------------------------------------
   // Mux (ternary) operator
   // ---------------------------------------------------------------------------

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -98,6 +98,11 @@ data class StructVal(val typeName: String, val fields: MutableMap<String, Value>
   fun invalidateUnion() {
     fields.values.forEach { if (it is HeaderVal) it.setInvalid() }
   }
+
+  /** P4 spec §8.20: setting a union member valid invalidates all other members. */
+  fun invalidateUnionExcept(keep: HeaderVal) {
+    fields.values.forEach { if (it is HeaderVal && it !== keep) it.setInvalid() }
+  }
 }
 
 /** A header stack (fixed-size array of headers with a next/last pointer). */


### PR DESCRIPTION
## Summary

- Enforce P4 spec §8.20 one-valid-at-a-time invariant for header unions: `setValid` and `extract` on a union member now invalidate all sibling members
- Promote 6 tests to CI suite: `union-bmv2`, `union-valid-bmv2`, `union1/2/3-bmv2` (already passing, stale annotations), `issue561-3-bmv2` (fixed by this PR)

## Test plan

- [x] `bazel test //...` passes (23/23)
- [x] `issue561-3-bmv2` now produces correct output (only the valid union member is emitted)
- [x] All 5 other union tests still pass after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)