### PR TITLE
Implement verify() extern; promote issue1824-bmv2 (151 → 152)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -114,6 +114,7 @@ corpus_test_suite(
         "issue-2123-3-bmv2",
         "issue1000-bmv2",
         "issue1062-1-bmv2",
+        "issue1824-bmv2",
         "issue2147-bmv2",
         "issue2153-bmv2",
         "issue2170-bmv2",
@@ -260,15 +261,14 @@ corpus_test_suite(
     name = "other_stf_corpus_test",
     tags = ["manual"],
     tests = [
-        "checksum2-bmv2",  # unhandled extern call: verify
-        "checksum3-bmv2",  # unhandled extern call: verify
+        "checksum2-bmv2",  # unhandled extern call: verify_checksum
+        "checksum3-bmv2",  # unhandled extern call: update_checksum
         "gauntlet_invalid_hdr_short_circuit-bmv2",  # un-parsed payload appended after deparser
-        "header-stack-ops-bmv2",  # unhandled extern call: verify
+        "header-stack-ops-bmv2",  # unhandled extern call: push_front/pop_front
         "issue1049-bmv2",  # unhandled extern call: hash
         "issue1097-2-bmv2",  # unhandled method call: write (register extern)
         "issue1566-bmv2",  # unhandled method call: count (counter extern)
         "issue1814-1-bmv2",  # unhandled method call: read (register extern)
-        "issue1824-bmv2",  # unhandled extern call: verify
         "issue1879-bmv2",  # undefined variable: inf_0 (inlined function locals)
         "issue3488-1-bmv2",  # expected packet on port 2 but got none
         "issue561-4-bmv2",  # header stack of unions (StructVal as stack element)
@@ -277,7 +277,7 @@ corpus_test_suite(
         "issue561-7-bmv2",  # header stack of unions (StructVal as stack element)
         "issue655-bmv2",  # unhandled extern call: verify_checksum
         "stack_complex-bmv2",  # field access on non-aggregate value: HeaderStackVal
-        "subparser-with-header-stack-bmv2",  # unhandled extern call: verify
+        "subparser-with-header-stack-bmv2",  # undefined variable: inlined function locals
         "table-entries-priority-bmv2",  # BMv2 @priority uses lower-is-better; P4Runtime uses higher-is-better
         "ternary2-bmv2",  # per-table action specialization lost (single p4info action ID)
         "v1model-special-ops-bmv2",  # unhandled extern call: verify_checksum

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -668,6 +668,15 @@ class Interpreter(
           BitVal(V1ModelArchitecture.DROP_PORT.toLong(), V1ModelArchitecture.PORT_BITS)
         UnitVal
       }
+      // verify(condition, error): P4 spec §12.8 parser assertion.
+      "verify" -> {
+        val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
+        if (!condition) {
+          val err = (evalExpr(call.argsList[1], env) as ErrorVal).member
+          throw ParserErrorException(err, "verify failed: $err")
+        }
+        UnitVal
+      }
       else -> error("unhandled extern call: $funcName")
     }
   }


### PR DESCRIPTION
## Summary

- Implement P4 spec §12.8 `verify(condition, error)` parser assertion extern
- When condition is false, throws `ParserErrorException` with the specified error name, caught by `V1ModelArchitecture` which sets `parser_error` and continues to ingress
- Promotes `issue1824-bmv2` whose sole blocker was the missing verify extern (151 → 152 passing)
- Updates annotations for 4 other tests where verify was the listed blocker but secondary blockers remain:
  - `checksum2-bmv2`: verify_checksum
  - `checksum3-bmv2`: update_checksum
  - `header-stack-ops-bmv2`: push_front/pop_front
  - `subparser-with-header-stack-bmv2`: undefined variable (inlined function locals)

## Test plan

- [x] `bazel test //...` passes (24/24, including 152 corpus tests)
- [x] `issue1824-bmv2` promoted to main suite and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)