### PR TITLE
Header-union stacks, extract side-effect fix; promote 4 tests (162 → 166)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -156,6 +156,10 @@ corpus_test_suite(
         "issue561-1-bmv2",
         "issue561-2-bmv2",
         "issue561-3-bmv2",
+        "issue561-4-bmv2",
+        "issue561-5-bmv2",
+        "issue561-6-bmv2",
+        "issue561-7-bmv2",
         "issue635-bmv2",
         "issue774-4-bmv2",
         "issue983-bmv2",
@@ -278,10 +282,6 @@ corpus_test_suite(
         "checksum3-bmv2",  # unhandled extern call: update_checksum
         "header-stack-ops-bmv2",  # unhandled extern call: push_front/pop_front
         "issue1049-bmv2",  # unhandled extern call: hash
-        "issue561-4-bmv2",  # header stack of unions (StructVal as stack element)
-        "issue561-5-bmv2",  # header stack of unions (StructVal as stack element)
-        "issue561-6-bmv2",  # header stack of unions (StructVal as stack element)
-        "issue561-7-bmv2",  # header stack of unions (StructVal as stack element)
         "issue655-bmv2",  # unhandled extern call: verify_checksum
         "table-entries-priority-bmv2",  # BMv2 @priority uses lower-is-better; P4Runtime uses higher-is-better
         "ternary2-bmv2",  # per-table action specialization lost (single p4info action ID)

--- a/simulator/DefaultValues.kt
+++ b/simulator/DefaultValues.kt
@@ -36,7 +36,7 @@ internal fun defaultValue(type: Type, types: Map<String, TypeDecl>): Value =
         elementTypeName = type.headerStack.elementType,
         headers =
           MutableList(type.headerStack.size.toInt()) {
-            defaultValue(type.headerStack.elementType, types) as HeaderVal
+            defaultValue(type.headerStack.elementType, types)
           },
       )
     else -> UnitVal // varbit<N>: variable-length; no fixed default

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -732,12 +732,23 @@ class Interpreter(
     }
   }
 
-  /** If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20). */
-  private fun invalidateUnionSiblings(expr: Expr, target: HeaderVal, env: Environment) {
+  /**
+   * If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20).
+   *
+   * When [parentOverride] is provided, uses it instead of re-evaluating the parent expression. This
+   * avoids double-evaluation of side-effecting expressions like `.next` on header stacks.
+   */
+  private fun invalidateUnionSiblings(
+    expr: Expr,
+    target: HeaderVal,
+    env: Environment,
+    parentOverride: StructVal? = null,
+  ) {
     if (!expr.hasFieldAccess()) return
     val parentType = expr.fieldAccess.expr.type
     if (!parentType.hasNamed() || types[parentType.named]?.hasHeaderUnion() != true) return
-    (evalExpr(expr.fieldAccess.expr, env) as StructVal).invalidateUnionExcept(target)
+    val parent = parentOverride ?: (evalExpr(expr.fieldAccess.expr, env) as StructVal)
+    parent.invalidateUnionExcept(target)
   }
 
   // -------------------------------------------------------------------------
@@ -749,10 +760,23 @@ class Interpreter(
     // P4's don't-care extract `p.extract<T>(_)` compiles to extract(arg) where
     // `arg` is an undeclared temporary. Create a throw-away header to consume bytes.
     val arg = call.argsList[0]
+    // When the arg is a field access into a union (e.g. hdr.u.next.byte), evaluate
+    // the union parent once and cache it so invalidateUnionSiblings doesn't
+    // re-evaluate side-effecting expressions like `.next` on header stacks.
+    var unionParent: StructVal? = null
     val header =
       if (arg.hasNameRef() && env.lookup(arg.nameRef.name) == null && arg.type.hasNamed()) {
         defaultValue(arg.type.named, types) as? HeaderVal
           ?: error("type not found for don't-care extract: ${arg.type.named}")
+      } else if (
+        arg.hasFieldAccess() &&
+          arg.fieldAccess.expr.type.hasNamed() &&
+          types[arg.fieldAccess.expr.type.named]?.hasHeaderUnion() == true
+      ) {
+        // Parent is a header union — resolve it once and extract the member header.
+        val parent = evalExpr(arg.fieldAccess.expr, env) as StructVal
+        unionParent = parent
+        parent.fields[arg.fieldAccess.fieldName] as HeaderVal
       } else {
         evalExpr(arg, env) as HeaderVal
       }
@@ -797,7 +821,7 @@ class Interpreter(
       newFields[field.name] = bitsToValue(field.type, raw, width)
       bitOffset += width
     }
-    invalidateUnionSiblings(call.argsList[0], header, env)
+    invalidateUnionSiblings(call.argsList[0], header, env, unionParent)
     header.setValid(newFields)
     return UnitVal
   }
@@ -949,7 +973,7 @@ class Interpreter(
       lhs.hasArrayIndex() -> {
         val stack = evalExpr(lhs.arrayIndex.expr, env) as HeaderStackVal
         val index = intValue(evalExpr(lhs.arrayIndex.index, env))
-        stack.headers[index] = copy as HeaderVal
+        stack.headers[index] = copy
       }
       lhs.hasSlice() -> {
         // Slice assignment: update [hi:lo] bits of the target.

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -109,10 +109,15 @@ data class StructVal(val typeName: String, val fields: MutableMap<String, Value>
   }
 }
 
-/** A header stack (fixed-size array of headers with a next/last pointer). */
+/**
+ * A header stack (fixed-size array of headers with a next/last pointer).
+ *
+ * Elements are typically [HeaderVal] but may be [StructVal] for header-union stacks (P4 spec
+ * §8.18).
+ */
 data class HeaderStackVal(
   val elementTypeName: String,
-  val headers: MutableList<HeaderVal>,
+  val headers: MutableList<Value>,
   var nextIndex: Int = 0,
 ) : Value() {
   val size: Int


### PR DESCRIPTION
## Summary

- **Header-union stacks**: widen `HeaderStackVal.headers` from `MutableList<HeaderVal>` to `MutableList<Value>` so header stacks can hold union elements (`StructVal`). Remove the `as HeaderVal` cast in `DefaultValues.kt` that crashed on union element types (P4 spec §8.18).
- **Extract side-effect fix**: `extract(hdr.u.next.byte)` was advancing `.next` twice — once to resolve the header, then again when `invalidateUnionSiblings` re-evaluated the parent expression. Now the union parent is resolved once during extract and passed through to avoid double-evaluation.
- **Promote 4 tests** to CI (162 → 166): `issue561-4-bmv2`, `issue561-5-bmv2`, `issue561-6-bmv2`, `issue561-7-bmv2`.

## Test plan

- [x] `bazel test //...` — 24/24 pass
- [x] `bazel test //e2e_tests/corpus:v1model_stf_corpus_test` — 166/166 pass
- [x] `./format.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)