### PR TITLE
p4runtime: add gRPC server backed by the 4ward simulator

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,16 +158,45 @@ No other P4 tool gives you this. BMv2 picks one path. Hardware picks one path.
 4ward can show you *all* paths — making it a powerful tool for testing,
 verification, and understanding complex P4 programs.
 
-## P4Runtime (Track 4)
+## P4Runtime (`p4runtime/`)
 
-Not yet! We're deliberately building the simulator first and getting it solid
-before adding the P4Runtime layer. When the time comes, the server will:
+The P4Runtime gRPC server is a thin translation layer between standard
+P4Runtime RPCs and the simulator's `SimRequest`/`SimResponse` protocol.
+All P4 logic stays in the simulator — the server just speaks gRPC.
 
-1. Speak P4Runtime gRPC to the controller.
-2. Translate requests into `SimRequest` proto messages.
-3. Forward them to the simulator.
+```
+Controller ──gRPC──▶ P4RuntimeService ──SimRequest──▶ Simulator
+                           │                              │
+                     translates protos              runs your program
+                     enforces preconditions          returns SimResponse
+```
 
-All the real P4 logic stays in the simulator where it belongs. See
+**Implemented RPCs:**
+
+| RPC | Status |
+|-----|--------|
+| `SetForwardingPipelineConfig` | Working — parses `P4BehavioralConfig` from `p4_device_config` bytes |
+| `Write` | Working — forwards `Update` protos directly to the simulator |
+| `Read` | Working — returns all table entries (wildcard read; filtering is TODO) |
+| `StreamChannel` | Working — arbitration + PacketOut→PacketIn via the simulator |
+| `GetForwardingPipelineConfig` | Stub (UNIMPLEMENTED) |
+| `Capabilities` | Stub (UNIMPLEMENTED) |
+
+**Key design decisions:**
+
+- **In-process, not subprocess.** The server calls `Simulator.handle()` directly
+  rather than piping through stdin/stdout. Same `SimRequest`/`SimResponse`
+  contract, just no serialization overhead.
+- **grpc-kotlin with coroutine Flows.** `StreamChannel` is a bidirectional
+  stream — Kotlin Flows map naturally to gRPC's streaming model.
+- **`synchronized(simulator)` for thread safety.** The simulator is
+  single-threaded; the gRPC server serializes concurrent requests with a lock.
+  Good enough for a reference implementation.
+- **Single controller.** First connection is master. No multi-controller
+  arbitration, no election ID tracking.
+
+**What's not here yet:** p4-constraints validation, `@p4runtime_translation`,
+digest support, idle timeout notifications, atomic write batches. See
 [ROADMAP.md](ROADMAP.md) Track 4 for the full scope.
 
 ## Why these languages?

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -27,10 +27,22 @@ guilt — just write it down so someone can find it later.
   (`register.read`/`.write`, `counter.count`, etc.) are not implemented.
   Blocks ~3 corpus tests.
 
-## Simulator
+## P4Runtime server
 
-- **`ReadEntries` is a stub.** The `ReadEntriesRequest` handler returns an
-  empty response (`Simulator.kt:143`).
+- **Single controller only.** No multi-controller arbitration or election ID
+  tracking. The first connection is master unconditionally.
+- **Wildcard reads only.** `Read` returns all table entries regardless of the
+  request's entity filter. Per-table and per-entry reads are not implemented.
+- **No p4-constraints validation.** `Write` does not enforce `@entry_restriction`
+  or `@action_restriction` annotations from the P4 source.
+- **No `@p4runtime_translation`.** Controller-facing values are passed through
+  to the simulator without translation. SAI P4 programs (which translate all
+  IDs to strings) will not work correctly until this is implemented.
+- **Missing RPCs.** `GetForwardingPipelineConfig` and `Capabilities` return
+  UNIMPLEMENTED.
+- **No digests, idle timeouts, or atomic write batches.**
+
+## Simulator
 - **Clone: I2E only, no metadata preservation.** `clone()` and `clone3()`
   support ingress-to-egress cloning with last-writer-wins for multiple calls
   (matching BMv2). E2E clone, `clone3` metadata field lists, resubmit, and

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,9 +13,11 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_kotlin", version = "2.3.0")
 bazel_dep(name = "rules_jvm_external", version = "6.10")
 
-# --- Protobuf ---
+# --- Protobuf & gRPC ---
 
 bazel_dep(name = "protobuf", version = "33.5")
+bazel_dep(name = "grpc-java", version = "1.78.0")
+bazel_dep(name = "grpc_kotlin", version = "1.5.0")
 
 # --- P4 ecosystem ---
 
@@ -32,7 +34,7 @@ git_override(
     remote = "https://github.com/smolkaj/p4c.git",
 )
 
-# --- JVM dependencies (protobuf runtime for Kotlin) ---
+# --- JVM dependencies ---
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
@@ -42,6 +44,17 @@ maven.install(
         "junit:junit:4.13.2",
         "com.facebook:ktfmt:0.61",
         "io.gitlab.arturbosch.detekt:detekt-cli:1.23.8",
+        # gRPC Kotlin runtime
+        "io.grpc:grpc-kotlin-stub:1.4.3",
+        "io.grpc:grpc-netty-shaded:1.68.1",
+        "io.grpc:grpc-services:1.68.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
+        "javax.annotation:javax.annotation-api:1.3.2",
+    ],
+    known_contributing_modules = [
+        "grpc-java",
+        "protobuf",
     ],
     repositories = [
         "https://repo1.maven.org/maven2",

--- a/e2e_tests/basic_table/BUILD.bazel
+++ b/e2e_tests/basic_table/BUILD.bazel
@@ -10,6 +10,7 @@ genrule(
         "@p4c//:core_p4",
         "@p4c//:p4include",
     ],
+    visibility = ["//p4runtime:__pkg__"],
 )
 
 kt_jvm_test(

--- a/e2e_tests/passthrough/BUILD.bazel
+++ b/e2e_tests/passthrough/BUILD.bazel
@@ -14,6 +14,7 @@ genrule(
         "@p4c//:core_p4",
         "@p4c//:p4include",
     ],
+    visibility = ["//p4runtime:__pkg__"],
 )
 
 # Runs the passthrough STF test against the 4ward simulator.

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -1,0 +1,103 @@
+load("@grpc-java//:java_grpc_library.bzl", "java_grpc_library")
+load("@grpc_kotlin//:kt_jvm_grpc.bzl", "kt_jvm_grpc_library")
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm_test")
+
+# =============================================================================
+# P4Runtime gRPC stubs (Kotlin)
+# =============================================================================
+
+# Java proto messages — needed as a dep for grpc stub generation.
+java_proto_library(
+    name = "p4runtime_java_proto",
+    deps = ["@p4runtime//proto/p4/v1:p4runtime_proto"],
+)
+
+java_proto_library(
+    name = "p4info_java_proto",
+    deps = ["@p4runtime//proto/p4/config/v1:p4info_proto"],
+)
+
+# Java gRPC stubs for P4Runtime service.
+java_grpc_library(
+    name = "p4runtime_java_grpc",
+    srcs = ["@p4runtime//proto/p4/v1:p4runtime_proto"],
+    deps = [":p4runtime_java_proto"],
+)
+
+# Kotlin gRPC stubs — coroutine-based service base class and client stub.
+kt_jvm_grpc_library(
+    name = "p4runtime_kt_grpc",
+    srcs = ["@p4runtime//proto/p4/v1:p4runtime_proto"],
+    deps = [":p4runtime_java_proto"],
+)
+
+# =============================================================================
+# P4Runtime server library
+# =============================================================================
+
+kt_jvm_library(
+    name = "p4runtime_lib",
+    srcs = glob(
+        ["*.kt"],
+        exclude = [
+            "*Test.kt",
+            "*TestHarness.kt",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":p4info_java_proto",
+        ":p4runtime_java_grpc",
+        ":p4runtime_java_proto",
+        ":p4runtime_kt_grpc",
+        "//simulator:ir_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_java_proto",
+        "//simulator:simulator_lib",
+        "@grpc-java//api",
+        "@grpc-java//netty",
+        "@grpc-java//stub",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_grpc_grpc_kotlin_stub",
+        "@maven//:io_grpc_grpc_netty_shaded",
+        "@maven//:javax_annotation_javax_annotation_api",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+    ],
+)
+
+kt_jvm_binary(
+    name = "p4runtime_server",
+    main_class = "fourward.p4runtime.P4RuntimeServerKt",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":p4runtime_lib"],
+)
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+kt_jvm_test(
+    name = "P4RuntimeConformanceTest",
+    srcs = [
+        "P4RuntimeConformanceTest.kt",
+        "P4RuntimeTestHarness.kt",
+    ],
+    data = [
+        "//e2e_tests/basic_table:basic_table_pb",
+        "//e2e_tests/passthrough:passthrough_pb",
+    ],
+    tags = ["manual"],
+    test_class = "fourward.p4runtime.P4RuntimeConformanceTest",
+    deps = [
+        ":p4runtime_lib",
+        "//simulator:ir_java_proto",
+        "@grpc-java//api",
+        "@grpc-java//inprocess",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_grpc_grpc_kotlin_stub",
+        "@maven//:junit_junit",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+    ],
+)

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -1,0 +1,373 @@
+package fourward.p4runtime
+
+import fourward.ir.v1.PipelineConfig
+import io.grpc.StatusException
+import java.nio.file.Paths
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.StreamMessageResponse
+
+/**
+ * P4Runtime conformance tests.
+ *
+ * Each test verifies one aspect of the P4Runtime server's behavior against the 4ward simulator.
+ * Tests are organized by RPC and numbered per the implementation plan.
+ *
+ * Tests use the basic_table.p4 fixture (exact-match table with forward/drop actions) unless a
+ * specific P4 feature is needed.
+ */
+class P4RuntimeConformanceTest {
+
+  private lateinit var harness: P4RuntimeTestHarness
+
+  @Before
+  fun setUp() {
+    harness = P4RuntimeTestHarness()
+  }
+
+  @After
+  fun tearDown() {
+    harness.close()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fixture loading
+  // ---------------------------------------------------------------------------
+
+  private fun loadBasicTableConfig(): PipelineConfig {
+    val r = System.getenv("JAVA_RUNFILES") ?: "."
+    val path = Paths.get(r, "_main/e2e_tests/basic_table/basic_table.txtpb")
+    val builder = PipelineConfig.newBuilder()
+    com.google.protobuf.TextFormat.merge(path.toFile().readText(), builder)
+    return builder.build()
+  }
+
+  private fun loadPassthroughConfig(): PipelineConfig {
+    val r = System.getenv("JAVA_RUNFILES") ?: "."
+    val path = Paths.get(r, "_main/e2e_tests/passthrough/passthrough.txtpb")
+    val builder = PipelineConfig.newBuilder()
+    com.google.protobuf.TextFormat.merge(path.toFile().readText(), builder)
+    return builder.build()
+  }
+
+  // =========================================================================
+  // SetForwardingPipelineConfig (scenarios 1-3)
+  // =========================================================================
+
+  @Test
+  fun `1 - load valid pipeline succeeds`() {
+    val config = loadBasicTableConfig()
+    val resp = harness.loadPipeline(config)
+    assertNotNull(resp)
+  }
+
+  @Test
+  fun `2 - load second pipeline replaces first`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    // Loading a different pipeline should succeed (replaces the first).
+    val resp = harness.loadPipeline(loadPassthroughConfig())
+    assertNotNull(resp)
+  }
+
+  @Test
+  fun `3 - load empty config returns error`() {
+    try {
+      harness.loadPipeline(PipelineConfig.getDefaultInstance())
+      fail("expected error for empty pipeline config")
+    } catch (e: StatusException) {
+      // Expected — invalid pipeline config should be rejected.
+      assertTrue(e.status.code.name, e.status.code != io.grpc.Status.Code.OK)
+    }
+  }
+
+  // =========================================================================
+  // Write (scenarios 4-8)
+  // =========================================================================
+
+  @Test
+  fun `4 - install table entry succeeds`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 1)
+    val resp = harness.installEntry(entry)
+    assertNotNull(resp)
+  }
+
+  @Test
+  fun `5 - modify existing entry succeeds`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 1)
+    harness.installEntry(entry)
+    // Modify to forward to a different port.
+    val modified = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 2)
+    val resp = harness.modifyEntry(modified)
+    assertNotNull(resp)
+  }
+
+  @Test
+  fun `6 - delete entry succeeds`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 1)
+    harness.installEntry(entry)
+    val resp = harness.deleteEntry(entry)
+    assertNotNull(resp)
+  }
+
+  @Test
+  fun `7 - write without pipeline returns error`() {
+    try {
+      val entity =
+        Entity.newBuilder()
+          .setTableEntry(
+            p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(1).build()
+          )
+          .build()
+      harness.installEntry(entity)
+      fail("expected error for write without pipeline")
+    } catch (e: StatusException) {
+      assertTrue(e.status.code.name, e.status.code != io.grpc.Status.Code.OK)
+    }
+  }
+
+  @Test
+  fun `8 - write with invalid table ID returns error`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    try {
+      val entity =
+        Entity.newBuilder()
+          .setTableEntry(
+            p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder()
+              .setTableId(99999) // Non-existent table.
+              .build()
+          )
+          .build()
+      harness.installEntry(entity)
+      fail("expected error for invalid table ID")
+    } catch (e: StatusException) {
+      assertTrue(e.status.code.name, e.status.code != io.grpc.Status.Code.OK)
+    }
+  }
+
+  // =========================================================================
+  // Read (scenarios 9-11)
+  // =========================================================================
+
+  @Test
+  fun `9 - read back installed entries matches written`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 1)
+    harness.installEntry(entry)
+    val entities = harness.readEntries()
+    assertTrue("expected at least one entity", entities.isNotEmpty())
+  }
+
+  @Test
+  fun `10 - read empty table returns empty response`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val entities = harness.readEntries()
+    assertTrue("expected empty read", entities.isEmpty())
+  }
+
+  @Test
+  fun `11 - read without pipeline returns error`() {
+    try {
+      harness.readEntries()
+      fail("expected error for read without pipeline")
+    } catch (e: StatusException) {
+      assertTrue(e.status.code.name, e.status.code != io.grpc.Status.Code.OK)
+    }
+  }
+
+  // =========================================================================
+  // StreamChannel (scenarios 12-15)
+  // =========================================================================
+
+  @Test
+  fun `12 - arbitration establishes master`() {
+    val responses = harness.sendPacketViaStream(byteArrayOf(), expectedResponses = 1)
+    assertTrue("expected arbitration response", responses.isNotEmpty())
+    assertTrue("expected arbitration ack", responses[0].hasArbitration())
+  }
+
+  @Test
+  fun `13 - PacketOut processed by simulator, PacketIn returned`() {
+    harness.loadPipeline(loadPassthroughConfig())
+    val payload = byteArrayOf(0xCA.toByte(), 0xFE.toByte())
+    val responses = harness.sendPacketViaStream(payload)
+    assertTrue("expected at least 2 responses", responses.size >= 2)
+    // First response is arbitration ack, second is PacketIn.
+    assertTrue("expected packet_in", responses[1].hasPacket())
+    assertEquals(
+      com.google.protobuf.ByteString.copyFrom(payload),
+      responses[1].packet.payload,
+    )
+  }
+
+  @Test
+  fun `14 - PacketOut with table entries has correct forwarding`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    // basic_table.p4 matches on etherType: install forward(port=1) for IPv4 (0x0800).
+    val entry = buildEtherTypeEntry(config, etherType = 0x0800, port = 1)
+    harness.installEntry(entry)
+    // Ethernet frame: dst=ff:ff:ff:ff:ff:ff src=00:00:00:00:00:01 etherType=0x0800 payload=DEAD
+    val payload = buildEthernetFrame(etherType = 0x0800)
+    val responses = harness.sendPacketViaStream(payload)
+    assertTrue("expected at least 2 responses", responses.size >= 2)
+    assertTrue("expected packet_in", responses[1].hasPacket())
+  }
+
+  @Test
+  fun `15 - multiple packets preserve ordering`() {
+    harness.loadPipeline(loadPassthroughConfig())
+    val payload1 = byteArrayOf(0x01, 0x02)
+    val payload2 = byteArrayOf(0x03, 0x04)
+    val r1 = harness.sendPacketViaStream(payload1)
+    val r2 = harness.sendPacketViaStream(payload2)
+    assertTrue("first packet returned", r1.any { it.hasPacket() })
+    assertTrue("second packet returned", r2.any { it.hasPacket() })
+    // Verify payloads match what was sent.
+    val pktIn1 = r1.first { it.hasPacket() }.packet
+    val pktIn2 = r2.first { it.hasPacket() }.packet
+    assertEquals(com.google.protobuf.ByteString.copyFrom(payload1), pktIn1.payload)
+    assertEquals(com.google.protobuf.ByteString.copyFrom(payload2), pktIn2.payload)
+  }
+
+  // =========================================================================
+  // Helpers
+  // =========================================================================
+
+  /**
+   * Builds a basic_table.p4 table entry: exact match on dst_addr, forward action with egress_port.
+   */
+  private fun buildBasicTableEntry(config: PipelineConfig, dstAddr: Long, port: Int): Entity {
+    val p4info = config.p4Info
+    val table = p4info.tablesList.first()
+    val forwardAction = p4info.actionsList.find { it.preamble.name.contains("forward") }!!
+
+    val matchField =
+      p4.v1.P4RuntimeOuterClass.FieldMatch.newBuilder()
+        .setFieldId(table.matchFieldsList.first().id)
+        .setExact(
+          p4.v1.P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+            .setValue(
+              com.google.protobuf.ByteString.copyFrom(
+                longToBytes(dstAddr, (table.matchFieldsList.first().bitwidth + 7) / 8)
+              )
+            )
+        )
+        .build()
+
+    val actionParam =
+      p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+        .setParamId(forwardAction.paramsList.first().id)
+        .setValue(
+          com.google.protobuf.ByteString.copyFrom(
+            longToBytes(port.toLong(), (forwardAction.paramsList.first().bitwidth + 7) / 8)
+          )
+        )
+        .build()
+
+    val tableEntry =
+      p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder()
+        .setTableId(table.preamble.id)
+        .addMatch(matchField)
+        .setAction(
+          p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(
+              p4.v1.P4RuntimeOuterClass.Action.newBuilder()
+                .setActionId(forwardAction.preamble.id)
+                .addParams(actionParam)
+            )
+        )
+        .build()
+
+    return Entity.newBuilder().setTableEntry(tableEntry).build()
+  }
+
+  /** Builds a basic_table entry matching etherType → forward(port). */
+  @Suppress("MagicNumber")
+  private fun buildEtherTypeEntry(config: PipelineConfig, etherType: Int, port: Int): Entity {
+    val p4info = config.p4Info
+    val table = p4info.tablesList.first()
+    val forwardAction = p4info.actionsList.find { it.preamble.name.contains("forward") }!!
+    val matchField = table.matchFieldsList.first()
+
+    val fieldMatch =
+      p4.v1.P4RuntimeOuterClass.FieldMatch.newBuilder()
+        .setFieldId(matchField.id)
+        .setExact(
+          p4.v1.P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+            .setValue(
+              com.google.protobuf.ByteString.copyFrom(
+                longToBytes(etherType.toLong(), (matchField.bitwidth + 7) / 8)
+              )
+            )
+        )
+        .build()
+
+    val actionParam =
+      p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+        .setParamId(forwardAction.paramsList.first().id)
+        .setValue(
+          com.google.protobuf.ByteString.copyFrom(
+            longToBytes(port.toLong(), (forwardAction.paramsList.first().bitwidth + 7) / 8)
+          )
+        )
+        .build()
+
+    val tableEntry =
+      p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder()
+        .setTableId(table.preamble.id)
+        .addMatch(fieldMatch)
+        .setAction(
+          p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(
+              p4.v1.P4RuntimeOuterClass.Action.newBuilder()
+                .setActionId(forwardAction.preamble.id)
+                .addParams(actionParam)
+            )
+        )
+        .build()
+
+    return Entity.newBuilder().setTableEntry(tableEntry).build()
+  }
+
+  /** Builds a minimal Ethernet frame: dst=FF:FF:FF:FF:FF:FF src=00:00:00:00:00:01 + etherType. */
+  @Suppress("MagicNumber")
+  private fun buildEthernetFrame(etherType: Int): ByteArray {
+    val frame = ByteArray(18) // 14-byte header + 4 bytes payload
+    // Dst MAC: broadcast
+    for (i in 0 until 6) frame[i] = 0xFF.toByte()
+    // Src MAC: 00:00:00:00:00:01
+    frame[11] = 0x01
+    // EtherType (big-endian)
+    frame[12] = (etherType shr 8).toByte()
+    frame[13] = (etherType and 0xFF).toByte()
+    // Payload
+    frame[14] = 0xDE.toByte()
+    frame[15] = 0xAD.toByte()
+    frame[16] = 0xBE.toByte()
+    frame[17] = 0xEF.toByte()
+    return frame
+  }
+
+  private fun longToBytes(value: Long, byteLen: Int): ByteArray {
+    val bytes = ByteArray(byteLen)
+    for (i in 0 until byteLen) {
+      bytes[byteLen - 1 - i] = (value shr (i * 8) and 0xFF).toByte()
+    }
+    return bytes
+  }
+}

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -11,9 +11,6 @@ import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import p4.v1.P4RuntimeOuterClass.Entity
-import p4.v1.P4RuntimeOuterClass.ReadRequest
-import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
-import p4.v1.P4RuntimeOuterClass.StreamMessageResponse
 
 /**
  * P4Runtime conformance tests.
@@ -42,17 +39,13 @@ class P4RuntimeConformanceTest {
   // Fixture loading
   // ---------------------------------------------------------------------------
 
-  private fun loadBasicTableConfig(): PipelineConfig {
-    val r = System.getenv("JAVA_RUNFILES") ?: "."
-    val path = Paths.get(r, "_main/e2e_tests/basic_table/basic_table.txtpb")
-    val builder = PipelineConfig.newBuilder()
-    com.google.protobuf.TextFormat.merge(path.toFile().readText(), builder)
-    return builder.build()
-  }
+  private fun loadBasicTableConfig() = loadConfig("e2e_tests/basic_table/basic_table.txtpb")
 
-  private fun loadPassthroughConfig(): PipelineConfig {
+  private fun loadPassthroughConfig() = loadConfig("e2e_tests/passthrough/passthrough.txtpb")
+
+  private fun loadConfig(relativePath: String): PipelineConfig {
     val r = System.getenv("JAVA_RUNFILES") ?: "."
-    val path = Paths.get(r, "_main/e2e_tests/passthrough/passthrough.txtpb")
+    val path = Paths.get(r, "_main/$relativePath")
     val builder = PipelineConfig.newBuilder()
     com.google.protobuf.TextFormat.merge(path.toFile().readText(), builder)
     return builder.build()
@@ -96,7 +89,7 @@ class P4RuntimeConformanceTest {
   fun `4 - install table entry succeeds`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    val entry = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 1)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
     val resp = harness.installEntry(entry)
     assertNotNull(resp)
   }
@@ -105,10 +98,10 @@ class P4RuntimeConformanceTest {
   fun `5 - modify existing entry succeeds`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    val entry = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 1)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
     harness.installEntry(entry)
     // Modify to forward to a different port.
-    val modified = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 2)
+    val modified = buildExactEntry(config, matchValue = 0x0800, port = 2)
     val resp = harness.modifyEntry(modified)
     assertNotNull(resp)
   }
@@ -117,7 +110,7 @@ class P4RuntimeConformanceTest {
   fun `6 - delete entry succeeds`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    val entry = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 1)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
     harness.installEntry(entry)
     val resp = harness.deleteEntry(entry)
     assertNotNull(resp)
@@ -128,9 +121,7 @@ class P4RuntimeConformanceTest {
     try {
       val entity =
         Entity.newBuilder()
-          .setTableEntry(
-            p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(1).build()
-          )
+          .setTableEntry(p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(1).build())
           .build()
       harness.installEntry(entity)
       fail("expected error for write without pipeline")
@@ -166,7 +157,7 @@ class P4RuntimeConformanceTest {
   fun `9 - read back installed entries matches written`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    val entry = buildBasicTableEntry(config, dstAddr = 0x0800000001, port = 1)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
     harness.installEntry(entry)
     val entities = harness.readEntries()
     assertTrue("expected at least one entity", entities.isNotEmpty())
@@ -208,18 +199,15 @@ class P4RuntimeConformanceTest {
     assertTrue("expected at least 2 responses", responses.size >= 2)
     // First response is arbitration ack, second is PacketIn.
     assertTrue("expected packet_in", responses[1].hasPacket())
-    assertEquals(
-      com.google.protobuf.ByteString.copyFrom(payload),
-      responses[1].packet.payload,
-    )
+    assertEquals(com.google.protobuf.ByteString.copyFrom(payload), responses[1].packet.payload)
   }
 
   @Test
   fun `14 - PacketOut with table entries has correct forwarding`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    // basic_table.p4 matches on etherType: install forward(port=1) for IPv4 (0x0800).
-    val entry = buildEtherTypeEntry(config, etherType = 0x0800, port = 1)
+    // basic_table.p4 matches on etherType: install forward(port=1) for IPv4.
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
     harness.installEntry(entry)
     // Ethernet frame: dst=ff:ff:ff:ff:ff:ff src=00:00:00:00:00:01 etherType=0x0800 payload=DEAD
     val payload = buildEthernetFrame(etherType = 0x0800)
@@ -231,74 +219,28 @@ class P4RuntimeConformanceTest {
   @Test
   fun `15 - multiple packets preserve ordering`() {
     harness.loadPipeline(loadPassthroughConfig())
-    val payload1 = byteArrayOf(0x01, 0x02)
-    val payload2 = byteArrayOf(0x03, 0x04)
-    val r1 = harness.sendPacketViaStream(payload1)
-    val r2 = harness.sendPacketViaStream(payload2)
-    assertTrue("first packet returned", r1.any { it.hasPacket() })
-    assertTrue("second packet returned", r2.any { it.hasPacket() })
-    // Verify payloads match what was sent.
-    val pktIn1 = r1.first { it.hasPacket() }.packet
-    val pktIn2 = r2.first { it.hasPacket() }.packet
-    assertEquals(com.google.protobuf.ByteString.copyFrom(payload1), pktIn1.payload)
-    assertEquals(com.google.protobuf.ByteString.copyFrom(payload2), pktIn2.payload)
+    harness.openStream().use { stream ->
+      stream.arbitrate()
+      val payload1 = byteArrayOf(0x01, 0x02)
+      val payload2 = byteArrayOf(0x03, 0x04)
+      val pkt1 = stream.sendPacket(payload1)
+      val pkt2 = stream.sendPacket(payload2)
+      assertNotNull("first packet returned", pkt1)
+      assertNotNull("second packet returned", pkt2)
+      assertTrue("first is packet_in", pkt1!!.hasPacket())
+      assertTrue("second is packet_in", pkt2!!.hasPacket())
+      assertEquals(com.google.protobuf.ByteString.copyFrom(payload1), pkt1.packet.payload)
+      assertEquals(com.google.protobuf.ByteString.copyFrom(payload2), pkt2.packet.payload)
+    }
   }
 
   // =========================================================================
   // Helpers
   // =========================================================================
 
-  /**
-   * Builds a basic_table.p4 table entry: exact match on dst_addr, forward action with egress_port.
-   */
-  private fun buildBasicTableEntry(config: PipelineConfig, dstAddr: Long, port: Int): Entity {
-    val p4info = config.p4Info
-    val table = p4info.tablesList.first()
-    val forwardAction = p4info.actionsList.find { it.preamble.name.contains("forward") }!!
-
-    val matchField =
-      p4.v1.P4RuntimeOuterClass.FieldMatch.newBuilder()
-        .setFieldId(table.matchFieldsList.first().id)
-        .setExact(
-          p4.v1.P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
-            .setValue(
-              com.google.protobuf.ByteString.copyFrom(
-                longToBytes(dstAddr, (table.matchFieldsList.first().bitwidth + 7) / 8)
-              )
-            )
-        )
-        .build()
-
-    val actionParam =
-      p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
-        .setParamId(forwardAction.paramsList.first().id)
-        .setValue(
-          com.google.protobuf.ByteString.copyFrom(
-            longToBytes(port.toLong(), (forwardAction.paramsList.first().bitwidth + 7) / 8)
-          )
-        )
-        .build()
-
-    val tableEntry =
-      p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder()
-        .setTableId(table.preamble.id)
-        .addMatch(matchField)
-        .setAction(
-          p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
-            .setAction(
-              p4.v1.P4RuntimeOuterClass.Action.newBuilder()
-                .setActionId(forwardAction.preamble.id)
-                .addParams(actionParam)
-            )
-        )
-        .build()
-
-    return Entity.newBuilder().setTableEntry(tableEntry).build()
-  }
-
-  /** Builds a basic_table entry matching etherType → forward(port). */
+  /** Builds a table entry: exact match on the table's first field → forward(port). */
   @Suppress("MagicNumber")
-  private fun buildEtherTypeEntry(config: PipelineConfig, etherType: Int, port: Int): Entity {
+  private fun buildExactEntry(config: PipelineConfig, matchValue: Long, port: Int): Entity {
     val p4info = config.p4Info
     val table = p4info.tablesList.first()
     val forwardAction = p4info.actionsList.find { it.preamble.name.contains("forward") }!!
@@ -311,7 +253,7 @@ class P4RuntimeConformanceTest {
           p4.v1.P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
             .setValue(
               com.google.protobuf.ByteString.copyFrom(
-                longToBytes(etherType.toLong(), (matchField.bitwidth + 7) / 8)
+                longToBytes(matchValue, (matchField.bitwidth + 7) / 8)
               )
             )
         )

--- a/p4runtime/P4RuntimeServer.kt
+++ b/p4runtime/P4RuntimeServer.kt
@@ -1,0 +1,43 @@
+package fourward.p4runtime
+
+import fourward.simulator.Simulator
+import io.grpc.Server
+import io.grpc.netty.NettyServerBuilder
+
+/** Wraps an in-process P4Runtime gRPC server backed by a 4ward [Simulator]. */
+class P4RuntimeServer(private val port: Int = DEFAULT_PORT) {
+
+  private val simulator = Simulator()
+  private val service = P4RuntimeService(simulator)
+  private lateinit var server: Server
+
+  fun start(): P4RuntimeServer {
+    server = NettyServerBuilder.forPort(port).addService(service).build().start()
+    Runtime.getRuntime().addShutdownHook(Thread { stop() })
+    return this
+  }
+
+  fun stop() {
+    if (::server.isInitialized) {
+      server.shutdown()
+    }
+  }
+
+  fun blockUntilShutdown() {
+    server.awaitTermination()
+  }
+
+  fun port(): Int = server.port
+
+  companion object {
+    const val DEFAULT_PORT = 9559
+  }
+}
+
+fun main(args: Array<String>) {
+  val port =
+    args.firstOrNull()?.removePrefix("--port=")?.toIntOrNull() ?: P4RuntimeServer.DEFAULT_PORT
+  val server = P4RuntimeServer(port).start()
+  println("P4Runtime server listening on port ${server.port()}")
+  server.blockUntilShutdown()
+}

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -38,12 +38,12 @@ class P4RuntimeService(private val simulator: Simulator) :
   P4RuntimeGrpcKt.P4RuntimeCoroutineImplBase() {
 
   @Volatile private var currentConfig: PipelineConfig? = null
-  @Volatile private var isMasterElected = false
 
   private fun requirePipeline() {
     if (currentConfig == null) {
-      throw Status.FAILED_PRECONDITION
-        .withDescription("No pipeline loaded; call SetForwardingPipelineConfig first")
+      throw Status.FAILED_PRECONDITION.withDescription(
+          "No pipeline loaded; call SetForwardingPipelineConfig first"
+        )
         .asException()
     }
   }
@@ -57,8 +57,9 @@ class P4RuntimeService(private val simulator: Simulator) :
   ): SetForwardingPipelineConfigResponse {
     val fwdConfig = request.config
     if (!fwdConfig.hasP4Info() || fwdConfig.p4DeviceConfig.isEmpty) {
-      throw Status.INVALID_ARGUMENT
-        .withDescription("ForwardingPipelineConfig must include p4info and p4_device_config")
+      throw Status.INVALID_ARGUMENT.withDescription(
+          "ForwardingPipelineConfig must include p4info and p4_device_config"
+        )
         .asException()
     }
 
@@ -66,16 +67,14 @@ class P4RuntimeService(private val simulator: Simulator) :
       try {
         P4BehavioralConfig.parseFrom(fwdConfig.p4DeviceConfig)
       } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
-        throw Status.INVALID_ARGUMENT
-          .withDescription("p4_device_config is not a valid P4BehavioralConfig: ${e.message}")
+        throw Status.INVALID_ARGUMENT.withDescription(
+            "p4_device_config is not a valid P4BehavioralConfig: ${e.message}"
+          )
           .asException()
       }
 
     val pipelineConfig =
-      PipelineConfig.newBuilder()
-        .setP4Info(fwdConfig.p4Info)
-        .setBehavioral(behavioral)
-        .build()
+      PipelineConfig.newBuilder().setP4Info(fwdConfig.p4Info).setBehavioral(behavioral).build()
 
     val simRequest =
       SimRequest.newBuilder()
@@ -84,8 +83,9 @@ class P4RuntimeService(private val simulator: Simulator) :
 
     val simResponse = synchronized(simulator) { simulator.handle(simRequest) }
     if (simResponse.hasError()) {
-      throw Status.INTERNAL
-        .withDescription("Simulator rejected pipeline: ${simResponse.error.message}")
+      throw Status.INTERNAL.withDescription(
+          "Simulator rejected pipeline: ${simResponse.error.message}"
+        )
         .asException()
     }
 
@@ -106,8 +106,7 @@ class P4RuntimeService(private val simulator: Simulator) :
           .build()
       val simResponse = synchronized(simulator) { simulator.handle(simRequest) }
       if (simResponse.hasError()) {
-        throw Status.INVALID_ARGUMENT
-          .withDescription("Write failed: ${simResponse.error.message}")
+        throw Status.INVALID_ARGUMENT.withDescription("Write failed: ${simResponse.error.message}")
           .asException()
       }
     }
@@ -126,14 +125,11 @@ class P4RuntimeService(private val simulator: Simulator) :
         .build()
     val simResponse = synchronized(simulator) { simulator.handle(simRequest) }
     if (simResponse.hasError()) {
-      throw Status.INTERNAL
-        .withDescription("Read failed: ${simResponse.error.message}")
+      throw Status.INTERNAL.withDescription("Read failed: ${simResponse.error.message}")
         .asException()
     }
     if (simResponse.readEntries.entitiesCount > 0) {
-      emit(
-        ReadResponse.newBuilder().addAllEntities(simResponse.readEntries.entitiesList).build()
-      )
+      emit(ReadResponse.newBuilder().addAllEntities(simResponse.readEntries.entitiesList).build())
     }
   }
 
@@ -146,7 +142,6 @@ class P4RuntimeService(private val simulator: Simulator) :
       requests.collect { msg ->
         when {
           msg.hasArbitration() -> {
-            isMasterElected = true
             emit(
               StreamMessageResponse.newBuilder()
                 .setArbitration(
@@ -154,8 +149,7 @@ class P4RuntimeService(private val simulator: Simulator) :
                     .setDeviceId(msg.arbitration.deviceId)
                     .setElectionId(msg.arbitration.electionId)
                     .setStatus(
-                      com.google.rpc.Status.newBuilder()
-                        .setCode(com.google.rpc.Code.OK_VALUE)
+                      com.google.rpc.Status.newBuilder().setCode(com.google.rpc.Code.OK_VALUE)
                     )
                 )
                 .build()
@@ -202,20 +196,18 @@ class P4RuntimeService(private val simulator: Simulator) :
     }
 
   /** Extracts ingress port from PacketOut metadata, defaulting to port 0. */
-  private fun extractIngressPort(
-    metadata: List<p4.v1.P4RuntimeOuterClass.PacketMetadata>
-  ): Int {
+  private fun extractIngressPort(metadata: List<p4.v1.P4RuntimeOuterClass.PacketMetadata>): Int {
     val portMeta = metadata.find { it.metadataId == INGRESS_PORT_METADATA_ID }
     return portMeta?.value?.toByteArray()?.fold(0) { acc, b -> (acc shl 8) or (b.toInt() and 0xFF) }
       ?: 0
   }
 
   private fun intToBytes(value: Int): ByteString {
-    // Encode as minimum-width big-endian (P4Runtime canonical form).
-    val bytes =
-      if (value <= 0xFF) byteArrayOf(value.toByte())
-      else byteArrayOf((value shr 8).toByte(), value.toByte())
-    return ByteString.copyFrom(bytes)
+    // Minimum-width unsigned big-endian (P4Runtime canonical form).
+    val bytes = ByteArray(4) { i -> (value shr ((3 - i) * 8) and 0xFF).toByte() }
+    val firstNonZero = bytes.indexOfFirst { it != 0.toByte() }
+    val start = if (firstNonZero < 0) 3 else firstNonZero
+    return ByteString.copyFrom(bytes, start, bytes.size - start)
   }
 
   // ---------------------------------------------------------------------------
@@ -225,8 +217,7 @@ class P4RuntimeService(private val simulator: Simulator) :
   override suspend fun getForwardingPipelineConfig(
     request: GetForwardingPipelineConfigRequest
   ): GetForwardingPipelineConfigResponse {
-    throw Status.UNIMPLEMENTED
-      .withDescription("GetForwardingPipelineConfig not yet implemented")
+    throw Status.UNIMPLEMENTED.withDescription("GetForwardingPipelineConfig not yet implemented")
       .asException()
   }
 

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -1,0 +1,246 @@
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import fourward.ir.v1.P4BehavioralConfig
+import fourward.ir.v1.PipelineConfig
+import fourward.sim.v1.LoadPipelineRequest
+import fourward.sim.v1.ProcessPacketRequest
+import fourward.sim.v1.ReadEntriesRequest
+import fourward.sim.v1.SimRequest
+import fourward.sim.v1.WriteEntryRequest
+import fourward.simulator.Simulator
+import io.grpc.Status
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import p4.v1.P4RuntimeGrpcKt
+import p4.v1.P4RuntimeOuterClass.CapabilitiesRequest
+import p4.v1.P4RuntimeOuterClass.CapabilitiesResponse
+import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigResponse
+import p4.v1.P4RuntimeOuterClass.MasterArbitrationUpdate
+import p4.v1.P4RuntimeOuterClass.PacketIn
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.ReadResponse
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigResponse
+import p4.v1.P4RuntimeOuterClass.StreamMessageRequest
+import p4.v1.P4RuntimeOuterClass.StreamMessageResponse
+import p4.v1.P4RuntimeOuterClass.WriteRequest
+import p4.v1.P4RuntimeOuterClass.WriteResponse
+
+/**
+ * P4Runtime gRPC service backed by a 4ward [Simulator].
+ *
+ * Simplifications: single controller (first connection is master), synchronous packet processing,
+ * no digest support.
+ */
+class P4RuntimeService(private val simulator: Simulator) :
+  P4RuntimeGrpcKt.P4RuntimeCoroutineImplBase() {
+
+  @Volatile private var currentConfig: PipelineConfig? = null
+  @Volatile private var isMasterElected = false
+
+  private fun requirePipeline() {
+    if (currentConfig == null) {
+      throw Status.FAILED_PRECONDITION
+        .withDescription("No pipeline loaded; call SetForwardingPipelineConfig first")
+        .asException()
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // SetForwardingPipelineConfig
+  // ---------------------------------------------------------------------------
+
+  override suspend fun setForwardingPipelineConfig(
+    request: SetForwardingPipelineConfigRequest
+  ): SetForwardingPipelineConfigResponse {
+    val fwdConfig = request.config
+    if (!fwdConfig.hasP4Info() || fwdConfig.p4DeviceConfig.isEmpty) {
+      throw Status.INVALID_ARGUMENT
+        .withDescription("ForwardingPipelineConfig must include p4info and p4_device_config")
+        .asException()
+    }
+
+    val behavioral =
+      try {
+        P4BehavioralConfig.parseFrom(fwdConfig.p4DeviceConfig)
+      } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
+        throw Status.INVALID_ARGUMENT
+          .withDescription("p4_device_config is not a valid P4BehavioralConfig: ${e.message}")
+          .asException()
+      }
+
+    val pipelineConfig =
+      PipelineConfig.newBuilder()
+        .setP4Info(fwdConfig.p4Info)
+        .setBehavioral(behavioral)
+        .build()
+
+    val simRequest =
+      SimRequest.newBuilder()
+        .setLoadPipeline(LoadPipelineRequest.newBuilder().setConfig(pipelineConfig))
+        .build()
+
+    val simResponse = synchronized(simulator) { simulator.handle(simRequest) }
+    if (simResponse.hasError()) {
+      throw Status.INTERNAL
+        .withDescription("Simulator rejected pipeline: ${simResponse.error.message}")
+        .asException()
+    }
+
+    currentConfig = pipelineConfig
+    return SetForwardingPipelineConfigResponse.getDefaultInstance()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write
+  // ---------------------------------------------------------------------------
+
+  override suspend fun write(request: WriteRequest): WriteResponse {
+    requirePipeline()
+    for (update in request.updatesList) {
+      val simRequest =
+        SimRequest.newBuilder()
+          .setWriteEntry(WriteEntryRequest.newBuilder().setUpdate(update))
+          .build()
+      val simResponse = synchronized(simulator) { simulator.handle(simRequest) }
+      if (simResponse.hasError()) {
+        throw Status.INVALID_ARGUMENT
+          .withDescription("Write failed: ${simResponse.error.message}")
+          .asException()
+      }
+    }
+    return WriteResponse.getDefaultInstance()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  override fun read(request: ReadRequest): Flow<ReadResponse> = flow {
+    requirePipeline()
+    val simRequest =
+      SimRequest.newBuilder()
+        .setReadEntries(ReadEntriesRequest.newBuilder().setRequest(request))
+        .build()
+    val simResponse = synchronized(simulator) { simulator.handle(simRequest) }
+    if (simResponse.hasError()) {
+      throw Status.INTERNAL
+        .withDescription("Read failed: ${simResponse.error.message}")
+        .asException()
+    }
+    if (simResponse.readEntries.entitiesCount > 0) {
+      emit(
+        ReadResponse.newBuilder().addAllEntities(simResponse.readEntries.entitiesList).build()
+      )
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // StreamChannel
+  // ---------------------------------------------------------------------------
+
+  override fun streamChannel(requests: Flow<StreamMessageRequest>): Flow<StreamMessageResponse> =
+    flow {
+      requests.collect { msg ->
+        when {
+          msg.hasArbitration() -> {
+            isMasterElected = true
+            emit(
+              StreamMessageResponse.newBuilder()
+                .setArbitration(
+                  MasterArbitrationUpdate.newBuilder()
+                    .setDeviceId(msg.arbitration.deviceId)
+                    .setElectionId(msg.arbitration.electionId)
+                    .setStatus(
+                      com.google.rpc.Status.newBuilder()
+                        .setCode(com.google.rpc.Code.OK_VALUE)
+                    )
+                )
+                .build()
+            )
+          }
+          msg.hasPacket() -> {
+            val packetOut = msg.packet
+            // Extract ingress port from packet_out metadata (field "ingress_port", ID 0 or 1).
+            val ingressPort = extractIngressPort(packetOut.metadataList)
+
+            val simRequest =
+              SimRequest.newBuilder()
+                .setProcessPacket(
+                  ProcessPacketRequest.newBuilder()
+                    .setIngressPort(ingressPort)
+                    .setPayload(packetOut.payload)
+                )
+                .build()
+
+            val simResponse = synchronized(simulator) { simulator.handle(simRequest) }
+            if (simResponse.hasError()) {
+              return@collect
+            }
+
+            // Convert output packets to PacketIn messages.
+            for (outputPacket in simResponse.processPacket.outputPacketsList) {
+              emit(
+                StreamMessageResponse.newBuilder()
+                  .setPacket(
+                    PacketIn.newBuilder()
+                      .setPayload(outputPacket.payload)
+                      .addMetadata(
+                        p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
+                          .setMetadataId(EGRESS_PORT_METADATA_ID)
+                          .setValue(intToBytes(outputPacket.egressPort))
+                      )
+                  )
+                  .build()
+              )
+            }
+          }
+        }
+      }
+    }
+
+  /** Extracts ingress port from PacketOut metadata, defaulting to port 0. */
+  private fun extractIngressPort(
+    metadata: List<p4.v1.P4RuntimeOuterClass.PacketMetadata>
+  ): Int {
+    val portMeta = metadata.find { it.metadataId == INGRESS_PORT_METADATA_ID }
+    return portMeta?.value?.toByteArray()?.fold(0) { acc, b -> (acc shl 8) or (b.toInt() and 0xFF) }
+      ?: 0
+  }
+
+  private fun intToBytes(value: Int): ByteString {
+    // Encode as minimum-width big-endian (P4Runtime canonical form).
+    val bytes =
+      if (value <= 0xFF) byteArrayOf(value.toByte())
+      else byteArrayOf((value shr 8).toByte(), value.toByte())
+    return ByteString.copyFrom(bytes)
+  }
+
+  // ---------------------------------------------------------------------------
+  // GetForwardingPipelineConfig
+  // ---------------------------------------------------------------------------
+
+  override suspend fun getForwardingPipelineConfig(
+    request: GetForwardingPipelineConfigRequest
+  ): GetForwardingPipelineConfigResponse {
+    throw Status.UNIMPLEMENTED
+      .withDescription("GetForwardingPipelineConfig not yet implemented")
+      .asException()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Capabilities
+  // ---------------------------------------------------------------------------
+
+  override suspend fun capabilities(request: CapabilitiesRequest): CapabilitiesResponse {
+    throw Status.UNIMPLEMENTED.withDescription("Capabilities not yet implemented").asException()
+  }
+
+  companion object {
+    // Well-known metadata IDs for v1model packet_in/packet_out headers.
+    private const val INGRESS_PORT_METADATA_ID = 1
+    private const val EGRESS_PORT_METADATA_ID = 2
+  }
+}

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -1,0 +1,166 @@
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import fourward.ir.v1.PipelineConfig
+import fourward.simulator.Simulator
+import io.grpc.ManagedChannel
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import java.io.Closeable
+import java.nio.file.Path
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import p4.v1.P4RuntimeGrpcKt.P4RuntimeCoroutineStub
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.MasterArbitrationUpdate
+import p4.v1.P4RuntimeOuterClass.PacketOut
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigResponse
+import p4.v1.P4RuntimeOuterClass.StreamMessageRequest
+import p4.v1.P4RuntimeOuterClass.StreamMessageResponse
+import p4.v1.P4RuntimeOuterClass.Uint128
+import p4.v1.P4RuntimeOuterClass.Update
+import p4.v1.P4RuntimeOuterClass.WriteRequest
+import p4.v1.P4RuntimeOuterClass.WriteResponse
+
+/**
+ * In-process test harness for the P4Runtime gRPC service.
+ *
+ * Starts an in-process gRPC server backed by a real [Simulator] and provides typed helpers for
+ * common operations. Uses grpc-java's InProcessTransport so no real network ports are needed.
+ */
+class P4RuntimeTestHarness : Closeable {
+
+  private val serverName = InProcessServerBuilder.generateName()
+  private val simulator = Simulator()
+  private val service = P4RuntimeService(simulator)
+
+  private val server =
+    InProcessServerBuilder.forName(serverName).directExecutor().addService(service).build().start()
+
+  private val channel: ManagedChannel =
+    InProcessChannelBuilder.forName(serverName).directExecutor().build()
+
+  val stub: P4RuntimeCoroutineStub = P4RuntimeCoroutineStub(channel)
+
+  // ---------------------------------------------------------------------------
+  // Pipeline management
+  // ---------------------------------------------------------------------------
+
+  fun loadPipeline(config: PipelineConfig): SetForwardingPipelineConfigResponse = runBlocking {
+    stub.setForwardingPipelineConfig(
+      SetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+        .setConfig(
+          ForwardingPipelineConfig.newBuilder()
+            .setP4Info(config.p4Info)
+            .setP4DeviceConfig(config.behavioral.toByteString())
+        )
+        .build()
+    )
+  }
+
+  fun loadPipeline(configPath: Path): SetForwardingPipelineConfigResponse {
+    val builder = PipelineConfig.newBuilder()
+    com.google.protobuf.TextFormat.merge(configPath.toFile().readText(), builder)
+    return loadPipeline(builder.build())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Table entry management
+  // ---------------------------------------------------------------------------
+
+  fun installEntry(entity: Entity): WriteResponse = runBlocking {
+    stub.write(
+      WriteRequest.newBuilder()
+        .setDeviceId(1)
+        .addUpdates(Update.newBuilder().setType(Update.Type.INSERT).setEntity(entity))
+        .build()
+    )
+  }
+
+  fun modifyEntry(entity: Entity): WriteResponse = runBlocking {
+    stub.write(
+      WriteRequest.newBuilder()
+        .setDeviceId(1)
+        .addUpdates(Update.newBuilder().setType(Update.Type.MODIFY).setEntity(entity))
+        .build()
+    )
+  }
+
+  fun deleteEntry(entity: Entity): WriteResponse = runBlocking {
+    stub.write(
+      WriteRequest.newBuilder()
+        .setDeviceId(1)
+        .addUpdates(Update.newBuilder().setType(Update.Type.DELETE).setEntity(entity))
+        .build()
+    )
+  }
+
+  fun readEntries(request: ReadRequest = ReadRequest.getDefaultInstance()): List<Entity> =
+    runBlocking {
+      val entities = mutableListOf<Entity>()
+      stub.read(request).collect { response -> entities.addAll(response.entitiesList) }
+      entities
+    }
+
+  // ---------------------------------------------------------------------------
+  // StreamChannel helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Performs master arbitration over a StreamChannel, sends a PacketOut, and collects the
+   * responses. Returns all StreamMessageResponse messages received (including the arbitration ack).
+   */
+  @Suppress("MagicNumber")
+  fun sendPacketViaStream(
+    payload: ByteArray,
+    ingressPort: Int = 0,
+    expectedResponses: Int = 2, // 1 arbitration ack + 1 packet_in per output
+  ): List<StreamMessageResponse> = runBlocking {
+    val requestFlow = MutableSharedFlow<StreamMessageRequest>(replay = 16)
+
+    // Arbitration: become master.
+    requestFlow.emit(
+      StreamMessageRequest.newBuilder()
+        .setArbitration(
+          MasterArbitrationUpdate.newBuilder()
+            .setDeviceId(1)
+            .setElectionId(Uint128.newBuilder().setHigh(0).setLow(1))
+        )
+        .build()
+    )
+
+    // PacketOut.
+    val packetOut =
+      PacketOut.newBuilder()
+        .setPayload(ByteString.copyFrom(payload))
+        .addMetadata(
+          p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
+            .setMetadataId(1) // ingress_port
+            .setValue(ByteString.copyFrom(byteArrayOf(ingressPort.toByte())))
+        )
+        .build()
+    requestFlow.emit(StreamMessageRequest.newBuilder().setPacket(packetOut).build())
+
+    val responseFlow = stub.streamChannel(requestFlow.take(2))
+
+    withTimeoutOrNull(STREAM_TIMEOUT_MS) { responseFlow.take(expectedResponses).toList() }
+      ?: emptyList()
+  }
+
+  override fun close() {
+    channel.shutdownNow()
+    server.shutdownNow()
+  }
+
+  companion object {
+    private const val STREAM_TIMEOUT_MS = 5000L
+  }
+}

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -8,10 +8,14 @@ import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import java.io.Closeable
 import java.nio.file.Path
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import p4.v1.P4RuntimeGrpcKt.P4RuntimeCoroutineStub
 import p4.v1.P4RuntimeOuterClass.Entity
@@ -114,45 +118,79 @@ class P4RuntimeTestHarness : Closeable {
   // StreamChannel helpers
   // ---------------------------------------------------------------------------
 
+  /** Opens a persistent bidirectional stream. Callers should use [Closeable.use] for cleanup. */
+  fun openStream(): StreamSession = StreamSession()
+
   /**
-   * Performs master arbitration over a StreamChannel, sends a PacketOut, and collects the
-   * responses. Returns all StreamMessageResponse messages received (including the arbitration ack).
+   * Convenience: opens a stream, arbitrates, sends one PacketOut, and returns the responses.
+   *
+   * Use [openStream] for multi-packet scenarios.
    */
-  @Suppress("MagicNumber")
   fun sendPacketViaStream(
     payload: ByteArray,
     ingressPort: Int = 0,
-    expectedResponses: Int = 2, // 1 arbitration ack + 1 packet_in per output
-  ): List<StreamMessageResponse> = runBlocking {
-    val requestFlow = MutableSharedFlow<StreamMessageRequest>(replay = 16)
+    expectedResponses: Int = 2,
+  ): List<StreamMessageResponse> =
+    openStream().use { session ->
+      val responses = mutableListOf<StreamMessageResponse>()
+      responses.add(session.arbitrate())
+      if (expectedResponses > 1 && payload.isNotEmpty()) {
+        session.sendPacket(payload, ingressPort)?.let { responses.add(it) }
+      }
+      responses
+    }
 
-    // Arbitration: become master.
-    requestFlow.emit(
-      StreamMessageRequest.newBuilder()
-        .setArbitration(
-          MasterArbitrationUpdate.newBuilder()
-            .setDeviceId(1)
-            .setElectionId(Uint128.newBuilder().setHigh(0).setLow(1))
-        )
-        .build()
-    )
+  /**
+   * A persistent bidirectional StreamChannel session.
+   *
+   * Call [arbitrate] once to become master, then [sendPacket] for each packet. The session
+   * maintains a single gRPC stream, avoiding re-arbitration per packet.
+   */
+  inner class StreamSession : Closeable {
+    private val scope = CoroutineScope(Dispatchers.Default)
+    private val requestChannel = Channel<StreamMessageRequest>(Channel.UNLIMITED)
+    private val responseChannel = Channel<StreamMessageResponse>(Channel.UNLIMITED)
 
-    // PacketOut.
-    val packetOut =
-      PacketOut.newBuilder()
-        .setPayload(ByteString.copyFrom(payload))
-        .addMetadata(
-          p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
-            .setMetadataId(1) // ingress_port
-            .setValue(ByteString.copyFrom(byteArrayOf(ingressPort.toByte())))
-        )
-        .build()
-    requestFlow.emit(StreamMessageRequest.newBuilder().setPacket(packetOut).build())
+    private val job =
+      scope.launch {
+        stub.streamChannel(requestChannel.consumeAsFlow()).collect { responseChannel.send(it) }
+      }
 
-    val responseFlow = stub.streamChannel(requestFlow.take(2))
+    fun arbitrate(deviceId: Long = 1, electionId: Long = 1): StreamMessageResponse = runBlocking {
+      requestChannel.send(
+        StreamMessageRequest.newBuilder()
+          .setArbitration(
+            MasterArbitrationUpdate.newBuilder()
+              .setDeviceId(deviceId)
+              .setElectionId(Uint128.newBuilder().setHigh(0).setLow(electionId))
+          )
+          .build()
+      )
+      withTimeout(STREAM_TIMEOUT_MS) { responseChannel.receive() }
+    }
 
-    withTimeoutOrNull(STREAM_TIMEOUT_MS) { responseFlow.take(expectedResponses).toList() }
-      ?: emptyList()
+    @Suppress("MagicNumber")
+    fun sendPacket(payload: ByteArray, ingressPort: Int = 0): StreamMessageResponse? = runBlocking {
+      requestChannel.send(
+        StreamMessageRequest.newBuilder()
+          .setPacket(
+            PacketOut.newBuilder()
+              .setPayload(ByteString.copyFrom(payload))
+              .addMetadata(
+                p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
+                  .setMetadataId(1) // ingress_port
+                  .setValue(portToBytes(ingressPort))
+              )
+          )
+          .build()
+      )
+      withTimeoutOrNull(STREAM_TIMEOUT_MS) { responseChannel.receive() }
+    }
+
+    override fun close() {
+      requestChannel.close()
+      scope.cancel()
+    }
   }
 
   override fun close() {
@@ -162,5 +200,13 @@ class P4RuntimeTestHarness : Closeable {
 
   companion object {
     private const val STREAM_TIMEOUT_MS = 5000L
+
+    /** Minimum-width unsigned big-endian encoding of a port number. */
+    private fun portToBytes(port: Int): ByteString {
+      val bytes = ByteArray(4) { i -> (port shr ((3 - i) * 8) and 0xFF).toByte() }
+      val firstNonZero = bytes.indexOfFirst { it != 0.toByte() }
+      val start = if (firstNonZero < 0) 3 else firstNonZero
+      return ByteString.copyFrom(bytes, start, bytes.size - start)
+    }
   }
 }

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -67,6 +67,7 @@ kt_jvm_library(
         ["*.kt"],
         exclude = ["*Test.kt"],
     ),
+    visibility = ["//visibility:public"],
     deps = [
         ":ir_java_proto",
         ":p4runtime_java_proto",

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -151,8 +151,10 @@ class Simulator {
 
   @Suppress("UnusedParameter") // req will be used when read filters are implemented
   private fun handleReadEntries(req: fourward.sim.v1.ReadEntriesRequest): SimResponse {
-    // TODO: implement read support.
-    return SimResponse.newBuilder().setReadEntries(ReadEntriesResponse.getDefaultInstance()).build()
+    val entities = tableStore.readAllEntities()
+    return SimResponse.newBuilder()
+      .setReadEntries(ReadEntriesResponse.newBuilder().addAllEntities(entities))
+      .build()
   }
 
   // -------------------------------------------------------------------------

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -149,7 +149,7 @@ class Simulator {
     return SimResponse.newBuilder().setWriteEntry(WriteEntryResponse.getDefaultInstance()).build()
   }
 
-  @Suppress("UnusedParameter") // req will be used when read filters are implemented
+  @Suppress("UnusedParameter") // will be used when read filters are implemented
   private fun handleReadEntries(req: fourward.sim.v1.ReadEntriesRequest): SimResponse {
     val entities = tableStore.readAllEntities()
     return SimResponse.newBuilder()

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -168,6 +168,21 @@ class TableStore {
     multicastGroups[groupId]
 
   // -------------------------------------------------------------------------
+  // Read
+  // -------------------------------------------------------------------------
+
+  /** Returns all stored entities as P4Runtime Entity protos. */
+  fun readAllEntities(): List<P4RuntimeOuterClass.Entity> {
+    val entities = mutableListOf<P4RuntimeOuterClass.Entity>()
+    for (entries in tables.values) {
+      for (entry in entries) {
+        entities += P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry).build()
+      }
+    }
+    return entities
+  }
+
+  // -------------------------------------------------------------------------
   // Lookup
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a P4Runtime gRPC server that translates standard P4Runtime RPCs into
calls to the existing `Simulator.handle()` method. Controllers can now manage
table entries and send/receive packets through the standard P4Runtime API
instead of the bespoke stdin/stdout subprocess protocol.

**Implemented RPCs:**
- `SetForwardingPipelineConfig` — parses `P4BehavioralConfig` from `p4_device_config` bytes
- `Write` — forwards `Update` protos directly to the simulator's `TableStore`
- `Read` — returns all table entries (wildcard; filtering is TODO)
- `StreamChannel` — master arbitration + PacketOut→simulator→PacketIn

**Key design decisions:**
- **In-process**, not subprocess — calls `Simulator.handle()` directly
- **grpc-kotlin** with coroutine Flows for bidirectional streaming
- **`synchronized(simulator)`** for thread safety (single-threaded simulator)
- **Single controller** — first connection is master (no election ID tracking)

**Test infrastructure:**
- `P4RuntimeTestHarness` — in-process gRPC server with typed helpers
- `StreamSession` — persistent bidirectional stream for multi-packet tests
- 15 conformance tests covering all four RPCs

**Docs:**
- ARCHITECTURE.md — replaced "Not yet!" placeholder with actual P4Runtime architecture
- LIMITATIONS.md — documented known gaps (single controller, wildcard reads, no p4-constraints, no @p4runtime_translation)

## Test plan

- [x] `bazel test //...` — all 30 existing tests pass
- [x] `bazel test //p4runtime:P4RuntimeConformanceTest` — all 15 conformance tests pass
- [x] `./lint.sh` clean
- [x] `./format.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)