### PR TITLE
docs: relabel coverage badge, add unit test coverage to Track 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <strong>Your P4 programs, finally explained.</strong>
   <br><br>
   <a href="https://github.com/smolkaj/4ward/actions/workflows/ci.yml"><img src="https://github.com/smolkaj/4ward/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://smolkaj.github.io/4ward/main/"><img src="https://img.shields.io/badge/coverage-report-blue" alt="Coverage"></a>
+  <a href="https://smolkaj.github.io/4ward/main/"><img src="https://img.shields.io/badge/unit_test_coverage-report-blue" alt="Unit test coverage"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,6 +92,12 @@ Build plumbing, CI improvements, cleanup. Picked up opportunistically — none
 of this blocks the other tracks. See [REFACTORING.md](REFACTORING.md) for
 the full list.
 
+One notable gap: **unit test coverage is low.** The simulator is heavily
+exercised by e2e tests (corpus, trace tree, p4testgen), but JaCoCo only
+instruments unit tests — so the coverage report undercounts significantly.
+Improving unit test coverage is valuable independently: unit tests are faster,
+more targeted, and catch regressions closer to the source.
+
 ### Track 3: trace trees
 
 **Priority: medium — start now | Parallelizable: yes**

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# Collects Kotlin code coverage for the simulator library.
+# Collects Kotlin unit test coverage for the simulator library.
+#
+# NOTE: This only instruments kt_jvm_test targets. E2e tests (corpus, trace
+# tree, p4testgen) run the simulator as a subprocess and are not captured by
+# JaCoCo, so the reported coverage undercounts actual code exercised.
 #
 # Usage:
 #   ./coverage.sh                                # run tests, produce LCOV


### PR DESCRIPTION
## Summary

The coverage report only measures unit tests — JaCoCo can't instrument e2e tests that run the simulator as a subprocess. The 52% line coverage figure significantly undercounts actual coverage.

- **README**: relabel badge from "coverage" to "unit_test_coverage" so it's honest about what it measures.
- **ROADMAP Track 2**: add a note about the gap and why improving unit test coverage is independently valuable (faster, more targeted, catches regressions closer to the source).
- **coverage.sh**: clarify scope in header comment — only kt_jvm_test targets, e2e tests not captured.

## Test plan

- [ ] Verify badge renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)