### PR TITLE
Support StructExpression in IR; implement verify/update_checksum

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -31,6 +31,8 @@ corpus_test_suite(
         "arith5-bmv2",
         "array-copy-bmv2",
         "bvec-hdr-bmv2",
+        "checksum2-bmv2",
+        "checksum3-bmv2",
         "default-action-arg-bmv2",
         "default_action-bmv2",
         "equality-varbit-bmv2",
@@ -161,6 +163,7 @@ corpus_test_suite(
         "issue561-6-bmv2",
         "issue561-7-bmv2",
         "issue635-bmv2",
+        "issue655-bmv2",
         "issue774-4-bmv2",
         "issue983-bmv2",
         "issue995-bmv2",
@@ -206,7 +209,7 @@ corpus_test_suite(
         "constant-in-calculation-bmv2",  # unhandled extern call: hash
         "enum-bmv2",  # missing ConvertEnums midend pass
         "extern-funcs-bmv2",  # unhandled extern call: extern_func
-        "ipv6-switch-ml-bmv2",  # multicast replication not implemented
+        "ipv6-switch-ml-bmv2",  # 128-bit IPv6 address slicing mismatch
     ],
 )
 
@@ -278,14 +281,11 @@ corpus_test_suite(
     name = "other_stf_corpus_test",
     tags = ["manual"],
     tests = [
-        "checksum2-bmv2",  # unhandled extern call: verify_checksum
-        "checksum3-bmv2",  # unhandled extern call: update_checksum
         "header-stack-ops-bmv2",  # unhandled extern call: push_front/pop_front
         "issue1049-bmv2",  # unhandled extern call: hash
-        "issue655-bmv2",  # unhandled extern call: verify_checksum
         "table-entries-priority-bmv2",  # BMv2 @priority uses lower-is-better; P4Runtime uses higher-is-better
         "ternary2-bmv2",  # per-table action specialization lost (single p4info action ID)
-        "v1model-special-ops-bmv2",  # unhandled extern call: verify_checksum
+        "v1model-special-ops-bmv2",  # needs resubmit/recirculate
     ],
 )
 

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -282,6 +282,13 @@ fourward::ir::v1::Expr FourWardBackend::emitExpr(const IR::Expression* expr) {
     for (const auto* arg : *mc->arguments) {
       *call->add_args() = emitExpr(arg->expression);
     }
+  } else if (const auto* se = expr->to<IR::StructExpression>()) {
+    auto* s = out.mutable_struct_expr();
+    for (const auto* comp : se->components) {
+      auto* field = s->add_fields();
+      field->set_name(comp->name.name.c_str());
+      *field->mutable_value() = emitExpr(comp->expression);
+    }
   } else {
     LOG1("WARNING: unhandled expression " << expr->node_type_name());
   }

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -88,6 +88,16 @@ kt_jvm_binary(
 # =============================================================================
 
 kt_jvm_test(
+    name = "ChecksumTest",
+    srcs = ["ChecksumTest.kt"],
+    test_class = "fourward.simulator.ChecksumTest",
+    deps = [
+        ":simulator_lib",
+        "@maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "BitVectorTest",
     srcs = ["BitVectorTest.kt"],
     test_class = "fourward.simulator.BitVectorTest",

--- a/simulator/Checksum.kt
+++ b/simulator/Checksum.kt
@@ -1,0 +1,31 @@
+package fourward.simulator
+
+import java.math.BigInteger
+
+private const val CSUM_WORD_BITS = 16
+private val CSUM_MASK = BigInteger.TWO.pow(CSUM_WORD_BITS).subtract(BigInteger.ONE)
+
+/**
+ * Ones' complement (csum16) checksum over the fields of a struct.
+ *
+ * Concatenates all fields into a bit string, pads to a 16-bit boundary, sums all 16-bit words with
+ * end-around carry, and returns the complement. This is the standard Internet checksum (RFC 1071)
+ * used by IPv4, TCP, and UDP.
+ */
+fun onesComplementChecksum(data: StructVal): BigInteger {
+  val combined =
+    data.fields.values.map { (it as BitVal).bits }.reduceOrNull { acc, bv -> acc.concat(bv) }
+      ?: return BigInteger.ZERO
+  val totalWidth = combined.width
+  val padded = ((totalWidth + CSUM_WORD_BITS - 1) / CSUM_WORD_BITS) * CSUM_WORD_BITS
+  var bits = combined.value.shiftLeft(padded - totalWidth)
+  var sum = BigInteger.ZERO
+  for (i in 0 until padded / CSUM_WORD_BITS) {
+    val word = bits.shiftRight(padded - (i + 1) * CSUM_WORD_BITS).and(CSUM_MASK)
+    sum = sum.add(word)
+  }
+  while (sum > CSUM_MASK) {
+    sum = sum.and(CSUM_MASK).add(sum.shiftRight(CSUM_WORD_BITS))
+  }
+  return CSUM_MASK.subtract(sum)
+}

--- a/simulator/ChecksumTest.kt
+++ b/simulator/ChecksumTest.kt
@@ -1,0 +1,92 @@
+package fourward.simulator
+
+import java.math.BigInteger
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChecksumTest {
+
+  private fun structOf(vararg fields: Pair<String, BitVal>): StructVal =
+    StructVal("test", fields.toMap(mutableMapOf()))
+
+  @Test
+  fun `single 16-bit field returns ones complement`() {
+    // ~0x0001 = 0xFFFE
+    val data = structOf("d" to BitVal(0x0001, 16))
+    assertEquals(BigInteger.valueOf(0xFFFE), onesComplementChecksum(data))
+  }
+
+  @Test
+  fun `complement of zero is all ones`() {
+    val data = structOf("d" to BitVal(0x0000, 16))
+    assertEquals(BigInteger.valueOf(0xFFFF), onesComplementChecksum(data))
+  }
+
+  @Test
+  fun `complement of all ones is zero`() {
+    val data = structOf("d" to BitVal(0xFFFF, 16))
+    assertEquals(BigInteger.ZERO, onesComplementChecksum(data))
+  }
+
+  @Test
+  fun `two 16-bit fields are summed with carry`() {
+    // 0xFFFF + 0x0001 = 0x10000, fold carry → 0x0001, complement → 0xFFFE
+    val data = structOf("a" to BitVal(0xFFFF, 16), "b" to BitVal(0x0001, 16))
+    assertEquals(BigInteger.valueOf(0xFFFE), onesComplementChecksum(data))
+  }
+
+  @Test
+  fun `IPv4 header checksum from RFC 1071`() {
+    // RFC 1071 example: 5 16-bit words summing to a known checksum.
+    val data =
+      structOf(
+        "w0" to BitVal(0x4500, 16),
+        "w1" to BitVal(0x0073, 16),
+        "w2" to BitVal(0x0000, 16),
+        "w3" to BitVal(0x4000, 16),
+        "w4" to BitVal(0x4006, 16),
+        // skip checksum field itself (would be 0x0000 for computation)
+        "w5" to BitVal(0xAC10, 16), // 172.16.x.x
+        "w6" to BitVal(0x0A63, 16),
+        "w7" to BitVal(0xAC10, 16),
+        "w8" to BitVal(0x0A0C, 16),
+      )
+    // Verify: sum of all words + checksum should fold to 0xFFFF.
+    val csum = onesComplementChecksum(data)
+    // Adding csum back to the data should yield 0xFFFF (valid checksum property).
+    val verify =
+      structOf(
+        "w0" to BitVal(0x4500, 16),
+        "w1" to BitVal(0x0073, 16),
+        "w2" to BitVal(0x0000, 16),
+        "w3" to BitVal(0x4000, 16),
+        "w4" to BitVal(0x4006, 16),
+        "w5" to BitVal(0xAC10, 16),
+        "w6" to BitVal(0x0A63, 16),
+        "w7" to BitVal(0xAC10, 16),
+        "w8" to BitVal(0x0A0C, 16),
+        "csum" to BitVal(csum.toLong(), 16),
+      )
+    assertEquals(BigInteger.ZERO, onesComplementChecksum(verify))
+  }
+
+  @Test
+  fun `non-aligned fields are padded to 16-bit boundary`() {
+    // Single 8-bit field 0xAB → padded to 0xAB00 → complement = 0x54FF
+    val data = structOf("x" to BitVal(0xAB, 8))
+    assertEquals(BigInteger.valueOf(0x54FF), onesComplementChecksum(data))
+  }
+
+  @Test
+  fun `mixed-width fields concatenate correctly`() {
+    // 4-bit 0xA + 12-bit 0xBCD = 16-bit word 0xABCD → complement = 0x5432
+    val data = structOf("hi" to BitVal(0xA, 4), "lo" to BitVal(0xBCD, 12))
+    assertEquals(BigInteger.valueOf(0x5432), onesComplementChecksum(data))
+  }
+
+  @Test
+  fun `empty struct returns zero`() {
+    val data = structOf()
+    assertEquals(BigInteger.ZERO, onesComplementChecksum(data))
+  }
+}

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -36,6 +36,7 @@ class Interpreter(
   private val tableStore: TableStore,
   private val packetCtx: PacketContext? = null,
   private val decisions: ForkDecisions = ForkDecisions(),
+  private val onChecksumError: (() -> Unit)? = null,
 ) {
   private val parsers: Map<String, ParserDecl> = config.parsersList.associateBy { it.name }
 
@@ -245,6 +246,7 @@ class Interpreter(
       expr.hasUnaryOp() -> evalUnaryOp(expr.unaryOp, env)
       expr.hasMethodCall() -> evalMethodCall(expr.methodCall, env)
       expr.hasMux() -> evalMux(expr.mux, env)
+      expr.hasStructExpr() -> evalStructExpr(expr.structExpr, expr.type, env)
       expr.hasTableApply() -> {
         val result = applyTable(expr.tableApply.tableName, env)
         when (expr.tableApply.accessKind) {
@@ -510,6 +512,17 @@ class Interpreter(
     if ((evalExpr(mux.condition, env) as BoolVal).value) evalExpr(mux.thenExpr, env)
     else evalExpr(mux.elseExpr, env)
 
+  private fun evalStructExpr(
+    se: fourward.ir.v1.StructExpr,
+    type: fourward.ir.v1.Type,
+    env: Environment,
+  ): Value {
+    require(type.hasNamed()) { "StructExpr must have a named type, got: $type" }
+    val typeName = type.named
+    val fields = se.fieldsList.associateTo(mutableMapOf()) { f -> f.name to evalExpr(f.value, env) }
+    return StructVal(typeName, fields)
+  }
+
   private fun evalMethodCall(call: MethodCall, env: Environment): Value {
     return when (call.method) {
       // Header validity methods: target is the header instance.
@@ -736,6 +749,33 @@ class Interpreter(
           CloneMode.THROW -> throw CloneFork(sessionId, packetCtx!!.getEvents())
           CloneMode.SUPPRESS -> {} // already recorded event, continue normally
           CloneMode.EXECUTE_CLONE -> throw JumpToEgressException()
+        }
+        UnitVal
+      }
+      // verify_checksum(condition, data, checksum, algo): v1model §14.
+      // Computes hash over data fields and compares with checksum; sets
+      // standard_metadata.checksum_error = 1 on mismatch.
+      "verify_checksum" -> {
+        val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
+        if (condition) {
+          val data = evalExpr(call.argsList[1], env) as StructVal
+          val expected = evalExpr(call.argsList[2], env) as BitVal
+          val computed = onesComplementChecksum(data)
+          if (computed != expected.bits.value) {
+            onChecksumError?.invoke()
+          }
+        }
+        UnitVal
+      }
+      // update_checksum(condition, data, checksum, algo): v1model §14.
+      // Computes hash over data fields and writes result into checksum (out param).
+      "update_checksum" -> {
+        val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
+        if (condition) {
+          val data = evalExpr(call.argsList[1], env) as StructVal
+          val computed = onesComplementChecksum(data)
+          val checksumWidth = call.argsList[2].type.bit.width
+          setLValue(call.argsList[2], BitVal(BitVector(computed, checksumWidth)), env)
         }
         UnitVal
       }

--- a/simulator/InterpreterExprTest.kt
+++ b/simulator/InterpreterExprTest.kt
@@ -691,4 +691,31 @@ class InterpreterExprTest {
     // setInvalid() zeros fields in place per P4 spec §8.17 (BMv2 treats them as zero)
     assertEquals(BitVal(0, 16), hdr.fields["etherType"])
   }
+
+  // ---------------------------------------------------------------------------
+  // StructExpr evaluation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `struct expression evaluates to StructVal with evaluated fields`() {
+    val expr =
+      Expr.newBuilder()
+        .setStructExpr(
+          fourward.ir.v1.StructExpr.newBuilder()
+            .addFields(
+              fourward.ir.v1.StructExprField.newBuilder().setName("a").setValue(bit(0xAB, 8))
+            )
+            .addFields(
+              fourward.ir.v1.StructExprField.newBuilder().setName("b").setValue(bit(0xCD, 8))
+            )
+        )
+        .setType(Type.newBuilder().setNamed("my_tuple"))
+        .build()
+
+    val result = interp().evalExpr(expr, emptyEnv)
+    val sv = result as StructVal
+    assertEquals("my_tuple", sv.typeName)
+    assertEquals(BitVal(0xAB, 8), sv.fields["a"])
+    assertEquals(BitVal(0xCD, 8), sv.fields["b"])
+  }
 }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -26,317 +26,302 @@ import fourward.sim.v1.TraceTree
  */
 class V1ModelArchitecture : Architecture {
 
-    /** Invariant inputs to the pipeline, shared across fork re-executions. */
-    private data class PipelineContext(
-        val ingressPort: UInt,
-        val payload: ByteArray,
-        val config: P4BehavioralConfig,
-        val tableStore: TableStore,
-    )
+  /** Invariant inputs to the pipeline, shared across fork re-executions. */
+  private data class PipelineContext(
+    val ingressPort: UInt,
+    val payload: ByteArray,
+    val config: P4BehavioralConfig,
+    val tableStore: TableStore,
+  )
 
-    /** Per-execution state created fresh for each pipeline run. */
-    private class PipelineState(
-        val packetCtx: PacketContext,
-        val interpreter: Interpreter,
-        val env: Environment,
-        val standardMetadata: StructVal,
-        config: P4BehavioralConfig,
-    ) {
-        private val stages = config.architecture.stagesList
-        val parserStage: PipelineStage? = stages.find { it.kind == StageKind.PARSER }
-        val deparserStage: PipelineStage? = stages.find { it.kind == StageKind.DEPARSER }
+  /** Per-execution state created fresh for each pipeline run. */
+  private class PipelineState(
+    val packetCtx: PacketContext,
+    val interpreter: Interpreter,
+    val env: Environment,
+    val standardMetadata: StructVal,
+    config: P4BehavioralConfig,
+  ) {
+    private val stages = config.architecture.stagesList
+    val parserStage: PipelineStage? = stages.find { it.kind == StageKind.PARSER }
+    val deparserStage: PipelineStage? = stages.find { it.kind == StageKind.DEPARSER }
 
-        // v1model: first 2 controls are ingress-side (verify checksum, ingress),
-        // last 2 are egress-side (egress, compute checksum).
-        private val controlStages = stages.filter { it.kind == StageKind.CONTROL }
-        val ingressControls: List<PipelineStage> = controlStages.take(INGRESS_CONTROL_COUNT)
-        val egressControls: List<PipelineStage> = controlStages.drop(INGRESS_CONTROL_COUNT)
+    // v1model: first 2 controls are ingress-side (verify checksum, ingress),
+    // last 2 are egress-side (egress, compute checksum).
+    private val controlStages = stages.filter { it.kind == StageKind.CONTROL }
+    val ingressControls: List<PipelineStage> = controlStages.take(INGRESS_CONTROL_COUNT)
+    val egressControls: List<PipelineStage> = controlStages.drop(INGRESS_CONTROL_COUNT)
+  }
+
+  override fun processPacket(
+    ingressPort: UInt,
+    payload: ByteArray,
+    config: P4BehavioralConfig,
+    tableStore: TableStore,
+  ): PipelineResult {
+    val ctx = PipelineContext(ingressPort, payload, config, tableStore)
+    return buildTraceTree(ctx, ForkDecisions(), prefixLength = 0)
+  }
+
+  /**
+   * Recursively builds a trace tree by re-executing the pipeline for each fork branch.
+   *
+   * When a [ForkException] is thrown (action selector, clone, or multicast), this method
+   * re-executes the full pipeline once per branch with appropriate [ForkDecisions], and assembles
+   * the results into a [TraceTree] with a [ForkNode]. Shared prefix events are stripped from
+   * branches.
+   */
+  private fun buildTraceTree(
+    ctx: PipelineContext,
+    decisions: ForkDecisions,
+    prefixLength: Int,
+  ): PipelineResult {
+    try {
+      val (outputs, trace) = runPipeline(ctx, decisions)
+      val stripped =
+        TraceTree.newBuilder().addAllEvents(trace.eventsList.drop(prefixLength)).build()
+      return PipelineResult(outputs, stripped)
+    } catch (fork: ForkException) {
+      val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+      val (reason, branches) = buildForkBranches(ctx, decisions, fork)
+      val tree =
+        TraceTree.newBuilder()
+          .addAllEvents(levelEvents)
+          .setFork(ForkNode.newBuilder().setReason(reason).addAllBranches(branches))
+          .build()
+      return PipelineResult(emptyList(), tree)
     }
+  }
 
-    override fun processPacket(
-        ingressPort: UInt,
-        payload: ByteArray,
-        config: P4BehavioralConfig,
-        tableStore: TableStore,
-    ): PipelineResult {
-        val ctx = PipelineContext(ingressPort, payload, config, tableStore)
-        return buildTraceTree(ctx, ForkDecisions(), prefixLength = 0)
-    }
-
-    /**
-     * Recursively builds a trace tree by re-executing the pipeline for each fork branch.
-     *
-     * When a [ForkException] is thrown (action selector, clone, or multicast), this method
-     * re-executes the full pipeline once per branch with appropriate [ForkDecisions], and assembles
-     * the results into a [TraceTree] with a [ForkNode]. Shared prefix events are stripped from
-     * branches.
-     */
-    private fun buildTraceTree(
-        ctx: PipelineContext,
-        decisions: ForkDecisions,
-        prefixLength: Int,
-    ): PipelineResult {
-        try {
-            val (outputs, trace) = runPipeline(ctx, decisions)
-            val stripped =
-                TraceTree.newBuilder().addAllEvents(trace.eventsList.drop(prefixLength)).build()
-            return PipelineResult(outputs, stripped)
-        } catch (fork: ForkException) {
-            val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
-            val (reason, branches) = buildForkBranches(ctx, decisions, fork)
-            val tree =
-                TraceTree.newBuilder()
-                    .addAllEvents(levelEvents)
-                    .setFork(ForkNode.newBuilder().setReason(reason).addAllBranches(branches))
-                    .build()
-            return PipelineResult(emptyList(), tree)
-        }
-    }
-
-    /** Dispatches fork handling to the appropriate branch builder. */
-    private fun buildForkBranches(
-        ctx: PipelineContext,
-        decisions: ForkDecisions,
-        fork: ForkException,
-    ): Pair<ForkReason, List<ForkBranch>> =
-        when (fork) {
-            is ActionSelectorFork -> {
-                val branches =
-                    fork.members.map { member ->
-                        val newDecisions =
-                            decisions.copy(
-                                selectorMembers =
-                                    decisions.selectorMembers + (fork.tableName to member.memberId)
-                            )
-                        forkBranch(
-                            "member_${member.memberId}",
-                            ctx,
-                            newDecisions,
-                            fork.eventsBeforeFork.size,
-                        )
-                    }
-                ForkReason.ACTION_SELECTOR to branches
-            }
-            is CloneFork -> {
-                val originalDecisions = decisions.copy(cloneMode = CloneMode.SUPPRESS)
-                val cloneDecisions =
-                    decisions.copy(
-                        cloneMode = CloneMode.EXECUTE_CLONE,
-                        cloneSessionId = fork.sessionId,
-                    )
-                val branches =
-                    listOf(
-                        forkBranch("original", ctx, originalDecisions, fork.eventsBeforeFork.size),
-                        forkBranch("clone", ctx, cloneDecisions, fork.eventsBeforeFork.size),
-                    )
-                ForkReason.CLONE to branches
-            }
-            is MulticastFork -> {
-                val branches =
-                    fork.replicas.map { replica ->
-                        val replicaDecisions = decisions.copy(multicastReplica = replica)
-                        forkBranch(
-                            "replica_${replica.rid}_port_${replica.port}",
-                            ctx,
-                            replicaDecisions,
-                            fork.eventsBeforeFork.size,
-                        )
-                    }
-                ForkReason.MULTICAST to branches
-            }
-        }
-
-    /** Re-executes the pipeline for one branch and wraps the result in a [ForkBranch]. */
-    private fun forkBranch(
-        label: String,
-        ctx: PipelineContext,
-        decisions: ForkDecisions,
-        prefixLength: Int,
-    ): ForkBranch {
-        val result = buildTraceTree(ctx, decisions, prefixLength)
-        return ForkBranch.newBuilder().setLabel(label).setSubtree(result.trace).build()
-    }
-
-    /**
-     * Creates a fresh [PipelineState] for one pipeline execution.
-     *
-     * Resolves type names, initialises standard_metadata, and binds parameter names across all
-     * stages. Stage topology (ingress/egress split) is derived by [PipelineState] itself.
-     */
-    private fun initPipelineState(ctx: PipelineContext, decisions: ForkDecisions): PipelineState {
-        val packetCtx = PacketContext(ctx.payload)
-        val env = Environment()
-        val config = ctx.config
-        val typesByName = config.typesList.associateBy { it.name }
-
-        // Derive the type names for hdr/meta/standard_metadata from the parser's
-        // parameter list, filtering out the architecture-level packet I/O params.
-        // v1model always declares: (packet_in, hdr, meta, standard_metadata) in that order.
-        val ioTypes = setOf("packet_in", "packet_out")
-        val parserUserParams =
-            config.parsersList.first().paramsList.filter {
-                it.type.hasNamed() && it.type.named !in ioTypes
-            }
-        require(parserUserParams.size == V1MODEL_USER_PARAM_COUNT) {
-            "Expected $V1MODEL_USER_PARAM_COUNT non-IO parser params, got ${parserUserParams.size}"
-        }
-        val headersTypeName = parserUserParams[0].type.named
-        val metaTypeName = parserUserParams[1].type.named
-        val standardMetaTypeName = parserUserParams[2].type.named
-
-        val standardMetadata =
-            (defaultValue(standardMetaTypeName, typesByName) as? StructVal)
-                ?: error("$standardMetaTypeName not found in IR types; is v1model.p4 included?")
-        check("ingress_port" in standardMetadata.fields) {
-            "$standardMetaTypeName has no ingress_port"
-        }
-        check("packet_length" in standardMetadata.fields) {
-            "$standardMetaTypeName has no packet_length"
-        }
-        standardMetadata.fields["ingress_port"] = BitVal(ctx.ingressPort.toLong(), PORT_BITS)
-        standardMetadata.fields["packet_length"] = BitVal(ctx.payload.size.toLong(), INT32_BITS)
-        standardMetadata.fields["parser_error"] = ErrorVal("NoError")
-
-        val interpreter =
-            Interpreter(ctx.config, ctx.tableStore, packetCtx, decisions) {
-                standardMetadata.fields["checksum_error"] = BitVal(1L, 1)
-            }
-
-        val sharedByType =
-            mapOf(
-                headersTypeName to defaultValue(headersTypeName, typesByName),
-                metaTypeName to defaultValue(metaTypeName, typesByName),
-                standardMetaTypeName to standardMetadata,
+  /** Dispatches fork handling to the appropriate branch builder. */
+  private fun buildForkBranches(
+    ctx: PipelineContext,
+    decisions: ForkDecisions,
+    fork: ForkException,
+  ): Pair<ForkReason, List<ForkBranch>> =
+    when (fork) {
+      is ActionSelectorFork -> {
+        val branches =
+          fork.members.map { member ->
+            val newDecisions =
+              decisions.copy(
+                selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId)
+              )
+            forkBranch("member_${member.memberId}", ctx, newDecisions, fork.eventsBeforeFork.size)
+          }
+        ForkReason.ACTION_SELECTOR to branches
+      }
+      is CloneFork -> {
+        val originalDecisions = decisions.copy(cloneMode = CloneMode.SUPPRESS)
+        val cloneDecisions =
+          decisions.copy(cloneMode = CloneMode.EXECUTE_CLONE, cloneSessionId = fork.sessionId)
+        val branches =
+          listOf(
+            forkBranch("original", ctx, originalDecisions, fork.eventsBeforeFork.size),
+            forkBranch("clone", ctx, cloneDecisions, fork.eventsBeforeFork.size),
+          )
+        ForkReason.CLONE to branches
+      }
+      is MulticastFork -> {
+        val branches =
+          fork.replicas.map { replica ->
+            val replicaDecisions = decisions.copy(multicastReplica = replica)
+            forkBranch(
+              "replica_${replica.rid}_port_${replica.port}",
+              ctx,
+              replicaDecisions,
+              fork.eventsBeforeFork.size,
             )
-        for (parser in config.parsersList) {
-            for (param in parser.paramsList) {
-                sharedByType[param.type.named]?.let { env.define(param.name, it) }
-            }
-        }
-        for (control in config.controlsList) {
-            for (param in control.paramsList) {
-                sharedByType[param.type.named]?.let { env.define(param.name, it) }
-            }
-        }
-
-        return PipelineState(packetCtx, interpreter, env, standardMetadata, config)
+          }
+        ForkReason.MULTICAST to branches
+      }
     }
 
-    /** Executes the full v1model pipeline once, returning output packets and flat trace. */
-    @Suppress("LoopWithTooManyJumpStatements")
-    private fun runPipeline(ctx: PipelineContext, decisions: ForkDecisions): PipelineResult {
-        val s = initPipelineState(ctx, decisions)
+  /** Re-executes the pipeline for one branch and wraps the result in a [ForkBranch]. */
+  private fun forkBranch(
+    label: String,
+    ctx: PipelineContext,
+    decisions: ForkDecisions,
+    prefixLength: Int,
+  ): ForkBranch {
+    val result = buildTraceTree(ctx, decisions, prefixLength)
+    return ForkBranch.newBuilder().setLabel(label).setSubtree(result.trace).build()
+  }
 
-        // --- Parser ---
-        if (s.parserStage != null) {
-            try {
-                s.interpreter.runParser(s.parserStage.blockName, s.env)
-            } catch (e: ExitException) {
-                return PipelineResult(emptyList(), s.packetCtx.buildTrace())
-            } catch (e: ParserErrorException) {
-                // BMv2 v1model: parser errors don't drop the packet. Set parser_error and
-                // continue to the ingress pipeline, letting the P4 program decide the fate.
-                s.standardMetadata.fields["parser_error"] = ErrorVal(e.errorName)
-            }
-        }
+  /**
+   * Creates a fresh [PipelineState] for one pipeline execution.
+   *
+   * Resolves type names, initialises standard_metadata, and binds parameter names across all
+   * stages. Stage topology (ingress/egress split) is derived by [PipelineState] itself.
+   */
+  private fun initPipelineState(ctx: PipelineContext, decisions: ForkDecisions): PipelineState {
+    val packetCtx = PacketContext(ctx.payload)
+    val env = Environment()
+    val config = ctx.config
+    val typesByName = config.typesList.associateBy { it.name }
 
-        // --- Ingress controls (verify checksum, ingress) ---
-        // JumpToEgressException signals clone-branch re-execution: stop ingress, run egress only.
-        var jumpToEgress = false
-        for (stage in s.ingressControls) {
-            try {
-                s.interpreter.runControl(stage.blockName, s.env)
-            } catch (_: ExitException) {
-                break
-            } catch (_: JumpToEgressException) {
-                jumpToEgress = true
-                break
-            }
-        }
+    // Derive the type names for hdr/meta/standard_metadata from the parser's
+    // parameter list, filtering out the architecture-level packet I/O params.
+    // v1model always declares: (packet_in, hdr, meta, standard_metadata) in that order.
+    val ioTypes = setOf("packet_in", "packet_out")
+    val parserUserParams =
+      config.parsersList.first().paramsList.filter {
+        it.type.hasNamed() && it.type.named !in ioTypes
+      }
+    require(parserUserParams.size == V1MODEL_USER_PARAM_COUNT) {
+      "Expected $V1MODEL_USER_PARAM_COUNT non-IO parser params, got ${parserUserParams.size}"
+    }
+    val headersTypeName = parserUserParams[0].type.named
+    val metaTypeName = parserUserParams[1].type.named
+    val standardMetaTypeName = parserUserParams[2].type.named
 
-        // --- Ingress→egress boundary: clone / multicast metadata setup ---
-        // All paths write egress_port into standardMetadata so the egress read is uniform.
-        if (jumpToEgress) {
-            // Clone branch: set instance_type and egress_port from clone session config.
-            val session =
-                ctx.tableStore.getCloneSession(decisions.cloneSessionId)
-                    ?: error("unknown clone session: ${decisions.cloneSessionId}")
-            val clonePort = session.replicasList.firstOrNull()?.egressPort ?: 0
-            s.standardMetadata.fields["instance_type"] = BitVal(CLONE_I2E_INSTANCE_TYPE, INT32_BITS)
-            s.standardMetadata.fields["egress_port"] = BitVal(clonePort.toLong(), PORT_BITS)
-        } else {
-            val mcastGrp =
-                (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
-            if (mcastGrp != 0 && decisions.multicastReplica == null) {
-                val group =
-                    ctx.tableStore.getMulticastGroup(mcastGrp)
-                        ?: error("unknown multicast group: $mcastGrp")
-                val replicas =
-                    group.replicasList.map { r -> MulticastReplica(r.instance, r.egressPort) }
-                throw MulticastFork(replicas, s.packetCtx.getEvents())
-            }
-            if (decisions.multicastReplica != null) {
-                s.standardMetadata.fields["instance_type"] =
-                    BitVal(REPLICATION_INSTANCE_TYPE, INT32_BITS)
-                s.standardMetadata.fields["egress_port"] =
-                    BitVal(decisions.multicastReplica.port.toLong(), PORT_BITS)
-                s.standardMetadata.fields["egress_rid"] =
-                    BitVal(decisions.multicastReplica.rid.toLong(), REPLICA_ID_BITS)
-            } else {
-                // Normal unicast: copy egress_spec → egress_port for uniform read below.
-                s.standardMetadata.fields["egress_port"] =
-                    s.standardMetadata.fields["egress_spec"] ?: BitVal(0, PORT_BITS)
-            }
-        }
+    val standardMetadata =
+      (defaultValue(standardMetaTypeName, typesByName) as? StructVal)
+        ?: error("$standardMetaTypeName not found in IR types; is v1model.p4 included?")
+    check("ingress_port" in standardMetadata.fields) { "$standardMetaTypeName has no ingress_port" }
+    check("packet_length" in standardMetadata.fields) {
+      "$standardMetaTypeName has no packet_length"
+    }
+    standardMetadata.fields["ingress_port"] = BitVal(ctx.ingressPort.toLong(), PORT_BITS)
+    standardMetadata.fields["packet_length"] = BitVal(ctx.payload.size.toLong(), INT32_BITS)
+    standardMetadata.fields["parser_error"] = ErrorVal("NoError")
 
-        // --- Egress controls (egress, compute checksum) ---
-        for (stage in s.egressControls) {
-            try {
-                s.interpreter.runControl(stage.blockName, s.env)
-            } catch (_: ExitException) {
-                break // skip remaining control stages; still run deparser below
-            }
-        }
+    val interpreter =
+      Interpreter(ctx.config, ctx.tableStore, packetCtx, decisions) {
+        standardMetadata.fields["checksum_error"] = BitVal(1L, 1)
+      }
 
-        val egressPort =
-            (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
-
-        // Port 511 is the v1model drop port (mark_to_drop sets egress_spec = 511).
-        if (egressPort == DROP_PORT) {
-            return PipelineResult(emptyList(), s.packetCtx.buildTrace())
-        }
-
-        // --- Deparser ---
-        if (s.deparserStage != null) {
-            s.interpreter.runControl(s.deparserStage.blockName, s.env)
-        }
-
-        // Append any bytes the parser did not extract (the un-parsed packet body).
-        // In P4, the deparser emits re-serialised headers; the remaining payload
-        // is transparently forwarded after them.
-        val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
-        val output = OutputPacket(egressPort.toUInt(), outputBytes)
-        return PipelineResult(listOf(output), s.packetCtx.buildTrace())
+    val sharedByType =
+      mapOf(
+        headersTypeName to defaultValue(headersTypeName, typesByName),
+        metaTypeName to defaultValue(metaTypeName, typesByName),
+        standardMetaTypeName to standardMetadata,
+      )
+    for (parser in config.parsersList) {
+      for (param in parser.paramsList) {
+        sharedByType[param.type.named]?.let { env.define(param.name, it) }
+      }
+    }
+    for (control in config.controlsList) {
+      for (param in control.paramsList) {
+        sharedByType[param.type.named]?.let { env.define(param.name, it) }
+      }
     }
 
-    companion object {
-        /** Port value used by mark_to_drop() to signal packet drop in v1model. */
-        const val DROP_PORT = 511
+    return PipelineState(packetCtx, interpreter, env, standardMetadata, config)
+  }
 
-        // Number of user-visible params in the v1model parser after removing packet_in/packet_out:
-        // (hdr, meta, standard_metadata).
-        private const val V1MODEL_USER_PARAM_COUNT = 3
+  /** Executes the full v1model pipeline once, returning output packets and flat trace. */
+  @Suppress("LoopWithTooManyJumpStatements")
+  private fun runPipeline(ctx: PipelineContext, decisions: ForkDecisions): PipelineResult {
+    val s = initPipelineState(ctx, decisions)
 
-        // v1model: first 2 control stages are ingress-side (verify checksum, ingress).
-        private const val INGRESS_CONTROL_COUNT = 2
-
-        // Bit widths for standard_metadata_t fields, as defined in v1model.p4.
-        const val PORT_BITS = 9
-        private const val INT32_BITS = 32
-        private const val REPLICA_ID_BITS = 16
-
-        // v1model instance_type values (BMv2 PktInstanceType convention).
-        private const val CLONE_I2E_INSTANCE_TYPE = 1L
-        private const val REPLICATION_INSTANCE_TYPE = 5L
+    // --- Parser ---
+    if (s.parserStage != null) {
+      try {
+        s.interpreter.runParser(s.parserStage.blockName, s.env)
+      } catch (e: ExitException) {
+        return PipelineResult(emptyList(), s.packetCtx.buildTrace())
+      } catch (e: ParserErrorException) {
+        // BMv2 v1model: parser errors don't drop the packet. Set parser_error and
+        // continue to the ingress pipeline, letting the P4 program decide the fate.
+        s.standardMetadata.fields["parser_error"] = ErrorVal(e.errorName)
+      }
     }
+
+    // --- Ingress controls (verify checksum, ingress) ---
+    // JumpToEgressException signals clone-branch re-execution: stop ingress, run egress only.
+    var jumpToEgress = false
+    for (stage in s.ingressControls) {
+      try {
+        s.interpreter.runControl(stage.blockName, s.env)
+      } catch (_: ExitException) {
+        break
+      } catch (_: JumpToEgressException) {
+        jumpToEgress = true
+        break
+      }
+    }
+
+    // --- Ingress→egress boundary: clone / multicast metadata setup ---
+    // All paths write egress_port into standardMetadata so the egress read is uniform.
+    if (jumpToEgress) {
+      // Clone branch: set instance_type and egress_port from clone session config.
+      val session =
+        ctx.tableStore.getCloneSession(decisions.cloneSessionId)
+          ?: error("unknown clone session: ${decisions.cloneSessionId}")
+      val clonePort = session.replicasList.firstOrNull()?.egressPort ?: 0
+      s.standardMetadata.fields["instance_type"] = BitVal(CLONE_I2E_INSTANCE_TYPE, INT32_BITS)
+      s.standardMetadata.fields["egress_port"] = BitVal(clonePort.toLong(), PORT_BITS)
+    } else {
+      val mcastGrp = (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
+      if (mcastGrp != 0 && decisions.multicastReplica == null) {
+        val group =
+          ctx.tableStore.getMulticastGroup(mcastGrp) ?: error("unknown multicast group: $mcastGrp")
+        val replicas = group.replicasList.map { r -> MulticastReplica(r.instance, r.egressPort) }
+        throw MulticastFork(replicas, s.packetCtx.getEvents())
+      }
+      if (decisions.multicastReplica != null) {
+        s.standardMetadata.fields["instance_type"] = BitVal(REPLICATION_INSTANCE_TYPE, INT32_BITS)
+        s.standardMetadata.fields["egress_port"] =
+          BitVal(decisions.multicastReplica.port.toLong(), PORT_BITS)
+        s.standardMetadata.fields["egress_rid"] =
+          BitVal(decisions.multicastReplica.rid.toLong(), REPLICA_ID_BITS)
+      } else {
+        // Normal unicast: copy egress_spec → egress_port for uniform read below.
+        s.standardMetadata.fields["egress_port"] =
+          s.standardMetadata.fields["egress_spec"] ?: BitVal(0, PORT_BITS)
+      }
+    }
+
+    // --- Egress controls (egress, compute checksum) ---
+    for (stage in s.egressControls) {
+      try {
+        s.interpreter.runControl(stage.blockName, s.env)
+      } catch (_: ExitException) {
+        break // skip remaining control stages; still run deparser below
+      }
+    }
+
+    val egressPort =
+      (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
+
+    // Port 511 is the v1model drop port (mark_to_drop sets egress_spec = 511).
+    if (egressPort == DROP_PORT) {
+      return PipelineResult(emptyList(), s.packetCtx.buildTrace())
+    }
+
+    // --- Deparser ---
+    if (s.deparserStage != null) {
+      s.interpreter.runControl(s.deparserStage.blockName, s.env)
+    }
+
+    // Append any bytes the parser did not extract (the un-parsed packet body).
+    // In P4, the deparser emits re-serialised headers; the remaining payload
+    // is transparently forwarded after them.
+    val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
+    val output = OutputPacket(egressPort.toUInt(), outputBytes)
+    return PipelineResult(listOf(output), s.packetCtx.buildTrace())
+  }
+
+  companion object {
+    /** Port value used by mark_to_drop() to signal packet drop in v1model. */
+    const val DROP_PORT = 511
+
+    // Number of user-visible params in the v1model parser after removing packet_in/packet_out:
+    // (hdr, meta, standard_metadata).
+    private const val V1MODEL_USER_PARAM_COUNT = 3
+
+    // v1model: first 2 control stages are ingress-side (verify checksum, ingress).
+    private const val INGRESS_CONTROL_COUNT = 2
+
+    // Bit widths for standard_metadata_t fields, as defined in v1model.p4.
+    const val PORT_BITS = 9
+    private const val INT32_BITS = 32
+    private const val REPLICA_ID_BITS = 16
+
+    // v1model instance_type values (BMv2 PktInstanceType convention).
+    private const val CLONE_I2E_INSTANCE_TYPE = 1L
+    private const val REPLICATION_INSTANCE_TYPE = 5L
+  }
 }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -26,298 +26,317 @@ import fourward.sim.v1.TraceTree
  */
 class V1ModelArchitecture : Architecture {
 
-  /** Invariant inputs to the pipeline, shared across fork re-executions. */
-  private data class PipelineContext(
-    val ingressPort: UInt,
-    val payload: ByteArray,
-    val config: P4BehavioralConfig,
-    val tableStore: TableStore,
-  )
+    /** Invariant inputs to the pipeline, shared across fork re-executions. */
+    private data class PipelineContext(
+        val ingressPort: UInt,
+        val payload: ByteArray,
+        val config: P4BehavioralConfig,
+        val tableStore: TableStore,
+    )
 
-  /** Per-execution state created fresh for each pipeline run. */
-  private class PipelineState(
-    val packetCtx: PacketContext,
-    val interpreter: Interpreter,
-    val env: Environment,
-    val standardMetadata: StructVal,
-    config: P4BehavioralConfig,
-  ) {
-    private val stages = config.architecture.stagesList
-    val parserStage: PipelineStage? = stages.find { it.kind == StageKind.PARSER }
-    val deparserStage: PipelineStage? = stages.find { it.kind == StageKind.DEPARSER }
+    /** Per-execution state created fresh for each pipeline run. */
+    private class PipelineState(
+        val packetCtx: PacketContext,
+        val interpreter: Interpreter,
+        val env: Environment,
+        val standardMetadata: StructVal,
+        config: P4BehavioralConfig,
+    ) {
+        private val stages = config.architecture.stagesList
+        val parserStage: PipelineStage? = stages.find { it.kind == StageKind.PARSER }
+        val deparserStage: PipelineStage? = stages.find { it.kind == StageKind.DEPARSER }
 
-    // v1model: first 2 controls are ingress-side (verify checksum, ingress),
-    // last 2 are egress-side (egress, compute checksum).
-    private val controlStages = stages.filter { it.kind == StageKind.CONTROL }
-    val ingressControls: List<PipelineStage> = controlStages.take(INGRESS_CONTROL_COUNT)
-    val egressControls: List<PipelineStage> = controlStages.drop(INGRESS_CONTROL_COUNT)
-  }
-
-  override fun processPacket(
-    ingressPort: UInt,
-    payload: ByteArray,
-    config: P4BehavioralConfig,
-    tableStore: TableStore,
-  ): PipelineResult {
-    val ctx = PipelineContext(ingressPort, payload, config, tableStore)
-    return buildTraceTree(ctx, ForkDecisions(), prefixLength = 0)
-  }
-
-  /**
-   * Recursively builds a trace tree by re-executing the pipeline for each fork branch.
-   *
-   * When a [ForkException] is thrown (action selector, clone, or multicast), this method
-   * re-executes the full pipeline once per branch with appropriate [ForkDecisions], and assembles
-   * the results into a [TraceTree] with a [ForkNode]. Shared prefix events are stripped from
-   * branches.
-   */
-  private fun buildTraceTree(
-    ctx: PipelineContext,
-    decisions: ForkDecisions,
-    prefixLength: Int,
-  ): PipelineResult {
-    try {
-      val (outputs, trace) = runPipeline(ctx, decisions)
-      val stripped =
-        TraceTree.newBuilder().addAllEvents(trace.eventsList.drop(prefixLength)).build()
-      return PipelineResult(outputs, stripped)
-    } catch (fork: ForkException) {
-      val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
-      val (reason, branches) = buildForkBranches(ctx, decisions, fork)
-      val tree =
-        TraceTree.newBuilder()
-          .addAllEvents(levelEvents)
-          .setFork(ForkNode.newBuilder().setReason(reason).addAllBranches(branches))
-          .build()
-      return PipelineResult(emptyList(), tree)
+        // v1model: first 2 controls are ingress-side (verify checksum, ingress),
+        // last 2 are egress-side (egress, compute checksum).
+        private val controlStages = stages.filter { it.kind == StageKind.CONTROL }
+        val ingressControls: List<PipelineStage> = controlStages.take(INGRESS_CONTROL_COUNT)
+        val egressControls: List<PipelineStage> = controlStages.drop(INGRESS_CONTROL_COUNT)
     }
-  }
 
-  /** Dispatches fork handling to the appropriate branch builder. */
-  private fun buildForkBranches(
-    ctx: PipelineContext,
-    decisions: ForkDecisions,
-    fork: ForkException,
-  ): Pair<ForkReason, List<ForkBranch>> =
-    when (fork) {
-      is ActionSelectorFork -> {
-        val branches =
-          fork.members.map { member ->
-            val newDecisions =
-              decisions.copy(
-                selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId)
-              )
-            forkBranch("member_${member.memberId}", ctx, newDecisions, fork.eventsBeforeFork.size)
-          }
-        ForkReason.ACTION_SELECTOR to branches
-      }
-      is CloneFork -> {
-        val originalDecisions = decisions.copy(cloneMode = CloneMode.SUPPRESS)
-        val cloneDecisions =
-          decisions.copy(cloneMode = CloneMode.EXECUTE_CLONE, cloneSessionId = fork.sessionId)
-        val branches =
-          listOf(
-            forkBranch("original", ctx, originalDecisions, fork.eventsBeforeFork.size),
-            forkBranch("clone", ctx, cloneDecisions, fork.eventsBeforeFork.size),
-          )
-        ForkReason.CLONE to branches
-      }
-      is MulticastFork -> {
-        val branches =
-          fork.replicas.map { replica ->
-            val replicaDecisions = decisions.copy(multicastReplica = replica)
-            forkBranch(
-              "replica_${replica.rid}_port_${replica.port}",
-              ctx,
-              replicaDecisions,
-              fork.eventsBeforeFork.size,
+    override fun processPacket(
+        ingressPort: UInt,
+        payload: ByteArray,
+        config: P4BehavioralConfig,
+        tableStore: TableStore,
+    ): PipelineResult {
+        val ctx = PipelineContext(ingressPort, payload, config, tableStore)
+        return buildTraceTree(ctx, ForkDecisions(), prefixLength = 0)
+    }
+
+    /**
+     * Recursively builds a trace tree by re-executing the pipeline for each fork branch.
+     *
+     * When a [ForkException] is thrown (action selector, clone, or multicast), this method
+     * re-executes the full pipeline once per branch with appropriate [ForkDecisions], and assembles
+     * the results into a [TraceTree] with a [ForkNode]. Shared prefix events are stripped from
+     * branches.
+     */
+    private fun buildTraceTree(
+        ctx: PipelineContext,
+        decisions: ForkDecisions,
+        prefixLength: Int,
+    ): PipelineResult {
+        try {
+            val (outputs, trace) = runPipeline(ctx, decisions)
+            val stripped =
+                TraceTree.newBuilder().addAllEvents(trace.eventsList.drop(prefixLength)).build()
+            return PipelineResult(outputs, stripped)
+        } catch (fork: ForkException) {
+            val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+            val (reason, branches) = buildForkBranches(ctx, decisions, fork)
+            val tree =
+                TraceTree.newBuilder()
+                    .addAllEvents(levelEvents)
+                    .setFork(ForkNode.newBuilder().setReason(reason).addAllBranches(branches))
+                    .build()
+            return PipelineResult(emptyList(), tree)
+        }
+    }
+
+    /** Dispatches fork handling to the appropriate branch builder. */
+    private fun buildForkBranches(
+        ctx: PipelineContext,
+        decisions: ForkDecisions,
+        fork: ForkException,
+    ): Pair<ForkReason, List<ForkBranch>> =
+        when (fork) {
+            is ActionSelectorFork -> {
+                val branches =
+                    fork.members.map { member ->
+                        val newDecisions =
+                            decisions.copy(
+                                selectorMembers =
+                                    decisions.selectorMembers + (fork.tableName to member.memberId)
+                            )
+                        forkBranch(
+                            "member_${member.memberId}",
+                            ctx,
+                            newDecisions,
+                            fork.eventsBeforeFork.size,
+                        )
+                    }
+                ForkReason.ACTION_SELECTOR to branches
+            }
+            is CloneFork -> {
+                val originalDecisions = decisions.copy(cloneMode = CloneMode.SUPPRESS)
+                val cloneDecisions =
+                    decisions.copy(
+                        cloneMode = CloneMode.EXECUTE_CLONE,
+                        cloneSessionId = fork.sessionId,
+                    )
+                val branches =
+                    listOf(
+                        forkBranch("original", ctx, originalDecisions, fork.eventsBeforeFork.size),
+                        forkBranch("clone", ctx, cloneDecisions, fork.eventsBeforeFork.size),
+                    )
+                ForkReason.CLONE to branches
+            }
+            is MulticastFork -> {
+                val branches =
+                    fork.replicas.map { replica ->
+                        val replicaDecisions = decisions.copy(multicastReplica = replica)
+                        forkBranch(
+                            "replica_${replica.rid}_port_${replica.port}",
+                            ctx,
+                            replicaDecisions,
+                            fork.eventsBeforeFork.size,
+                        )
+                    }
+                ForkReason.MULTICAST to branches
+            }
+        }
+
+    /** Re-executes the pipeline for one branch and wraps the result in a [ForkBranch]. */
+    private fun forkBranch(
+        label: String,
+        ctx: PipelineContext,
+        decisions: ForkDecisions,
+        prefixLength: Int,
+    ): ForkBranch {
+        val result = buildTraceTree(ctx, decisions, prefixLength)
+        return ForkBranch.newBuilder().setLabel(label).setSubtree(result.trace).build()
+    }
+
+    /**
+     * Creates a fresh [PipelineState] for one pipeline execution.
+     *
+     * Resolves type names, initialises standard_metadata, and binds parameter names across all
+     * stages. Stage topology (ingress/egress split) is derived by [PipelineState] itself.
+     */
+    private fun initPipelineState(ctx: PipelineContext, decisions: ForkDecisions): PipelineState {
+        val packetCtx = PacketContext(ctx.payload)
+        val env = Environment()
+        val config = ctx.config
+        val typesByName = config.typesList.associateBy { it.name }
+
+        // Derive the type names for hdr/meta/standard_metadata from the parser's
+        // parameter list, filtering out the architecture-level packet I/O params.
+        // v1model always declares: (packet_in, hdr, meta, standard_metadata) in that order.
+        val ioTypes = setOf("packet_in", "packet_out")
+        val parserUserParams =
+            config.parsersList.first().paramsList.filter {
+                it.type.hasNamed() && it.type.named !in ioTypes
+            }
+        require(parserUserParams.size == V1MODEL_USER_PARAM_COUNT) {
+            "Expected $V1MODEL_USER_PARAM_COUNT non-IO parser params, got ${parserUserParams.size}"
+        }
+        val headersTypeName = parserUserParams[0].type.named
+        val metaTypeName = parserUserParams[1].type.named
+        val standardMetaTypeName = parserUserParams[2].type.named
+
+        val standardMetadata =
+            (defaultValue(standardMetaTypeName, typesByName) as? StructVal)
+                ?: error("$standardMetaTypeName not found in IR types; is v1model.p4 included?")
+        check("ingress_port" in standardMetadata.fields) {
+            "$standardMetaTypeName has no ingress_port"
+        }
+        check("packet_length" in standardMetadata.fields) {
+            "$standardMetaTypeName has no packet_length"
+        }
+        standardMetadata.fields["ingress_port"] = BitVal(ctx.ingressPort.toLong(), PORT_BITS)
+        standardMetadata.fields["packet_length"] = BitVal(ctx.payload.size.toLong(), INT32_BITS)
+        standardMetadata.fields["parser_error"] = ErrorVal("NoError")
+
+        val interpreter =
+            Interpreter(ctx.config, ctx.tableStore, packetCtx, decisions) {
+                standardMetadata.fields["checksum_error"] = BitVal(1L, 1)
+            }
+
+        val sharedByType =
+            mapOf(
+                headersTypeName to defaultValue(headersTypeName, typesByName),
+                metaTypeName to defaultValue(metaTypeName, typesByName),
+                standardMetaTypeName to standardMetadata,
             )
-          }
-        ForkReason.MULTICAST to branches
-      }
+        for (parser in config.parsersList) {
+            for (param in parser.paramsList) {
+                sharedByType[param.type.named]?.let { env.define(param.name, it) }
+            }
+        }
+        for (control in config.controlsList) {
+            for (param in control.paramsList) {
+                sharedByType[param.type.named]?.let { env.define(param.name, it) }
+            }
+        }
+
+        return PipelineState(packetCtx, interpreter, env, standardMetadata, config)
     }
 
-  /** Re-executes the pipeline for one branch and wraps the result in a [ForkBranch]. */
-  private fun forkBranch(
-    label: String,
-    ctx: PipelineContext,
-    decisions: ForkDecisions,
-    prefixLength: Int,
-  ): ForkBranch {
-    val result = buildTraceTree(ctx, decisions, prefixLength)
-    return ForkBranch.newBuilder().setLabel(label).setSubtree(result.trace).build()
-  }
+    /** Executes the full v1model pipeline once, returning output packets and flat trace. */
+    @Suppress("LoopWithTooManyJumpStatements")
+    private fun runPipeline(ctx: PipelineContext, decisions: ForkDecisions): PipelineResult {
+        val s = initPipelineState(ctx, decisions)
 
-  /**
-   * Creates a fresh [PipelineState] for one pipeline execution.
-   *
-   * Resolves type names, initialises standard_metadata, and binds parameter names across all
-   * stages. Stage topology (ingress/egress split) is derived by [PipelineState] itself.
-   */
-  private fun initPipelineState(ctx: PipelineContext, decisions: ForkDecisions): PipelineState {
-    val packetCtx = PacketContext(ctx.payload)
-    val interpreter = Interpreter(ctx.config, ctx.tableStore, packetCtx, decisions)
-    val env = Environment()
-    val config = ctx.config
-    val typesByName = config.typesList.associateBy { it.name }
+        // --- Parser ---
+        if (s.parserStage != null) {
+            try {
+                s.interpreter.runParser(s.parserStage.blockName, s.env)
+            } catch (e: ExitException) {
+                return PipelineResult(emptyList(), s.packetCtx.buildTrace())
+            } catch (e: ParserErrorException) {
+                // BMv2 v1model: parser errors don't drop the packet. Set parser_error and
+                // continue to the ingress pipeline, letting the P4 program decide the fate.
+                s.standardMetadata.fields["parser_error"] = ErrorVal(e.errorName)
+            }
+        }
 
-    // Derive the type names for hdr/meta/standard_metadata from the parser's
-    // parameter list, filtering out the architecture-level packet I/O params.
-    // v1model always declares: (packet_in, hdr, meta, standard_metadata) in that order.
-    val ioTypes = setOf("packet_in", "packet_out")
-    val parserUserParams =
-      config.parsersList.first().paramsList.filter {
-        it.type.hasNamed() && it.type.named !in ioTypes
-      }
-    require(parserUserParams.size == V1MODEL_USER_PARAM_COUNT) {
-      "Expected $V1MODEL_USER_PARAM_COUNT non-IO parser params, got ${parserUserParams.size}"
-    }
-    val headersTypeName = parserUserParams[0].type.named
-    val metaTypeName = parserUserParams[1].type.named
-    val standardMetaTypeName = parserUserParams[2].type.named
+        // --- Ingress controls (verify checksum, ingress) ---
+        // JumpToEgressException signals clone-branch re-execution: stop ingress, run egress only.
+        var jumpToEgress = false
+        for (stage in s.ingressControls) {
+            try {
+                s.interpreter.runControl(stage.blockName, s.env)
+            } catch (_: ExitException) {
+                break
+            } catch (_: JumpToEgressException) {
+                jumpToEgress = true
+                break
+            }
+        }
 
-    val standardMetadata =
-      (defaultValue(standardMetaTypeName, typesByName) as? StructVal)
-        ?: error("$standardMetaTypeName not found in IR types; is v1model.p4 included?")
-    check("ingress_port" in standardMetadata.fields) { "$standardMetaTypeName has no ingress_port" }
-    check("packet_length" in standardMetadata.fields) {
-      "$standardMetaTypeName has no packet_length"
-    }
-    standardMetadata.fields["ingress_port"] = BitVal(ctx.ingressPort.toLong(), PORT_BITS)
-    standardMetadata.fields["packet_length"] = BitVal(ctx.payload.size.toLong(), INT32_BITS)
-    standardMetadata.fields["parser_error"] = ErrorVal("NoError")
+        // --- Ingress→egress boundary: clone / multicast metadata setup ---
+        // All paths write egress_port into standardMetadata so the egress read is uniform.
+        if (jumpToEgress) {
+            // Clone branch: set instance_type and egress_port from clone session config.
+            val session =
+                ctx.tableStore.getCloneSession(decisions.cloneSessionId)
+                    ?: error("unknown clone session: ${decisions.cloneSessionId}")
+            val clonePort = session.replicasList.firstOrNull()?.egressPort ?: 0
+            s.standardMetadata.fields["instance_type"] = BitVal(CLONE_I2E_INSTANCE_TYPE, INT32_BITS)
+            s.standardMetadata.fields["egress_port"] = BitVal(clonePort.toLong(), PORT_BITS)
+        } else {
+            val mcastGrp =
+                (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
+            if (mcastGrp != 0 && decisions.multicastReplica == null) {
+                val group =
+                    ctx.tableStore.getMulticastGroup(mcastGrp)
+                        ?: error("unknown multicast group: $mcastGrp")
+                val replicas =
+                    group.replicasList.map { r -> MulticastReplica(r.instance, r.egressPort) }
+                throw MulticastFork(replicas, s.packetCtx.getEvents())
+            }
+            if (decisions.multicastReplica != null) {
+                s.standardMetadata.fields["instance_type"] =
+                    BitVal(REPLICATION_INSTANCE_TYPE, INT32_BITS)
+                s.standardMetadata.fields["egress_port"] =
+                    BitVal(decisions.multicastReplica.port.toLong(), PORT_BITS)
+                s.standardMetadata.fields["egress_rid"] =
+                    BitVal(decisions.multicastReplica.rid.toLong(), REPLICA_ID_BITS)
+            } else {
+                // Normal unicast: copy egress_spec → egress_port for uniform read below.
+                s.standardMetadata.fields["egress_port"] =
+                    s.standardMetadata.fields["egress_spec"] ?: BitVal(0, PORT_BITS)
+            }
+        }
 
-    val sharedByType =
-      mapOf(
-        headersTypeName to defaultValue(headersTypeName, typesByName),
-        metaTypeName to defaultValue(metaTypeName, typesByName),
-        standardMetaTypeName to standardMetadata,
-      )
-    for (parser in config.parsersList) {
-      for (param in parser.paramsList) {
-        sharedByType[param.type.named]?.let { env.define(param.name, it) }
-      }
-    }
-    for (control in config.controlsList) {
-      for (param in control.paramsList) {
-        sharedByType[param.type.named]?.let { env.define(param.name, it) }
-      }
-    }
+        // --- Egress controls (egress, compute checksum) ---
+        for (stage in s.egressControls) {
+            try {
+                s.interpreter.runControl(stage.blockName, s.env)
+            } catch (_: ExitException) {
+                break // skip remaining control stages; still run deparser below
+            }
+        }
 
-    return PipelineState(packetCtx, interpreter, env, standardMetadata, config)
-  }
+        val egressPort =
+            (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
 
-  /** Executes the full v1model pipeline once, returning output packets and flat trace. */
-  @Suppress("LoopWithTooManyJumpStatements")
-  private fun runPipeline(ctx: PipelineContext, decisions: ForkDecisions): PipelineResult {
-    val s = initPipelineState(ctx, decisions)
+        // Port 511 is the v1model drop port (mark_to_drop sets egress_spec = 511).
+        if (egressPort == DROP_PORT) {
+            return PipelineResult(emptyList(), s.packetCtx.buildTrace())
+        }
 
-    // --- Parser ---
-    if (s.parserStage != null) {
-      try {
-        s.interpreter.runParser(s.parserStage.blockName, s.env)
-      } catch (e: ExitException) {
-        return PipelineResult(emptyList(), s.packetCtx.buildTrace())
-      } catch (e: ParserErrorException) {
-        // BMv2 v1model: parser errors don't drop the packet. Set parser_error and
-        // continue to the ingress pipeline, letting the P4 program decide the fate.
-        s.standardMetadata.fields["parser_error"] = ErrorVal(e.errorName)
-      }
-    }
+        // --- Deparser ---
+        if (s.deparserStage != null) {
+            s.interpreter.runControl(s.deparserStage.blockName, s.env)
+        }
 
-    // --- Ingress controls (verify checksum, ingress) ---
-    // JumpToEgressException signals clone-branch re-execution: stop ingress, run egress only.
-    var jumpToEgress = false
-    for (stage in s.ingressControls) {
-      try {
-        s.interpreter.runControl(stage.blockName, s.env)
-      } catch (_: ExitException) {
-        break
-      } catch (_: JumpToEgressException) {
-        jumpToEgress = true
-        break
-      }
+        // Append any bytes the parser did not extract (the un-parsed packet body).
+        // In P4, the deparser emits re-serialised headers; the remaining payload
+        // is transparently forwarded after them.
+        val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
+        val output = OutputPacket(egressPort.toUInt(), outputBytes)
+        return PipelineResult(listOf(output), s.packetCtx.buildTrace())
     }
 
-    // --- Ingress→egress boundary: clone / multicast metadata setup ---
-    // All paths write egress_port into standardMetadata so the egress read is uniform.
-    if (jumpToEgress) {
-      // Clone branch: set instance_type and egress_port from clone session config.
-      val session =
-        ctx.tableStore.getCloneSession(decisions.cloneSessionId)
-          ?: error("unknown clone session: ${decisions.cloneSessionId}")
-      val clonePort = session.replicasList.firstOrNull()?.egressPort ?: 0
-      s.standardMetadata.fields["instance_type"] = BitVal(CLONE_I2E_INSTANCE_TYPE, INT32_BITS)
-      s.standardMetadata.fields["egress_port"] = BitVal(clonePort.toLong(), PORT_BITS)
-    } else {
-      val mcastGrp = (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
-      if (mcastGrp != 0 && decisions.multicastReplica == null) {
-        val group =
-          ctx.tableStore.getMulticastGroup(mcastGrp) ?: error("unknown multicast group: $mcastGrp")
-        val replicas = group.replicasList.map { r -> MulticastReplica(r.instance, r.egressPort) }
-        throw MulticastFork(replicas, s.packetCtx.getEvents())
-      }
-      if (decisions.multicastReplica != null) {
-        s.standardMetadata.fields["instance_type"] = BitVal(REPLICATION_INSTANCE_TYPE, INT32_BITS)
-        s.standardMetadata.fields["egress_port"] =
-          BitVal(decisions.multicastReplica.port.toLong(), PORT_BITS)
-        s.standardMetadata.fields["egress_rid"] =
-          BitVal(decisions.multicastReplica.rid.toLong(), REPLICA_ID_BITS)
-      } else {
-        // Normal unicast: copy egress_spec → egress_port for uniform read below.
-        s.standardMetadata.fields["egress_port"] =
-          s.standardMetadata.fields["egress_spec"] ?: BitVal(0, PORT_BITS)
-      }
+    companion object {
+        /** Port value used by mark_to_drop() to signal packet drop in v1model. */
+        const val DROP_PORT = 511
+
+        // Number of user-visible params in the v1model parser after removing packet_in/packet_out:
+        // (hdr, meta, standard_metadata).
+        private const val V1MODEL_USER_PARAM_COUNT = 3
+
+        // v1model: first 2 control stages are ingress-side (verify checksum, ingress).
+        private const val INGRESS_CONTROL_COUNT = 2
+
+        // Bit widths for standard_metadata_t fields, as defined in v1model.p4.
+        const val PORT_BITS = 9
+        private const val INT32_BITS = 32
+        private const val REPLICA_ID_BITS = 16
+
+        // v1model instance_type values (BMv2 PktInstanceType convention).
+        private const val CLONE_I2E_INSTANCE_TYPE = 1L
+        private const val REPLICATION_INSTANCE_TYPE = 5L
     }
-
-    // --- Egress controls (egress, compute checksum) ---
-    for (stage in s.egressControls) {
-      try {
-        s.interpreter.runControl(stage.blockName, s.env)
-      } catch (_: ExitException) {
-        break // skip remaining control stages; still run deparser below
-      }
-    }
-
-    val egressPort =
-      (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
-
-    // Port 511 is the v1model drop port (mark_to_drop sets egress_spec = 511).
-    if (egressPort == DROP_PORT) {
-      return PipelineResult(emptyList(), s.packetCtx.buildTrace())
-    }
-
-    // --- Deparser ---
-    if (s.deparserStage != null) {
-      s.interpreter.runControl(s.deparserStage.blockName, s.env)
-    }
-
-    // Append any bytes the parser did not extract (the un-parsed packet body).
-    // In P4, the deparser emits re-serialised headers; the remaining payload
-    // is transparently forwarded after them.
-    val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
-    val output = OutputPacket(egressPort.toUInt(), outputBytes)
-    return PipelineResult(listOf(output), s.packetCtx.buildTrace())
-  }
-
-  companion object {
-    /** Port value used by mark_to_drop() to signal packet drop in v1model. */
-    const val DROP_PORT = 511
-
-    // Number of user-visible params in the v1model parser after removing packet_in/packet_out:
-    // (hdr, meta, standard_metadata).
-    private const val V1MODEL_USER_PARAM_COUNT = 3
-
-    // v1model: first 2 control stages are ingress-side (verify checksum, ingress).
-    private const val INGRESS_CONTROL_COUNT = 2
-
-    // Bit widths for standard_metadata_t fields, as defined in v1model.p4.
-    const val PORT_BITS = 9
-    private const val INT32_BITS = 32
-    private const val REPLICA_ID_BITS = 16
-
-    // v1model instance_type values (BMv2 PktInstanceType convention).
-    private const val CLONE_I2E_INSTANCE_TYPE = 1L
-    private const val REPLICATION_INSTANCE_TYPE = 5L
-  }
 }

--- a/simulator/ir.proto
+++ b/simulator/ir.proto
@@ -363,7 +363,8 @@ message Expr {
     UnaryOp unary_op = 9;
     MethodCall method_call = 10;
     TableApplyExpr table_apply = 11;
-    MuxExpr mux = 12;  // condition ? then_expr : else_expr
+    MuxExpr mux = 12;             // condition ? then_expr : else_expr
+    StructExpr struct_expr = 13;  // { field1, field2, ... }
   }
 
   Type type = 100;  // always present
@@ -374,6 +375,17 @@ message MuxExpr {
   Expr condition = 1;
   Expr then_expr = 2;
   Expr else_expr = 3;
+}
+
+// Struct/tuple literal expression: { field1 = expr1, field2 = expr2, ... }
+// Used by externs like verify_checksum whose data argument is a list expression
+// that p4c lowers to a StructExpression.
+message StructExpr {
+  repeated StructExprField fields = 1;
+}
+message StructExprField {
+  string name = 1;
+  Expr value = 2;
 }
 
 message Literal {


### PR DESCRIPTION
## Summary

p4c lowers list expressions (e.g. the data argument to `verify_checksum`) to `IR::StructExpression` nodes, which the backend silently dropped — producing empty `Expr` messages with only a type annotation. This blocked all externs that take a tuple/list argument (`verify_checksum`, `update_checksum`, `hash`).

Three-layer fix across proto IR, C++ backend, and Kotlin simulator:

- **Proto**: Add `StructExpr` message + `struct_expr` oneof field to `Expr` (field 13)
- **Backend**: Handle `IR::StructExpression` in `emitExpr()`, emitting field names and recursively-emitted values
- **Simulator**: Evaluate `struct_expr` to `StructVal`; implement `verify_checksum` (ones' complement checksum comparison, sets `standard_metadata.checksum_error` on mismatch) and `update_checksum` (computes and writes checksum to out parameter)

The Interpreter stays architecture-agnostic — `V1ModelArchitecture` wires up an `onChecksumError` callback rather than leaking `standard_metadata` into the Interpreter. The ones' complement checksum lives in its own `Checksum.kt` (pure function using `BitVector.concat`, ready for `hash` extern reuse).

Also fixes a pre-existing ktfmt style mismatch in `V1ModelArchitecture.kt` (google-style → kotlinlang-style to match CI).

Promotes **checksum2-bmv2**, **checksum3-bmv2**, and **issue655-bmv2** from the manual `other_stf_corpus_test` suite into the CI-gated `v1model_stf_corpus_test` suite (167 → 170 passing corpus tests).

## Test plan

- [x] All 25 `bazel test //...` targets pass (including 170 corpus tests)
- [x] Unit test for `StructExpr` evaluation in `InterpreterExprTest`
- [x] Unit test suite for `onesComplementChecksum` in `ChecksumTest` (8 tests: single field, zero/ones, carry folding, RFC 1071 IPv4 round-trip, non-aligned padding, mixed-width fields, empty struct)
- [x] `./format.sh` and `./lint.sh` clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)