### PR TITLE
Fix multicast node handle lookup; set instance_type for replicas

### DIFF
--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -100,10 +100,11 @@ fun installStfEntries(sim: SimulatorClient, stf: StfFile, p4Info: P4InfoOuterCla
     val resp = sim.writeEntry(resolveStfMirroringAdd(mirror))
     if (resp.hasError()) error("WriteEntry (mirroring) failed: ${resp.error.message}")
   }
-  val mcNodes = stf.pre.mcNodeCreates.associateBy { it.rid }
   for (mcGroup in stf.pre.mcGroupCreates) {
     val resp =
-      sim.writeEntry(resolveStfMulticastGroup(mcGroup.groupId, mcNodes, stf.pre.mcNodeAssociates))
+      sim.writeEntry(
+        resolveStfMulticastGroup(mcGroup.groupId, stf.pre.mcNodeCreates, stf.pre.mcNodeAssociates)
+      )
     if (resp.hasError()) error("WriteEntry (multicast) failed: ${resp.error.message}")
   }
   for (member in stf.memberDirectives) {
@@ -546,17 +547,21 @@ fun resolveStfMirroringAdd(directive: StfMirroringAdd): WriteEntryRequest {
  *
  * BMv2 STF uses three directives to configure multicast: mc_mgrp_create, mc_node_create, and
  * mc_node_associate. We merge them into a single MulticastGroupEntry with all replicas.
+ *
+ * [nodes] is ordered by creation time; BMv2 assigns node handles as sequential indices starting at
+ * 0, so mc_node_associate references nodes by list index.
  */
 fun resolveStfMulticastGroup(
   groupId: Int,
-  nodes: Map<Int, StfMcNodeCreate>,
+  nodes: List<StfMcNodeCreate>,
   associations: List<StfMcNodeAssociate>,
 ): WriteEntryRequest {
   val replicas =
     associations
       .filter { it.groupId == groupId }
       .flatMap { assoc ->
-        val node = nodes[assoc.nodeHandle] ?: error("unknown mc node handle: ${assoc.nodeHandle}")
+        val node =
+          nodes.getOrNull(assoc.nodeHandle) ?: error("unknown mc node handle: ${assoc.nodeHandle}")
         node.ports.map { port ->
           P4RuntimeOuterClass.Replica.newBuilder().setEgressPort(port).setInstance(node.rid).build()
         }

--- a/e2e_tests/stf/StfParserTest.kt
+++ b/e2e_tests/stf/StfParserTest.kt
@@ -512,6 +512,29 @@ class StfParserTest {
   }
 
   // ---------------------------------------------------------------------------
+  // resolveStfMulticastGroup — node handle keying
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `resolveStfMulticastGroup resolves nodes by sequential handle not by rid`() {
+    // BMv2 assigns handles 0, 1, 2... as nodes are created.
+    // mc_node_associate references these handles (list indices), not the node RIDs.
+    val nodes =
+      listOf(
+        StfMcNodeCreate(rid = 400, ports = listOf(6)),
+        StfMcNodeCreate(rid = 401, ports = listOf(7)),
+        StfMcNodeCreate(rid = 402, ports = listOf(8)),
+      )
+    val assocs = listOf(StfMcNodeAssociate(groupId = 1, nodeHandle = 0))
+    val req = resolveStfMulticastGroup(1, nodes, assocs)
+    val group = req.update.entity.packetReplicationEngineEntry.multicastGroupEntry
+    assertEquals(1, group.multicastGroupId)
+    assertEquals(1, group.replicasCount)
+    assertEquals(6, group.replicasList[0].egressPort)
+    assertEquals(400, group.replicasList[0].instance)
+  }
+
+  // ---------------------------------------------------------------------------
   // encodeValue
   // ---------------------------------------------------------------------------
 

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -258,6 +258,7 @@ class V1ModelArchitecture : Architecture {
         throw MulticastFork(replicas, s.packetCtx.getEvents())
       }
       if (decisions.multicastReplica != null) {
+        s.standardMetadata.fields["instance_type"] = BitVal(REPLICATION_INSTANCE_TYPE, INT32_BITS)
         s.standardMetadata.fields["egress_port"] =
           BitVal(decisions.multicastReplica.port.toLong(), PORT_BITS)
         s.standardMetadata.fields["egress_rid"] =
@@ -315,7 +316,8 @@ class V1ModelArchitecture : Architecture {
     private const val INT32_BITS = 32
     private const val REPLICA_ID_BITS = 16
 
-    // v1model instance_type values (BMv2 convention).
+    // v1model instance_type values (BMv2 PktInstanceType convention).
     private const val CLONE_I2E_INSTANCE_TYPE = 1L
+    private const val REPLICATION_INSTANCE_TYPE = 5L
   }
 }


### PR DESCRIPTION
## Summary

- **Fix mc_node_associate lookup**: STF runner keyed multicast nodes by RID instead of BMv2's auto-incrementing handle. `mc_node_associate 1113 0` tried to find node with RID=0, but the first node has RID=400 and handle=0.
- **Set instance_type=5 for multicast replicas**: P4 programs check `IS_REPLICATED(std_meta)` (instance_type == 5) to detect multicast copies. The simulator wasn't setting this, so egress code paths for replicated packets were never taken.

The fix changes `resolveStfMulticastGroup` to accept a `List<StfMcNodeCreate>` (ordered by creation time) instead of `Map<Int, StfMcNodeCreate>`, since BMv2 node handles are sequential list indices — a map keyed by sequential integers is just a slower list.

Unblocks multicast-dependent corpus tests (ipv6-switch-ml-bmv2 and v1model-special-ops-bmv2 no longer crash on mc_node lookup, though they have other remaining issues — 128-bit address slicing and verify_checksum respectively).

## Test plan

- [x] Unit test for `resolveStfMulticastGroup` with handle-based keying
- [x] All 24 tests pass (`bazel test //...`)
- [x] v1model-special-ops error changes from `unknown mc node handle: 0` to `unhandled extern call: verify_checksum` (multicast path now works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)