### PR TITLE
docs: call out CI speed and reliability in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ daily progress.
 **CAUTION:** We will aggressively refactor to build the best system we can;
 nothing is sacred except correctness and the test suite — until we reach 1.0.
 
+## CI that has your back
+
+We think fast, reliable CI is key to keeping developers happy and productive.
+
+Every PR gets built, linted, and tested on both Ubuntu and macOS in about
+2 minutes — with a differential coverage report in about 5. No flakes, no
+"works on my machine." See for yourself on the
+[BuildBuddy dashboard](https://4ward.buildbuddy.io/trends/).
+
 ## Documentation
 
 | Document | Purpose |


### PR DESCRIPTION
## Summary

- Adds a "CI that has your back" section to the README, between "Where things stand" and "Documentation"
- Calls out real CI timing (~2 min build/lint/test, ~5 min with coverage) as a project differentiator
- Links to the public [BuildBuddy dashboard](https://4ward.buildbuddy.io/trends/) so readers can verify

## Motivation

Fast, reliable CI is a core value of this project but was invisible in the README — just a badge. This makes it a first-class callout for contributors and evaluators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)