### PR TITLE
Add clone+multicast and multicast+selector trace tree tests

### DIFF
--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -13,11 +13,13 @@ _P4_PROGRAMS = [
     "action_selector_3",
     "action_selector_miss",
     "action_selector_nested",
+    "clone_and_multicast",
     "clone_ingress_egress",
     "clone_plus_selector",
     "clone_with_egress",
     "multicast",
     "multicast_drop_replica",
+    "multicast_selector",
     "selector_exit",
 ]
 

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -1,0 +1,38 @@
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+events {
+  clone {
+    session_id: 100
+  }
+}
+fork {
+  reason: CLONE
+  branches {
+    label: "original"
+    subtree {
+      fork {
+        reason: MULTICAST
+        branches {
+          label: "replica_0_port_1"
+          subtree {
+          }
+        }
+        branches {
+          label: "replica_0_port_2"
+          subtree {
+          }
+        }
+      }
+    }
+  }
+  branches {
+    label: "clone"
+    subtree {
+    }
+  }
+}

--- a/e2e_tests/trace_tree/clone_and_multicast.p4
+++ b/e2e_tests/trace_tree/clone_and_multicast.p4
@@ -1,0 +1,48 @@
+/* clone_and_multicast.p4 — clone and multicast in the same pipeline.
+ *
+ * Ingress clones (I2E, session 100) then sets mcast_grp = 1.  The trace
+ * tree should fork at the clone point; within the "original" branch, it
+ * should fork again for multicast replicas.  The "clone" branch should
+ * unicast to the clone session port with no multicast.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply {
+        clone(CloneType.I2E, 32w100);
+        smeta.mcast_grp = 1;
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/clone_and_multicast.stf
+++ b/e2e_tests/trace_tree/clone_and_multicast.stf
@@ -1,0 +1,7 @@
+# clone_and_multicast.stf — clone + multicast in the same pipeline.
+
+mirroring_add 100 3
+mc_mgrp_create 1
+mc_node_create 0 1 2
+mc_node_associate 1 0
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -1,0 +1,104 @@
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+}
+fork {
+  reason: MULTICAST
+  branches {
+    label: "replica_0_port_1"
+    subtree {
+      events {
+        table_lookup {
+          table_name: "egress_selector"
+          hit: true
+          matched_entry {
+            table_id: 43223807
+            match {
+              field_id: 1
+              exact {
+                value: "\377\377\377\377\377\377"
+              }
+            }
+            action {
+              action_profile_group_id: 1
+            }
+          }
+          action_name: "tag_a"
+        }
+      }
+      fork {
+        reason: ACTION_SELECTOR
+        branches {
+          label: "member_0"
+          subtree {
+            events {
+              action_execution {
+                action_name: "tag_a"
+              }
+            }
+          }
+        }
+        branches {
+          label: "member_1"
+          subtree {
+            events {
+              action_execution {
+                action_name: "tag_b"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  branches {
+    label: "replica_0_port_2"
+    subtree {
+      events {
+        table_lookup {
+          table_name: "egress_selector"
+          hit: true
+          matched_entry {
+            table_id: 43223807
+            match {
+              field_id: 1
+              exact {
+                value: "\377\377\377\377\377\377"
+              }
+            }
+            action {
+              action_profile_group_id: 1
+            }
+          }
+          action_name: "tag_a"
+        }
+      }
+      fork {
+        reason: ACTION_SELECTOR
+        branches {
+          label: "member_0"
+          subtree {
+            events {
+              action_execution {
+                action_name: "tag_a"
+              }
+            }
+          }
+        }
+        branches {
+          label: "member_1"
+          subtree {
+            events {
+              action_execution {
+                action_name: "tag_b"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/multicast_selector.p4
+++ b/e2e_tests/trace_tree/multicast_selector.p4
@@ -1,0 +1,66 @@
+/* multicast_selector.p4 — multicast where each replica hits an action selector.
+ *
+ * Ingress sets mcast_grp = 1 (2 replicas on ports 1, 2).  Egress has an
+ * action selector table with 2 members.  The trace tree should fork for
+ * multicast first, then within each replica branch, fork again for the
+ * action selector — producing 3 levels of nesting.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply {
+        smeta.mcast_grp = 1;
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) {
+
+    action tag_a() { hdr.ethernet.dstAddr = 0xAAAAAAAAAAAA; }
+    action tag_b() { hdr.ethernet.dstAddr = 0xBBBBBBBBBBBB; }
+    action noop()  {}
+
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) egress_sel;
+
+    table egress_selector {
+        key = {
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { tag_a; tag_b; noop; }
+        implementation = egress_sel;
+        default_action = noop();
+    }
+
+    apply { egress_selector.apply(); }
+}
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/multicast_selector.stf
+++ b/e2e_tests/trace_tree/multicast_selector.stf
@@ -1,0 +1,10 @@
+# multicast_selector.stf — multicast + egress action selector.
+
+mc_mgrp_create 1
+mc_node_create 0 1 2
+mc_node_associate 1 0
+member egress_sel 0 tag_a
+member egress_sel 1 tag_b
+group egress_sel 1 0 1
+add egress_selector hdr.ethernet.dstAddr:0xFFFFFFFFFFFF group=1
+packet 0 FFFFFFFFFFFF 000000000001 0800


### PR DESCRIPTION
## Summary

Closes the two remaining fork-type interaction gaps identified during
Track 3 confidence review:

- **`clone_and_multicast`** — ingress clones (I2E) then sets `mcast_grp`.
  The trace tree forks at the clone point; the "original" branch nests a
  MULTICAST fork with 2 replicas. The "clone" branch unicasts to the
  clone session port. Verifies that fork decisions (CloneMode, multicast
  replica) don't interfere across fork types.

- **`multicast_selector`** — multicast with 2 replicas where each replica
  hits an action selector in egress (2 members: `tag_a`, `tag_b`). Produces
  3 levels of nesting: MULTICAST → ACTION_SELECTOR. Verifies that prefix
  stripping and decision accumulation work correctly at depth > 2.

Golden trace tree suite: 10 → 12 tests. All fork types and their pairwise
interactions are now covered.

## Test plan

- [x] All 12 golden trace tree tests pass
- [x] Full test suite (24 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)