### PR TITLE
docs: update README with current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Ever stare at a packet leaving a switch and wonder *what just happened in
 there?* 4ward is a glass-box P4 simulator that tells you exactly what happened
 to your packet — every parser transition, every table lookup, every action, every
-branch — delivered as a structured trace you can actually read.
+branch — delivered as a structured trace tree you can actually read.
 
 ```
              p4c + 4ward backend
@@ -21,7 +21,7 @@ branch — delivered as a structured trace you can actually read.
                      ▼
             ┌────────────────┐
  packet ──▶ │  4ward sim     │──▶ output packets
-            │  (Kotlin/JVM)  │──▶ execution trace  (the good stuff)
+            │  (Kotlin/JVM)  │──▶ trace tree  (the good stuff)
             └────────────────┘
                      ▲
              P4Runtime writes
@@ -31,13 +31,15 @@ branch — delivered as a structured trace you can actually read.
 
 ## Why 4ward?
 
-| | BMv2 | Real hardware | **4ward** |
+| | Real hardware | BMv2 | **4ward** |
 |---|---|---|---|
 | Runs P4 programs | sure | sure | **yep** |
-| Execution trace | text | nope | **proto/JSON** |
-| All possible traces | nope | nope | **trace trees!** |
+| Spec-compliant | varies | needs workarounds | **out of the box** |
+| Trace format | nope | text | **proto/JSON** |
+| All possible traces | nope | not natively | **trace trees!** |
 | Architecture-generic | nope | nope | **yes!** |
-| P4Runtime | sure | sure | **yep** |
+| P4Runtime | sure | has gaps | **100% spec-compliant (planned)** |
+| AI friendly | nope | nope | **built by AI, for everyone** |
 | Simple, readable codebase | ehh | ehh | **yes!** |
 
 4ward is a **spec-compliant reference implementation** of the
@@ -59,14 +61,17 @@ bazel build //...
 # Run all tests.
 bazel test //...
 
-# Simulate a P4 program (once the backend and simulator are on your PATH).
-p4c-4ward --arch v1model my_program.p4 -o my_program.txtpb
-4ward my_program.txtpb < input.stf
+# Compile a P4 program to the proto IR.
+bazel run //p4c_backend:p4c-4ward -- --arch v1model \
+  $(pwd)/my_program.p4 -o $(pwd)/my_program.txtpb
+
+# Simulate it (reads an STF scenario on stdin).
+bazel run //simulator:simulator -- $(pwd)/my_program.txtpb < input.stf
 ```
 
 ## See what your packets are up to
 
-Given a simple IPv4 forwarding program, 4ward produces traces like this:
+Given a simple IPv4 forwarding program, 4ward produces trace trees like this:
 
 ```json
 {
@@ -88,7 +93,7 @@ Given a simple IPv4 forwarding program, 4ward produces traces like this:
 }
 ```
 
-No printf debugging. No Wireshark. No guessing. Just the trace.
+No printf debugging. No Wireshark. No guessing. Just the trace tree.
 
 ## Not just one trace — all of them
 
@@ -127,19 +132,22 @@ understand not just what your program *did*, but everything it *can* do.
 │   ├── ir.proto            Behavioral IR (the contract between backend & sim)
 │   └── simulator.proto     Simulator service protocol (stdin/stdout framing)
 ├── p4c_backend/            p4c backend plugin (C++, emits the proto IR)
-└── e2e_tests/              STF test runner and test programs
-    └── stf/                STF runner
+└── e2e_tests/
+    ├── stf/                STF runner (shared subprocess + packet I/O)
+    ├── corpus/             p4c STF corpus (216 tests, bulk regression)
+    ├── trace_tree/         Golden trace-tree tests
+    ├── p4testgen/          p4testgen integration (auto-generated paths)
+    └── <feature>/          Hand-written feature tests (passthrough, lpm, …)
 ```
 
 Curious about the design? [ARCHITECTURE.md](ARCHITECTURE.md) has the full story.
 
 ## Where things stand
 
-4ward is pre-1.0 and growing fast. The core is working — proto IR, p4c
-backend, Kotlin simulator, STF test runner, and CI pipeline are all in place.
-We will aggressively refactor to build the best system we can; nothing is
-sacred except correctness and the test suite. See [ROADMAP.md](ROADMAP.md)
-for what's next and [STATUS.md](STATUS.md) for daily progress.
+4ward is pre-1.0 and growing fast. The core pipeline works end-to-end. We will aggressively
+refactor to build the best system we can; nothing is sacred except
+correctness and the test suite. See [ROADMAP.md](ROADMAP.md) for what's next
+and [STATUS.md](STATUS.md) for daily progress.
 
 ## Documentation
 

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -24,7 +24,8 @@ import fourward.sim.v1.TraceTree
  *
  * References:
  * - v1model.p4: https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4
- * - BMv2 simple_switch semantics: https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md
+ * - BMv2 simple_switch semantics:
+ *   https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md
  */
 class V1ModelArchitecture : Architecture {
 


### PR DESCRIPTION
## Summary

Refresh several outdated README sections:

- **Why 4ward? table**: reorder columns (HW | BMv2 | 4ward) for direct comparison. Add rows for spec compliance ("needs workarounds" vs "out of the box"), AI-friendly codebase ("built by AI, for everyone"), and nuanced entries (BMv2 P4Runtime "has gaps", trace trees "not natively").
- **Quick start**: replace bare CLI commands with `bazel run` invocations — the actual way to run the tools.
- **Project structure**: expand `e2e_tests/` tree to reflect corpus, trace_tree, p4testgen, and hand-written feature tests.
- **Where things stand**: tighten to essentials, keep refactoring philosophy.
- **Terminology**: use "trace tree" consistently throughout (diagram, intro, example section).
- **Formatting**: wrap long URL in V1ModelArchitecture.kt.

## Test plan

- [ ] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)