### PR TITLE
Simplify execExtract union handling

### DIFF
--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -732,11 +732,16 @@ class Interpreter(
     }
   }
 
+  /** Whether [expr] is a field access into a header union. */
+  private fun isUnionFieldAccess(expr: Expr): Boolean =
+    expr.hasFieldAccess() &&
+      expr.fieldAccess.expr.type.let { t ->
+        t.hasNamed() && types[t.named]?.hasHeaderUnion() == true
+      }
+
   /** If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20). */
   private fun invalidateUnionSiblings(expr: Expr, target: HeaderVal, env: Environment) {
-    if (!expr.hasFieldAccess()) return
-    val parentType = expr.fieldAccess.expr.type
-    if (!parentType.hasNamed() || types[parentType.named]?.hasHeaderUnion() != true) return
+    if (!isUnionFieldAccess(expr)) return
     val parent = evalExpr(expr.fieldAccess.expr, env) as StructVal
     parent.invalidateUnionExcept(target)
   }
@@ -758,11 +763,7 @@ class Interpreter(
       if (arg.hasNameRef() && env.lookup(arg.nameRef.name) == null && arg.type.hasNamed()) {
         defaultValue(arg.type.named, types) as? HeaderVal
           ?: error("type not found for don't-care extract: ${arg.type.named}")
-      } else if (
-        arg.hasFieldAccess() &&
-          arg.fieldAccess.expr.type.hasNamed() &&
-          types[arg.fieldAccess.expr.type.named]?.hasHeaderUnion() == true
-      ) {
+      } else if (isUnionFieldAccess(arg)) {
         // Parent is a header union — resolve it once, invalidate siblings (P4 §8.20).
         val parent = evalExpr(arg.fieldAccess.expr, env) as StructVal
         val member = parent.fields[arg.fieldAccess.fieldName] as HeaderVal

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -732,22 +732,12 @@ class Interpreter(
     }
   }
 
-  /**
-   * If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20).
-   *
-   * When [parentOverride] is provided, uses it instead of re-evaluating the parent expression. This
-   * avoids double-evaluation of side-effecting expressions like `.next` on header stacks.
-   */
-  private fun invalidateUnionSiblings(
-    expr: Expr,
-    target: HeaderVal,
-    env: Environment,
-    parentOverride: StructVal? = null,
-  ) {
+  /** If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20). */
+  private fun invalidateUnionSiblings(expr: Expr, target: HeaderVal, env: Environment) {
     if (!expr.hasFieldAccess()) return
     val parentType = expr.fieldAccess.expr.type
     if (!parentType.hasNamed() || types[parentType.named]?.hasHeaderUnion() != true) return
-    val parent = parentOverride ?: (evalExpr(expr.fieldAccess.expr, env) as StructVal)
+    val parent = evalExpr(expr.fieldAccess.expr, env) as StructVal
     parent.invalidateUnionExcept(target)
   }
 
@@ -760,10 +750,10 @@ class Interpreter(
     // P4's don't-care extract `p.extract<T>(_)` compiles to extract(arg) where
     // `arg` is an undeclared temporary. Create a throw-away header to consume bytes.
     val arg = call.argsList[0]
-    // When the arg is a field access into a union (e.g. hdr.u.next.byte), evaluate
-    // the union parent once and cache it so invalidateUnionSiblings doesn't
-    // re-evaluate side-effecting expressions like `.next` on header stacks.
-    var unionParent: StructVal? = null
+    // When the arg is a field access into a union (e.g. hdr.u.next.byte), resolve the
+    // union parent once and invalidate siblings inline. This avoids re-evaluating
+    // side-effecting expressions like `.next` on header stacks.
+    var unionHandled = false
     val header =
       if (arg.hasNameRef() && env.lookup(arg.nameRef.name) == null && arg.type.hasNamed()) {
         defaultValue(arg.type.named, types) as? HeaderVal
@@ -773,10 +763,12 @@ class Interpreter(
           arg.fieldAccess.expr.type.hasNamed() &&
           types[arg.fieldAccess.expr.type.named]?.hasHeaderUnion() == true
       ) {
-        // Parent is a header union — resolve it once and extract the member header.
+        // Parent is a header union — resolve it once, invalidate siblings (P4 §8.20).
         val parent = evalExpr(arg.fieldAccess.expr, env) as StructVal
-        unionParent = parent
-        parent.fields[arg.fieldAccess.fieldName] as HeaderVal
+        val member = parent.fields[arg.fieldAccess.fieldName] as HeaderVal
+        parent.invalidateUnionExcept(member)
+        unionHandled = true
+        member
       } else {
         evalExpr(arg, env) as HeaderVal
       }
@@ -821,7 +813,7 @@ class Interpreter(
       newFields[field.name] = bitsToValue(field.type, raw, width)
       bitOffset += width
     }
-    invalidateUnionSiblings(call.argsList[0], header, env, unionParent)
+    if (!unionHandled) invalidateUnionSiblings(call.argsList[0], header, env)
     header.setValid(newFields)
     return UnitVal
   }

--- a/simulator/InterpreterPacketTest.kt
+++ b/simulator/InterpreterPacketTest.kt
@@ -16,8 +16,10 @@ package fourward.simulator
 
 import fourward.ir.v1.BitType
 import fourward.ir.v1.Expr
+import fourward.ir.v1.FieldAccess
 import fourward.ir.v1.FieldDecl
 import fourward.ir.v1.HeaderDecl
+import fourward.ir.v1.HeaderUnionDecl
 import fourward.ir.v1.MethodCall
 import fourward.ir.v1.NameRef
 import fourward.ir.v1.P4BehavioralConfig
@@ -25,6 +27,7 @@ import fourward.ir.v1.Type
 import fourward.ir.v1.TypeDecl
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -235,5 +238,116 @@ class InterpreterPacketTest {
     interp.evalExpr(packetCall("emit", "hdr"), env)
 
     assertArrayEquals(input, pktCtx.outputPayload())
+  }
+
+  // ---------------------------------------------------------------------------
+  // extract into header union members (P4 §8.20)
+  // ---------------------------------------------------------------------------
+
+  private fun namedType(name: String): Type = Type.newBuilder().setNamed(name).build()
+
+  private fun headerUnionType(typeName: String, vararg members: Pair<String, String>): TypeDecl =
+    TypeDecl.newBuilder()
+      .setName(typeName)
+      .setHeaderUnion(
+        HeaderUnionDecl.newBuilder().also { u ->
+          for ((name, headerTypeName) in members) {
+            u.addFields(FieldDecl.newBuilder().setName(name).setType(namedType(headerTypeName)))
+          }
+        }
+      )
+      .build()
+
+  /** Builds an extract call whose argument is a field access: `pkt.extract(unionVar.member)`. */
+  private fun unionExtractCall(unionVar: String, member: String, unionTypeName: String): Expr =
+    Expr.newBuilder()
+      .setMethodCall(
+        MethodCall.newBuilder()
+          .setTarget(nameRef("pkt"))
+          .setMethod("extract")
+          .addArgs(
+            Expr.newBuilder()
+              .setFieldAccess(
+                FieldAccess.newBuilder()
+                  .setExpr(
+                    Expr.newBuilder()
+                      .setNameRef(NameRef.newBuilder().setName(unionVar))
+                      .setType(namedType(unionTypeName))
+                  )
+                  .setFieldName(member)
+              )
+          )
+      )
+      .build()
+
+  @Test
+  fun `extract into union member invalidates siblings`() {
+    // Union with two 8-bit headers: extracting into member "a" should invalidate "b".
+    val hdrA = headerType("a_t", "f" to 8)
+    val hdrB = headerType("b_t", "f" to 8)
+    val union = headerUnionType("u_t", "a" to "a_t", "b" to "b_t")
+
+    val memberA = HeaderVal("a_t", mutableMapOf("f" to BitVal(0, 8)), valid = false)
+    val memberB = HeaderVal("b_t", mutableMapOf("f" to BitVal(0x42, 8)), valid = true)
+    val unionVal = StructVal("u_t", mutableMapOf("a" to memberA, "b" to memberB))
+
+    val pktCtx = PacketContext(byteArrayOf(0x01))
+    val env = Environment()
+    env.define("u", unionVal)
+
+    interp(pktCtx, hdrA, hdrB, union).evalExpr(unionExtractCall("u", "a", "u_t"), env)
+
+    // Member "a" should be valid with extracted data.
+    assertTrue(memberA.valid)
+    assertEquals(BitVal(1, 8), memberA.fields["f"])
+    // Member "b" should be invalidated (P4 §8.20: one-valid-at-a-time).
+    assertFalse(memberB.valid)
+  }
+
+  @Test
+  fun `extract into union member when no sibling was valid`() {
+    // Both members start invalid; extract should still set the target valid.
+    val hdrA = headerType("a_t", "f" to 8)
+    val hdrB = headerType("b_t", "f" to 8)
+    val union = headerUnionType("u_t", "a" to "a_t", "b" to "b_t")
+
+    val memberA = HeaderVal("a_t", mutableMapOf("f" to BitVal(0, 8)), valid = false)
+    val memberB = HeaderVal("b_t", mutableMapOf("f" to BitVal(0, 8)), valid = false)
+    val unionVal = StructVal("u_t", mutableMapOf("a" to memberA, "b" to memberB))
+
+    val pktCtx = PacketContext(byteArrayOf(0xFF.toByte()))
+    val env = Environment()
+    env.define("u", unionVal)
+
+    interp(pktCtx, hdrA, hdrB, union).evalExpr(unionExtractCall("u", "a", "u_t"), env)
+
+    assertTrue(memberA.valid)
+    assertEquals(BitVal(0xFF, 8), memberA.fields["f"])
+    assertFalse(memberB.valid)
+  }
+
+  @Test
+  fun `sequential union extracts swap validity`() {
+    // Extract "a", then extract "b" — only "b" should be valid at the end.
+    val hdrA = headerType("a_t", "f" to 8)
+    val hdrB = headerType("b_t", "f" to 8)
+    val union = headerUnionType("u_t", "a" to "a_t", "b" to "b_t")
+
+    val memberA = HeaderVal("a_t", mutableMapOf("f" to BitVal(0, 8)), valid = false)
+    val memberB = HeaderVal("b_t", mutableMapOf("f" to BitVal(0, 8)), valid = false)
+    val unionVal = StructVal("u_t", mutableMapOf("a" to memberA, "b" to memberB))
+
+    val pktCtx = PacketContext(byteArrayOf(0x01, 0x02))
+    val env = Environment()
+    env.define("u", unionVal)
+
+    val interp = interp(pktCtx, hdrA, hdrB, union)
+    interp.evalExpr(unionExtractCall("u", "a", "u_t"), env)
+    interp.evalExpr(unionExtractCall("u", "b", "u_t"), env)
+
+    // After second extract, "a" is invalidated and "b" is valid.
+    assertFalse(memberA.valid)
+    assertTrue(memberB.valid)
+    assertEquals(BitVal(2, 8), memberB.fields["f"])
   }
 }


### PR DESCRIPTION
## Summary

- Handle union invalidation inline in `execExtract`'s union branch where the parent is already resolved, instead of threading a `parentOverride` parameter through `invalidateUnionSiblings`
- Extract `isUnionFieldAccess()` predicate to deduplicate the union-detection check shared between `invalidateUnionSiblings` and `execExtract`
- Add unit tests for extract into header union members (P4 §8.20 one-valid-at-a-time semantics)

Follow-up cleanup to #111.

## Test plan

- [x] `bazel test //e2e_tests/corpus:v1model_stf_corpus_test` — all 166 tests pass
- [x] `bazel test //simulator/...` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)