### PR TITLE
Signed saturation, parser errors, initial defaults; promote 3 (148 → 151)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -25,6 +25,7 @@ corpus_test_suite(
         "arith4-bmv2",
         "arith5-bmv2",
         "array-copy-bmv2",
+        "bvec-hdr-bmv2",
         "equality-varbit-bmv2",
         "flag_lost-bmv2",
         "gauntlet_action_mux-bmv2",
@@ -152,6 +153,7 @@ corpus_test_suite(
         "parser_error-bmv2",
         "runtime-index-2-bmv2",
         "runtime-index-bmv2",
+        "saturated-bmv2",
         "table-entries-exact-bmv2",
         "table-entries-exact-ternary-bmv2",
         "table-entries-lpm-bmv2",
@@ -159,6 +161,7 @@ corpus_test_suite(
         "table-entries-range-bmv2",
         "table-entries-ser-enum-bmv2",
         "table-entries-ternary-bmv2",
+        "test-parserinvalidargument-error-bmv2",
         "union-bmv2",
         "union-valid-bmv2",
         "union1-bmv2",
@@ -257,12 +260,11 @@ corpus_test_suite(
     name = "other_stf_corpus_test",
     tags = ["manual"],
     tests = [
-        "bvec-hdr-bmv2",  # expected packet on port 2 but got none; payload mismatch
         "checksum2-bmv2",  # unhandled extern call: verify
         "checksum3-bmv2",  # unhandled extern call: verify
-        "gauntlet_invalid_hdr_short_circuit-bmv2",  # payload mismatch
+        "gauntlet_invalid_hdr_short_circuit-bmv2",  # un-parsed payload appended after deparser
         "header-stack-ops-bmv2",  # unhandled extern call: verify
-        "issue1049-bmv2",  # payload mismatch
+        "issue1049-bmv2",  # unhandled extern call: hash
         "issue1097-2-bmv2",  # unhandled method call: write (register extern)
         "issue1566-bmv2",  # unhandled method call: count (counter extern)
         "issue1814-1-bmv2",  # unhandled method call: read (register extern)
@@ -274,12 +276,10 @@ corpus_test_suite(
         "issue561-6-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-7-bmv2",  # header stack of unions (StructVal as stack element)
         "issue655-bmv2",  # unhandled extern call: verify_checksum
-        "saturated-bmv2",  # payload mismatch
         "stack_complex-bmv2",  # field access on non-aggregate value: HeaderStackVal
         "subparser-with-header-stack-bmv2",  # unhandled extern call: verify
         "table-entries-priority-bmv2",  # BMv2 @priority uses lower-is-better; P4Runtime uses higher-is-better
-        "ternary2-bmv2",  # payload mismatch
-        "test-parserinvalidargument-error-bmv2",  # payload mismatch
+        "ternary2-bmv2",  # per-table action specialization lost (single p4info action ID)
         "v1model-special-ops-bmv2",  # unhandled extern call: verify_checksum
     ],
 )

--- a/simulator/BitVector.kt
+++ b/simulator/BitVector.kt
@@ -169,11 +169,8 @@ data class SignedBitVector(val value: BigInteger, val width: Int) {
     return SignedBitVector(result.coerceIn(minVal, maxVal), width)
   }
 
-  private val minVal
-    get() = BigInteger.TWO.pow(width - 1).negate()
-
-  private val maxVal
-    get() = BigInteger.TWO.pow(width - 1) - BigInteger.ONE
+  private val minVal by lazy { BigInteger.TWO.pow(width - 1).negate() }
+  private val maxVal by lazy { BigInteger.TWO.pow(width - 1) - BigInteger.ONE }
 
   /** Reinterprets the bits as an unsigned [BitVector]. */
   fun toUnsigned(): BitVector {

--- a/simulator/BitVector.kt
+++ b/simulator/BitVector.kt
@@ -155,6 +155,26 @@ data class SignedBitVector(val value: BigInteger, val width: Int) {
     }
   }
 
+  /** Saturating addition: clamps to [minVal, maxVal] on overflow. */
+  fun addSat(other: SignedBitVector): SignedBitVector {
+    require(width == other.width)
+    val result = value + other.value
+    return SignedBitVector(result.coerceIn(minVal, maxVal), width)
+  }
+
+  /** Saturating subtraction: clamps to [minVal, maxVal] on underflow. */
+  fun subSat(other: SignedBitVector): SignedBitVector {
+    require(width == other.width)
+    val result = value - other.value
+    return SignedBitVector(result.coerceIn(minVal, maxVal), width)
+  }
+
+  private val minVal
+    get() = BigInteger.TWO.pow(width - 1).negate()
+
+  private val maxVal
+    get() = BigInteger.TWO.pow(width - 1) - BigInteger.ONE
+
   /** Reinterprets the bits as an unsigned [BitVector]. */
   fun toUnsigned(): BitVector {
     val unsigned =

--- a/simulator/BitVectorTest.kt
+++ b/simulator/BitVectorTest.kt
@@ -74,4 +74,28 @@ class BitVectorTest {
     val s = SignedBitVector(BigInteger.valueOf(-1), 8)
     assertEquals(BitVector.ofInt(0xFF, 8), s.toUnsigned())
   }
+
+  @Test
+  fun `signed saturating addition clamps to max`() {
+    // int<16>: 32766 |+| 10 = 32767 (clamped from 32776)
+    val a = SignedBitVector(BigInteger.valueOf(32766), 16)
+    val b = SignedBitVector(BigInteger.valueOf(10), 16)
+    assertEquals(SignedBitVector(BigInteger.valueOf(32767), 16), a.addSat(b))
+  }
+
+  @Test
+  fun `signed saturating subtraction clamps to min`() {
+    // int<16>: -32766 |-| 10 = -32768 (clamped from -32776)
+    val a = SignedBitVector(BigInteger.valueOf(-32766), 16)
+    val b = SignedBitVector(BigInteger.valueOf(10), 16)
+    assertEquals(SignedBitVector(BigInteger.valueOf(-32768), 16), a.subSat(b))
+  }
+
+  @Test
+  fun `signed saturation no-ops within range`() {
+    val a = SignedBitVector(BigInteger.valueOf(10), 16)
+    val b = SignedBitVector(BigInteger.valueOf(20), 16)
+    assertEquals(SignedBitVector(BigInteger.valueOf(30), 16), a.addSat(b))
+    assertEquals(SignedBitVector(BigInteger.valueOf(-10), 16), a.subSat(b))
+  }
 }

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -110,7 +110,10 @@ class PacketContext(payload: ByteArray) {
  * In v1model/BMv2, this corresponds to a `PacketTooShort` parser error. The packet is dropped
  * rather than propagating as a simulator processing failure.
  */
-class PacketTooShortException(message: String) : Exception(message)
+class PacketTooShortException(message: String) : ParserErrorException("PacketTooShort", message)
+
+/** Thrown by the interpreter when a parser error occurs (P4 spec §12.8). */
+open class ParserErrorException(val errorName: String, message: String) : Exception(message)
 
 /** A simple byte-level cursor over a packet buffer. */
 private class PacketBuffer(private val data: ByteArray) {

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -410,8 +410,18 @@ class Interpreter(
       // bit<N>-only operations (no int<N> equivalent in P4 spec).
       BinaryOperator.DIV -> BitVal((left as BitVal).bits / (right as BitVal).bits)
       BinaryOperator.MOD -> BitVal((left as BitVal).bits % (right as BitVal).bits)
-      BinaryOperator.ADD_SAT -> BitVal((left as BitVal).bits.addSat((right as BitVal).bits))
-      BinaryOperator.SUB_SAT -> BitVal((left as BitVal).bits.subSat((right as BitVal).bits))
+      BinaryOperator.ADD_SAT ->
+        when (left) {
+          is BitVal -> BitVal(left.bits.addSat((right as BitVal).bits))
+          is IntVal -> IntVal(left.bits.addSat((right as IntVal).bits))
+          else -> error("ADD_SAT on non-fixed-width: $left")
+        }
+      BinaryOperator.SUB_SAT ->
+        when (left) {
+          is BitVal -> BitVal(left.bits.subSat((right as BitVal).bits))
+          is IntVal -> IntVal(left.bits.subSat((right as IntVal).bits))
+          else -> error("SUB_SAT on non-fixed-width: $left")
+        }
       BinaryOperator.SHL -> BitVal((left as BitVal).bits.shl(intValue(right)))
       BinaryOperator.SHR -> BitVal((left as BitVal).bits.shr(intValue(right)))
       // Equality uses data-class structural equality (works for both bit<N> and int<N>).
@@ -691,6 +701,24 @@ class Interpreter(
     // field. The second argument gives the varbit field's runtime length in bits.
     val varbitBits: Int =
       if (call.argsCount > 1) (evalExpr(call.argsList[1], env) as BitVal).bits.value.toInt() else 0
+
+    // P4 spec §12.8.1: varbit length must be a multiple of 8.
+    if (varbitBits > 0 && varbitBits % 8 != 0) {
+      throw ParserErrorException(
+        "ParserInvalidArgument",
+        "varbit extract length $varbitBits is not a multiple of 8",
+      )
+    }
+    // P4 spec §12.8.1: varbit length must not exceed the declared max width.
+    if (varbitBits > 0) {
+      val varbitField = headerDecl.fieldsList.find { it.type.hasVarbit() }
+      if (varbitField != null && varbitBits > varbitField.type.varbit.maxWidth) {
+        throw ParserErrorException(
+          "HeaderTooShort",
+          "varbit extract length $varbitBits exceeds max width ${varbitField.type.varbit.maxWidth}",
+        )
+      }
+    }
 
     // Read the entire header at once and load it into a single BigInteger (MSB-first).
     // This handles sub-byte fields (e.g. IPv4's bit<4> version and ihl) correctly:

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -407,9 +407,10 @@ class Interpreter(
       BinaryOperator.BIT_AND -> liftBitwise(left, right) { a, b -> a and b }
       BinaryOperator.BIT_OR -> liftBitwise(left, right) { a, b -> a or b }
       BinaryOperator.BIT_XOR -> liftBitwise(left, right) { a, b -> a xor b }
-      // bit<N>-only operations (no int<N> equivalent in P4 spec).
+      // bit<N>-only: division/modulo are unsigned-only in P4.
       BinaryOperator.DIV -> BitVal((left as BitVal).bits / (right as BitVal).bits)
       BinaryOperator.MOD -> BitVal((left as BitVal).bits % (right as BitVal).bits)
+      // Saturating ops can't use liftBitwise: signed/unsigned have different clamp bounds.
       BinaryOperator.ADD_SAT ->
         when (left) {
           is BitVal -> BitVal(left.bits.addSat((right as BitVal).bits))

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -703,15 +703,14 @@ class Interpreter(
     val varbitBits: Int =
       if (call.argsCount > 1) (evalExpr(call.argsList[1], env) as BitVal).bits.value.toInt() else 0
 
-    // P4 spec §12.8.1: varbit length must be a multiple of 8.
-    if (varbitBits > 0 && varbitBits % 8 != 0) {
-      throw ParserErrorException(
-        "ParserInvalidArgument",
-        "varbit extract length $varbitBits is not a multiple of 8",
-      )
-    }
-    // P4 spec §12.8.1: varbit length must not exceed the declared max width.
+    // P4 spec §12.8.1: validate varbit extract constraints.
     if (varbitBits > 0) {
+      if (varbitBits % 8 != 0) {
+        throw ParserErrorException(
+          "ParserInvalidArgument",
+          "varbit extract length $varbitBits is not a multiple of 8",
+        )
+      }
       val varbitField = headerDecl.fieldsList.find { it.type.hasVarbit() }
       if (varbitField != null && varbitBits > varbitField.type.varbit.maxWidth) {
         throw ParserErrorException(

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -71,9 +71,14 @@ class Simulator {
     tableStore.loadMappings(tableNameById, actionNameById)
 
     for (table in config.p4Info.tablesList) {
-      if (table.constDefaultActionId != 0) {
+      // const_default_action_id: immutable default set in the P4 source with `const`.
+      // initial_default_action: mutable default set in the P4 source without `const`.
+      val defaultActionId =
+        if (table.constDefaultActionId != 0) table.constDefaultActionId
+        else if (table.hasInitialDefaultAction()) table.initialDefaultAction.actionId else 0
+      if (defaultActionId != 0) {
         val tableName = tableNameById[table.preamble.id] ?: continue
-        val actionName = actionNameById[table.constDefaultActionId] ?: "NoAction"
+        val actionName = actionNameById[defaultActionId] ?: "NoAction"
         tableStore.setDefaultAction(tableName, actionName)
       }
     }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -59,6 +59,7 @@ class V1ModelArchitecture : Architecture {
     }
     standardMetadata.fields["ingress_port"] = BitVal(ingressPort.toLong(), PORT_BITS)
     standardMetadata.fields["packet_length"] = BitVal(payload.size.toLong(), INT32_BITS)
+    standardMetadata.fields["parser_error"] = ErrorVal("NoError")
 
     // Map each shared type name to its initialised object so we can bind whatever
     // local parameter names each stage uses (e.g. "smeta" vs "standard_metadata").
@@ -93,10 +94,10 @@ class V1ModelArchitecture : Architecture {
         interpreter.runParser(parserStage.blockName, env)
       } catch (e: ExitException) {
         return PipelineResult(emptyList(), packetCtx.buildTrace())
-      } catch (e: PacketTooShortException) {
+      } catch (e: ParserErrorException) {
         // BMv2 v1model: parser errors don't drop the packet. Set parser_error and
         // continue to the ingress pipeline, letting the P4 program decide the fate.
-        standardMetadata.fields["parser_error"] = ErrorVal("PacketTooShort")
+        standardMetadata.fields["parser_error"] = ErrorVal(e.errorName)
       }
     }
 


### PR DESCRIPTION
## Summary

- **Signed saturating arithmetic**: `ADD_SAT`/`SUB_SAT` now handle `int<N>` operands via `SignedBitVector.addSat/subSat` with proper signed clamping bounds `[-2^(N-1), 2^(N-1)-1]`
- **Parser error model**: initialize `parser_error` to `NoError` (was `UnitVal`); detect `ParserInvalidArgument` (non-byte-aligned varbit) and `HeaderTooShort` (varbit exceeds max width) via `ParserErrorException` base class
- **Initial default actions**: handle p4info `initial_default_action` for mutable defaults (declared without `const`)
- **Promote 3 tests**: `saturated-bmv2`, `test-parserinvalidargument-error-bmv2`, `bvec-hdr-bmv2` (stale annotation)
- **Update annotations** for `issue1049`, `ternary2`, `gauntlet_invalid_hdr_short_circuit` with accurate root causes
- **Cleanup**: cache `SignedBitVector` min/max bounds via `lazy`, combine varbit validation blocks

## Test plan

- [x] `bazel test //...` passes (23/23)
- [x] `saturated-bmv2` exercises both unsigned `bit<8>` and signed `int<16>` saturating ops
- [x] `test-parserinvalidargument-error-bmv2` exercises NoError, HeaderTooShort, and ParserInvalidArgument
- [x] `bvec-hdr-bmv2` was already passing
- [x] Unit tests for `SignedBitVector.addSat/subSat` edge cases (clamp-to-max, clamp-to-min, within-range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)