### PR TITLE
Strengthen trace tree coverage; extract installStfEntries

### DIFF
--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -49,42 +49,10 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
         return TestResult.Failure("LoadPipeline failed: ${loadResp.error.message}")
       }
 
-      // Install PRE entries (clone sessions, multicast groups).
-      for (mirror in stf.pre.mirroringAdds) {
-        val writeResp = sim.writeEntry(resolveStfMirroringAdd(mirror))
-        if (writeResp.hasError()) {
-          return TestResult.Failure("WriteEntry (mirroring) failed: ${writeResp.error.message}")
-        }
-      }
-      val mcNodes = stf.pre.mcNodeCreates.associateBy { it.rid }
-      for (mcGroup in stf.pre.mcGroupCreates) {
-        val writeResp =
-          sim.writeEntry(
-            resolveStfMulticastGroup(mcGroup.groupId, mcNodes, stf.pre.mcNodeAssociates)
-          )
-        if (writeResp.hasError()) {
-          return TestResult.Failure("WriteEntry (multicast) failed: ${writeResp.error.message}")
-        }
-      }
-
-      // Install action profile members, groups, and table entries.
-      for (member in stf.memberDirectives) {
-        val writeResp = sim.writeEntry(resolveStfMember(member, config.p4Info))
-        if (writeResp.hasError()) {
-          return TestResult.Failure("WriteEntry (member) failed: ${writeResp.error.message}")
-        }
-      }
-      for (group in stf.groupDirectives) {
-        val writeResp = sim.writeEntry(resolveStfGroup(group, config.p4Info))
-        if (writeResp.hasError()) {
-          return TestResult.Failure("WriteEntry (group) failed: ${writeResp.error.message}")
-        }
-      }
-      for (directive in stf.tableEntries) {
-        val writeResp = sim.writeEntry(resolveStfTableEntry(directive, config.p4Info))
-        if (writeResp.hasError()) {
-          return TestResult.Failure("WriteEntry failed: ${writeResp.error.message}")
-        }
+      try {
+        installStfEntries(sim, stf, config.p4Info)
+      } catch (e: IllegalStateException) {
+        return TestResult.Failure(e.message ?: "WriteEntry failed")
       }
 
       val failures = mutableListOf<String>()
@@ -120,6 +88,35 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
       return if (failures.isEmpty()) TestResult.Pass
       else TestResult.Failure(failures.joinToString("\n"))
     }
+  }
+}
+
+/**
+ * Installs all STF-declared entries (PRE, action profile members/groups, table entries) into the
+ * simulator. Throws [IllegalStateException] on write failure.
+ */
+fun installStfEntries(sim: SimulatorClient, stf: StfFile, p4Info: P4InfoOuterClass.P4Info) {
+  for (mirror in stf.pre.mirroringAdds) {
+    val resp = sim.writeEntry(resolveStfMirroringAdd(mirror))
+    if (resp.hasError()) error("WriteEntry (mirroring) failed: ${resp.error.message}")
+  }
+  val mcNodes = stf.pre.mcNodeCreates.associateBy { it.rid }
+  for (mcGroup in stf.pre.mcGroupCreates) {
+    val resp =
+      sim.writeEntry(resolveStfMulticastGroup(mcGroup.groupId, mcNodes, stf.pre.mcNodeAssociates))
+    if (resp.hasError()) error("WriteEntry (multicast) failed: ${resp.error.message}")
+  }
+  for (member in stf.memberDirectives) {
+    val resp = sim.writeEntry(resolveStfMember(member, p4Info))
+    if (resp.hasError()) error("WriteEntry (member) failed: ${resp.error.message}")
+  }
+  for (group in stf.groupDirectives) {
+    val resp = sim.writeEntry(resolveStfGroup(group, p4Info))
+    if (resp.hasError()) error("WriteEntry (group) failed: ${resp.error.message}")
+  }
+  for (directive in stf.tableEntries) {
+    val resp = sim.writeEntry(resolveStfTableEntry(directive, p4Info))
+    if (resp.hasError()) error("WriteEntry (table) failed: ${resp.error.message}")
   }
 }
 

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -15,7 +15,10 @@ _P4_PROGRAMS = [
     "action_selector_nested",
     "clone_ingress_egress",
     "clone_plus_selector",
+    "clone_with_egress",
     "multicast",
+    "multicast_drop_replica",
+    "selector_exit",
 ]
 
 _PASSING = _P4_PROGRAMS

--- a/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
+++ b/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
@@ -3,11 +3,7 @@ package fourward.e2e.tracetree
 import com.google.protobuf.TextFormat
 import fourward.e2e.SimulatorClient
 import fourward.e2e.StfFile
-import fourward.e2e.resolveStfGroup
-import fourward.e2e.resolveStfMember
-import fourward.e2e.resolveStfMirroringAdd
-import fourward.e2e.resolveStfMulticastGroup
-import fourward.e2e.resolveStfTableEntry
+import fourward.e2e.installStfEntries
 import fourward.ir.v1.PipelineConfig
 import fourward.sim.v1.TraceTree
 import java.nio.file.Path
@@ -85,33 +81,7 @@ class GoldenTraceTreeTest(private val testName: String) {
       val loadResp = sim.loadPipeline(config)
       if (loadResp.hasError()) fail("LoadPipeline failed: ${loadResp.error.message}")
 
-      // Install PRE entries (clone sessions, multicast groups).
-      for (mirror in stf.pre.mirroringAdds) {
-        val writeResp = sim.writeEntry(resolveStfMirroringAdd(mirror))
-        if (writeResp.hasError()) fail("WriteEntry (mirroring) failed: ${writeResp.error.message}")
-      }
-      val mcNodes = stf.pre.mcNodeCreates.associateBy { it.rid }
-      for (mcGroup in stf.pre.mcGroupCreates) {
-        val writeResp =
-          sim.writeEntry(
-            resolveStfMulticastGroup(mcGroup.groupId, mcNodes, stf.pre.mcNodeAssociates)
-          )
-        if (writeResp.hasError()) fail("WriteEntry (multicast) failed: ${writeResp.error.message}")
-      }
-
-      // Install action profile members, groups, and table entries.
-      for (member in stf.memberDirectives) {
-        val writeResp = sim.writeEntry(resolveStfMember(member, config.p4Info))
-        if (writeResp.hasError()) fail("WriteEntry (member) failed: ${writeResp.error.message}")
-      }
-      for (group in stf.groupDirectives) {
-        val writeResp = sim.writeEntry(resolveStfGroup(group, config.p4Info))
-        if (writeResp.hasError()) fail("WriteEntry (group) failed: ${writeResp.error.message}")
-      }
-      for (directive in stf.tableEntries) {
-        val writeResp = sim.writeEntry(resolveStfTableEntry(directive, config.p4Info))
-        if (writeResp.hasError()) fail("WriteEntry failed: ${writeResp.error.message}")
-      }
+      installStfEntries(sim, stf, config.p4Info)
 
       val packet = stf.packets.first()
       val resp = sim.processPacket(packet.ingressPort, packet.payload)

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -1,0 +1,79 @@
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  clone {
+    session_id: 100
+  }
+}
+fork {
+  reason: CLONE
+  branches {
+    label: "original"
+    subtree {
+      events {
+        table_lookup {
+          table_name: "egress_classify"
+          hit: true
+          matched_entry {
+            table_id: 43808281
+            match {
+              field_id: 1
+              exact {
+                value: "\000\000\000\000"
+              }
+            }
+            action {
+              action {
+                action_id: 23337001
+              }
+            }
+            is_const: true
+          }
+          action_name: "tag_original"
+        }
+      }
+      events {
+        action_execution {
+          action_name: "tag_original"
+        }
+      }
+    }
+  }
+  branches {
+    label: "clone"
+    subtree {
+      events {
+        table_lookup {
+          table_name: "egress_classify"
+          hit: true
+          matched_entry {
+            table_id: 43808281
+            match {
+              field_id: 1
+              exact {
+                value: "\000\000\000\001"
+              }
+            }
+            action {
+              action {
+                action_id: 20863306
+              }
+            }
+            is_const: true
+          }
+          action_name: "tag_clone"
+        }
+      }
+      events {
+        action_execution {
+          action_name: "tag_clone"
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/clone_with_egress.p4
+++ b/e2e_tests/trace_tree/clone_with_egress.p4
@@ -1,0 +1,63 @@
+/* clone_with_egress.p4 — clone where egress behavior differs per branch.
+ *
+ * Ingress clones the packet (I2E, session 100) and sets egress_spec = 2.
+ * Egress reads instance_type: the original packet (instance_type == 0)
+ * applies a table that sets dstAddr; the clone (instance_type == 1) applies
+ * a different table that sets srcAddr.  This verifies that both branches
+ * actually execute egress with the correct metadata.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply {
+        smeta.egress_spec = 2;
+        clone3(CloneType.I2E, 32w100, {});
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) {
+    action tag_original() { hdr.ethernet.dstAddr = 0xAAAAAAAAAAAA; }
+    action tag_clone()    { hdr.ethernet.srcAddr = 0xBBBBBBBBBBBB; }
+
+    table egress_classify {
+        key = { smeta.instance_type : exact; }
+        actions = { tag_original; tag_clone; }
+        const entries = {
+            0 : tag_original();
+            1 : tag_clone();
+        }
+    }
+
+    apply { egress_classify.apply(); }
+}
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/clone_with_egress.stf
+++ b/e2e_tests/trace_tree/clone_with_egress.stf
@@ -1,0 +1,5 @@
+# clone_with_egress.stf — clone where egress behavior differs per branch.
+# Clone session 100 sends clones to port 3.
+
+mirroring_add 100 3
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -1,0 +1,40 @@
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+fork {
+  reason: MULTICAST
+  branches {
+    label: "replica_0_port_1"
+    subtree {
+      events {
+        branch {
+          taken: false
+        }
+      }
+    }
+  }
+  branches {
+    label: "replica_0_port_2"
+    subtree {
+      events {
+        branch {
+          taken: true
+        }
+      }
+    }
+  }
+  branches {
+    label: "replica_0_port_3"
+    subtree {
+      events {
+        branch {
+          taken: false
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/multicast_drop_replica.p4
+++ b/e2e_tests/trace_tree/multicast_drop_replica.p4
@@ -1,0 +1,52 @@
+/* multicast_drop_replica.p4 — multicast where one replica drops in egress.
+ *
+ * Ingress sets mcast_grp = 1 (replicas on ports 1, 2, 3).  Egress calls
+ * mark_to_drop() when egress_port == 2.  The trace tree should show 3
+ * replica branches, with the port-2 branch producing no output packet.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply {
+        smeta.mcast_grp = 1;
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) {
+    apply {
+        if (smeta.egress_port == 2) {
+            mark_to_drop(smeta);
+        }
+    }
+}
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/multicast_drop_replica.stf
+++ b/e2e_tests/trace_tree/multicast_drop_replica.stf
@@ -1,0 +1,6 @@
+# multicast_drop_replica.stf — multicast where egress drops port 2.
+
+mc_mgrp_create 1
+mc_node_create 0 1 2 3
+mc_node_associate 1 0
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/selector_exit.golden.txtpb
+++ b/e2e_tests/trace_tree/selector_exit.golden.txtpb
@@ -1,0 +1,84 @@
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  table_lookup {
+    table_name: "selector_table"
+    hit: true
+    matched_entry {
+      table_id: 46743760
+      match {
+        field_id: 1
+        exact {
+          value: "\377\377\377\377\377\377"
+        }
+      }
+      action {
+        action_profile_group_id: 1
+      }
+    }
+    action_name: "set_port"
+  }
+}
+fork {
+  reason: ACTION_SELECTOR
+  branches {
+    label: "member_0"
+    subtree {
+      events {
+        action_execution {
+          action_name: "set_port"
+          params {
+            key: "port"
+            value: "\000\001"
+          }
+        }
+      }
+      events {
+        table_lookup {
+          table_name: "after_selector"
+          hit: true
+          matched_entry {
+            table_id: 41238816
+            match {
+              field_id: 1
+              exact {
+                value: "\b\000"
+              }
+            }
+            action {
+              action {
+                action_id: 21723794
+              }
+            }
+            is_const: true
+          }
+          action_name: "overwrite"
+        }
+      }
+      events {
+        action_execution {
+          action_name: "overwrite"
+        }
+      }
+    }
+  }
+  branches {
+    label: "member_1"
+    subtree {
+      events {
+        action_execution {
+          action_name: "set_port_and_exit"
+          params {
+            key: "port_2"
+            value: "\000\001"
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/selector_exit.p4
+++ b/e2e_tests/trace_tree/selector_exit.p4
@@ -1,0 +1,73 @@
+/* selector_exit.p4 — action selector where one member calls exit.
+ *
+ * The selector table has 2 members.  Member 0 sets egress_spec = 1 normally.
+ * Member 1 sets egress_spec = 1 then calls exit.  After the selector table,
+ * ingress applies a second table that overwrites egress_spec = 9.  The exit
+ * in member 1's branch should skip the second table, so the two branches
+ * should produce different traces.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    action set_port(bit<9> port) { smeta.egress_spec = port; }
+    action set_port_and_exit(bit<9> port) { smeta.egress_spec = port; exit; }
+    action drop() { mark_to_drop(smeta); }
+
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) sel;
+
+    table selector_table {
+        key = {
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { set_port; set_port_and_exit; drop; }
+        implementation = sel;
+        default_action = drop();
+    }
+
+    action overwrite() { smeta.egress_spec = 9; }
+    table after_selector {
+        key = { hdr.ethernet.etherType : exact; }
+        actions = { overwrite; }
+        const entries = { 0x0800 : overwrite(); }
+    }
+
+    apply {
+        selector_table.apply();
+        after_selector.apply();
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/selector_exit.stf
+++ b/e2e_tests/trace_tree/selector_exit.stf
@@ -1,0 +1,7 @@
+# selector_exit.stf — action selector where member 1 calls exit.
+
+member sel 0 set_port port=0x0001
+member sel 1 set_port_and_exit port=0x0001
+group sel 1 0 1
+add selector_table hdr.ethernet.dstAddr:0xFFFFFFFFFFFF group=1
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -243,8 +243,10 @@ class V1ModelArchitecture : Architecture {
     // All paths write egress_port into standardMetadata so the egress read is uniform.
     if (jumpToEgress) {
       // Clone branch: set instance_type and egress_port from clone session config.
-      val session = ctx.tableStore.getCloneSession(decisions.cloneSessionId)
-      val clonePort = session?.replicasList?.firstOrNull()?.egressPort ?: 0
+      val session =
+        ctx.tableStore.getCloneSession(decisions.cloneSessionId)
+          ?: error("unknown clone session: ${decisions.cloneSessionId}")
+      val clonePort = session.replicasList.firstOrNull()?.egressPort ?: 0
       s.standardMetadata.fields["instance_type"] = BitVal(CLONE_I2E_INSTANCE_TYPE, INT32_BITS)
       s.standardMetadata.fields["egress_port"] = BitVal(clonePort.toLong(), PORT_BITS)
     } else {


### PR DESCRIPTION
## Summary

Confidence review of Track 3 (trace trees) identified that existing golden
tests had mostly-empty egress subtrees — clone and multicast branches weren't
exercising egress-side logic. This PR closes those gaps and cleans up some
code along the way.

- **3 new golden trace tree tests** (7 → 10 total):
  - `clone_with_egress` — clone where both branches run egress with different
    `instance_type`, hitting different const-entries table actions
  - `multicast_drop_replica` — multicast with 3 replicas where egress calls
    `mark_to_drop()` on port 2
  - `selector_exit` — action selector where one member calls `exit`, verifying
    that the trace correctly truncates (second table skipped)

- **Extract `installStfEntries()`** — the ~30-line entry installation block
  was duplicated between `StfRunner.run()` and
  `GoldenTraceTreeTest.captureTraceTree()`. Now a single shared function.

- **Error on missing clone session** — `V1ModelArchitecture` previously
  defaulted to port 0 on unknown clone session ID. Now throws, consistent
  with the multicast group lookup.

## Test plan

- [x] All 10 golden trace tree tests pass
- [x] Full test suite (24 tests) passes
- [x] Format and lint clean (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)