### PR TITLE
corpus: SimplifyComparisons midend pass + enum promotion (174 → 176 passing)

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -36,6 +36,8 @@ corpus_test_suite(
         "constant-in-calculation-bmv2",
         "default-action-arg-bmv2",
         "default_action-bmv2",
+        "enum-bmv2",
+        "equality-bmv2",
         "equality-varbit-bmv2",
         "flag_lost-bmv2",
         "gauntlet_action_mux-bmv2",
@@ -210,7 +212,6 @@ corpus_test_suite(
     ],
     tags = ["manual"],
     tests = [
-        "enum-bmv2",  # missing ConvertEnums midend pass
         "extern-funcs-bmv2",  # unhandled extern call: extern_func
     ],
 )
@@ -268,22 +269,12 @@ corpus_test_suite(
     ],
 )
 
-# Tests blocked on header stack operations (push/pop, size/lastIndex).
-# These fail with header stack-related errors.
-corpus_test_suite(
-    name = "header_stack_stf_corpus_test",
-    tags = ["manual"],
-    tests = [
-        "equality-bmv2",  # header stack comparison (struct equality with stacks)
-    ],
-)
-
 # Tests blocked on various unclassified missing features.
 corpus_test_suite(
     name = "other_stf_corpus_test",
     tags = ["manual"],
     tests = [
-        "table-entries-priority-bmv2",  # p4c ignores @priority; BMv2 handles it via non-P4Runtime path
+        "table-entries-priority-bmv2",  # p4c P4Runtime serializer ignores @priority on const entries
         "ternary2-bmv2",  # per-table action specialization lost (single p4info action ID)
         "v1model-special-ops-bmv2",  # needs resubmit/recirculate
     ],

--- a/p4c_backend/midend.cpp
+++ b/p4c_backend/midend.cpp
@@ -36,6 +36,7 @@ MidEnd::MidEnd(FourWardOptions& options) {
       new P4::FlattenHeaders(&typeMap),
       new P4::EliminateTuples(&typeMap),
       new P4::CopyStructures(&typeMap),
+      new P4::SimplifyComparisons(&typeMap),
       new P4::LocalCopyPropagation(&typeMap),
       new P4::SimplifyKey(
           &typeMap,


### PR DESCRIPTION
## Summary

- Add the standard p4c `SimplifyComparisons` midend pass, which decomposes
  header- and struct-level `==` into field-by-field AND-chains. This fixes
  `equality-bmv2`.
- Promote `enum-bmv2` to the passing CI suite (already passing since plain
  enum support landed in PR #121).
- Remove the now-empty `header_stack_stf_corpus_test` suite.

## Deferred: table-entries-priority-bmv2

The original plan included fixing ternary priority scoring, but investigation
revealed the root cause is in p4c's P4Runtime serializer: it auto-assigns
descending priorities for const tables and ignores `@priority` annotations
entirely (`p4RuntimeSerializer.cpp:1092`, the `isConst` branch). BMv2's JSON
backend handles `@priority` differently. Fixing this requires post-processing
priorities in the C++ backend to match BMv2's convention — a separate PR.

## Test plan

- [x] `bazel test //...` — 29/29 pass (176 corpus tests)
- [x] `./format.sh` clean
- [x] `./lint.sh` — detekt clean (clang-tidy not installed locally, CI will cover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)