### PR TITLE
docs: refresh README and spec links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ implementations.
 
 4ward is a spec-compliant reference implementation. The authoritative source
 for language semantics is the
-[P4₁₆ Language Specification (v1.2.5)](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html).
+[P4₁₆ Language Specification](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html).
 **When in doubt, consult the spec.** If the spec is ambiguous, follow p4c's
 behaviour and document the ambiguity with a comment citing the relevant spec
 section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ tree. Rebase and squash when merging back.
 
 4ward is a spec-compliant reference implementation. When implementing a
 feature or resolving an ambiguity, consult:
-- [P4₁₆ Language Specification (v1.2.5)](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html)
+- [P4₁₆ Language Specification](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html)
   — the language spec. Cite section numbers in comments on non-obvious semantics.
 - [BMv2 simple_switch documentation](https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md)
   — the de facto spec for v1model architecture semantics (clone/resubmit/recirculate

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ branch — delivered as a structured trace tree you can actually read.
 
 ## Why 4ward?
 
+4ward is a **spec-compliant reference implementation** of the
+[P4₁₆ language](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html)
+and [P4Runtime](https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.html),
+optimised for **correctness, observability, and extensibility** rather than
+performance. Think of it as a debugger that speaks P4, not a production data
+plane.
+
 | | Real hardware | BMv2 | **4ward** |
 |---|---|---|---|
 | Runs P4 programs | sure | sure | **yep** |
@@ -47,14 +54,9 @@ branch — delivered as a structured trace tree you can actually read.
 | Simple, readable codebase | ehh | ehh | **yes!** |
 | Fast, rigorous CI | nope | slow | **[~2 min](https://4ward.buildbuddy.io/trends/)** |
 
-4ward is a **spec-compliant reference implementation** of the
-[P4₁₆ language](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html),
-optimised for **correctness and observability** rather than performance. Think of
-it as a debugger that speaks P4, not a production data plane.
-
 ## Quick start
 
-Tested on macOS and Ubuntu. You need [Bazel](https://bazel.build) 9+ (or just
+[Tested on](https://4ward.buildbuddy.io/tests/) macOS and Ubuntu. You need [Bazel](https://bazel.build) 9+ (or just
 grab [Bazelisk](https://github.com/bazelbuild/bazelisk) and forget about it)
 and a C++20 compiler for the p4c backend. Everything else is hermetic — Bazel
 handles it.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ want to hack on it, keep reading.
 ## Design goal: spec-compliant reference implementation
 
 4ward's primary goal is to be a faithful implementation of the
-[P4₁₆ language specification](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html).
+[P4₁₆ language specification](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html).
 Every language feature should behave exactly as the spec describes. When the
 spec is ambiguous, we follow p4c's reference compiler behaviour and document
 the ambiguity. When the spec is clear, we follow it — even if BMv2 or other

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Add new fields instead.
 ## On correctness
 
 4ward is a spec-compliant reference implementation: it should behave exactly as
-the [P4₁₆ spec](https://p4.org/wp-content/uploads/sites/53/2024/10/P4-16-spec-v1.2.5.html)
+the [P4₁₆ spec](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html)
 describes. When you're unsure about a language detail, check the spec. If the
 spec is ambiguous, follow p4c's behaviour and document the ambiguity in a
 comment citing the relevant section.


### PR DESCRIPTION
## Summary

- Move the "Why 4ward?" description text above the comparison table
- Add P4Runtime spec link alongside the P4₁₆ spec link
- Link "Tested on" to the [BuildBuddy test dashboard](https://4ward.buildbuddy.io/tests/)
- Update all P4₁₆ spec URLs (5 files) to the [working-draft permalink](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html) so they don't go stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)