### PR TITLE
Document BMv2 simple_switch as v1model reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,12 @@ tree. Rebase and squash when merging back.
 ## P4 spec compliance
 
 4ward is a spec-compliant reference implementation. When implementing a
-feature or resolving an ambiguity, consult the
-[P4₁₆ Language Specification (v1.2.5)](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html).
-Cite spec section numbers in comments on non-obvious semantics.
+feature or resolving an ambiguity, consult:
+- [P4₁₆ Language Specification (v1.2.5)](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html)
+  — the language spec. Cite section numbers in comments on non-obvious semantics.
+- [BMv2 simple_switch documentation](https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md)
+  — the de facto spec for v1model architecture semantics (clone/resubmit/recirculate
+  ordering, last-writer-wins, metadata preservation, ingress→egress boundary).
 
 ## Tool use
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -18,10 +18,11 @@ guilt — just write it down so someone can find it later.
 
 ## Externs
 
-- **`mark_to_drop` is the only extern function.** All other v1model externs
-  — `hash`, `verify_checksum`, `update_checksum`, `verify`, `random`,
-  `digest`, `log_msg` — are unimplemented and will crash with
-  `"unhandled extern call"`. Blocks ~6 corpus tests (verify/checksum).
+- **Limited extern functions.** `mark_to_drop`, `verify`, `clone`, and
+  `clone3` are implemented. All other v1model externs — `hash`,
+  `verify_checksum`, `update_checksum`, `random`, `digest`, `log_msg` —
+  are unimplemented and will crash with `"unhandled extern call"`.
+  Blocks ~6 corpus tests (verify/checksum).
 - **No register, counter, or meter support.** Extern object methods
   (`register.read`/`.write`, `counter.count`, etc.) are not implemented.
   Blocks ~3 corpus tests.
@@ -32,7 +33,9 @@ guilt — just write it down so someone can find it later.
   empty response (`Simulator.kt:143`).
 - **Clone: I2E only, no metadata preservation.** `clone()` and `clone3()`
   support ingress-to-egress cloning. E2E clone, `clone3` metadata field
-  lists, resubmit, and recirculate are not implemented.
+  lists, resubmit, and recirculate are not implemented. Multiple clone
+  calls in one pipeline are not handled correctly — BMv2 uses
+  last-writer-wins semantics, but 4ward forks on the first call.
 - **Multicast: basic replication only.** Multicast group replication works
   for the trace tree (forking per replica). PRE entries are installed via
   P4Runtime `PacketReplicationEngineEntry`.

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -724,6 +724,8 @@ class Interpreter(
         UnitVal
       }
       // clone(type, session) / clone3(type, session, data): P4 v1model I2E/E2E clone.
+      // See https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md
+      // TODO(v1model): only I2E is implemented; BMv2 uses last-writer-wins for multiple calls.
       "clone",
       "clone3" -> {
         val sessionId = (evalExpr(call.argsList[1], env) as BitVal).bits.value.toInt()

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -22,7 +22,9 @@ import fourward.sim.v1.TraceTree
  * - clone (I2E) via ForkException / re-execution.
  * - multicast group replication via ForkException / re-execution.
  *
- * Reference: https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4
+ * References:
+ * - v1model.p4: https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4
+ * - BMv2 simple_switch semantics: https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md
  */
 class V1ModelArchitecture : Architecture {
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — add BMv2 simple_switch docs as a primary reference for
  v1model architecture semantics, alongside the P4₁₆ language spec.
- **V1ModelArchitecture.kt** — add simple_switch link to class-level doc.
- **Interpreter.kt** — add reference and TODO at the clone/clone3 extern,
  noting the last-writer-wins gap for multiple calls.
- **LIMITATIONS.md** — update implemented externs list (was stale: "mark_to_drop
  is the only extern"); document multiple-clone-calls behavioral gap.

## Test plan

- [x] Doc-only changes to CLAUDE.md, LIMITATIONS.md
- [x] Comment-only changes to Interpreter.kt, V1ModelArchitecture.kt
- [x] `bazel test //...` passes (no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)