### PR TITLE
trace: source location info on trace events

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -128,25 +128,18 @@ Blocked on buf support for proto edition 2024.
 
 ---
 
-## Trace tree golden files: approximate → exact
+## Extract shared interpreter test helpers
 
-**Files**: `e2e_tests/trace_tree/*.golden.txtpb`
+**Files**: `simulator/Interpreter*Test.kt` (6 files)
 
-**Problem**: The golden trace tree files written in PR 1 are approximations —
-they don't match actual simulator output. Specific issues:
+**Problem**: Proto-building helpers (`boolLit`, `bit`, `nameRef`, `ifStmt`,
+`controlConfig`) are duplicated as private functions across 6 test files.
+The copies are identical or near-identical (some add optional parameters).
 
-- **Name mismatches**: golden files use qualified names
-  (`MyIngress.routing`) but the simulator uses p4info aliases (`routing`).
-- **Missing `matched_entry`**: the `table_lookup` event includes the full
-  `TableEntry` proto on hit, omitted in the golden files.
-- **Empty clone/multicast subtrees**: fork branches for clone and multicast
-  have no events, making the assertion structurally weak.
-- **Placeholder selector labels and params**: action selector member names
-  and parameter values are guesses.
-
-**Fix**: As each feature is implemented (PRs 2–4), capture the actual
-simulator output and update the corresponding golden files to match exactly.
-Mark each golden file done by removing its TODO comment.
+**Fix**: Extract into a shared `InterpreterTestDsl.kt` test utility. The
+most general version of each helper (e.g. `controlConfig` with a
+`controlName` parameter, `ifStmt` with optional `sourceInfo`) subsumes
+the others.
 
 ---
 

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_3.p4"
-    line: 881
+    line: 22
     column: 10
     source_fragment: "start"
   }
@@ -31,7 +31,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_3.p4"
-    line: 908
+    line: 49
     column: 12
     source_fragment: "ecmp.apply()"
   }
@@ -51,7 +51,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 908
+          line: 49
           column: 12
           source_fragment: "ecmp.apply()"
         }
@@ -77,7 +77,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 908
+          line: 49
           column: 12
           source_fragment: "ecmp.apply()"
         }
@@ -103,7 +103,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 908
+          line: 49
           column: 12
           source_fragment: "ecmp.apply()"
         }

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -4,6 +4,12 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/action_selector_3.p4"
+    line: 881
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   table_lookup {
@@ -23,6 +29,12 @@ events {
     }
     action_name: "set_port"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/action_selector_3.p4"
+    line: 908
+    column: 12
+    source_fragment: "ecmp.apply()"
+  }
 }
 fork_outcome {
   reason: ACTION_SELECTOR
@@ -36,6 +48,12 @@ fork_outcome {
             key: "port"
             value: "\000\001"
           }
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/action_selector_3.p4"
+          line: 908
+          column: 12
+          source_fragment: "ecmp.apply()"
         }
       }
       packet_outcome {
@@ -57,6 +75,12 @@ fork_outcome {
             value: "\000\002"
           }
         }
+        source_info {
+          file: "e2e_tests/trace_tree/action_selector_3.p4"
+          line: 908
+          column: 12
+          source_fragment: "ecmp.apply()"
+        }
       }
       packet_outcome {
         output {
@@ -76,6 +100,12 @@ fork_outcome {
             key: "port"
             value: "\000\003"
           }
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/action_selector_3.p4"
+          line: 908
+          column: 12
+          source_fragment: "ecmp.apply()"
         }
       }
       packet_outcome {

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"
-    line: 881
+    line: 22
     column: 10
     source_fragment: "start"
   }
@@ -19,7 +19,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"
-    line: 908
+    line: 49
     column: 12
     source_fragment: "ecmp.apply()"
   }
@@ -30,7 +30,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"
-    line: 908
+    line: 49
     column: 12
     source_fragment: "ecmp.apply()"
   }
@@ -41,7 +41,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"
-    line: 894
+    line: 35
     column: 20
     source_fragment: "mark_to_drop(smeta)"
   }

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -4,6 +4,12 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/action_selector_miss.p4"
+    line: 881
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   table_lookup {
@@ -11,10 +17,33 @@ events {
     hit: false
     action_name: "drop"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/action_selector_miss.p4"
+    line: 908
+    column: 12
+    source_fragment: "ecmp.apply()"
+  }
 }
 events {
   action_execution {
     action_name: "drop"
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/action_selector_miss.p4"
+    line: 908
+    column: 12
+    source_fragment: "ecmp.apply()"
+  }
+}
+events {
+  mark_to_drop {
+    reason: MARK_TO_DROP
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/action_selector_miss.p4"
+    line: 894
+    column: 20
+    source_fragment: "mark_to_drop(smeta)"
   }
 }
 packet_outcome {

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_nested.p4"
-    line: 881
+    line: 22
     column: 10
     source_fragment: "start"
   }
@@ -31,7 +31,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_nested.p4"
-    line: 921
+    line: 62
     column: 8
     source_fragment: "stage1.apply()"
   }
@@ -51,7 +51,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 921
+          line: 62
           column: 8
           source_fragment: "stage1.apply()"
         }
@@ -76,7 +76,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 922
+          line: 63
           column: 8
           source_fragment: "stage2.apply()"
         }
@@ -96,7 +96,7 @@ fork_outcome {
               }
               source_info {
                 file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 922
+                line: 63
                 column: 8
                 source_fragment: "stage2.apply()"
               }
@@ -122,7 +122,7 @@ fork_outcome {
               }
               source_info {
                 file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 922
+                line: 63
                 column: 8
                 source_fragment: "stage2.apply()"
               }
@@ -151,7 +151,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 921
+          line: 62
           column: 8
           source_fragment: "stage1.apply()"
         }
@@ -176,7 +176,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 922
+          line: 63
           column: 8
           source_fragment: "stage2.apply()"
         }
@@ -196,7 +196,7 @@ fork_outcome {
               }
               source_info {
                 file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 922
+                line: 63
                 column: 8
                 source_fragment: "stage2.apply()"
               }
@@ -222,7 +222,7 @@ fork_outcome {
               }
               source_info {
                 file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 922
+                line: 63
                 column: 8
                 source_fragment: "stage2.apply()"
               }

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -4,6 +4,12 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/action_selector_nested.p4"
+    line: 881
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   table_lookup {
@@ -23,6 +29,12 @@ events {
     }
     action_name: "set_tag"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/action_selector_nested.p4"
+    line: 921
+    column: 8
+    source_fragment: "stage1.apply()"
+  }
 }
 fork_outcome {
   reason: ACTION_SELECTOR
@@ -36,6 +48,12 @@ fork_outcome {
             key: "tag_1"
             value: "\001"
           }
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/action_selector_nested.p4"
+          line: 921
+          column: 8
+          source_fragment: "stage1.apply()"
         }
       }
       events {
@@ -56,6 +74,12 @@ fork_outcome {
           }
           action_name: "set_port"
         }
+        source_info {
+          file: "e2e_tests/trace_tree/action_selector_nested.p4"
+          line: 922
+          column: 8
+          source_fragment: "stage2.apply()"
+        }
       }
       fork_outcome {
         reason: ACTION_SELECTOR
@@ -69,6 +93,12 @@ fork_outcome {
                   key: "port"
                   value: "\000\001"
                 }
+              }
+              source_info {
+                file: "e2e_tests/trace_tree/action_selector_nested.p4"
+                line: 922
+                column: 8
+                source_fragment: "stage2.apply()"
               }
             }
             packet_outcome {
@@ -89,6 +119,12 @@ fork_outcome {
                   key: "port"
                   value: "\000\002"
                 }
+              }
+              source_info {
+                file: "e2e_tests/trace_tree/action_selector_nested.p4"
+                line: 922
+                column: 8
+                source_fragment: "stage2.apply()"
               }
             }
             packet_outcome {
@@ -113,6 +149,12 @@ fork_outcome {
             value: "\002"
           }
         }
+        source_info {
+          file: "e2e_tests/trace_tree/action_selector_nested.p4"
+          line: 921
+          column: 8
+          source_fragment: "stage1.apply()"
+        }
       }
       events {
         table_lookup {
@@ -132,6 +174,12 @@ fork_outcome {
           }
           action_name: "set_port"
         }
+        source_info {
+          file: "e2e_tests/trace_tree/action_selector_nested.p4"
+          line: 922
+          column: 8
+          source_fragment: "stage2.apply()"
+        }
       }
       fork_outcome {
         reason: ACTION_SELECTOR
@@ -145,6 +193,12 @@ fork_outcome {
                   key: "port"
                   value: "\000\001"
                 }
+              }
+              source_info {
+                file: "e2e_tests/trace_tree/action_selector_nested.p4"
+                line: 922
+                column: 8
+                source_fragment: "stage2.apply()"
               }
             }
             packet_outcome {
@@ -165,6 +219,12 @@ fork_outcome {
                   key: "port"
                   value: "\000\002"
                 }
+              }
+              source_info {
+                file: "e2e_tests/trace_tree/action_selector_nested.p4"
+                line: 922
+                column: 8
+                source_fragment: "stage2.apply()"
               }
             }
             packet_outcome {

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_and_multicast.p4"
-    line: 882
+    line: 23
     column: 10
     source_fragment: "start"
   }
@@ -17,7 +17,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_and_multicast.p4"
-    line: 894
+    line: 35
     column: 8
     source_fragment: "clone(CloneType.I2E, 32w100)"
   }

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -4,10 +4,22 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_and_multicast.p4"
+    line: 882
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   clone {
     session_id: 100
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_and_multicast.p4"
+    line: 894
+    column: 8
+    source_fragment: "clone(CloneType.I2E, 32w100)"
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_ingress_egress.p4"
-    line: 881
+    line: 22
     column: 10
     source_fragment: "start"
   }
@@ -17,7 +17,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_ingress_egress.p4"
-    line: 894
+    line: 35
     column: 8
     source_fragment: "clone(CloneType.I2E, 32w100)"
   }

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -4,10 +4,22 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_ingress_egress.p4"
+    line: 881
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   clone {
     session_id: 100
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_ingress_egress.p4"
+    line: 894
+    column: 8
+    source_fragment: "clone(CloneType.I2E, 32w100)"
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_last_wins.p4"
-    line: 881
+    line: 22
     column: 10
     source_fragment: "start"
   }
@@ -17,7 +17,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_last_wins.p4"
-    line: 894
+    line: 35
     column: 8
     source_fragment: "clone(CloneType.I2E, 32w200)"
   }
@@ -28,7 +28,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_last_wins.p4"
-    line: 895
+    line: 36
     column: 8
     source_fragment: "clone(CloneType.I2E, 32w100)"
   }

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -4,15 +4,33 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_last_wins.p4"
+    line: 881
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   clone {
     session_id: 200
   }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_last_wins.p4"
+    line: 894
+    column: 8
+    source_fragment: "clone(CloneType.I2E, 32w200)"
+  }
 }
 events {
   clone {
     session_id: 100
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_last_wins.p4"
+    line: 895
+    column: 8
+    source_fragment: "clone(CloneType.I2E, 32w100)"
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-    line: 882
+    line: 23
     column: 10
     source_fragment: "start"
   }
@@ -17,7 +17,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-    line: 910
+    line: 51
     column: 8
     source_fragment: "clone(CloneType.I2E, 32w100)"
   }
@@ -42,7 +42,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-    line: 911
+    line: 52
     column: 8
     source_fragment: "ecmp.apply()"
   }
@@ -62,7 +62,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-          line: 911
+          line: 52
           column: 8
           source_fragment: "ecmp.apply()"
         }
@@ -107,7 +107,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-          line: 911
+          line: 52
           column: 8
           source_fragment: "ecmp.apply()"
         }

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -4,10 +4,22 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+    line: 882
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   clone {
     session_id: 100
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+    line: 910
+    column: 8
+    source_fragment: "clone(CloneType.I2E, 32w100)"
   }
 }
 events {
@@ -28,6 +40,12 @@ events {
     }
     action_name: "set_port"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+    line: 911
+    column: 8
+    source_fragment: "ecmp.apply()"
+  }
 }
 fork_outcome {
   reason: ACTION_SELECTOR
@@ -41,6 +59,12 @@ fork_outcome {
             key: "port"
             value: "\000\001"
           }
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+          line: 911
+          column: 8
+          source_fragment: "ecmp.apply()"
         }
       }
       fork_outcome {
@@ -80,6 +104,12 @@ fork_outcome {
             key: "port"
             value: "\000\002"
           }
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+          line: 911
+          column: 8
+          source_fragment: "ecmp.apply()"
         }
       }
       fork_outcome {

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -4,10 +4,22 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_with_egress.p4"
+    line: 883
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   clone {
     session_id: 100
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/clone_with_egress.p4"
+    line: 896
+    column: 8
+    source_fragment: "clone3(CloneType.I2E, 32w100, {})"
   }
 }
 fork_outcome {
@@ -36,10 +48,22 @@ fork_outcome {
           }
           action_name: "tag_original"
         }
+        source_info {
+          file: "e2e_tests/trace_tree/clone_with_egress.p4"
+          line: 914
+          column: 12
+          source_fragment: "egress_classify.apply()"
+        }
       }
       events {
         action_execution {
           action_name: "tag_original"
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/clone_with_egress.p4"
+          line: 914
+          column: 12
+          source_fragment: "egress_classify.apply()"
         }
       }
       packet_outcome {
@@ -74,10 +98,22 @@ fork_outcome {
           }
           action_name: "tag_clone"
         }
+        source_info {
+          file: "e2e_tests/trace_tree/clone_with_egress.p4"
+          line: 914
+          column: 12
+          source_fragment: "egress_classify.apply()"
+        }
       }
       events {
         action_execution {
           action_name: "tag_clone"
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/clone_with_egress.p4"
+          line: 914
+          column: 12
+          source_fragment: "egress_classify.apply()"
         }
       }
       packet_outcome {

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_with_egress.p4"
-    line: 883
+    line: 24
     column: 10
     source_fragment: "start"
   }
@@ -17,7 +17,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/clone_with_egress.p4"
-    line: 896
+    line: 37
     column: 8
     source_fragment: "clone3(CloneType.I2E, 32w100, {})"
   }
@@ -50,7 +50,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 914
+          line: 55
           column: 12
           source_fragment: "egress_classify.apply()"
         }
@@ -61,7 +61,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 914
+          line: 55
           column: 12
           source_fragment: "egress_classify.apply()"
         }
@@ -100,7 +100,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 914
+          line: 55
           column: 12
           source_fragment: "egress_classify.apply()"
         }
@@ -111,7 +111,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 914
+          line: 55
           column: 12
           source_fragment: "egress_classify.apply()"
         }

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -4,6 +4,12 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/multicast.p4"
+    line: 880
+    column: 10
+    source_fragment: "start"
+  }
 }
 fork_outcome {
   reason: MULTICAST

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/multicast.p4"
-    line: 880
+    line: 21
     column: 10
     source_fragment: "start"
   }

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-    line: 881
+    line: 22
     column: 10
     source_fragment: "start"
   }
@@ -23,7 +23,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-          line: 900
+          line: 41
           column: 8
           source_fragment: "IfStatement"
         }
@@ -46,7 +46,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-          line: 900
+          line: 41
           column: 8
           source_fragment: "IfStatement"
         }
@@ -57,7 +57,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-          line: 901
+          line: 42
           column: 12
           source_fragment: "mark_to_drop(smeta)"
         }
@@ -80,7 +80,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-          line: 900
+          line: 41
           column: 8
           source_fragment: "IfStatement"
         }

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -4,6 +4,12 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+    line: 881
+    column: 10
+    source_fragment: "start"
+  }
 }
 fork_outcome {
   reason: MULTICAST
@@ -12,7 +18,14 @@ fork_outcome {
     subtree {
       events {
         branch {
+          control_name: "MyEgress"
           taken: false
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+          line: 900
+          column: 8
+          source_fragment: "IfStatement"
         }
       }
       packet_outcome {
@@ -28,7 +41,25 @@ fork_outcome {
     subtree {
       events {
         branch {
+          control_name: "MyEgress"
           taken: true
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+          line: 900
+          column: 8
+          source_fragment: "IfStatement"
+        }
+      }
+      events {
+        mark_to_drop {
+          reason: MARK_TO_DROP
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+          line: 901
+          column: 12
+          source_fragment: "mark_to_drop(smeta)"
         }
       }
       packet_outcome {
@@ -44,7 +75,14 @@ fork_outcome {
     subtree {
       events {
         branch {
+          control_name: "MyEgress"
           taken: false
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+          line: 900
+          column: 8
+          source_fragment: "IfStatement"
         }
       }
       packet_outcome {

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -4,6 +4,12 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/multicast_selector.p4"
+    line: 882
+    column: 10
+    source_fragment: "start"
+  }
 }
 fork_outcome {
   reason: MULTICAST
@@ -28,6 +34,12 @@ fork_outcome {
           }
           action_name: "tag_a"
         }
+        source_info {
+          file: "e2e_tests/trace_tree/multicast_selector.p4"
+          line: 917
+          column: 12
+          source_fragment: "egress_selector.apply()"
+        }
       }
       fork_outcome {
         reason: ACTION_SELECTOR
@@ -37,6 +49,12 @@ fork_outcome {
             events {
               action_execution {
                 action_name: "tag_a"
+              }
+              source_info {
+                file: "e2e_tests/trace_tree/multicast_selector.p4"
+                line: 917
+                column: 12
+                source_fragment: "egress_selector.apply()"
               }
             }
             packet_outcome {
@@ -53,6 +71,12 @@ fork_outcome {
             events {
               action_execution {
                 action_name: "tag_b"
+              }
+              source_info {
+                file: "e2e_tests/trace_tree/multicast_selector.p4"
+                line: 917
+                column: 12
+                source_fragment: "egress_selector.apply()"
               }
             }
             packet_outcome {
@@ -87,6 +111,12 @@ fork_outcome {
           }
           action_name: "tag_a"
         }
+        source_info {
+          file: "e2e_tests/trace_tree/multicast_selector.p4"
+          line: 917
+          column: 12
+          source_fragment: "egress_selector.apply()"
+        }
       }
       fork_outcome {
         reason: ACTION_SELECTOR
@@ -96,6 +126,12 @@ fork_outcome {
             events {
               action_execution {
                 action_name: "tag_a"
+              }
+              source_info {
+                file: "e2e_tests/trace_tree/multicast_selector.p4"
+                line: 917
+                column: 12
+                source_fragment: "egress_selector.apply()"
               }
             }
             packet_outcome {
@@ -112,6 +148,12 @@ fork_outcome {
             events {
               action_execution {
                 action_name: "tag_b"
+              }
+              source_info {
+                file: "e2e_tests/trace_tree/multicast_selector.p4"
+                line: 917
+                column: 12
+                source_fragment: "egress_selector.apply()"
               }
             }
             packet_outcome {

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/multicast_selector.p4"
-    line: 882
+    line: 23
     column: 10
     source_fragment: "start"
   }
@@ -36,7 +36,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_selector.p4"
-          line: 917
+          line: 58
           column: 12
           source_fragment: "egress_selector.apply()"
         }
@@ -52,7 +52,7 @@ fork_outcome {
               }
               source_info {
                 file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 917
+                line: 58
                 column: 12
                 source_fragment: "egress_selector.apply()"
               }
@@ -74,7 +74,7 @@ fork_outcome {
               }
               source_info {
                 file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 917
+                line: 58
                 column: 12
                 source_fragment: "egress_selector.apply()"
               }
@@ -113,7 +113,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_selector.p4"
-          line: 917
+          line: 58
           column: 12
           source_fragment: "egress_selector.apply()"
         }
@@ -129,7 +129,7 @@ fork_outcome {
               }
               source_info {
                 file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 917
+                line: 58
                 column: 12
                 source_fragment: "egress_selector.apply()"
               }
@@ -151,7 +151,7 @@ fork_outcome {
               }
               source_info {
                 file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 917
+                line: 58
                 column: 12
                 source_fragment: "egress_selector.apply()"
               }

--- a/e2e_tests/trace_tree/no_fork.golden.txtpb
+++ b/e2e_tests/trace_tree/no_fork.golden.txtpb
@@ -4,6 +4,12 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/no_fork.p4"
+    line: 881
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   table_lookup {
@@ -29,6 +35,12 @@ events {
     }
     action_name: "forward"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/no_fork.p4"
+    line: 900
+    column: 12
+    source_fragment: "routing.apply()"
+  }
 }
 events {
   action_execution {
@@ -37,6 +49,12 @@ events {
       key: "port"
       value: "\000\001"
     }
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/no_fork.p4"
+    line: 900
+    column: 12
+    source_fragment: "routing.apply()"
   }
 }
 packet_outcome {

--- a/e2e_tests/trace_tree/no_fork.golden.txtpb
+++ b/e2e_tests/trace_tree/no_fork.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/no_fork.p4"
-    line: 881
+    line: 22
     column: 10
     source_fragment: "start"
   }
@@ -37,7 +37,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/no_fork.p4"
-    line: 900
+    line: 41
     column: 12
     source_fragment: "routing.apply()"
   }
@@ -52,7 +52,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/no_fork.p4"
-    line: 900
+    line: 41
     column: 12
     source_fragment: "routing.apply()"
   }

--- a/e2e_tests/trace_tree/selector_exit.golden.txtpb
+++ b/e2e_tests/trace_tree/selector_exit.golden.txtpb
@@ -4,6 +4,12 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/selector_exit.p4"
+    line: 883
+    column: 10
+    source_fragment: "start"
+  }
 }
 events {
   table_lookup {
@@ -23,6 +29,12 @@ events {
     }
     action_name: "set_port"
   }
+  source_info {
+    file: "e2e_tests/trace_tree/selector_exit.p4"
+    line: 919
+    column: 8
+    source_fragment: "selector_table.apply()"
+  }
 }
 fork_outcome {
   reason: ACTION_SELECTOR
@@ -36,6 +48,12 @@ fork_outcome {
             key: "port"
             value: "\000\001"
           }
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/selector_exit.p4"
+          line: 919
+          column: 8
+          source_fragment: "selector_table.apply()"
         }
       }
       events {
@@ -59,10 +77,22 @@ fork_outcome {
           }
           action_name: "overwrite"
         }
+        source_info {
+          file: "e2e_tests/trace_tree/selector_exit.p4"
+          line: 920
+          column: 8
+          source_fragment: "after_selector.apply()"
+        }
       }
       events {
         action_execution {
           action_name: "overwrite"
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/selector_exit.p4"
+          line: 920
+          column: 8
+          source_fragment: "after_selector.apply()"
         }
       }
       packet_outcome {
@@ -83,6 +113,12 @@ fork_outcome {
             key: "port_2"
             value: "\000\001"
           }
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/selector_exit.p4"
+          line: 919
+          column: 8
+          source_fragment: "selector_table.apply()"
         }
       }
       packet_outcome {

--- a/e2e_tests/trace_tree/selector_exit.golden.txtpb
+++ b/e2e_tests/trace_tree/selector_exit.golden.txtpb
@@ -6,7 +6,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/selector_exit.p4"
-    line: 883
+    line: 24
     column: 10
     source_fragment: "start"
   }
@@ -31,7 +31,7 @@ events {
   }
   source_info {
     file: "e2e_tests/trace_tree/selector_exit.p4"
-    line: 919
+    line: 60
     column: 8
     source_fragment: "selector_table.apply()"
   }
@@ -51,7 +51,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 919
+          line: 60
           column: 8
           source_fragment: "selector_table.apply()"
         }
@@ -79,7 +79,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 920
+          line: 61
           column: 8
           source_fragment: "after_selector.apply()"
         }
@@ -90,7 +90,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 920
+          line: 61
           column: 8
           source_fragment: "after_selector.apply()"
         }
@@ -116,7 +116,7 @@ fork_outcome {
         }
         source_info {
           file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 919
+          line: 60
           column: 8
           source_fragment: "selector_table.apply()"
         }

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -302,6 +302,23 @@ fourward::ir::v1::Expr FourWardBackend::emitExpr(const IR::Expression* expr) {
 }
 
 // =============================================================================
+// Source location
+// =============================================================================
+
+fourward::ir::v1::SourceInfo FourWardBackend::emitSourceInfo(
+    const IR::Node* node) {
+  fourward::ir::v1::SourceInfo out;
+  auto si = node->getSourceInfo();
+  if (si.isValid()) {
+    out.set_file(si.getSourceFile().c_str());
+    out.set_line(si.getStart().getLineNumber());
+    out.set_column(si.getStart().getColumnNumber());
+  }
+  out.set_source_fragment(node->toString().c_str());
+  return out;
+}
+
+// =============================================================================
 // Statement emission
 // =============================================================================
 
@@ -418,6 +435,7 @@ fourward::ir::v1::Stmt FourWardBackend::emitStmt(const IR::StatOrDecl* node) {
   } else {
     LOG1("WARNING: unhandled statement " << node->node_type_name());
   }
+  *out.mutable_source_info() = emitSourceInfo(node);
   return out;
 }
 
@@ -548,6 +566,7 @@ void FourWardBackend::emitParser(const IR::P4Parser* parser) {
   for (const auto* state : parser->states) {
     auto* ps = pd->add_states();
     ps->set_name(state->name.name.c_str());
+    *ps->mutable_source_info() = emitSourceInfo(state);
 
     for (const auto* stmt : state->components) {
       *ps->add_stmts() = emitStmt(stmt);

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -311,7 +311,7 @@ fourward::ir::v1::SourceInfo FourWardBackend::emitSourceInfo(
   auto si = node->getSourceInfo();
   if (si.isValid()) {
     out.set_file(si.getSourceFile().c_str());
-    out.set_line(si.getStart().getLineNumber());
+    out.set_line(si.toPosition().sourceLine);
     out.set_column(si.getStart().getColumnNumber());
   }
   out.set_source_fragment(node->toString().c_str());

--- a/p4c_backend/backend.h
+++ b/p4c_backend/backend.h
@@ -80,6 +80,7 @@ class FourWardBackend : public Inspector {
   fourward::ir::v1::Expr emitExpr(const IR::Expression* expr);
   fourward::ir::v1::Stmt emitStmt(const IR::StatOrDecl* stmt);
   fourward::ir::v1::BlockStmt emitBlock(const IR::BlockStatement* block);
+  fourward::ir::v1::SourceInfo emitSourceInfo(const IR::Node* node);
 
   std::string outputFilePath() const;
 };

--- a/p4c_backend/backend.h
+++ b/p4c_backend/backend.h
@@ -80,7 +80,7 @@ class FourWardBackend : public Inspector {
   fourward::ir::v1::Expr emitExpr(const IR::Expression* expr);
   fourward::ir::v1::Stmt emitStmt(const IR::StatOrDecl* stmt);
   fourward::ir::v1::BlockStmt emitBlock(const IR::BlockStatement* block);
-  fourward::ir::v1::SourceInfo emitSourceInfo(const IR::Node* node);
+  static fourward::ir::v1::SourceInfo emitSourceInfo(const IR::Node* node);
 
   std::string outputFilePath() const;
 };

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -221,3 +221,15 @@ kt_jvm_test(
         "@maven//:junit_junit",
     ],
 )
+
+kt_jvm_test(
+    name = "InterpreterTraceEventTest",
+    srcs = ["InterpreterTraceEventTest.kt"],
+    test_class = "fourward.simulator.InterpreterTraceEventTest",
+    deps = [
+        ":ir_java_proto",
+        ":simulator_java_proto",
+        ":simulator_lib",
+        "@maven//:junit_junit",
+    ],
+)

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -8,6 +8,7 @@ import fourward.ir.v1.Literal
 import fourward.ir.v1.MethodCall
 import fourward.ir.v1.P4BehavioralConfig
 import fourward.ir.v1.ParserDecl
+import fourward.ir.v1.SourceInfo
 import fourward.ir.v1.Stmt
 import fourward.ir.v1.TableApplyExpr
 import fourward.ir.v1.TableBehavior
@@ -15,6 +16,8 @@ import fourward.ir.v1.Type
 import fourward.ir.v1.UnaryOperator
 import fourward.sim.v1.ActionExecutionEvent
 import fourward.sim.v1.BranchEvent
+import fourward.sim.v1.DropReason
+import fourward.sim.v1.MarkToDropEvent
 import fourward.sim.v1.ParserTransitionEvent
 import fourward.sim.v1.TableLookupEvent
 import fourward.sim.v1.TraceEvent
@@ -70,6 +73,19 @@ class Interpreter(
 
   private val types = config.typesList.associateBy { it.name }
 
+  /** Source info of the statement currently being executed, for trace events. */
+  private var currentSourceInfo: SourceInfo? = null
+
+  /** Name of the control block currently being executed, for BranchEvent. */
+  private var currentControlName: String? = null
+
+  /** Builds a TraceEvent with source info attached, if available. */
+  private fun traceEventBuilder(sourceInfo: SourceInfo? = currentSourceInfo): TraceEvent.Builder {
+    val b = TraceEvent.newBuilder()
+    sourceInfo?.let { b.sourceInfo = it }
+    return b
+  }
+
   // -------------------------------------------------------------------------
   // Parser
   // -------------------------------------------------------------------------
@@ -97,7 +113,7 @@ class Interpreter(
         }
 
       packetCtx?.addTraceEvent(
-        TraceEvent.newBuilder()
+        traceEventBuilder(if (state.hasSourceInfo()) state.sourceInfo else null)
           .setParserTransition(
             ParserTransitionEvent.newBuilder()
               .setParserName(parser.name)
@@ -153,6 +169,7 @@ class Interpreter(
 
   fun runControl(controlName: String, env: Environment) {
     val control = controls[controlName] ?: error("unknown control: $controlName")
+    currentControlName = controlName
     withLocalScope(control.localVarsList, env) { execBlock(control.applyBodyList, env) }
   }
 
@@ -185,6 +202,7 @@ class Interpreter(
   }
 
   private fun execStmt(stmt: Stmt, env: Environment) {
+    if (stmt.hasSourceInfo()) currentSourceInfo = stmt.sourceInfo else currentSourceInfo = null
     when {
       stmt.hasAssignment() ->
         setLValue(stmt.assignment.lhs, evalExpr(stmt.assignment.rhs, env), env)
@@ -201,10 +219,12 @@ class Interpreter(
   private fun execIf(ifStmt: fourward.ir.v1.IfStmt, env: Environment) {
     val condition = (evalExpr(ifStmt.condition, env) as BoolVal).value
 
-    // The control name is not directly available in the Stmt proto; we use
-    // a placeholder here. A richer trace could include source location info.
     packetCtx?.addTraceEvent(
-      TraceEvent.newBuilder().setBranch(BranchEvent.newBuilder().setTaken(condition)).build()
+      traceEventBuilder()
+        .setBranch(
+          BranchEvent.newBuilder().setControlName(currentControlName ?: "").setTaken(condition)
+        )
+        .build()
     )
 
     if (condition) {
@@ -618,7 +638,7 @@ class Interpreter(
     val result = tableStore.lookup(tableName, keyValues)
 
     packetCtx?.addTraceEvent(
-      TraceEvent.newBuilder()
+      traceEventBuilder()
         .setTableLookup(
           TableLookupEvent.newBuilder()
             .setTableName(tableName)
@@ -659,7 +679,7 @@ class Interpreter(
     // requiring the backend to emit an explicit empty ActionDecl for it.
     if (actionName == "NoAction") {
       packetCtx?.addTraceEvent(
-        TraceEvent.newBuilder()
+        traceEventBuilder()
           .setActionExecution(ActionExecutionEvent.newBuilder().setActionName(actionName))
           .build()
       )
@@ -686,7 +706,7 @@ class Interpreter(
       }
 
       packetCtx?.addTraceEvent(
-        TraceEvent.newBuilder()
+        traceEventBuilder()
           .setActionExecution(
             ActionExecutionEvent.newBuilder()
               .setActionName(actionName)
@@ -746,6 +766,11 @@ class Interpreter(
     return when (funcName) {
       // mark_to_drop(standard_metadata): sets egress_spec to the v1model drop port (511).
       "mark_to_drop" -> {
+        packetCtx?.addTraceEvent(
+          traceEventBuilder()
+            .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
+            .build()
+        )
         val smeta = evalExpr(call.argsList[0], env) as StructVal
         smeta.fields["egress_spec"] =
           BitVal(V1ModelArchitecture.DROP_PORT.toLong(), V1ModelArchitecture.PORT_BITS)
@@ -769,7 +794,7 @@ class Interpreter(
       "clone3" -> {
         val sessionId = (evalExpr(call.argsList[1], env) as BitVal).bits.value.toInt()
         packetCtx?.addTraceEvent(
-          TraceEvent.newBuilder()
+          traceEventBuilder()
             .setClone(fourward.sim.v1.CloneEvent.newBuilder().setSessionId(sessionId))
             .build()
         )
@@ -822,7 +847,6 @@ class Interpreter(
     }
   }
 
-  /** Whether [expr] is a field access into a header union. */
   /** Whether [expr] is a field access into a header union. */
   private fun isUnionFieldAccess(expr: Expr): Boolean =
     expr.hasFieldAccess() &&

--- a/simulator/InterpreterTraceEventTest.kt
+++ b/simulator/InterpreterTraceEventTest.kt
@@ -1,0 +1,165 @@
+package fourward.simulator
+
+import fourward.ir.v1.BlockStmt
+import fourward.ir.v1.ControlDecl
+import fourward.ir.v1.Expr
+import fourward.ir.v1.IfStmt
+import fourward.ir.v1.Literal
+import fourward.ir.v1.MethodCall
+import fourward.ir.v1.MethodCallStmt
+import fourward.ir.v1.NameRef
+import fourward.ir.v1.P4BehavioralConfig
+import fourward.ir.v1.SourceInfo
+import fourward.ir.v1.Stmt
+import fourward.ir.v1.Type
+import fourward.sim.v1.DropReason
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for trace event emission in the [Interpreter].
+ *
+ * Covers: MarkToDropEvent emission, BranchEvent.control_name, and SourceInfo propagation.
+ */
+class InterpreterTraceEventTest {
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private fun boolLit(v: Boolean): Expr =
+    Expr.newBuilder()
+      .setLiteral(Literal.newBuilder().setBoolean(v))
+      .setType(Type.newBuilder().setBoolean(true))
+      .build()
+
+  /** Builds a mark_to_drop(sm) method call statement. */
+  private fun markToDropStmt(sourceInfo: SourceInfo? = null): Stmt {
+    val call =
+      Expr.newBuilder()
+        .setMethodCall(
+          MethodCall.newBuilder()
+            .setTarget(Expr.newBuilder().setNameRef(NameRef.newBuilder().setName("mark_to_drop")))
+            .setMethod("__call__")
+            .addArgs(Expr.newBuilder().setNameRef(NameRef.newBuilder().setName("sm")))
+        )
+        .build()
+    val builder = Stmt.newBuilder().setMethodCall(MethodCallStmt.newBuilder().setCall(call))
+    if (sourceInfo != null) builder.sourceInfo = sourceInfo
+    return builder.build()
+  }
+
+  /** Builds an if statement with optional source_info. */
+  private fun ifStmt(
+    condition: Expr,
+    thenStmts: List<Stmt> = emptyList(),
+    elseStmts: List<Stmt> = emptyList(),
+    sourceInfo: SourceInfo? = null,
+  ): Stmt {
+    val builder =
+      Stmt.newBuilder()
+        .setIfStmt(
+          IfStmt.newBuilder()
+            .setCondition(condition)
+            .setThenBlock(BlockStmt.newBuilder().addAllStmts(thenStmts))
+            .setElseBlock(BlockStmt.newBuilder().addAllStmts(elseStmts))
+        )
+    if (sourceInfo != null) builder.sourceInfo = sourceInfo
+    return builder.build()
+  }
+
+  private fun controlConfig(controlName: String, vararg stmts: Stmt): P4BehavioralConfig =
+    P4BehavioralConfig.newBuilder()
+      .addControls(
+        ControlDecl.newBuilder().setName(controlName).addAllApplyBody(stmts.toList())
+      )
+      .build()
+
+  private fun standardMetadataEnv(): Environment {
+    val env = Environment()
+    val sm =
+      StructVal(
+        "standard_metadata_t",
+        mutableMapOf("egress_spec" to BitVal(0, V1ModelArchitecture.PORT_BITS)),
+      )
+    env.define("sm", sm)
+    return env
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 1: mark_to_drop emits MarkToDropEvent
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `mark_to_drop emits MarkToDropEvent with MARK_TO_DROP reason`() {
+    val config = controlConfig("MyIngress", markToDropStmt())
+    val env = standardMetadataEnv()
+    val pktCtx = PacketContext(byteArrayOf())
+    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", env)
+
+    val markToDropEvents = pktCtx.getEvents().filter { it.hasMarkToDrop() }
+    assertEquals("expected exactly one MarkToDropEvent", 1, markToDropEvents.size)
+    assertEquals(DropReason.MARK_TO_DROP, markToDropEvents[0].markToDrop.reason)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 2: BranchEvent carries control_name
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `BranchEvent carries control name`() {
+    val config = controlConfig("MyIngress", ifStmt(boolLit(true)))
+    val env = Environment()
+    val pktCtx = PacketContext(byteArrayOf())
+    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", env)
+
+    val branchEvents = pktCtx.getEvents().filter { it.hasBranch() }
+    assertEquals(1, branchEvents.size)
+    assertEquals("MyIngress", branchEvents[0].branch.controlName)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 3: trace events carry source_info from Stmt
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `trace events carry source info from Stmt`() {
+    val si =
+      SourceInfo.newBuilder()
+        .setFile("test.p4")
+        .setLine(42)
+        .setColumn(4)
+        .setSourceFragment("hdr.ipv4.isValid()")
+        .build()
+    val config = controlConfig("MyIngress", ifStmt(boolLit(true), sourceInfo = si))
+    val env = Environment()
+    val pktCtx = PacketContext(byteArrayOf())
+    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", env)
+
+    val branchEvents = pktCtx.getEvents().filter { it.hasBranch() }
+    assertEquals(1, branchEvents.size)
+    assertTrue(branchEvents[0].hasSourceInfo())
+    assertEquals("test.p4", branchEvents[0].sourceInfo.file)
+    assertEquals(42, branchEvents[0].sourceInfo.line)
+    assertEquals(4, branchEvents[0].sourceInfo.column)
+    assertEquals("hdr.ipv4.isValid()", branchEvents[0].sourceInfo.sourceFragment)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 4: source_info absent when Stmt has no source_info
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `source info absent when Stmt has no source_info`() {
+    val config = controlConfig("MyIngress", ifStmt(boolLit(true)))
+    val env = Environment()
+    val pktCtx = PacketContext(byteArrayOf())
+    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", env)
+
+    val branchEvents = pktCtx.getEvents().filter { it.hasBranch() }
+    assertEquals(1, branchEvents.size)
+    assertFalse(branchEvents[0].hasSourceInfo())
+  }
+}

--- a/simulator/InterpreterTraceEventTest.kt
+++ b/simulator/InterpreterTraceEventTest.kt
@@ -9,8 +9,11 @@ import fourward.ir.v1.MethodCall
 import fourward.ir.v1.MethodCallStmt
 import fourward.ir.v1.NameRef
 import fourward.ir.v1.P4BehavioralConfig
+import fourward.ir.v1.ParserDecl
+import fourward.ir.v1.ParserState
 import fourward.ir.v1.SourceInfo
 import fourward.ir.v1.Stmt
+import fourward.ir.v1.Transition
 import fourward.ir.v1.Type
 import fourward.sim.v1.DropReason
 import org.junit.Assert.assertEquals
@@ -72,9 +75,7 @@ class InterpreterTraceEventTest {
 
   private fun controlConfig(controlName: String, vararg stmts: Stmt): P4BehavioralConfig =
     P4BehavioralConfig.newBuilder()
-      .addControls(
-        ControlDecl.newBuilder().setName(controlName).addAllApplyBody(stmts.toList())
-      )
+      .addControls(ControlDecl.newBuilder().setName(controlName).addAllApplyBody(stmts.toList()))
       .build()
 
   private fun standardMetadataEnv(): Environment {
@@ -86,6 +87,22 @@ class InterpreterTraceEventTest {
       )
     env.define("sm", sm)
     return env
+  }
+
+  private fun sourceInfo(file: String, line: Int, fragment: String): SourceInfo =
+    SourceInfo.newBuilder().setFile(file).setLine(line).setSourceFragment(fragment).build()
+
+  private fun parserState(
+    name: String,
+    nextState: String,
+    sourceInfo: SourceInfo? = null,
+  ): ParserState {
+    val builder =
+      ParserState.newBuilder()
+        .setName(name)
+        .setTransition(Transition.newBuilder().setNextState(nextState))
+    if (sourceInfo != null) builder.sourceInfo = sourceInfo
+    return builder.build()
   }
 
   // ---------------------------------------------------------------------------
@@ -161,5 +178,75 @@ class InterpreterTraceEventTest {
     val branchEvents = pktCtx.getEvents().filter { it.hasBranch() }
     assertEquals(1, branchEvents.size)
     assertFalse(branchEvents[0].hasSourceInfo())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 5: parser transitions carry source_info from ParserState
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `parser transition carries source_info from ParserState`() {
+    val si = sourceInfo("test.p4", 10, "start")
+    val parser =
+      ParserDecl.newBuilder().setName("P").addStates(parserState("start", "accept", si)).build()
+    val config = P4BehavioralConfig.newBuilder().addParsers(parser).build()
+    val pktCtx = PacketContext(byteArrayOf())
+    Interpreter(config, TableStore(), pktCtx).runParser("P", Environment())
+
+    val transitions = pktCtx.getEvents().filter { it.hasParserTransition() }
+    assertEquals(1, transitions.size)
+    assertTrue(transitions[0].hasSourceInfo())
+    assertEquals("test.p4", transitions[0].sourceInfo.file)
+    assertEquals(10, transitions[0].sourceInfo.line)
+    assertEquals("start", transitions[0].sourceInfo.sourceFragment)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 6: multi-state parser — each transition gets its own source_info
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `multi-state parser transitions each carry their own source_info`() {
+    val si1 = sourceInfo("test.p4", 10, "start")
+    val si2 = sourceInfo("test.p4", 20, "parse_header")
+    val parser =
+      ParserDecl.newBuilder()
+        .setName("P")
+        .addStates(parserState("start", "parse_header", si1))
+        .addStates(parserState("parse_header", "accept", si2))
+        .build()
+    val config = P4BehavioralConfig.newBuilder().addParsers(parser).build()
+    val pktCtx = PacketContext(byteArrayOf())
+    Interpreter(config, TableStore(), pktCtx).runParser("P", Environment())
+
+    val transitions = pktCtx.getEvents().filter { it.hasParserTransition() }
+    assertEquals(2, transitions.size)
+    assertEquals("start", transitions[0].sourceInfo.sourceFragment)
+    assertEquals(10, transitions[0].sourceInfo.line)
+    assertEquals("parse_header", transitions[1].sourceInfo.sourceFragment)
+    assertEquals(20, transitions[1].sourceInfo.line)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 7: sequential statements each carry their own source_info
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `sequential statements carry independent source_info`() {
+    val si1 = sourceInfo("test.p4", 10, "if (true)")
+    val si2 = sourceInfo("test.p4", 20, "mark_to_drop(sm)")
+    val config =
+      controlConfig("MyIngress", ifStmt(boolLit(true), sourceInfo = si1), markToDropStmt(si2))
+    val env = standardMetadataEnv()
+    val pktCtx = PacketContext(byteArrayOf())
+    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", env)
+
+    val events = pktCtx.getEvents()
+    val branchEvent = events.first { it.hasBranch() }
+    val markToDropEvent = events.first { it.hasMarkToDrop() }
+    assertEquals("if (true)", branchEvent.sourceInfo.sourceFragment)
+    assertEquals(10, branchEvent.sourceInfo.line)
+    assertEquals("mark_to_drop(sm)", markToDropEvent.sourceInfo.sourceFragment)
+    assertEquals(20, markToDropEvent.sourceInfo.line)
   }
 }

--- a/simulator/ir.proto
+++ b/simulator/ir.proto
@@ -213,6 +213,8 @@ message ParserState {
   string name = 1;
   repeated Stmt stmts = 2;
   Transition transition = 3;
+
+  SourceInfo source_info = 100;
 }
 
 message Transition {
@@ -292,6 +294,21 @@ message TableKey {
 }
 
 // =============================================================================
+// Source location
+// =============================================================================
+
+// Source location from the P4 compiler, attached to statements and parser
+// states so the simulator can propagate it into trace events.
+message SourceInfo {
+  string file = 1;
+  uint32 line = 2;
+  uint32 column = 3;
+  // Reconstructed P4 source text for the node (e.g. "mark_to_drop(sm)" or
+  // "hdr.ipv4.isValid()").
+  string source_fragment = 4;
+}
+
+// =============================================================================
 // Statements
 // =============================================================================
 
@@ -305,6 +322,8 @@ message Stmt {
     ExitStmt exit = 6;
     ReturnStmt return_stmt = 7;
   }
+
+  SourceInfo source_info = 100;
 }
 
 message AssignmentStmt {

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -150,6 +150,8 @@ message TraceEvent {
     MarkToDropEvent mark_to_drop = 6;
     CloneEvent clone = 7;
   }
+
+  fourward.ir.v1.SourceInfo source_info = 100;
 }
 
 // Fired on every parser state transition, including the final transition to


### PR DESCRIPTION
## Summary

- Every trace event now carries the P4 source location (file, line, column,
  source fragment) of the statement that produced it — so traces tell the
  full story without needing the original source file.
- Fixes two existing gaps: `MarkToDropEvent` was defined in the proto but
  never emitted, and `BranchEvent.control_name` was never populated.

## Approach

**Proto**: New `SourceInfo` message in `ir.proto`; added as field 100 on
`Stmt`, `ParserState`, and `TraceEvent`.

**Backend** (`p4c_backend`): New `emitSourceInfo()` helper extracts
file/line/column from p4c's `IR::Node::getSourceInfo()` and the source
fragment from `toString()`. Called for every statement and parser state.

**Interpreter**: `traceEventBuilder()` helper attaches the current
statement's source info to every trace event. Parser transitions use the
`ParserState`'s own source info instead. New `currentControlName` field
populates `BranchEvent.control_name`.

**Tests**: 7 unit tests in `InterpreterTraceEventTest.kt` covering
MarkToDropEvent emission, BranchEvent.control_name, source info propagation,
backwards compatibility when source info is absent, parser transition
source info, multi-state parser isolation, and sequential statement
independence. All 13 golden trace tree files regenerated.

## Test plan

- [x] `bazel test //...` — all 30 tests pass
- [x] `./format.sh && ./lint.sh` — clean
- [x] Spot-checked golden file (`no_fork.golden.txtpb`) for meaningful
  source_info values

🤖 Generated with [Claude Code](https://claude.com/claude-code)