### PR TITLE
corpus: per-table action specialization (177 → 178 passing)

### DIFF
--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -110,9 +110,12 @@ persistent session that resets table state between STFs.
 
 **Problem**: `matchesMasked` is `private` in `Runner.kt`, so
 `StfParserTest.kt` has an identical copy to test the logic independently.
+Kotlin `internal` visibility doesn't cross Bazel target boundaries (each
+`kt_jvm_library`/`kt_jvm_test` is a separate module).
 
-**Fix**: Change visibility from `private` to `internal` so the test can
-import the production implementation directly.
+**Fix**: Move `matchesMasked` to a shared utility in a common target that
+both `stf_runner` and `StfParserTest` depend on, or merge the test into the
+same target.
 
 ---
 

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -191,6 +191,7 @@ corpus_test_suite(
         "table-entries-range-bmv2",
         "table-entries-ser-enum-bmv2",
         "table-entries-ternary-bmv2",
+        "ternary2-bmv2",
         "test-parserinvalidargument-error-bmv2",
         "union-bmv2",
         "union-valid-bmv2",
@@ -275,7 +276,6 @@ corpus_test_suite(
     name = "other_stf_corpus_test",
     tags = ["manual"],
     tests = [
-        "ternary2-bmv2",  # per-table action specialization lost (single p4info action ID)
         "v1model-special-ops-bmv2",  # needs resubmit/recirculate
     ],
 )

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -91,7 +91,9 @@ class StfRunner(private val simulatorBinary: Path, private val pipelineConfigPat
           failures += "expected packet on port ${expected.port} but got none"
         } else {
           val actual = outputQueue.removeAt(idx)
-          if (!actual.payload.matchesMasked(expected.payload, expected.mask)) {
+          if (
+            !actual.payload.matchesMasked(expected.payload, expected.mask, expected.exactLength)
+          ) {
             failures +=
               "port ${expected.port}: payload mismatch\n" +
                 "  expected: ${expected.payload.hex(expected.mask)}\n" +
@@ -230,11 +232,13 @@ data class StfFile(
           }
           "expect" -> {
             val port = tokens[1].toInt()
-            // "$" marks end-of-packet (length assertion); our runner already does exact-length
-            // comparison, so strip it. It can appear standalone or appended to the last byte.
-            val hexStr = tokens.drop(2).joinToString("").replace("$", "")
+            val raw = tokens.drop(2).joinToString("")
+            // "$" marks end-of-packet: assert actual length == expected length.
+            // Without "$", trailing bytes in actual are ignored (BMv2 semantics).
+            val exactLength = raw.contains('$')
+            val hexStr = raw.replace("$", "")
             val (payload, mask) = decodeExpect(hexStr)
-            expects += StfExpectedOutput(port, payload, mask)
+            expects += StfExpectedOutput(port, payload, mask, exactLength)
           }
           "add" -> tableEntries += parseAdd(tokens.drop(1))
           "setdefault" -> tableEntries += parseSetDefault(tokens.drop(1))
@@ -613,6 +617,13 @@ private fun writeEntryRequest(
     .setUpdate(P4RuntimeOuterClass.Update.newBuilder().setType(type).setEntity(entity))
     .build()
 
+/** Returns a bit-precise hex mask for the given bitwidth (e.g. 9 → "0x01FF", 16 → "0xFFFF"). */
+private fun allOnesMask(bitwidth: Int): String {
+  val byteLen = (bitwidth + 7) / 8
+  val value = BigInteger.ONE.shiftLeft(bitwidth).subtract(BigInteger.ONE)
+  return "0x" + value.toString(16).padStart(byteLen * 2, '0')
+}
+
 private fun findTable(name: String, p4info: P4InfoOuterClass.P4Info): P4InfoOuterClass.Table =
   p4info.tablesList.find { it.preamble.alias == name || it.preamble.name == name }
     ?: p4info.tablesList.find { it.preamble.name.endsWith(".$name") }
@@ -648,24 +659,39 @@ private fun resolveStfMatchField(
       }
       ?: error("unknown match field '${m.fieldName}' in table '$tableName'")
   val fmBuilder = P4RuntimeOuterClass.FieldMatch.newBuilder().setFieldId(mf.id)
-  when (m.kind) {
-    MatchKind.EXACT ->
-      fmBuilder.setExact(
-        P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
-          .setValue(encodeValue(m.value, mf.bitwidth))
-      )
-    MatchKind.LPM ->
+  val encodedValue = encodeValue(m.value, mf.bitwidth)
+
+  // BMv2 STF values without wildcards parse as EXACT, but the table's
+  // match_type may differ.  Promote to the p4info type so that
+  // priority-based scoring (ternary/range) and optional semantics work.
+  val p4infoType = mf.matchType
+  when {
+    m.kind == MatchKind.LPM ->
       fmBuilder.setLpm(
         P4RuntimeOuterClass.FieldMatch.LPM.newBuilder()
-          .setValue(encodeValue(m.value, mf.bitwidth))
+          .setValue(encodedValue)
           .setPrefixLen(m.prefixLen!!)
       )
-    MatchKind.TERNARY ->
+    m.kind == MatchKind.TERNARY ||
+      (m.kind == MatchKind.EXACT &&
+        p4infoType == P4InfoOuterClass.MatchField.MatchType.TERNARY) -> {
+      val mask = m.mask ?: allOnesMask(mf.bitwidth)
       fmBuilder.setTernary(
         P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
-          .setValue(encodeValue(m.value, mf.bitwidth))
-          .setMask(encodeValue(m.mask!!, mf.bitwidth))
+          .setValue(encodedValue)
+          .setMask(encodeValue(mask, mf.bitwidth))
       )
+    }
+    m.kind == MatchKind.EXACT && p4infoType == P4InfoOuterClass.MatchField.MatchType.RANGE ->
+      fmBuilder.setRange(
+        P4RuntimeOuterClass.FieldMatch.Range.newBuilder().setLow(encodedValue).setHigh(encodedValue)
+      )
+    m.kind == MatchKind.EXACT && p4infoType == P4InfoOuterClass.MatchField.MatchType.OPTIONAL ->
+      fmBuilder.setOptional(
+        P4RuntimeOuterClass.FieldMatch.Optional.newBuilder().setValue(encodedValue)
+      )
+    else ->
+      fmBuilder.setExact(P4RuntimeOuterClass.FieldMatch.Exact.newBuilder().setValue(encodedValue))
   }
   return fmBuilder.build()
 }
@@ -708,7 +734,12 @@ fun encodeValue(raw: String, bitwidth: Int): ByteString {
 
 data class StfPacket(val ingressPort: Int, val payload: ByteArray)
 
-class StfExpectedOutput(val port: Int, val payload: ByteArray, val mask: ByteArray)
+class StfExpectedOutput(
+  val port: Int,
+  val payload: ByteArray,
+  val mask: ByteArray,
+  val exactLength: Boolean = false,
+)
 
 /** A parsed table directive (`add` or `setdefault`), before p4info resolution. */
 sealed interface StfTableDirective {
@@ -873,10 +904,20 @@ private fun decodeExpect(hexStr: String): Pair<ByteArray, ByteArray> {
   return payload to mask
 }
 
-/** Returns true iff every non-wildcard byte (mask != 0) matches expected. */
-private fun ByteArray.matchesMasked(expected: ByteArray, mask: ByteArray): Boolean {
-  if (size != expected.size) return false
-  return indices.all { i ->
+/**
+ * Returns true iff every non-wildcard byte (mask != 0) matches expected.
+ *
+ * When [exactLength] is true, actual and expected must have the same length. When false, actual may
+ * be longer — trailing bytes are ignored (BMv2 STF semantics for expects without a trailing `$`).
+ */
+private fun ByteArray.matchesMasked(
+  expected: ByteArray,
+  mask: ByteArray,
+  exactLength: Boolean,
+): Boolean {
+  if (exactLength && size != expected.size) return false
+  if (size < expected.size) return false
+  return expected.indices.all { i ->
     (this[i].toInt() and mask[i].toInt()) == (expected[i].toInt() and mask[i].toInt())
   }
 }

--- a/e2e_tests/stf/StfParserTest.kt
+++ b/e2e_tests/stf/StfParserTest.kt
@@ -574,12 +574,17 @@ class StfParserTest {
   }
 
   // ---------------------------------------------------------------------------
-  // matchesMasked (via expect parsing + manual comparison)
+  // matchesMasked — mirrors the private function in Runner.kt
   // ---------------------------------------------------------------------------
 
-  private fun ByteArray.matchesMasked(expected: ByteArray, mask: ByteArray): Boolean {
-    if (size != expected.size) return false
-    return indices.all { i ->
+  private fun ByteArray.matchesMasked(
+    expected: ByteArray,
+    mask: ByteArray,
+    exactLength: Boolean = true,
+  ): Boolean {
+    if (exactLength && size != expected.size) return false
+    if (size < expected.size) return false
+    return expected.indices.all { i ->
       (this[i].toInt() and mask[i].toInt()) == (expected[i].toInt() and mask[i].toInt())
     }
   }
@@ -589,7 +594,7 @@ class StfParserTest {
     val actual = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val expected = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val mask = byteArrayOf(0xFF.toByte(), 0xFF.toByte())
-    assertTrue(actual.matchesMasked(expected, mask))
+    assertTrue(actual.matchesMasked(expected, mask, exactLength = true))
   }
 
   @Test
@@ -597,7 +602,7 @@ class StfParserTest {
     val actual = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val expected = byteArrayOf(0xAA.toByte(), 0xCC.toByte())
     val mask = byteArrayOf(0xFF.toByte(), 0xFF.toByte())
-    assertTrue(!actual.matchesMasked(expected, mask))
+    assertTrue(!actual.matchesMasked(expected, mask, exactLength = true))
   }
 
   @Test
@@ -605,7 +610,7 @@ class StfParserTest {
     val actual = byteArrayOf(0xDE.toByte(), 0xAD.toByte())
     val expected = byteArrayOf(0x00, 0x00)
     val mask = byteArrayOf(0x00, 0x00)
-    assertTrue(actual.matchesMasked(expected, mask))
+    assertTrue(actual.matchesMasked(expected, mask, exactLength = true))
   }
 
   @Test
@@ -613,14 +618,53 @@ class StfParserTest {
     val actual = byteArrayOf(0xFF.toByte(), 0xBB.toByte())
     val expected = byteArrayOf(0x00, 0xBB.toByte())
     val mask = byteArrayOf(0x00, 0xFF.toByte()) // first byte is wildcard
-    assertTrue(actual.matchesMasked(expected, mask))
+    assertTrue(actual.matchesMasked(expected, mask, exactLength = true))
   }
 
   @Test
-  fun `matchesMasked length mismatch is never equal`() {
+  fun `matchesMasked actual shorter than expected always fails`() {
     val actual = byteArrayOf(0xAA.toByte())
     val expected = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val mask = byteArrayOf(0xFF.toByte(), 0xFF.toByte())
-    assertTrue(!actual.matchesMasked(expected, mask))
+    assertTrue(!actual.matchesMasked(expected, mask, exactLength = true))
+    assertTrue(!actual.matchesMasked(expected, mask, exactLength = false))
+  }
+
+  @Test
+  fun `matchesMasked prefix mode allows longer actual`() {
+    val actual = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte())
+    val expected = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
+    val mask = byteArrayOf(0xFF.toByte(), 0xFF.toByte())
+    // exactLength=true: mismatch (lengths differ)
+    assertTrue(!actual.matchesMasked(expected, mask, exactLength = true))
+    // exactLength=false: matches on the prefix
+    assertTrue(actual.matchesMasked(expected, mask, exactLength = false))
+  }
+
+  @Test
+  fun `matchesMasked prefix mode still checks content`() {
+    val actual = byteArrayOf(0xAA.toByte(), 0xFF.toByte(), 0xCC.toByte())
+    val expected = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
+    val mask = byteArrayOf(0xFF.toByte(), 0xFF.toByte())
+    // Second byte differs, so even in prefix mode it should fail
+    assertTrue(!actual.matchesMasked(expected, mask, exactLength = false))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Expect parsing: exactLength ($ marker)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `expect with dollar sign sets exactLength true`() {
+    val stf = parse("expect 1 AABB$")
+    assertEquals(1, stf.expects.size)
+    assertTrue(stf.expects[0].exactLength)
+  }
+
+  @Test
+  fun `expect without dollar sign sets exactLength false`() {
+    val stf = parse("expect 1 AABB")
+    assertEquals(1, stf.expects.size)
+    assertTrue(!stf.expects[0].exactLength)
   }
 }

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -741,6 +741,19 @@ void FourWardBackend::emitTable(const IR::P4Table* table) {
     *tk->mutable_expr() = emitExpr(keyElem->expression);
     ++keyIdx;
   }
+
+  // Record per-table action specializations so the interpreter can resolve
+  // the correct midend copy when the p4info returns a single original name.
+  const auto* actionList = table->getActionList();
+  if (actionList) {
+    for (const auto* ale : actionList->actionList) {
+      auto id = ale->getName();
+      if (id.name != id.originalName) {
+        (*tb->mutable_action_overrides())[id.originalName.c_str()] =
+            id.name.c_str();
+      }
+    }
+  }
 }
 
 void FourWardBackend::emitArchitecture(const IR::ToplevelBlock* toplevel) {

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -656,15 +656,20 @@ class Interpreter(
         val member =
           result.members.find { it.memberId == forced }
             ?: error("forced member $forced not found in table $tableName")
-        execAction(member.actionName, member.params, env)
+        val resolvedMember =
+          tableBehavior.actionOverridesMap[member.actionName] ?: member.actionName
+        execAction(resolvedMember, member.params, env)
         return TableResult(result.hit, member.actionName)
       }
       // First encounter: throw to let the architecture build the trace tree.
       throw ActionSelectorFork(tableName, result.members, packetCtx!!.getEvents())
     }
 
+    // Resolve per-table action specialization: the p4info uses original names,
+    // but the midend may have created per-table copies with distinct bodies.
+    val resolvedName = tableBehavior.actionOverridesMap[result.actionName] ?: result.actionName
     val params = result.entry?.action?.action?.paramsList ?: result.actionParams
-    execAction(result.actionName, params, env)
+    execAction(resolvedName, params, env)
     return TableResult(result.hit, result.actionName)
   }
 

--- a/simulator/InterpreterControlTest.kt
+++ b/simulator/InterpreterControlTest.kt
@@ -10,6 +10,7 @@ import fourward.ir.v1.Expr
 import fourward.ir.v1.FieldAccess
 import fourward.ir.v1.IfStmt
 import fourward.ir.v1.Literal
+import fourward.ir.v1.MethodCallStmt
 import fourward.ir.v1.NameRef
 import fourward.ir.v1.P4BehavioralConfig
 import fourward.ir.v1.Stmt
@@ -412,5 +413,67 @@ class InterpreterControlTest {
       )
       .runControl("MyControl", env)
     assertEquals(BitVal(2, 8), env.lookup("x"))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-table action override resolution
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Config with table "t" having action_overrides "setbyte" → "setbyte_1". The first copy
+   * ("setbyte") sets x=1; the second copy ("setbyte_1") sets x=2.
+   */
+  private fun actionOverrideConfig(controlBody: Stmt): P4BehavioralConfig =
+    P4BehavioralConfig.newBuilder()
+      .addTables(TableBehavior.newBuilder().setName("t").putActionOverrides("setbyte", "setbyte_1"))
+      .addActions(ActionDecl.newBuilder().setName("setbyte").addBody(assign("x", bit(1, 8))))
+      .addActions(
+        ActionDecl.newBuilder()
+          .setName("setbyte")
+          .setCurrentName("setbyte_1")
+          .addBody(assign("x", bit(2, 8)))
+      )
+      .addControls(ControlDecl.newBuilder().setName("MyControl").addApplyBody(controlBody))
+      .build()
+
+  @Test
+  fun `action override resolves per-table specialized copy`() {
+    // The p4info returns "setbyte" for all tables, but action_overrides maps it
+    // to "setbyte_1" for table "t", so setbyte_1's body should execute (x=2).
+    val ts = TableStore().also { it.setForcedHit("t", "setbyte") }
+    val applyTable =
+      Stmt.newBuilder()
+        .setMethodCall(
+          MethodCallStmt.newBuilder()
+            .setCall(Expr.newBuilder().setTableApply(TableApplyExpr.newBuilder().setTableName("t")))
+        )
+        .build()
+    val env = emptyEnv
+    env.define("x", BitVal(0, 8))
+    interp(actionOverrideConfig(applyTable), ts).runControl("MyControl", env)
+    assertEquals(BitVal(2, 8), env.lookup("x"))
+  }
+
+  @Test
+  fun `action override returns original name for switch matching`() {
+    // The override resolves to "setbyte_1" for execution, but the switch
+    // statement should match on the original name "setbyte".
+    val ts = TableStore().also { it.setForcedHit("t", "setbyte") }
+    val config =
+      actionOverrideConfig(
+        switchOn(
+          "t",
+          mapOf("setbyte" to listOf(assign("y", bit(10, 8)))),
+          listOf(assign("y", bit(20, 8))),
+        )
+      )
+    val env = emptyEnv
+    env.define("x", BitVal(0, 8))
+    env.define("y", BitVal(0, 8))
+    interp(config, ts).runControl("MyControl", env)
+    // The override executed setbyte_1's body (x=2)
+    assertEquals(BitVal(2, 8), env.lookup("x"))
+    // The switch matched on the original name "setbyte" (y=10, not default 20)
+    assertEquals(BitVal(10, 8), env.lookup("y"))
   }
 }

--- a/simulator/ir.proto
+++ b/simulator/ir.proto
@@ -286,6 +286,12 @@ message TableBehavior {
   // In the same order as p4info match_fields. The simulator evaluates each
   // expression to produce the lookup key.
   repeated TableKey keys = 2;
+
+  // Maps original action name → midend-specialized name for this table.
+  // When p4c duplicates an action for per-table specialization (e.g.
+  // "setbyte" → "setbyte_1"), the p4info still uses the single original
+  // action ID. This map lets the interpreter resolve the correct copy.
+  map<string, string> action_overrides = 3;
 }
 
 message TableKey {


### PR DESCRIPTION
## Summary

When p4c's midend duplicates an action for per-table specialization (e.g. `setbyte` → `setbyte_1`), the p4info retains a single action ID. Without a per-table mapping, the interpreter always executed the first copy regardless of which table matched — breaking `ternary2-bmv2` which uses `setbyte` across 4 tables with different `out` parameter bindings.

- **New `action_overrides` proto field** on `TableBehavior`: maps original action name → midend-specialized name per table
- **Backend** populates overrides in `emitTable()` when an action's midend name differs from its original
- **Interpreter** resolves the override before executing, returning the original name for switch-case matching
- **STF runner fixes**: match-kind promotion (EXACT values in ternary/range/optional tables now promoted to the p4info type), bit-precise `allOnesMask`, and `$`-based exact-length matching for expects

## Test plan

- [x] `ternary2-bmv2` promoted from manual to passing suite
- [x] Unit tests for action override resolution (executes correct body, returns original name for switch matching)
- [x] Unit tests for `matchesMasked` prefix-length and exact-length semantics
- [x] Unit tests for `$` marker parsing in STF expects
- [x] `bazel test //...` — all 30 tests pass
- [x] `./format.sh` and `./lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)