### PR TITLE
Parser local vars, field-access copy semantics; promote 3 tests (159 → 162)

### DIFF
--- a/e2e_tests/corpus.bzl
+++ b/e2e_tests/corpus.bzl
@@ -17,7 +17,7 @@ This creates:
 
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
-def corpus_test_suite(name, tests, tags = [], includes = []):
+def corpus_test_suite(name, tests, tags = [], includes = [], stf_overrides = {}):
     """Compiles p4c corpus P4 files and runs all STF tests in a single JVM.
 
     Args:
@@ -27,6 +27,9 @@ def corpus_test_suite(name, tests, tags = [], includes = []):
         includes: extra P4 file labels needed as #include dependencies (e.g.
                   skeleton headers). Their directory is added to the p4c
                   include path.
+        stf_overrides: dict mapping test base names to local STF file labels,
+                  overriding the upstream @p4c STF. Use when the upstream STF
+                  expectation is wrong (e.g. missing un-parsed payload).
     """
     data = ["//simulator"]
 
@@ -39,7 +42,6 @@ def corpus_test_suite(name, tests, tags = [], includes = []):
 
     for test in tests:
         p4_src = "@p4c//testdata/p4_16_samples:" + test + ".p4"
-        stf_src = "@p4c//testdata/p4_16_samples:" + test + ".stf"
 
         native.genrule(
             name = test + "_pb",
@@ -54,16 +56,20 @@ def corpus_test_suite(name, tests, tags = [], includes = []):
             ],
         )
 
-        native.genrule(
-            name = test + "_stf",
-            srcs = [stf_src],
-            outs = [test + ".stf"],
-            cmd = "cp $< $@",
-            tags = tags,
-        )
+        if test in stf_overrides:
+            # Local override: use the file directly, no genrule needed.
+            data.append(stf_overrides[test])
+        else:
+            native.genrule(
+                name = test + "_stf",
+                srcs = ["@p4c//testdata/p4_16_samples:" + test + ".stf"],
+                outs = [test + ".stf"],
+                cmd = "cp $< $@",
+                tags = tags,
+            )
+            data.append(":" + test + "_stf")
 
         data.append(":" + test + "_pb")
-        data.append(":" + test + "_stf")
 
     kt_jvm_test(
         name = name,

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -15,6 +15,11 @@ corpus_test_suite(
         "@p4c//testdata/p4_16_samples:arith-skeleton.p4",
         "@p4c//testdata/p4_16_samples:ml-headers.p4",
     ],
+    stf_overrides = {
+        # Upstream STF expects 14 bytes but omits 3 bytes of un-parsed payload
+        # that v1model appends after deparsed headers.
+        "gauntlet_invalid_hdr_short_circuit-bmv2": "//e2e_tests/corpus:gauntlet_invalid_hdr_short_circuit-bmv2.stf",
+    },
     tests = [
         "arith-bmv2",
         "arith-inline-bmv2",
@@ -84,6 +89,7 @@ corpus_test_suite(
         "gauntlet_int_casting-bmv2",
         "gauntlet_int_slice-bmv2",
         "gauntlet_invalid_hdr_assign-bmv2",
+        "gauntlet_invalid_hdr_short_circuit-bmv2",
         "gauntlet_list_as_in_argument-bmv2",
         "gauntlet_mux_eval-bmv2",
         "gauntlet_mux_hdr-bmv2",
@@ -120,6 +126,7 @@ corpus_test_suite(
         "issue1566-bmv2",
         "issue1814-1-bmv2",
         "issue1824-bmv2",
+        "issue1879-bmv2",
         "issue2147-bmv2",
         "issue2153-bmv2",
         "issue2170-bmv2",
@@ -162,6 +169,7 @@ corpus_test_suite(
         "runtime-index-bmv2",
         "saturated-bmv2",
         "stack_complex-bmv2",
+        "subparser-with-header-stack-bmv2",
         "table-entries-exact-bmv2",
         "table-entries-exact-ternary-bmv2",
         "table-entries-lpm-bmv2",
@@ -268,16 +276,13 @@ corpus_test_suite(
     tests = [
         "checksum2-bmv2",  # unhandled extern call: verify_checksum
         "checksum3-bmv2",  # unhandled extern call: update_checksum
-        "gauntlet_invalid_hdr_short_circuit-bmv2",  # un-parsed payload appended after deparser
         "header-stack-ops-bmv2",  # unhandled extern call: push_front/pop_front
         "issue1049-bmv2",  # unhandled extern call: hash
-        "issue1879-bmv2",  # undefined variable: inf_0 (inlined function locals)
         "issue561-4-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-5-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-6-bmv2",  # header stack of unions (StructVal as stack element)
         "issue561-7-bmv2",  # header stack of unions (StructVal as stack element)
         "issue655-bmv2",  # unhandled extern call: verify_checksum
-        "subparser-with-header-stack-bmv2",  # undefined variable: inlined function locals
         "table-entries-priority-bmv2",  # BMv2 @priority uses lower-is-better; P4Runtime uses higher-is-better
         "ternary2-bmv2",  # per-table action specialization lost (single p4info action ID)
         "v1model-special-ops-bmv2",  # unhandled extern call: verify_checksum

--- a/e2e_tests/corpus/gauntlet_invalid_hdr_short_circuit-bmv2.stf
+++ b/e2e_tests/corpus/gauntlet_invalid_hdr_short_circuit-bmv2.stf
@@ -1,0 +1,5 @@
+# Corrected STF: upstream expects 14 bytes but un-parsed payload (3 bytes)
+# must be appended after deparsed headers per v1model semantics.
+# See V1ModelArchitecture.kt: outputPayload() + drainRemainingInput().
+packet 0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+expect 0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -526,6 +526,18 @@ void FourWardBackend::emitParser(const IR::P4Parser* parser) {
     }
   }
 
+  // Emit parser-local variables (e.g. from inlined sub-parsers).
+  for (const auto* decl : parser->parserLocals) {
+    if (const auto* varDecl = decl->to<IR::Declaration_Variable>()) {
+      auto* vd = pd->add_local_vars();
+      vd->set_name(varDecl->name.name.c_str());
+      *vd->mutable_type() = emitType(varDecl->type);
+      if (varDecl->initializer) {
+        *vd->mutable_initializer() = emitExpr(varDecl->initializer);
+      }
+    }
+  }
+
   for (const auto* state : parser->states) {
     auto* ps = pd->add_states();
     ps->set_name(state->name.name.c_str());

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -76,18 +76,7 @@ class Interpreter(
 
   fun runParser(parserName: String, env: Environment) {
     val parser = parsers[parserName] ?: error("unknown parser: $parserName")
-    env.pushScope()
-    try {
-      for (varDecl in parser.localVarsList) {
-        val init =
-          if (varDecl.hasInitializer()) evalExpr(varDecl.initializer, env)
-          else defaultValue(varDecl.type, types)
-        env.define(varDecl.name, init)
-      }
-      runParserState(parser, "start", env)
-    } finally {
-      env.popScope()
-    }
+    withLocalScope(parser.localVarsList, env) { runParserState(parser, "start", env) }
   }
 
   private fun runParserState(parser: ParserDecl, startState: String, env: Environment) {
@@ -164,15 +153,24 @@ class Interpreter(
 
   fun runControl(controlName: String, env: Environment) {
     val control = controls[controlName] ?: error("unknown control: $controlName")
+    withLocalScope(control.localVarsList, env) { execBlock(control.applyBodyList, env) }
+  }
+
+  /** Pushes a scope, defines [localVars], runs [body], then pops the scope. */
+  private inline fun withLocalScope(
+    localVars: List<fourward.ir.v1.VarDecl>,
+    env: Environment,
+    body: () -> Unit,
+  ) {
     env.pushScope()
     try {
-      for (varDecl in control.localVarsList) {
+      for (varDecl in localVars) {
         val init =
           if (varDecl.hasInitializer()) evalExpr(varDecl.initializer, env)
           else defaultValue(varDecl.type, types)
         env.define(varDecl.name, init)
       }
-      execBlock(control.applyBodyList, env)
+      body()
     } finally {
       env.popScope()
     }
@@ -928,28 +926,20 @@ class Interpreter(
   // -------------------------------------------------------------------------
 
   private fun setLValue(lhs: Expr, value: Value, env: Environment) {
+    // P4 assignment is copy-by-value. Headers and structs carry mutable fields maps,
+    // so we copy them to prevent aliasing (e.g. `x = h.h; x.a = 2` must not modify `h.h.a`).
+    val copy =
+      when (value) {
+        is HeaderVal -> value.copy()
+        is StructVal -> value.copy()
+        else -> value
+      }
     when {
       lhs.hasNameRef() -> {
-        // P4 assignment is copy-by-value. Headers and structs carry a mutable fields map,
-        // so we copy them here to prevent aliasing (e.g. `x = h.h; x.a = 2` must not
-        // modify `h.h.a`).
-        val copy =
-          when (value) {
-            is HeaderVal -> value.copy()
-            is StructVal -> value.copy()
-            else -> value
-          }
         env.update(lhs.nameRef.name, copy)
       }
       lhs.hasFieldAccess() -> {
         val target = evalExpr(lhs.fieldAccess.expr, env)
-        // Copy aggregates to prevent aliasing (same reason as nameRef above).
-        val copy =
-          when (value) {
-            is HeaderVal -> value.copy()
-            is StructVal -> value.copy()
-            else -> value
-          }
         when (target) {
           is HeaderVal -> target.fields[lhs.fieldAccess.fieldName] = copy
           is StructVal -> target.fields[lhs.fieldAccess.fieldName] = copy
@@ -959,7 +949,6 @@ class Interpreter(
       lhs.hasArrayIndex() -> {
         val stack = evalExpr(lhs.arrayIndex.expr, env) as HeaderStackVal
         val index = intValue(evalExpr(lhs.arrayIndex.index, env))
-        val copy = if (value is HeaderVal) value.copy() else value
         stack.headers[index] = copy as HeaderVal
       }
       lhs.hasSlice() -> {

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -76,7 +76,18 @@ class Interpreter(
 
   fun runParser(parserName: String, env: Environment) {
     val parser = parsers[parserName] ?: error("unknown parser: $parserName")
-    runParserState(parser, "start", env)
+    env.pushScope()
+    try {
+      for (varDecl in parser.localVarsList) {
+        val init =
+          if (varDecl.hasInitializer()) evalExpr(varDecl.initializer, env)
+          else defaultValue(varDecl.type, types)
+        env.define(varDecl.name, init)
+      }
+      runParserState(parser, "start", env)
+    } finally {
+      env.popScope()
+    }
   }
 
   private fun runParserState(parser: ParserDecl, startState: String, env: Environment) {
@@ -932,9 +943,16 @@ class Interpreter(
       }
       lhs.hasFieldAccess() -> {
         val target = evalExpr(lhs.fieldAccess.expr, env)
+        // Copy aggregates to prevent aliasing (same reason as nameRef above).
+        val copy =
+          when (value) {
+            is HeaderVal -> value.copy()
+            is StructVal -> value.copy()
+            else -> value
+          }
         when (target) {
-          is HeaderVal -> target.fields[lhs.fieldAccess.fieldName] = value
-          is StructVal -> target.fields[lhs.fieldAccess.fieldName] = value
+          is HeaderVal -> target.fields[lhs.fieldAccess.fieldName] = copy
+          is StructVal -> target.fields[lhs.fieldAccess.fieldName] = copy
           else -> error("field assignment on non-aggregate: $target")
         }
       }

--- a/simulator/ir.proto
+++ b/simulator/ir.proto
@@ -205,6 +205,7 @@ message ParserDecl {
   string name = 1;
   repeated ParamDecl params = 2;
   repeated ParserState states = 3;
+  repeated VarDecl local_vars = 4;
 }
 
 message ParserState {


### PR DESCRIPTION
## Summary

- **Parser local variables**: add `local_vars` to `ParserDecl` across proto, C++ backend, and Kotlin simulator — mirrors the existing `ControlDecl` pattern. Fixes inlined sub-parser variables (`inf_0`, `meta_0`, etc.) that were undefined at runtime.
- **Field-access copy semantics**: fix aliasing bug in `setLValue` where `fieldAccess` assignments stored `HeaderVal`/`StructVal` by reference instead of copying. The same sub-parser local variable was reused across multiple inlined calls, corrupting previously-extracted headers. Hoisted the copy-on-assign logic to a single site at the top of `setLValue`, eliminating 3 duplicate copy blocks.
- **`withLocalScope` helper**: extracted shared scope-push/local-var-init/scope-pop pattern from `runParser` and `runControl` into a single inline helper.
- **STF override mechanism**: add `stf_overrides` parameter to `corpus_test_suite` for tests where the upstream p4c STF expectation is wrong. Used for `gauntlet_invalid_hdr_short_circuit-bmv2` where upstream omits un-parsed payload that v1model appends after deparsed headers.
- **Promote 3 tests** to CI (159 → 162): `issue1879-bmv2`, `subparser-with-header-stack-bmv2`, `gauntlet_invalid_hdr_short_circuit-bmv2`.

## Test plan

- [x] `bazel test //...` — 24/24 pass
- [x] `bazel test //e2e_tests/corpus:v1model_stf_corpus_test` — 162/162 pass
- [x] `./format.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)