### PR TITLE
readme: add docs/ and tools/ to project structure tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ No printf debugging. No Wireshark. No guessing.
 │   ├── ir.proto            Behavioral IR (the contract between backend & sim)
 │   └── simulator.proto     Simulator service protocol (stdin/stdout framing)
 ├── p4c_backend/            p4c backend plugin (C++, emits the proto IR)
-└── e2e_tests/
-    ├── stf/                STF runner (shared subprocess + packet I/O)
-    ├── corpus/             p4c STF corpus (bulk regression)
-    ├── trace_tree/         Golden trace-tree tests
-    ├── p4testgen/          p4testgen integration (auto-generated paths)
-    └── <feature>/          Hand-written feature tests (passthrough, lpm, …)
+├── e2e_tests/
+│   ├── stf/                STF runner (shared subprocess + packet I/O)
+│   ├── corpus/             p4c STF corpus (bulk regression)
+│   ├── trace_tree/         Golden trace-tree tests
+│   ├── p4testgen/          p4testgen integration (auto-generated paths)
+│   └── <feature>/          Hand-written feature tests (passthrough, lpm, …)
+├── docs/                   Project documentation
+└── tools/                  Developer scripts (format, lint, coverage, …)
 ```
 
 Curious about the design? [ARCHITECTURE.md](docs/ARCHITECTURE.md) has the full story.


### PR DESCRIPTION
## Summary

Follow-up to #142: the project structure tree in README.md was missing the
new `docs/` and `tools/` directories. Also fixes `e2e_tests/` to not appear
as the last entry (it's no longer the final top-level directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)