### PR TITLE
Store default action arguments; promote 3 tests (152 → 155)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -26,6 +26,8 @@ corpus_test_suite(
         "arith5-bmv2",
         "array-copy-bmv2",
         "bvec-hdr-bmv2",
+        "default-action-arg-bmv2",
+        "default_action-bmv2",
         "equality-varbit-bmv2",
         "flag_lost-bmv2",
         "gauntlet_action_mux-bmv2",
@@ -132,6 +134,7 @@ corpus_test_suite(
         "issue2488-bmv2",
         "issue2498-bmv2",
         "issue2614-bmv2",
+        "issue3488-1-bmv2",
         "issue3488-bmv2",
         "issue447-1-bmv2",
         "issue447-2-bmv2",
@@ -185,11 +188,9 @@ corpus_test_suite(
     tags = ["manual"],
     tests = [
         "constant-in-calculation-bmv2",  # unhandled extern call: hash
-        "default-action-arg-bmv2",  # UnitVal as action param default
-        "default_action-bmv2",  # UnitVal as action param default
-        "enum-bmv2",  # unhandled expression kind (enum)
+        "enum-bmv2",  # missing ConvertEnums midend pass
         "extern-funcs-bmv2",  # unhandled extern call: extern_func
-        "ipv6-switch-ml-bmv2",  # expected packet on port 6 but got none
+        "ipv6-switch-ml-bmv2",  # multicast replication not implemented
     ],
 )
 
@@ -270,7 +271,6 @@ corpus_test_suite(
         "issue1566-bmv2",  # unhandled method call: count (counter extern)
         "issue1814-1-bmv2",  # unhandled method call: read (register extern)
         "issue1879-bmv2",  # undefined variable: inf_0 (inlined function locals)
-        "issue3488-1-bmv2",  # expected packet on port 2 but got none
         "issue561-4-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-5-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-6-bmv2",  # header stack of unions (StructVal as stack element)

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -548,22 +548,23 @@ class Interpreter(
     val tableBehavior = tables[tableName] ?: error("unknown table: $tableName")
     val keyValues = tableBehavior.keysList.map { key -> key.fieldName to evalExpr(key.expr, env) }
 
-    val (hit, entry, actionName) = tableStore.lookup(tableName, keyValues)
+    val result = tableStore.lookup(tableName, keyValues)
 
     packetCtx?.addTraceEvent(
       TraceEvent.newBuilder()
         .setTableLookup(
           TableLookupEvent.newBuilder()
             .setTableName(tableName)
-            .setHit(hit)
-            .setActionName(actionName)
-            .also { if (entry != null) it.setMatchedEntry(entry) }
+            .setHit(result.hit)
+            .setActionName(result.actionName)
+            .also { if (result.entry != null) it.setMatchedEntry(result.entry) }
         )
         .build()
     )
 
-    execAction(actionName, entry?.action?.action?.paramsList ?: emptyList(), env)
-    return TableResult(hit, actionName)
+    val params = result.entry?.action?.action?.paramsList ?: result.actionParams
+    execAction(result.actionName, params, env)
+    return TableResult(result.hit, result.actionName)
   }
 
   private fun execAction(

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -79,7 +79,17 @@ class Simulator {
       if (defaultActionId != 0) {
         val tableName = tableNameById[table.preamble.id] ?: continue
         val actionName = actionNameById[defaultActionId] ?: "NoAction"
-        tableStore.setDefaultAction(tableName, actionName)
+        // Convert p4info TableActionCall.Argument to P4Runtime Action.Param.
+        val params =
+          if (table.hasInitialDefaultAction())
+            table.initialDefaultAction.argumentsList.map { arg ->
+              p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+                .setParamId(arg.paramId)
+                .setValue(arg.value)
+                .build()
+            }
+          else emptyList()
+        tableStore.setDefaultAction(tableName, actionName, params)
       }
     }
 

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -21,8 +21,13 @@ class TableStore {
   // tableName -> list of entries, ordered by insertion (priority is explicit in the entry)
   private val tables: MutableMap<String, MutableList<TableEntry>> = mutableMapOf()
 
-  // tableName -> default action name (from p4info)
-  private val defaultActions: MutableMap<String, String> = mutableMapOf()
+  // tableName -> default action name + arguments (from p4info)
+  private data class DefaultAction(
+    val name: String,
+    val params: List<p4.v1.P4RuntimeOuterClass.Action.Param> = emptyList(),
+  )
+
+  private val defaultActions: MutableMap<String, DefaultAction> = mutableMapOf()
 
   // For unit tests that cannot easily construct TableEntry protos: makes lookup() return
   // hit=true with this action rather than searching the entry list.
@@ -48,8 +53,12 @@ class TableStore {
     forcedHits.clear()
   }
 
-  fun setDefaultAction(tableName: String, actionName: String) {
-    defaultActions[tableName] = actionName
+  fun setDefaultAction(
+    tableName: String,
+    actionName: String,
+    params: List<p4.v1.P4RuntimeOuterClass.Action.Param> = emptyList(),
+  ) {
+    defaultActions[tableName] = DefaultAction(actionName, params)
   }
 
   // -------------------------------------------------------------------------
@@ -78,7 +87,12 @@ class TableStore {
   // Lookup
   // -------------------------------------------------------------------------
 
-  data class LookupResult(val hit: Boolean, val entry: TableEntry?, val actionName: String)
+  data class LookupResult(
+    val hit: Boolean,
+    val entry: TableEntry?,
+    val actionName: String,
+    val actionParams: List<p4.v1.P4RuntimeOuterClass.Action.Param> = emptyList(),
+  )
 
   /**
    * Looks up [keyValues] in [tableName]. Returns the best-matching entry or, on a miss, the default
@@ -93,7 +107,7 @@ class TableStore {
     }
 
     val entries = tables[tableName] ?: emptyList<TableEntry>()
-    val defaultAction = defaultActions[tableName] ?: "NoAction"
+    val default = defaultActions[tableName] ?: DefaultAction("NoAction")
 
     data class Candidate(val entry: TableEntry, val score: Long)
 
@@ -104,7 +118,8 @@ class TableStore {
       }
 
     val best =
-      candidates.maxByOrNull { it.score } ?: return LookupResult(false, null, defaultAction)
+      candidates.maxByOrNull { it.score }
+        ?: return LookupResult(false, null, default.name, default.params)
 
     val actionId = best.entry.action.action.actionId
     val actionName = actionNameById[actionId] ?: error("unknown action ID: $actionId")


### PR DESCRIPTION
## Summary

- Default actions with arguments (e.g. `const default_action = send(2)`) were stored name-only, discarding the argument values. On a table miss, action parameters were bound to `UnitVal` instead of the declared defaults, causing `ClassCastException`.
- Fix: store default action arguments in `TableStore` alongside the action name. Convert p4info `TableActionCall.Argument` to P4Runtime `Action.Param` during pipeline loading. Thread params through `LookupResult` so the interpreter binds them on miss.
- Promotes 3 tests (152 → 155): `default-action-arg-bmv2`, `default_action-bmv2`, `issue3488-1-bmv2`
- Updates annotations: `enum-bmv2` (missing `ConvertEnums` midend pass), `ipv6-switch-ml-bmv2` (multicast not implemented)

## Investigation notes

Also investigated 4 other one-offs — none fixable in this PR:
- `ternary2-bmv2`: per-table action specialization lost (flat `actionNameById` map needs per-table mapping)
- `enum-bmv2`: missing `ConvertEnums` midend pass (compiler-side)
- `ipv6-switch-ml-bmv2`: multicast replication not implemented
- `gauntlet_invalid_hdr_short_circuit-bmv2`, `table-entries-priority-bmv2`: investigation pending

## Test plan

- [x] `bazel test //...` passes (24/24, including 155 corpus tests)
- [x] All 3 promoted tests pass individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)