### PR TITLE
coverage: fix regression from destroyForcibly, add coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Run coverage
         run: |
-          ARGS=(--html)
+          ARGS=(--html --min-coverage 80)
           if [[ -s /tmp/baseline.lcov && -s /tmp/pr.diff ]]; then
             ARGS+=(--baseline /tmp/baseline.lcov --diff /tmp/pr.diff)
           fi

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
-# Collects Kotlin code coverage for the simulator library.
+# Collects Kotlin test coverage for the simulator library.
+#
+# Coverage comes from two sources:
+#   1. Unit tests (kt_jvm_test targets) — instrumented directly by JaCoCo.
+#   2. E2e tests — the simulator subprocess inherits COVERAGE=1 and JaCoCo
+#      flushes probe data on graceful shutdown (SIGTERM).
 #
 # Usage:
 #   ./coverage.sh                                # run tests, produce LCOV
 #   ./coverage.sh --html                         # also generate HTML report
 #   ./coverage.sh --html --baseline B --diff D   # HTML with differential coverage
+#   ./coverage.sh --min-coverage 80              # fail if coverage < 80%
 #
 # Options:
 #   --html              Generate an HTML report (requires genhtml / lcov).
 #   --baseline <file>   Baseline LCOV for differential coverage (genhtml --baseline-file).
 #   --diff <file>       Unified diff for differential coverage (genhtml --diff-file).
+#   --min-coverage <N>  Fail if line coverage percentage is below N (default: none).
 #
 # Bazel 9's built-in `bazel coverage` pipeline doesn't produce LCOV data for
 # kt_jvm_test targets.  Two independent bugs conspire:
@@ -35,12 +42,14 @@ set -euo pipefail
 WANT_HTML=false
 BASELINE_FILE=""
 DIFF_FILE=""
+MIN_COVERAGE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --html)     WANT_HTML=true; shift ;;
-    --baseline) BASELINE_FILE="${2:?--baseline requires a file argument}"; shift 2 ;;
-    --diff)     DIFF_FILE="${2:?--diff requires a file argument}"; shift 2 ;;
-    *)          echo "Unknown option: $1" >&2; exit 1 ;;
+    --html)         WANT_HTML=true; shift ;;
+    --baseline)     BASELINE_FILE="${2:?--baseline requires a file argument}"; shift 2 ;;
+    --diff)         DIFF_FILE="${2:?--diff requires a file argument}"; shift 2 ;;
+    --min-coverage) MIN_COVERAGE="${2:?--min-coverage requires a number}"; shift 2 ;;
+    *)              echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
 
@@ -302,6 +311,11 @@ echo "LCOV report: ${MERGED}"
 if [[ ${total_lf} -gt 0 ]]; then
   pct=$(( 100 * total_lh / total_lf ))
   echo "Line coverage: ${total_lh}/${total_lf} (${pct}%)"
+fi
+
+if [[ -n "${MIN_COVERAGE}" && ${total_lf} -gt 0 && ${pct} -lt ${MIN_COVERAGE} ]]; then
+  echo "Error: line coverage ${pct}% is below minimum ${MIN_COVERAGE}%" >&2
+  exit 1
 fi
 
 # ── Persist LCOV ─────────────────────────────────────────────────────────────

--- a/e2e_tests/stf/SimulatorClient.kt
+++ b/e2e_tests/stf/SimulatorClient.kt
@@ -10,6 +10,7 @@ import java.io.Closeable
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 
 /**
  * Client for the 4ward simulator subprocess protocol.
@@ -64,7 +65,16 @@ class SimulatorClient(simulatorBinary: Path) : Closeable {
 
   override fun close() {
     output.close()
-    process.destroyForcibly().waitFor()
+    // Graceful shutdown so JaCoCo's shutdown hook can flush coverage data.
+    // Fall back to SIGKILL if the process doesn't exit promptly.
+    process.destroy()
+    if (!process.waitFor(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      process.destroyForcibly().waitFor()
+    }
     input.close()
+  }
+
+  private companion object {
+    const val SHUTDOWN_TIMEOUT_SECONDS = 5L
   }
 }


### PR DESCRIPTION
## Summary

Fixes the coverage regression reported in #128 and adds a guardrail to prevent similar regressions.

- **Root cause**: PR #108 changed `SimulatorClient.close()` from `process.destroy()` to `process.destroyForcibly().waitFor()`. `destroyForcibly()` sends SIGKILL, which kills the simulator subprocess immediately — before JaCoCo's shutdown hook can flush `.exec` probe data. This dropped coverage from 89% to 55% (171 → 8 `.exec` files).

- **Fix**: Use `destroy()` (SIGTERM) with a 5-second timeout, falling back to `destroyForcibly()` only if the process hangs. This lets JaCoCo flush while still ensuring cleanup.

- **Guardrail**: Add `--min-coverage` flag to `coverage.sh`, wired to 80% in CI. Future regressions will fail the build instead of silently degrading.

## Test plan

- [x] `bazel test //...` passes locally (all 25 tests green)
- [ ] CI coverage job should restore to ~89% and pass the 80% floor check

🤖 Generated with [Claude Code](https://claude.com/claude-code)