### PR TITLE
Register/counter externs, BoolVal table keys; promote 4 (155 → 159)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -116,6 +116,9 @@ corpus_test_suite(
         "issue-2123-3-bmv2",
         "issue1000-bmv2",
         "issue1062-1-bmv2",
+        "issue1097-2-bmv2",
+        "issue1566-bmv2",
+        "issue1814-1-bmv2",
         "issue1824-bmv2",
         "issue2147-bmv2",
         "issue2153-bmv2",
@@ -158,6 +161,7 @@ corpus_test_suite(
         "runtime-index-2-bmv2",
         "runtime-index-bmv2",
         "saturated-bmv2",
+        "stack_complex-bmv2",
         "table-entries-exact-bmv2",
         "table-entries-exact-ternary-bmv2",
         "table-entries-lpm-bmv2",
@@ -267,16 +271,12 @@ corpus_test_suite(
         "gauntlet_invalid_hdr_short_circuit-bmv2",  # un-parsed payload appended after deparser
         "header-stack-ops-bmv2",  # unhandled extern call: push_front/pop_front
         "issue1049-bmv2",  # unhandled extern call: hash
-        "issue1097-2-bmv2",  # unhandled method call: write (register extern)
-        "issue1566-bmv2",  # unhandled method call: count (counter extern)
-        "issue1814-1-bmv2",  # unhandled method call: read (register extern)
         "issue1879-bmv2",  # undefined variable: inf_0 (inlined function locals)
         "issue561-4-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-5-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-6-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-7-bmv2",  # header stack of unions (StructVal as stack element)
         "issue655-bmv2",  # unhandled extern call: verify_checksum
-        "stack_complex-bmv2",  # field access on non-aggregate value: HeaderStackVal
         "subparser-with-header-stack-bmv2",  # undefined variable: inlined function locals
         "table-entries-priority-bmv2",  # BMv2 @priority uses lower-is-better; P4Runtime uses higher-is-better
         "ternary2-bmv2",  # per-table action specialization lost (single p4info action ID)

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -530,6 +530,25 @@ class Interpreter(
       // (not in env); the header is the first argument.
       "extract" -> execExtract(call, env)
       "emit" -> execEmit(call, env)
+      // register.read(dst, index): reads the value at index into the out param dst.
+      "read" -> {
+        val regName = call.target.nameRef.name
+        val index = (evalExpr(call.argsList[1], env) as BitVal).bits.value.toInt()
+        val value =
+          tableStore.registerRead(regName, index) ?: defaultValue(call.argsList[0].type, types)
+        setLValue(call.argsList[0], value, env)
+        UnitVal
+      }
+      // register.write(index, value): stores value at index.
+      "write" -> {
+        val regName = call.target.nameRef.name
+        val index = (evalExpr(call.argsList[0], env) as BitVal).bits.value.toInt()
+        val value = evalExpr(call.argsList[1], env)
+        tableStore.registerWrite(regName, index, value)
+        UnitVal
+      }
+      // counter.count(index): fire-and-forget side-effect, invisible to data plane.
+      "count" -> UnitVal
       // "__call__" is used for free functions and direct action calls. Check actions first;
       // fall back to extern handling (mark_to_drop, etc.) for unrecognised names.
       "__call__" -> {

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -31,6 +31,9 @@ class TableStore {
 
   private val defaultActions: MutableMap<String, DefaultAction> = mutableMapOf()
 
+  // registerName -> index -> stored value (persists across packets)
+  private val registers: MutableMap<String, MutableMap<Int, Value>> = mutableMapOf()
+
   // For unit tests that cannot easily construct TableEntry protos: makes lookup() return
   // hit=true with this action rather than searching the entry list.
   private val forcedHits: MutableMap<String, String> = mutableMapOf()
@@ -70,6 +73,7 @@ class TableStore {
     this.actionNameById = actionNameById
     tables.clear()
     forcedHits.clear()
+    registers.clear()
     profileMembers.clear()
     profileGroups.clear()
     tableActionProfile.clear()
@@ -89,6 +93,16 @@ class TableStore {
     params: List<p4.v1.P4RuntimeOuterClass.Action.Param> = emptyList(),
   ) {
     defaultActions[tableName] = DefaultAction(actionName, params)
+  }
+
+  // -------------------------------------------------------------------------
+  // Registers
+  // -------------------------------------------------------------------------
+
+  fun registerRead(name: String, index: Int): Value? = registers[name]?.get(index)
+
+  fun registerWrite(name: String, index: Int, value: Value) {
+    registers.getOrPut(name) { mutableMapOf() }[index] = value
   }
 
   // -------------------------------------------------------------------------
@@ -228,7 +242,12 @@ class TableStore {
         keyValues.find { it.first == match.fieldId.toString() }
           ?: return null // no key value for this match field
 
-      val bits = (value as? BitVal)?.bits ?: return null
+      val bits =
+        when (value) {
+          is BitVal -> value.bits
+          is BoolVal -> BitVector.ofInt(if (value.value) 1 else 0, 1)
+          else -> return null
+        }
 
       when {
         match.hasExact() -> {

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -245,7 +245,7 @@ class TableStore {
       val bits =
         when (value) {
           is BitVal -> value.bits
-          is BoolVal -> BitVector.ofInt(if (value.value) 1 else 0, 1)
+          is BoolVal -> if (value.value) BOOL_TRUE_BITS else BOOL_FALSE_BITS
           else -> return null
         }
 
@@ -290,5 +290,10 @@ class TableStore {
       }
     }
     return score
+  }
+
+  companion object {
+    private val BOOL_TRUE_BITS = BitVector.ofInt(1, 1)
+    private val BOOL_FALSE_BITS = BitVector.ofInt(0, 1)
   }
 }

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -159,6 +159,14 @@ class TableStoreTest {
   }
 
   @Test
+  fun `exact match hit with BoolVal key`() {
+    write(exactEntry(fieldId = 1, value = byteArrayOf(0x00), actionId = 42))
+    val result = store.lookup(TABLE_NAME, listOf("1" to BoolVal(false)))
+    assertTrue(result.hit)
+    assertEquals("action42", result.actionName)
+  }
+
+  @Test
   fun `exact match miss on different value`() {
     write(exactEntry(fieldId = 1, value = byteArrayOf(0x0A), actionId = 42))
     val result = store.lookup(TABLE_NAME, listOf("1" to BitVal(11, 8)))


### PR DESCRIPTION
## Summary

- **Register extern**: implement `register.read(dst, idx)` and `register.write(idx, val)` in the interpreter, backed by per-register index→value maps in `TableStore` that persist across packets.
- **Counter extern**: implement `counter.count(idx)` as a no-op (counters are invisible to the data plane).
- **BoolVal table keys**: fix `scoreEntry` to handle `BoolVal` keys in exact-match lookups (previously silently returned miss). Cache `BOOL_TRUE_BITS`/`BOOL_FALSE_BITS` constants to avoid per-lookup allocation.
- **Promote 4 tests** to CI (155 → 159): `issue1097-2-bmv2`, `issue1566-bmv2`, `issue1814-1-bmv2`, `stack_complex-bmv2`.

## Test plan

- [x] `bazel test //simulator:all` — 8/8 pass (includes new BoolVal exact match unit test)
- [x] `bazel test //e2e_tests/corpus:v1model_stf_corpus_test` — 159/159 pass
- [x] `./format.sh` and `./lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)