### PR TITLE
trace trees PR 2: no_fork golden test passes

### DIFF
--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -4,9 +4,8 @@ load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 # Trace tree golden tests (Track 3)
 #
 # Each test compiles a P4 program, sends a packet, and compares the resulting
-# TraceTree against a golden .txtpb file.  All tests are expected to fail
-# until the corresponding feature is implemented.  They are tagged "manual"
-# so they don't break CI.
+# TraceTree against a golden .txtpb file.  Passing tests run in CI; tests for
+# unimplemented features are tagged "manual".
 # =============================================================================
 
 _P4_PROGRAMS = [
@@ -18,6 +17,12 @@ _P4_PROGRAMS = [
     "clone_plus_selector",
     "multicast",
 ]
+
+_PASSING = [
+    "no_fork",
+]
+
+_MANUAL = [p for p in _P4_PROGRAMS if p not in _PASSING]
 
 [genrule(
     name = "%s_pb" % name,
@@ -31,22 +36,36 @@ _P4_PROGRAMS = [
     ],
 ) for name in _P4_PROGRAMS]
 
+_TEST_DEPS = [
+    "//e2e_tests/stf:stf_runner",
+    "//simulator:ir_java_proto",
+    "//simulator:p4runtime_java_proto",
+    "//simulator:simulator_java_proto",
+    "@maven//:com_google_protobuf_protobuf_java",
+    "@maven//:junit_junit",
+]
+
 kt_jvm_test(
     name = "golden_trace_tree_test",
     srcs = ["GoldenTraceTreeTest.kt"],
-    data = ["%s.stf" % n for n in _P4_PROGRAMS] +
-           ["%s.golden.txtpb" % n for n in _P4_PROGRAMS] +
-           [":%s_pb" % n for n in _P4_PROGRAMS] + [
+    data = ["%s.stf" % n for n in _PASSING] +
+           ["%s.golden.txtpb" % n for n in _PASSING] +
+           [":%s_pb" % n for n in _PASSING] + [
+        "//simulator",
+    ],
+    test_class = "fourward.e2e.tracetree.GoldenTraceTreeTest",
+    deps = _TEST_DEPS,
+)
+
+kt_jvm_test(
+    name = "golden_trace_tree_test_manual",
+    srcs = ["GoldenTraceTreeTest.kt"],
+    data = ["%s.stf" % n for n in _MANUAL] +
+           ["%s.golden.txtpb" % n for n in _MANUAL] +
+           [":%s_pb" % n for n in _MANUAL] + [
         "//simulator",
     ],
     tags = ["manual"],
     test_class = "fourward.e2e.tracetree.GoldenTraceTreeTest",
-    deps = [
-        "//e2e_tests/stf:stf_runner",
-        "//simulator:ir_java_proto",
-        "//simulator:p4runtime_java_proto",
-        "//simulator:simulator_java_proto",
-        "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:junit_junit",
-    ],
+    deps = _TEST_DEPS,
 )

--- a/e2e_tests/trace_tree/no_fork.golden.txtpb
+++ b/e2e_tests/trace_tree/no_fork.golden.txtpb
@@ -1,10 +1,5 @@
 # Expected trace tree for no_fork: zero-fork tree (no ForkNode).
 # Parser transition + table hit + action execution — nothing else.
-#
-# TODO(PR 2): update to match actual simulator output. Known diffs:
-# - table/action names use p4info aliases ("routing", "forward"), not
-#   qualified names ("MyIngress.routing", "MyIngress.forward")
-# - table_lookup.matched_entry is populated on hit (omitted here)
 events {
   parser_transition {
     parser_name: "MyParser"
@@ -14,14 +9,35 @@ events {
 }
 events {
   table_lookup {
-    table_name: "MyIngress.routing"
+    table_name: "routing"
     hit: true
-    action_name: "MyIngress.forward"
+    matched_entry {
+      table_id: 34192369
+      match {
+        field_id: 1
+        exact {
+          value: "\377\377\377\377\377\377"
+        }
+      }
+      action {
+        action {
+          action_id: 29683729
+          params {
+            param_id: 1
+            value: "\000\001"
+          }
+        }
+      }
+    }
+    action_name: "forward"
   }
 }
 events {
   action_execution {
-    action_name: "MyIngress.forward"
-    params { key: "port" value: "\000\001" }
+    action_name: "forward"
+    params {
+      key: "port"
+      value: "\000\001"
+    }
   }
 }


### PR DESCRIPTION
## Summary

PR 2 of the trace tree track (Track 3). The `no_fork` golden test now passes —
the simulator already produces zero-fork `TraceTree` output (wired in PR #101),
so this PR just updates the golden file to match actual output and promotes the
test to CI.

- **Golden file updated**: `no_fork.golden.txtpb` now matches real simulator
  output — p4info aliases for names, `matched_entry` populated on hit.
- **Test split**: `golden_trace_tree_test` runs passing tests in CI;
  `golden_trace_tree_test_manual` holds the 6 tests waiting on action
  selectors, clone, and multicast.

## Test plan

- [x] `bazel test //...` passes (24 tests, up from 23 — `no_fork` is new)
- [x] `bazel test //e2e_tests/trace_tree:golden_trace_tree_test` passes
- [x] `bazel test //e2e_tests/trace_tree:golden_trace_tree_test_manual` runs
      6 tests, all fail (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)