### PR TITLE
docs: document missing P4Runtime entity types

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -35,6 +35,10 @@ guilt — just write it down so someone can find it later.
   not work correctly.
 - **Missing RPCs.** `GetForwardingPipelineConfig` and `Capabilities` return
   UNIMPLEMENTED.
+- **No counters, meters, or registers via P4Runtime.** These work via the
+  simulator protocol but cannot be managed through the gRPC server.
+- **No action profiles or groups via P4Runtime.** Action selector tables and
+  group management are not implemented.
 - **No digests, idle timeouts, or atomic write batches.**
 
 ## Simulator


### PR DESCRIPTION
## Summary

- Add counters/meters/registers and action profiles/groups to the P4Runtime
  limitations section — these work via the simulator protocol but aren't
  exposed through the gRPC server yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)