### PR TITLE
Clone and multicast forking for trace trees

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -30,10 +30,12 @@ guilt — just write it down so someone can find it later.
 
 - **`ReadEntries` is a stub.** The `ReadEntriesRequest` handler returns an
   empty response (`Simulator.kt:143`).
-- **No clone, resubmit, or recirculate.** `V1ModelArchitecture` defines the
-  stage pipeline but does not implement packet cloning, resubmission, or
-  recirculation. Packets are processed in a single ingress→egress pass.
-- **No multicast.** Multicast group replication is not implemented.
+- **Clone: I2E only, no metadata preservation.** `clone()` and `clone3()`
+  support ingress-to-egress cloning. E2E clone, `clone3` metadata field
+  lists, resubmit, and recirculate are not implemented.
+- **Multicast: basic replication only.** Multicast group replication works
+  for the trace tree (forking per replica). PRE entries are installed via
+  P4Runtime `PacketReplicationEngineEntry`.
 
 ## Header types
 

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -11,6 +11,8 @@ import p4.v1.P4RuntimeOuterClass
 
 /** BMv2 STF files use `$N` for array indices; normalize to `[N]`. */
 private val ARRAY_INDEX_REGEX = Regex("\\$(\\d+)")
+private val WHITESPACE_REGEX = Regex("\\s+")
+private val INTEGER_REGEX = Regex("\\d+")
 
 /**
  * Runs a single STF test against the 4ward simulator.
@@ -47,6 +49,37 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
         return TestResult.Failure("LoadPipeline failed: ${loadResp.error.message}")
       }
 
+      // Install PRE entries (clone sessions, multicast groups).
+      for (mirror in stf.pre.mirroringAdds) {
+        val writeResp = sim.writeEntry(resolveStfMirroringAdd(mirror))
+        if (writeResp.hasError()) {
+          return TestResult.Failure("WriteEntry (mirroring) failed: ${writeResp.error.message}")
+        }
+      }
+      val mcNodes = stf.pre.mcNodeCreates.associateBy { it.rid }
+      for (mcGroup in stf.pre.mcGroupCreates) {
+        val writeResp =
+          sim.writeEntry(
+            resolveStfMulticastGroup(mcGroup.groupId, mcNodes, stf.pre.mcNodeAssociates)
+          )
+        if (writeResp.hasError()) {
+          return TestResult.Failure("WriteEntry (multicast) failed: ${writeResp.error.message}")
+        }
+      }
+
+      // Install action profile members, groups, and table entries.
+      for (member in stf.memberDirectives) {
+        val writeResp = sim.writeEntry(resolveStfMember(member, config.p4Info))
+        if (writeResp.hasError()) {
+          return TestResult.Failure("WriteEntry (member) failed: ${writeResp.error.message}")
+        }
+      }
+      for (group in stf.groupDirectives) {
+        val writeResp = sim.writeEntry(resolveStfGroup(group, config.p4Info))
+        if (writeResp.hasError()) {
+          return TestResult.Failure("WriteEntry (group) failed: ${writeResp.error.message}")
+        }
+      }
       for (directive in stf.tableEntries) {
         val writeResp = sim.writeEntry(resolveStfTableEntry(directive, config.p4Info))
         if (writeResp.hasError()) {
@@ -115,11 +148,20 @@ fun runStfTest(testName: String, pkg: String = "e2e_tests/$testName"): TestResul
 fun runStf(runfiles: String, configPath: Path, stfPath: Path): TestResult =
   StfRunner(Paths.get(runfiles, "_main/simulator/simulator"), configPath).run(stfPath)
 
+/** Packet Replication Engine configuration parsed from STF directives. */
+data class StfPreConfig(
+  val mirroringAdds: List<StfMirroringAdd> = emptyList(),
+  val mcGroupCreates: List<StfMcGroupCreate> = emptyList(),
+  val mcNodeCreates: List<StfMcNodeCreate> = emptyList(),
+  val mcNodeAssociates: List<StfMcNodeAssociate> = emptyList(),
+)
+
 /** A parsed .stf file. */
 data class StfFile(
   val tableEntries: List<StfTableDirective>,
   val memberDirectives: List<StfMemberDirective>,
   val groupDirectives: List<StfGroupDirective>,
+  val pre: StfPreConfig,
   val packets: List<StfPacket>,
   val expects: List<StfExpectedOutput>,
 ) {
@@ -133,8 +175,13 @@ data class StfFile(
      * - `setdefault <table> <action(params)>` — override a table's default action
      * - `member <profile> <member_id> <action(params)>` — action profile member
      * - `group <profile> <group_id> <member_id>...` — action profile group
+     * - `mirroring_add <session_id> <egress_port>` — clone session
+     * - `mc_mgrp_create <group_id>` — multicast group
+     * - `mc_node_create <rid> <port> [<port> ...]` — multicast node
+     * - `mc_node_associate <group_id> <node_handle>` — associate node with group
      * - `# comment`
      */
+    @Suppress("CyclomaticComplexMethod")
     fun parse(path: Path): StfFile {
       val lines =
         path
@@ -146,11 +193,15 @@ data class StfFile(
       val tableEntries = mutableListOf<StfTableDirective>()
       val memberDirectives = mutableListOf<StfMemberDirective>()
       val groupDirectives = mutableListOf<StfGroupDirective>()
+      val mirroringAdds = mutableListOf<StfMirroringAdd>()
+      val mcGroupCreates = mutableListOf<StfMcGroupCreate>()
+      val mcNodeCreates = mutableListOf<StfMcNodeCreate>()
+      val mcNodeAssociates = mutableListOf<StfMcNodeAssociate>()
       val packets = mutableListOf<StfPacket>()
       val expects = mutableListOf<StfExpectedOutput>()
 
       for (line in lines) {
-        val tokens = line.split(Regex("\\s+"))
+        val tokens = line.split(WHITESPACE_REGEX)
         when (tokens[0].lowercase()) {
           "packet" -> {
             val port = tokens[1].toInt()
@@ -169,10 +220,21 @@ data class StfFile(
           "setdefault" -> tableEntries += parseSetDefault(tokens.drop(1))
           "member" -> memberDirectives += parseMember(tokens.drop(1))
           "group" -> groupDirectives += parseGroup(tokens.drop(1))
+          "mirroring_add" -> mirroringAdds += parseMirroringAdd(tokens.drop(1))
+          "mc_mgrp_create" -> mcGroupCreates += parseMcGroupCreate(tokens.drop(1))
+          "mc_node_create" -> mcNodeCreates += parseMcNodeCreate(tokens.drop(1))
+          "mc_node_associate" -> mcNodeAssociates += parseMcNodeAssociate(tokens.drop(1))
         }
       }
 
-      return StfFile(tableEntries, memberDirectives, groupDirectives, packets, expects)
+      return StfFile(
+        tableEntries,
+        memberDirectives,
+        groupDirectives,
+        StfPreConfig(mirroringAdds, mcGroupCreates, mcNodeCreates, mcNodeAssociates),
+        packets,
+        expects,
+      )
     }
 
     /**
@@ -190,7 +252,7 @@ data class StfFile(
 
       // Optional priority: a token that is a plain integer (no ':' or '(').
       var priority: Int? = null
-      if (idx < tokens.size && tokens[idx].matches(Regex("\\d+"))) {
+      if (idx < tokens.size && tokens[idx].matches(INTEGER_REGEX)) {
         priority = tokens[idx].toInt()
         idx++
       }
@@ -311,6 +373,30 @@ data class StfFile(
       val memberIds = tokens.drop(2).map { it.toInt() }
       return StfGroupDirective(profileName, groupId, memberIds)
     }
+
+    /** Parses: `mirroring_add <session_id> <egress_port>` */
+    private fun parseMirroringAdd(tokens: List<String>): StfMirroringAdd {
+      require(tokens.size >= 2) { "mirroring_add needs session_id and egress_port" }
+      return StfMirroringAdd(tokens[0].toInt(), tokens[1].toInt())
+    }
+
+    /** Parses: `mc_mgrp_create <group_id>` */
+    private fun parseMcGroupCreate(tokens: List<String>): StfMcGroupCreate {
+      require(tokens.isNotEmpty()) { "mc_mgrp_create needs group_id" }
+      return StfMcGroupCreate(tokens[0].toInt())
+    }
+
+    /** Parses: `mc_node_create <rid> <port> [<port> ...]` */
+    private fun parseMcNodeCreate(tokens: List<String>): StfMcNodeCreate {
+      require(tokens.size >= 2) { "mc_node_create needs rid and at least one port" }
+      return StfMcNodeCreate(tokens[0].toInt(), tokens.drop(1).map { it.toInt() })
+    }
+
+    /** Parses: `mc_node_associate <group_id> <node_handle>` */
+    private fun parseMcNodeAssociate(tokens: List<String>): StfMcNodeAssociate {
+      require(tokens.size >= 2) { "mc_node_associate needs group_id and node_handle" }
+      return StfMcNodeAssociate(tokens[0].toInt(), tokens[1].toInt())
+    }
   }
 }
 
@@ -374,13 +460,10 @@ fun resolveStfTableEntry(
       }
     }
 
-  return WriteEntryRequest.newBuilder()
-    .setUpdate(
-      P4RuntimeOuterClass.Update.newBuilder()
-        .setType(updateType)
-        .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(tableEntry))
-    )
-    .build()
+  return writeEntryRequest(
+    P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(tableEntry).build(),
+    updateType,
+  )
 }
 
 /** Resolves an STF member directive to a P4Runtime WriteEntryRequest. */
@@ -413,13 +496,9 @@ fun resolveStfMember(
       )
       .build()
 
-  return WriteEntryRequest.newBuilder()
-    .setUpdate(
-      P4RuntimeOuterClass.Update.newBuilder()
-        .setType(P4RuntimeOuterClass.Update.Type.INSERT)
-        .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setActionProfileMember(member))
-    )
-    .build()
+  return writeEntryRequest(
+    P4RuntimeOuterClass.Entity.newBuilder().setActionProfileMember(member).build()
+  )
 }
 
 /** Resolves an STF group directive to a P4Runtime WriteEntryRequest. */
@@ -443,14 +522,72 @@ fun resolveStfGroup(
       )
       .build()
 
-  return WriteEntryRequest.newBuilder()
-    .setUpdate(
-      P4RuntimeOuterClass.Update.newBuilder()
-        .setType(P4RuntimeOuterClass.Update.Type.INSERT)
-        .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setActionProfileGroup(group))
-    )
-    .build()
+  return writeEntryRequest(
+    P4RuntimeOuterClass.Entity.newBuilder().setActionProfileGroup(group).build()
+  )
 }
+
+/** Resolves a mirroring_add directive to a P4Runtime WriteEntryRequest (clone session). */
+fun resolveStfMirroringAdd(directive: StfMirroringAdd): WriteEntryRequest {
+  val session =
+    P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
+      .setSessionId(directive.sessionId)
+      .addReplicas(P4RuntimeOuterClass.Replica.newBuilder().setEgressPort(directive.egressPort))
+      .build()
+
+  return writeEntryRequest(
+    P4RuntimeOuterClass.Entity.newBuilder()
+      .setPacketReplicationEngineEntry(
+        P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder().setCloneSessionEntry(session)
+      )
+      .build()
+  )
+}
+
+/**
+ * Resolves multicast STF directives into a P4Runtime WriteEntryRequest.
+ *
+ * BMv2 STF uses three directives to configure multicast: mc_mgrp_create, mc_node_create, and
+ * mc_node_associate. We merge them into a single MulticastGroupEntry with all replicas.
+ */
+fun resolveStfMulticastGroup(
+  groupId: Int,
+  nodes: Map<Int, StfMcNodeCreate>,
+  associations: List<StfMcNodeAssociate>,
+): WriteEntryRequest {
+  val replicas =
+    associations
+      .filter { it.groupId == groupId }
+      .flatMap { assoc ->
+        val node = nodes[assoc.nodeHandle] ?: error("unknown mc node handle: ${assoc.nodeHandle}")
+        node.ports.map { port ->
+          P4RuntimeOuterClass.Replica.newBuilder().setEgressPort(port).setInstance(node.rid).build()
+        }
+      }
+
+  val group =
+    P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
+      .setMulticastGroupId(groupId)
+      .addAllReplicas(replicas)
+      .build()
+
+  return writeEntryRequest(
+    P4RuntimeOuterClass.Entity.newBuilder()
+      .setPacketReplicationEngineEntry(
+        P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder().setMulticastGroupEntry(group)
+      )
+      .build()
+  )
+}
+
+/** Wraps a P4Runtime Entity in a WriteEntryRequest with the given update type. */
+private fun writeEntryRequest(
+  entity: P4RuntimeOuterClass.Entity,
+  type: P4RuntimeOuterClass.Update.Type = P4RuntimeOuterClass.Update.Type.INSERT,
+): WriteEntryRequest =
+  WriteEntryRequest.newBuilder()
+    .setUpdate(P4RuntimeOuterClass.Update.newBuilder().setType(type).setEntity(entity))
+    .build()
 
 private fun findTable(name: String, p4info: P4InfoOuterClass.P4Info): P4InfoOuterClass.Table =
   p4info.tablesList.find { it.preamble.alias == name || it.preamble.name == name }
@@ -593,6 +730,14 @@ data class StfMemberDirective(
 )
 
 data class StfGroupDirective(val profileName: String, val groupId: Int, val memberIds: List<Int>)
+
+data class StfMirroringAdd(val sessionId: Int, val egressPort: Int)
+
+data class StfMcGroupCreate(val groupId: Int)
+
+data class StfMcNodeCreate(val rid: Int, val ports: List<Int>)
+
+data class StfMcNodeAssociate(val groupId: Int, val nodeHandle: Int)
 
 /** Strips surrounding double-quotes, if present. */
 private fun String.unquote(): String = removeSurrounding("\"")

--- a/e2e_tests/stf/StfParserTest.kt
+++ b/e2e_tests/stf/StfParserTest.kt
@@ -449,6 +449,69 @@ class StfParserTest {
   }
 
   // ---------------------------------------------------------------------------
+  // PRE directives: mirroring_add, mc_mgrp_create, mc_node_create, mc_node_associate
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `mirroring_add parsed into pre config`() {
+    val stf = parse("mirroring_add 100 5\npacket 0 FF")
+    assertEquals(1, stf.pre.mirroringAdds.size)
+    assertEquals(100, stf.pre.mirroringAdds[0].sessionId)
+    assertEquals(5, stf.pre.mirroringAdds[0].egressPort)
+  }
+
+  @Test
+  fun `mc_mgrp_create parsed into pre config`() {
+    val stf = parse("mc_mgrp_create 7\npacket 0 FF")
+    assertEquals(1, stf.pre.mcGroupCreates.size)
+    assertEquals(7, stf.pre.mcGroupCreates[0].groupId)
+  }
+
+  @Test
+  fun `mc_node_create parsed with multiple ports`() {
+    val stf = parse("mc_node_create 0 1 2 3\npacket 0 FF")
+    assertEquals(1, stf.pre.mcNodeCreates.size)
+    val node = stf.pre.mcNodeCreates[0]
+    assertEquals(0, node.rid)
+    assertEquals(listOf(1, 2, 3), node.ports)
+  }
+
+  @Test
+  fun `mc_node_associate parsed into pre config`() {
+    val stf = parse("mc_node_associate 1 0\npacket 0 FF")
+    assertEquals(1, stf.pre.mcNodeAssociates.size)
+    assertEquals(1, stf.pre.mcNodeAssociates[0].groupId)
+    assertEquals(0, stf.pre.mcNodeAssociates[0].nodeHandle)
+  }
+
+  @Test
+  fun `full multicast PRE config parsed together`() {
+    val stf =
+      parse(
+        """
+        mc_mgrp_create 1
+        mc_node_create 0 1 2 3
+        mc_node_associate 1 0
+        packet 0 FF
+        """
+          .trimIndent()
+      )
+    assertEquals(1, stf.pre.mcGroupCreates.size)
+    assertEquals(1, stf.pre.mcNodeCreates.size)
+    assertEquals(1, stf.pre.mcNodeAssociates.size)
+    assertEquals(listOf(1, 2, 3), stf.pre.mcNodeCreates[0].ports)
+  }
+
+  @Test
+  fun `empty file has empty pre config`() {
+    val stf = parse("packet 0 FF")
+    assertTrue(stf.pre.mirroringAdds.isEmpty())
+    assertTrue(stf.pre.mcGroupCreates.isEmpty())
+    assertTrue(stf.pre.mcNodeCreates.isEmpty())
+    assertTrue(stf.pre.mcNodeAssociates.isEmpty())
+  }
+
+  // ---------------------------------------------------------------------------
   // encodeValue
   // ---------------------------------------------------------------------------
 

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -18,14 +18,9 @@ _P4_PROGRAMS = [
     "multicast",
 ]
 
-_PASSING = [
-    "action_selector_3",
-    "action_selector_miss",
-    "action_selector_nested",
-    "no_fork",
-]
+_PASSING = _P4_PROGRAMS
 
-_MANUAL = [p for p in _P4_PROGRAMS if p not in _PASSING]
+_MANUAL = []
 
 [genrule(
     name = "%s_pb" % name,

--- a/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
+++ b/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
@@ -5,6 +5,8 @@ import fourward.e2e.SimulatorClient
 import fourward.e2e.StfFile
 import fourward.e2e.resolveStfGroup
 import fourward.e2e.resolveStfMember
+import fourward.e2e.resolveStfMirroringAdd
+import fourward.e2e.resolveStfMulticastGroup
 import fourward.e2e.resolveStfTableEntry
 import fourward.ir.v1.PipelineConfig
 import fourward.sim.v1.TraceTree
@@ -83,6 +85,21 @@ class GoldenTraceTreeTest(private val testName: String) {
       val loadResp = sim.loadPipeline(config)
       if (loadResp.hasError()) fail("LoadPipeline failed: ${loadResp.error.message}")
 
+      // Install PRE entries (clone sessions, multicast groups).
+      for (mirror in stf.pre.mirroringAdds) {
+        val writeResp = sim.writeEntry(resolveStfMirroringAdd(mirror))
+        if (writeResp.hasError()) fail("WriteEntry (mirroring) failed: ${writeResp.error.message}")
+      }
+      val mcNodes = stf.pre.mcNodeCreates.associateBy { it.rid }
+      for (mcGroup in stf.pre.mcGroupCreates) {
+        val writeResp =
+          sim.writeEntry(
+            resolveStfMulticastGroup(mcGroup.groupId, mcNodes, stf.pre.mcNodeAssociates)
+          )
+        if (writeResp.hasError()) fail("WriteEntry (multicast) failed: ${writeResp.error.message}")
+      }
+
+      // Install action profile members, groups, and table entries.
       for (member in stf.memberDirectives) {
         val writeResp = sim.writeEntry(resolveStfMember(member, config.p4Info))
         if (writeResp.hasError()) fail("WriteEntry (member) failed: ${writeResp.error.message}")

--- a/e2e_tests/trace_tree/clone_ingress_egress.stf
+++ b/e2e_tests/trace_tree/clone_ingress_egress.stf
@@ -1,3 +1,4 @@
 # clone_ingress_egress.stf — clone3 from ingress to egress.
 
+mirroring_add 100 1
 packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -1,9 +1,6 @@
 # Expected trace tree for clone_plus_selector: clone fork + selector fork.
 # First fork at clone; within the "original" branch, a second fork at the
 # selector table.
-#
-# TODO(PR 4): populate clone subtree with actual egress pipeline events.
-# TODO(PR 3): update selector member labels/params once implemented.
 events {
   parser_transition {
     parser_name: "MyParser"
@@ -23,9 +20,21 @@ fork {
     subtree {
       events {
         table_lookup {
-          table_name: "MyIngress.ecmp"
+          table_name: "ecmp"
           hit: true
-          action_name: "MyIngress.set_port"
+          matched_entry {
+            table_id: 43283160
+            match {
+              field_id: 1
+              exact {
+                value: "\377\377\377\377\377\377"
+              }
+            }
+            action {
+              action_profile_group_id: 1
+            }
+          }
+          action_name: "set_port"
         }
       }
       fork {
@@ -35,8 +44,11 @@ fork {
           subtree {
             events {
               action_execution {
-                action_name: "MyIngress.set_port"
-                params { key: "port" value: "\000\001" }
+                action_name: "set_port"
+                params {
+                  key: "port"
+                  value: "\000\001"
+                }
               }
             }
           }
@@ -46,8 +58,11 @@ fork {
           subtree {
             events {
               action_execution {
-                action_name: "MyIngress.set_port"
-                params { key: "port" value: "\000\002" }
+                action_name: "set_port"
+                params {
+                  key: "port"
+                  value: "\000\002"
+                }
               }
             }
           }
@@ -58,7 +73,6 @@ fork {
   branches {
     label: "clone"
     subtree {
-      # Cloned packet enters the egress pipeline.
     }
   }
 }

--- a/e2e_tests/trace_tree/clone_plus_selector.stf
+++ b/e2e_tests/trace_tree/clone_plus_selector.stf
@@ -1,3 +1,8 @@
 # clone_plus_selector.stf — clone3 + action selector.
 
+mirroring_add 100 1
+member ecmp_selector 0 set_port port=0x0001
+member ecmp_selector 1 set_port port=0x0002
+group ecmp_selector 1 0 1
+add ecmp hdr.ethernet.dstAddr:0xFFFFFFFFFFFF group=1
 packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/multicast.stf
+++ b/e2e_tests/trace_tree/multicast.stf
@@ -1,5 +1,6 @@
 # multicast.stf — multicast group with 3 replicas.
-# Multicast group configuration will be installed via P4Runtime
-# once the simulator supports multicast groups.
 
+mc_mgrp_create 1
+mc_node_create 0 1 2 3
+mc_node_associate 1 0
 packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -15,7 +15,6 @@ import fourward.ir.v1.Type
 import fourward.ir.v1.UnaryOperator
 import fourward.sim.v1.ActionExecutionEvent
 import fourward.sim.v1.BranchEvent
-import fourward.sim.v1.ForkReason
 import fourward.sim.v1.ParserTransitionEvent
 import fourward.sim.v1.TableLookupEvent
 import fourward.sim.v1.TraceEvent
@@ -36,7 +35,7 @@ class Interpreter(
   private val config: P4BehavioralConfig,
   private val tableStore: TableStore,
   private val packetCtx: PacketContext? = null,
-  private val forcedSelections: Map<String, Int> = emptyMap(),
+  private val decisions: ForkDecisions = ForkDecisions(),
 ) {
   private val parsers: Map<String, ParserDecl> = config.parsersList.associateBy { it.name }
 
@@ -594,7 +593,7 @@ class Interpreter(
     )
 
     if (result.members != null) {
-      val forced = forcedSelections[tableName]
+      val forced = decisions.selectorMembers[tableName]
       if (forced != null) {
         // Re-execution with a forced member — execute that member's action directly.
         val member =
@@ -604,12 +603,7 @@ class Interpreter(
         return TableResult(result.hit, member.actionName)
       }
       // First encounter: throw to let the architecture build the trace tree.
-      throw ForkException(
-        tableName,
-        ForkReason.ACTION_SELECTOR,
-        result.members,
-        packetCtx!!.getEvents(),
-      )
+      throw ActionSelectorFork(tableName, result.members, packetCtx!!.getEvents())
     }
 
     val params = result.entry?.action?.action?.paramsList ?: result.actionParams
@@ -709,6 +703,7 @@ class Interpreter(
   // Extern function calls  (method == "__call__", target is a NameRef)
   // -------------------------------------------------------------------------
 
+  @Suppress("ThrowsCount")
   private fun execExternCall(call: MethodCall, env: Environment): Value {
     val funcName = call.target.nameRef.name
     return when (funcName) {
@@ -725,6 +720,22 @@ class Interpreter(
         if (!condition) {
           val err = (evalExpr(call.argsList[1], env) as ErrorVal).member
           throw ParserErrorException(err, "verify failed: $err")
+        }
+        UnitVal
+      }
+      // clone(type, session) / clone3(type, session, data): P4 v1model I2E/E2E clone.
+      "clone",
+      "clone3" -> {
+        val sessionId = (evalExpr(call.argsList[1], env) as BitVal).bits.value.toInt()
+        packetCtx?.addTraceEvent(
+          TraceEvent.newBuilder()
+            .setClone(fourward.sim.v1.CloneEvent.newBuilder().setSessionId(sessionId))
+            .build()
+        )
+        when (decisions.cloneMode) {
+          CloneMode.THROW -> throw CloneFork(sessionId, packetCtx!!.getEvents())
+          CloneMode.SUPPRESS -> {} // already recorded event, continue normally
+          CloneMode.EXECUTE_CLONE -> throw JumpToEgressException()
         }
         UnitVal
       }
@@ -980,14 +991,43 @@ class ExitException : Exception()
 class ReturnException(val value: Value) : Exception()
 
 /**
- * Thrown when a table with an action selector implementation hits a group entry.
+ * Thrown at non-deterministic choice points to signal the architecture to fork the trace tree.
  *
- * The architecture catches this and re-executes the pipeline for each group member, building the
- * trace tree by stripping shared prefixes.
+ * The architecture catches this and re-executes the pipeline for each branch, building a tree by
+ * stripping shared prefix events.
  */
-class ForkException(
+sealed class ForkException(val eventsBeforeFork: List<TraceEvent>) : Exception()
+
+/** Fork at an action selector group hit — one branch per group member. */
+class ActionSelectorFork(
   val tableName: String,
-  val reason: ForkReason,
   val members: List<TableStore.MemberAction>,
-  val eventsBeforeFork: List<TraceEvent>,
-) : Exception()
+  eventsBeforeFork: List<TraceEvent>,
+) : ForkException(eventsBeforeFork)
+
+/** Fork at a clone() call — "original" and "clone" branches. */
+class CloneFork(val sessionId: Int, eventsBeforeFork: List<TraceEvent>) :
+  ForkException(eventsBeforeFork)
+
+/** Fork at the ingress→egress boundary when mcast_grp is set — one branch per replica. */
+class MulticastFork(val replicas: List<MulticastReplica>, eventsBeforeFork: List<TraceEvent>) :
+  ForkException(eventsBeforeFork)
+
+/** Thrown during clone-branch re-execution to skip remaining ingress and jump to egress. */
+class JumpToEgressException : Exception()
+
+/** Policies for re-execution of a pipeline branch in the trace tree. */
+data class ForkDecisions(
+  val selectorMembers: Map<String, Int> = emptyMap(),
+  val cloneMode: CloneMode = CloneMode.THROW,
+  val cloneSessionId: Int = 0,
+  val multicastReplica: MulticastReplica? = null,
+)
+
+enum class CloneMode {
+  THROW,
+  SUPPRESS,
+  EXECUTE_CLONE,
+}
+
+data class MulticastReplica(val rid: Int, val port: Int)

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -51,6 +51,11 @@ class TableStore {
   // tableName → action_profile_id (populated from p4info at load time)
   private val tableActionProfile: MutableMap<String, Int> = mutableMapOf()
 
+  // PRE (Packet Replication Engine) storage
+  private val cloneSessions: MutableMap<Int, P4RuntimeOuterClass.CloneSessionEntry> = mutableMapOf()
+  private val multicastGroups: MutableMap<Int, P4RuntimeOuterClass.MulticastGroupEntry> =
+    mutableMapOf()
+
   fun setForcedHit(tableName: String, actionName: String) {
     forcedHits[tableName] = actionName
   }
@@ -77,6 +82,8 @@ class TableStore {
     profileMembers.clear()
     profileGroups.clear()
     tableActionProfile.clear()
+    cloneSessions.clear()
+    multicastGroups.clear()
 
     // Register which tables use action profiles (implementation_id != 0).
     for (table in p4infoTables) {
@@ -114,6 +121,7 @@ class TableStore {
     when {
       entity.hasActionProfileMember() -> writeProfileMember(entity.actionProfileMember)
       entity.hasActionProfileGroup() -> writeProfileGroup(entity.actionProfileGroup)
+      entity.hasPacketReplicationEngineEntry() -> writePreEntry(entity.packetReplicationEngineEntry)
       else -> writeTableEntry(update)
     }
   }
@@ -143,6 +151,21 @@ class TableStore {
   private fun writeProfileGroup(group: P4RuntimeOuterClass.ActionProfileGroup) {
     profileGroups.getOrPut(group.actionProfileId) { mutableMapOf() }[group.groupId] = group
   }
+
+  private fun writePreEntry(pre: P4RuntimeOuterClass.PacketReplicationEngineEntry) {
+    when {
+      pre.hasCloneSessionEntry() ->
+        cloneSessions[pre.cloneSessionEntry.sessionId] = pre.cloneSessionEntry
+      pre.hasMulticastGroupEntry() ->
+        multicastGroups[pre.multicastGroupEntry.multicastGroupId] = pre.multicastGroupEntry
+    }
+  }
+
+  fun getCloneSession(sessionId: Int): P4RuntimeOuterClass.CloneSessionEntry? =
+    cloneSessions[sessionId]
+
+  fun getMulticastGroup(groupId: Int): P4RuntimeOuterClass.MulticastGroupEntry? =
+    multicastGroups[groupId]
 
   // -------------------------------------------------------------------------
   // Lookup

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -536,6 +536,100 @@ class TableStoreTest {
   }
 
   // ---------------------------------------------------------------------------
+  // PRE: clone sessions and multicast groups
+  // ---------------------------------------------------------------------------
+
+  private fun writeCloneSession(sessionId: Int, egressPort: Int) {
+    store.write(
+      Update.newBuilder()
+        .setType(Update.Type.INSERT)
+        .setEntity(
+          Entity.newBuilder()
+            .setPacketReplicationEngineEntry(
+              P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+                .setCloneSessionEntry(
+                  P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
+                    .setSessionId(sessionId)
+                    .addReplicas(P4RuntimeOuterClass.Replica.newBuilder().setEgressPort(egressPort))
+                )
+            )
+        )
+        .build()
+    )
+  }
+
+  private fun writeMulticastGroup(groupId: Int, replicas: List<Pair<Int, Int>>) {
+    store.write(
+      Update.newBuilder()
+        .setType(Update.Type.INSERT)
+        .setEntity(
+          Entity.newBuilder()
+            .setPacketReplicationEngineEntry(
+              P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+                .setMulticastGroupEntry(
+                  P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
+                    .setMulticastGroupId(groupId)
+                    .addAllReplicas(
+                      replicas.map { (rid, port) ->
+                        P4RuntimeOuterClass.Replica.newBuilder()
+                          .setInstance(rid)
+                          .setEgressPort(port)
+                          .build()
+                      }
+                    )
+                )
+            )
+        )
+        .build()
+    )
+  }
+
+  @Test
+  fun `clone session round-trip`() {
+    writeCloneSession(sessionId = 100, egressPort = 5)
+    val session = store.getCloneSession(100)
+    assertNotNull(session)
+    assertEquals(100, session!!.sessionId)
+    assertEquals(5, session.replicasList[0].egressPort)
+  }
+
+  @Test
+  fun `clone session miss returns null`() {
+    assertNull(store.getCloneSession(999))
+  }
+
+  @Test
+  fun `multicast group round-trip`() {
+    writeMulticastGroup(groupId = 1, replicas = listOf(0 to 1, 0 to 2, 0 to 3))
+    val group = store.getMulticastGroup(1)
+    assertNotNull(group)
+    assertEquals(1, group!!.multicastGroupId)
+    assertEquals(3, group.replicasCount)
+    assertEquals(1, group.replicasList[0].egressPort)
+    assertEquals(2, group.replicasList[1].egressPort)
+    assertEquals(3, group.replicasList[2].egressPort)
+  }
+
+  @Test
+  fun `multicast group miss returns null`() {
+    assertNull(store.getMulticastGroup(999))
+  }
+
+  @Test
+  fun `loadMappings clears PRE entries`() {
+    writeCloneSession(sessionId = 1, egressPort = 5)
+    writeMulticastGroup(groupId = 1, replicas = listOf(0 to 1))
+
+    store.loadMappings(
+      tableNameById = mapOf(TABLE_ID to TABLE_NAME),
+      actionNameById = ACTION_ID_TO_NAME,
+    )
+
+    assertNull(store.getCloneSession(1))
+    assertNull(store.getMulticastGroup(1))
+  }
+
+  // ---------------------------------------------------------------------------
   // Constants
   // ---------------------------------------------------------------------------
 

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -1,9 +1,11 @@
 package fourward.simulator
 
 import fourward.ir.v1.P4BehavioralConfig
+import fourward.ir.v1.PipelineStage
 import fourward.ir.v1.StageKind
 import fourward.sim.v1.ForkBranch
 import fourward.sim.v1.ForkNode
+import fourward.sim.v1.ForkReason
 import fourward.sim.v1.TraceTree
 
 /**
@@ -12,12 +14,13 @@ import fourward.sim.v1.TraceTree
  * v1model is the original BMv2 architecture, defined in v1model.p4. The pipeline runs six stages in
  * fixed order:
  *
- * MyParser → MyVerifyChecksum → MyIngress → MyEgress → MyComputeChecksum → MyDeparser
+ * MyParser -> MyVerifyChecksum -> MyIngress -> MyEgress -> MyComputeChecksum -> MyDeparser
  *
  * Architecture-specific behaviour implemented here:
  * - standard_metadata_t initialisation and egress_spec routing.
  * - mark_to_drop() (sets egress_spec to DROP_PORT = 511).
- * - clone/resubmit/recirculate stubs (not yet fully implemented).
+ * - clone (I2E) via ForkException / re-execution.
+ * - multicast group replication via ForkException / re-execution.
  *
  * Reference: https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4
  */
@@ -31,6 +34,25 @@ class V1ModelArchitecture : Architecture {
     val tableStore: TableStore,
   )
 
+  /** Per-execution state created fresh for each pipeline run. */
+  private class PipelineState(
+    val packetCtx: PacketContext,
+    val interpreter: Interpreter,
+    val env: Environment,
+    val standardMetadata: StructVal,
+    config: P4BehavioralConfig,
+  ) {
+    private val stages = config.architecture.stagesList
+    val parserStage: PipelineStage? = stages.find { it.kind == StageKind.PARSER }
+    val deparserStage: PipelineStage? = stages.find { it.kind == StageKind.DEPARSER }
+
+    // v1model: first 2 controls are ingress-side (verify checksum, ingress),
+    // last 2 are egress-side (egress, compute checksum).
+    private val controlStages = stages.filter { it.kind == StageKind.CONTROL }
+    val ingressControls: List<PipelineStage> = controlStages.take(INGRESS_CONTROL_COUNT)
+    val egressControls: List<PipelineStage> = controlStages.drop(INGRESS_CONTROL_COUNT)
+  }
+
   override fun processPacket(
     ingressPort: UInt,
     payload: ByteArray,
@@ -38,56 +60,105 @@ class V1ModelArchitecture : Architecture {
     tableStore: TableStore,
   ): PipelineResult {
     val ctx = PipelineContext(ingressPort, payload, config, tableStore)
-    return buildTraceTree(ctx, emptyMap(), prefixLength = 0)
+    return buildTraceTree(ctx, ForkDecisions(), prefixLength = 0)
   }
 
   /**
    * Recursively builds a trace tree by re-executing the pipeline for each fork branch.
    *
-   * When a [ForkException] is thrown (e.g. action selector group hit), this method re-executes the
-   * full pipeline once per group member with that member "forced", and assembles the results into a
-   * [TraceTree] with a [ForkNode]. Shared prefix events are stripped from branches.
+   * When a [ForkException] is thrown (action selector, clone, or multicast), this method
+   * re-executes the full pipeline once per branch with appropriate [ForkDecisions], and assembles
+   * the results into a [TraceTree] with a [ForkNode]. Shared prefix events are stripped from
+   * branches.
    */
   private fun buildTraceTree(
     ctx: PipelineContext,
-    forcedSelections: Map<String, Int>,
+    decisions: ForkDecisions,
     prefixLength: Int,
   ): PipelineResult {
     try {
-      val (outputs, trace) = runPipeline(ctx, forcedSelections)
+      val (outputs, trace) = runPipeline(ctx, decisions)
       val stripped =
         TraceTree.newBuilder().addAllEvents(trace.eventsList.drop(prefixLength)).build()
       return PipelineResult(outputs, stripped)
     } catch (fork: ForkException) {
       val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
-      val branches =
-        fork.members.map { member ->
-          val newForced = forcedSelections + (fork.tableName to member.memberId)
-          val branchResult = buildTraceTree(ctx, newForced, fork.eventsBeforeFork.size)
-          ForkBranch.newBuilder()
-            .setLabel("member_${member.memberId}")
-            .setSubtree(branchResult.trace)
-            .build()
-        }
+      val (reason, branches) = buildForkBranches(ctx, decisions, fork)
       val tree =
         TraceTree.newBuilder()
           .addAllEvents(levelEvents)
-          .setFork(ForkNode.newBuilder().setReason(fork.reason).addAllBranches(branches))
+          .setFork(ForkNode.newBuilder().setReason(reason).addAllBranches(branches))
           .build()
       return PipelineResult(emptyList(), tree)
     }
   }
 
-  /** Executes the full v1model pipeline once, returning output packets and flat trace. */
-  private fun runPipeline(
+  /** Dispatches fork handling to the appropriate branch builder. */
+  private fun buildForkBranches(
     ctx: PipelineContext,
-    forcedSelections: Map<String, Int>,
-  ): PipelineResult {
+    decisions: ForkDecisions,
+    fork: ForkException,
+  ): Pair<ForkReason, List<ForkBranch>> =
+    when (fork) {
+      is ActionSelectorFork -> {
+        val branches =
+          fork.members.map { member ->
+            val newDecisions =
+              decisions.copy(
+                selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId)
+              )
+            forkBranch("member_${member.memberId}", ctx, newDecisions, fork.eventsBeforeFork.size)
+          }
+        ForkReason.ACTION_SELECTOR to branches
+      }
+      is CloneFork -> {
+        val originalDecisions = decisions.copy(cloneMode = CloneMode.SUPPRESS)
+        val cloneDecisions =
+          decisions.copy(cloneMode = CloneMode.EXECUTE_CLONE, cloneSessionId = fork.sessionId)
+        val branches =
+          listOf(
+            forkBranch("original", ctx, originalDecisions, fork.eventsBeforeFork.size),
+            forkBranch("clone", ctx, cloneDecisions, fork.eventsBeforeFork.size),
+          )
+        ForkReason.CLONE to branches
+      }
+      is MulticastFork -> {
+        val branches =
+          fork.replicas.map { replica ->
+            val replicaDecisions = decisions.copy(multicastReplica = replica)
+            forkBranch(
+              "replica_${replica.rid}_port_${replica.port}",
+              ctx,
+              replicaDecisions,
+              fork.eventsBeforeFork.size,
+            )
+          }
+        ForkReason.MULTICAST to branches
+      }
+    }
+
+  /** Re-executes the pipeline for one branch and wraps the result in a [ForkBranch]. */
+  private fun forkBranch(
+    label: String,
+    ctx: PipelineContext,
+    decisions: ForkDecisions,
+    prefixLength: Int,
+  ): ForkBranch {
+    val result = buildTraceTree(ctx, decisions, prefixLength)
+    return ForkBranch.newBuilder().setLabel(label).setSubtree(result.trace).build()
+  }
+
+  /**
+   * Creates a fresh [PipelineState] for one pipeline execution.
+   *
+   * Resolves type names, initialises standard_metadata, and binds parameter names across all
+   * stages. Stage topology (ingress/egress split) is derived by [PipelineState] itself.
+   */
+  private fun initPipelineState(ctx: PipelineContext, decisions: ForkDecisions): PipelineState {
     val packetCtx = PacketContext(ctx.payload)
-    val interpreter = Interpreter(ctx.config, ctx.tableStore, packetCtx, forcedSelections)
+    val interpreter = Interpreter(ctx.config, ctx.tableStore, packetCtx, decisions)
     val env = Environment()
     val config = ctx.config
-
     val typesByName = config.typesList.associateBy { it.name }
 
     // Derive the type names for hdr/meta/standard_metadata from the parser's
@@ -101,16 +172,13 @@ class V1ModelArchitecture : Architecture {
     require(parserUserParams.size == V1MODEL_USER_PARAM_COUNT) {
       "Expected $V1MODEL_USER_PARAM_COUNT non-IO parser params, got ${parserUserParams.size}"
     }
-    val headersTypeName = parserUserParams[0].type.named // e.g. "headers_t"
-    val metaTypeName = parserUserParams[1].type.named // e.g. "metadata_t"
-    val standardMetaTypeName = parserUserParams[2].type.named // e.g. "standard_metadata_t"
+    val headersTypeName = parserUserParams[0].type.named
+    val metaTypeName = parserUserParams[1].type.named
+    val standardMetaTypeName = parserUserParams[2].type.named
 
-    // Build standard_metadata from the IR type so all declared fields are present with zero
-    // defaults, then set the fields that have non-zero initial values.
     val standardMetadata =
       (defaultValue(standardMetaTypeName, typesByName) as? StructVal)
         ?: error("$standardMetaTypeName not found in IR types; is v1model.p4 included?")
-    // These fields are guaranteed by the v1model.p4 spec; the checks catch non-standard setups.
     check("ingress_port" in standardMetadata.fields) { "$standardMetaTypeName has no ingress_port" }
     check("packet_length" in standardMetadata.fields) {
       "$standardMetaTypeName has no packet_length"
@@ -119,17 +187,12 @@ class V1ModelArchitecture : Architecture {
     standardMetadata.fields["packet_length"] = BitVal(ctx.payload.size.toLong(), INT32_BITS)
     standardMetadata.fields["parser_error"] = ErrorVal("NoError")
 
-    // Map each shared type name to its initialised object so we can bind whatever
-    // local parameter names each stage uses (e.g. "smeta" vs "standard_metadata").
     val sharedByType =
       mapOf(
         headersTypeName to defaultValue(headersTypeName, typesByName),
         metaTypeName to defaultValue(metaTypeName, typesByName),
         standardMetaTypeName to standardMetadata,
       )
-
-    // Bind every stage's parameter names upfront. All stages share the same
-    // underlying objects; different stages may just use different local names.
     for (parser in config.parsersList) {
       for (param in parser.paramsList) {
         sharedByType[param.type.named]?.let { env.define(param.name, it) }
@@ -141,54 +204,97 @@ class V1ModelArchitecture : Architecture {
       }
     }
 
-    val stages = config.architecture.stagesList
-    val parserStage = stages.find { it.kind == StageKind.PARSER }
-    val controlStages = stages.filter { it.kind == StageKind.CONTROL }
-    val deparserStage = stages.find { it.kind == StageKind.DEPARSER }
+    return PipelineState(packetCtx, interpreter, env, standardMetadata, config)
+  }
+
+  /** Executes the full v1model pipeline once, returning output packets and flat trace. */
+  @Suppress("LoopWithTooManyJumpStatements")
+  private fun runPipeline(ctx: PipelineContext, decisions: ForkDecisions): PipelineResult {
+    val s = initPipelineState(ctx, decisions)
 
     // --- Parser ---
-    if (parserStage != null) {
+    if (s.parserStage != null) {
       try {
-        interpreter.runParser(parserStage.blockName, env)
+        s.interpreter.runParser(s.parserStage.blockName, s.env)
       } catch (e: ExitException) {
-        return PipelineResult(emptyList(), packetCtx.buildTrace())
+        return PipelineResult(emptyList(), s.packetCtx.buildTrace())
       } catch (e: ParserErrorException) {
         // BMv2 v1model: parser errors don't drop the packet. Set parser_error and
         // continue to the ingress pipeline, letting the P4 program decide the fate.
-        standardMetadata.fields["parser_error"] = ErrorVal(e.errorName)
+        s.standardMetadata.fields["parser_error"] = ErrorVal(e.errorName)
       }
     }
 
-    // --- Controls (verify checksum, ingress, egress, compute checksum) ---
-    // P4 exit terminates all active control blocks up to the pipeline level but
-    // does NOT drop the packet — forwarding is still governed by egress_spec at
-    // the time of the exit (P4 spec §12.4, v1model semantics).
-    for (stage in controlStages) {
+    // --- Ingress controls (verify checksum, ingress) ---
+    // JumpToEgressException signals clone-branch re-execution: stop ingress, run egress only.
+    var jumpToEgress = false
+    for (stage in s.ingressControls) {
       try {
-        interpreter.runControl(stage.blockName, env)
-      } catch (e: ExitException) {
+        s.interpreter.runControl(stage.blockName, s.env)
+      } catch (_: ExitException) {
+        break
+      } catch (_: JumpToEgressException) {
+        jumpToEgress = true
+        break
+      }
+    }
+
+    // --- Ingress→egress boundary: clone / multicast metadata setup ---
+    // All paths write egress_port into standardMetadata so the egress read is uniform.
+    if (jumpToEgress) {
+      // Clone branch: set instance_type and egress_port from clone session config.
+      val session = ctx.tableStore.getCloneSession(decisions.cloneSessionId)
+      val clonePort = session?.replicasList?.firstOrNull()?.egressPort ?: 0
+      s.standardMetadata.fields["instance_type"] = BitVal(CLONE_I2E_INSTANCE_TYPE, INT32_BITS)
+      s.standardMetadata.fields["egress_port"] = BitVal(clonePort.toLong(), PORT_BITS)
+    } else {
+      val mcastGrp = (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
+      if (mcastGrp != 0 && decisions.multicastReplica == null) {
+        val group =
+          ctx.tableStore.getMulticastGroup(mcastGrp) ?: error("unknown multicast group: $mcastGrp")
+        val replicas = group.replicasList.map { r -> MulticastReplica(r.instance, r.egressPort) }
+        throw MulticastFork(replicas, s.packetCtx.getEvents())
+      }
+      if (decisions.multicastReplica != null) {
+        s.standardMetadata.fields["egress_port"] =
+          BitVal(decisions.multicastReplica.port.toLong(), PORT_BITS)
+        s.standardMetadata.fields["egress_rid"] =
+          BitVal(decisions.multicastReplica.rid.toLong(), REPLICA_ID_BITS)
+      } else {
+        // Normal unicast: copy egress_spec → egress_port for uniform read below.
+        s.standardMetadata.fields["egress_port"] =
+          s.standardMetadata.fields["egress_spec"] ?: BitVal(0, PORT_BITS)
+      }
+    }
+
+    // --- Egress controls (egress, compute checksum) ---
+    for (stage in s.egressControls) {
+      try {
+        s.interpreter.runControl(stage.blockName, s.env)
+      } catch (_: ExitException) {
         break // skip remaining control stages; still run deparser below
       }
     }
 
-    val egressSpec = (standardMetadata.fields["egress_spec"] as? BitVal)?.bits?.value?.toInt() ?: 0
+    val egressPort =
+      (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
 
     // Port 511 is the v1model drop port (mark_to_drop sets egress_spec = 511).
-    if (egressSpec == DROP_PORT) {
-      return PipelineResult(emptyList(), packetCtx.buildTrace())
+    if (egressPort == DROP_PORT) {
+      return PipelineResult(emptyList(), s.packetCtx.buildTrace())
     }
 
     // --- Deparser ---
-    if (deparserStage != null) {
-      interpreter.runControl(deparserStage.blockName, env)
+    if (s.deparserStage != null) {
+      s.interpreter.runControl(s.deparserStage.blockName, s.env)
     }
 
     // Append any bytes the parser did not extract (the un-parsed packet body).
     // In P4, the deparser emits re-serialised headers; the remaining payload
     // is transparently forwarded after them.
-    val outputBytes = packetCtx.outputPayload() + packetCtx.drainRemainingInput()
-    val output = OutputPacket(egressSpec.toUInt(), outputBytes)
-    return PipelineResult(listOf(output), packetCtx.buildTrace())
+    val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
+    val output = OutputPacket(egressPort.toUInt(), outputBytes)
+    return PipelineResult(listOf(output), s.packetCtx.buildTrace())
   }
 
   companion object {
@@ -199,8 +305,15 @@ class V1ModelArchitecture : Architecture {
     // (hdr, meta, standard_metadata).
     private const val V1MODEL_USER_PARAM_COUNT = 3
 
+    // v1model: first 2 control stages are ingress-side (verify checksum, ingress).
+    private const val INGRESS_CONTROL_COUNT = 2
+
     // Bit widths for standard_metadata_t fields, as defined in v1model.p4.
     const val PORT_BITS = 9
     private const val INT32_BITS = 32
+    private const val REPLICA_ID_BITS = 16
+
+    // v1model instance_type values (BMv2 convention).
+    private const val CLONE_I2E_INSTANCE_TYPE = 1L
   }
 }


### PR DESCRIPTION
## Summary

Completes the trace tree fork system by implementing clone (I2E) and multicast
group replication, building on the action selector forking from PR #108.

- **Clone forking** at the `clone()` call site — "original" branch continues
  with clone suppressed (may trigger further forks like selectors);
  "clone" branch re-executes with `JumpToEgressException` to run only egress
  with clone session metadata (`instance_type=1`, `egress_port` from session)
- **Multicast forking** at the ingress→egress boundary when `mcast_grp` is set
  — one branch per replica with `egress_port` and `egress_rid` from the group
- **`ForkException` sealed hierarchy** replacing the flat class — `ActionSelectorFork`,
  `CloneFork`, `MulticastFork` with `ForkDecisions` carrying per-branch policies
- **PRE storage** in `TableStore` for clone sessions and multicast groups via
  P4Runtime `PacketReplicationEngineEntry`
- **STF parser** handles `mirroring_add`, `mc_mgrp_create`, `mc_node_create`,
  `mc_node_associate`; `StfRunner` now installs all entry types (PRE, members,
  groups, tables)
- **V1ModelArchitecture refactored** — `PipelineState` extraction, ingress/egress
  control split, unified egress_port resolution across clone/multicast/unicast paths

All 7 golden trace tree tests pass (0 remaining manual). 24/24 tests green.

## Test plan

- [x] `bazel test //...` — 24 tests pass
- [x] 3 promoted golden tests: `clone_ingress_egress`, `clone_plus_selector`, `multicast`
- [x] New unit tests for STF PRE directive parsing and TableStore PRE round-trips
- [x] `./format.sh` and `./lint.sh` clean (0 new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)