### PR TITLE
corpus: fix checksum tests via varbit field access + _with_payload externs

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -31,6 +31,8 @@ corpus_test_suite(
         "arith5-bmv2",
         "array-copy-bmv2",
         "bvec-hdr-bmv2",
+        "checksum-l4-bmv2",
+        "checksum1-bmv2",
         "checksum2-bmv2",
         "checksum3-bmv2",
         "constant-in-calculation-bmv2",
@@ -255,17 +257,6 @@ corpus_test_suite(
         "psa-top-level-assignments-bmv2",
         "psa-unicast-or-drop-bmv2",
         "psa-unicast-or-drop-corrected-bmv2",
-    ],
-)
-
-# Tests blocked on checksum/varbit extern support (verify_checksum_with_payload,
-# varbit field access by name).
-corpus_test_suite(
-    name = "checksum_stf_corpus_test",
-    tags = ["manual"],
-    tests = [
-        "checksum-l4-bmv2",
-        "checksum1-bmv2",
     ],
 )
 

--- a/simulator/BitVector.kt
+++ b/simulator/BitVector.kt
@@ -11,9 +11,14 @@ import java.math.BigInteger
 data class BitVector(val value: BigInteger, val width: Int) {
 
   init {
-    require(width > 0) { "width must be positive, got $width" }
+    // Width 0 is valid for varbit fields with no runtime data (e.g. IPv4 options when IHL=5).
+    require(width >= 0) { "width must be non-negative, got $width" }
     require(value >= BigInteger.ZERO) { "value must be non-negative, got $value" }
-    require(value < BigInteger.TWO.pow(width)) { "value $value does not fit in $width bits" }
+    if (width > 0) {
+      require(value < BigInteger.TWO.pow(width)) { "value $value does not fit in $width bits" }
+    } else {
+      require(value == BigInteger.ZERO) { "zero-width BitVector must have value 0" }
+    }
   }
 
   // Arithmetic — all results are truncated to [width] bits.

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -94,6 +94,9 @@ class PacketContext(payload: ByteArray) {
   /** Returns all bytes not yet consumed by the parser (the un-parsed packet body). */
   fun drainRemainingInput(): ByteArray = buffer.readAll()
 
+  /** Peeks at remaining input bytes without consuming them. */
+  fun peekRemainingInput(): ByteArray = buffer.peekAll()
+
   // -------------------------------------------------------------------------
   // Clone
   // -------------------------------------------------------------------------
@@ -137,6 +140,9 @@ private class PacketBuffer(private val data: ByteArray) {
   fun remaining(): Int = data.size - offset
 
   fun readAll(): ByteArray = data.copyOfRange(offset, data.size).also { offset = data.size }
+
+  /** Returns all remaining bytes without advancing the cursor. */
+  fun peekAll(): ByteArray = data.copyOfRange(offset, data.size)
 
   fun read(count: Int): ByteArray {
     if (count > remaining()) {

--- a/simulator/Hash.kt
+++ b/simulator/Hash.kt
@@ -17,14 +17,12 @@ private fun concatFields(data: StructVal): BitVector? =
   data.fields.values.map { (it as BitVal).bits }.reduceOrNull { acc, bv -> acc.concat(bv) }
 
 /**
- * Ones' complement (csum16) checksum over the fields of a struct.
+ * Ones' complement (csum16) checksum over a bit vector.
  *
- * Concatenates all fields into a bit string, pads to a 16-bit boundary, sums all 16-bit words with
- * end-around carry, and returns the complement. This is the standard Internet checksum (RFC 1071)
- * used by IPv4, TCP, and UDP.
+ * Pads to a 16-bit boundary, sums all 16-bit words with end-around carry, and returns the
+ * complement. This is the standard Internet checksum (RFC 1071) used by IPv4, TCP, and UDP.
  */
-fun onesComplementChecksum(data: StructVal): BigInteger {
-  val combined = concatFields(data) ?: return BigInteger.ZERO
+private fun onesComplementChecksumBits(combined: BitVector): BigInteger {
   val totalWidth = combined.width
   val padded = ((totalWidth + CSUM_WORD_BITS - 1) / CSUM_WORD_BITS) * CSUM_WORD_BITS
   var bits = combined.value.shiftLeft(padded - totalWidth)
@@ -37,6 +35,12 @@ fun onesComplementChecksum(data: StructVal): BigInteger {
     sum = sum.and(CSUM_MASK).add(sum.shiftRight(CSUM_WORD_BITS))
   }
   return CSUM_MASK.subtract(sum)
+}
+
+/** Ones' complement (csum16) checksum over the fields of a struct. */
+fun onesComplementChecksum(data: StructVal): BigInteger {
+  val combined = concatFields(data) ?: return BigInteger.ZERO
+  return onesComplementChecksumBits(combined)
 }
 
 /**
@@ -73,17 +77,36 @@ private fun structToBytes(data: StructVal): ByteArray =
 /**
  * Computes a hash over [data] using the specified [algorithm].
  *
- * Supports csum16 (ones' complement), crc16, and crc32 — the algorithms used by BMv2's
+ * Supports csum16 (ones' complement), crc16, crc32, and identity — the algorithms used by BMv2's
  * simple_switch. Returns the raw hash value as a [BigInteger].
  */
 fun computeHash(algorithm: String, data: StructVal): BigInteger =
+  computeHashWithPayload(algorithm, data, ByteArray(0))
+
+/**
+ * Like [computeHash] but appends [payload] (the unparsed packet remainder) to the hash input.
+ *
+ * Used by the `_with_payload` checksum externs (v1model §14) which include the packet body beyond
+ * the parsed headers in the checksum computation.
+ */
+fun computeHashWithPayload(algorithm: String, data: StructVal, payload: ByteArray): BigInteger =
   when (algorithm) {
-    "csum16" -> onesComplementChecksum(data)
-    "crc16" -> BigInteger.valueOf(crc16(structToBytes(data)).toLong())
-    "crc32" -> BigInteger.valueOf(crc32(structToBytes(data)))
-    "identity" -> {
-      val bytes = structToBytes(data)
-      if (bytes.isEmpty()) BigInteger.ZERO else BigInteger(1, bytes)
+    "csum16" -> {
+      val fieldBits = concatFields(data)
+      val payloadBits =
+        if (payload.isNotEmpty()) BitVector(BigInteger(1, payload), payload.size * 8) else null
+      val combined =
+        listOfNotNull(fieldBits, payloadBits).reduceOrNull { a, b -> a.concat(b) }
+          ?: return BigInteger.ZERO
+      onesComplementChecksumBits(combined)
     }
-    else -> error("unsupported hash algorithm: $algorithm")
+    else -> {
+      val bytes = structToBytes(data) + payload
+      when (algorithm) {
+        "crc16" -> BigInteger.valueOf(crc16(bytes).toLong())
+        "crc32" -> BigInteger.valueOf(crc32(bytes))
+        "identity" -> if (bytes.isEmpty()) BigInteger.ZERO else BigInteger(1, bytes)
+        else -> error("unsupported hash algorithm: $algorithm")
+      }
+    }
   }

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -813,30 +813,37 @@ class Interpreter(
         packetCtx?.pendingCloneSessionId = sessionId
         UnitVal
       }
-      // verify_checksum(condition, data, checksum, algo): v1model §14.
-      // Computes hash over data fields and compares with checksum; sets
-      // standard_metadata.checksum_error = 1 on mismatch.
-      "verify_checksum" -> {
+      // verify_checksum[_with_payload](condition, data, checksum, algo): v1model §14.
+      // Computes hash over data fields (and optionally the unparsed packet body) and
+      // compares with checksum; sets standard_metadata.checksum_error = 1 on mismatch.
+      "verify_checksum",
+      "verify_checksum_with_payload" -> {
         val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
         if (condition) {
           val data = evalExpr(call.argsList[1], env) as StructVal
           val expected = evalExpr(call.argsList[2], env) as BitVal
           val algo = (evalExpr(call.argsList[3], env) as EnumVal).member
-          val computed = computeHash(algo, data)
+          val payload =
+            if (funcName.endsWith("_with_payload")) packet.peekRemainingInput() else ByteArray(0)
+          val computed = computeHashWithPayload(algo, data, payload)
           if (computed != expected.bits.value) {
             onChecksumError?.invoke()
           }
         }
         UnitVal
       }
-      // update_checksum(condition, data, checksum, algo): v1model §14.
-      // Computes hash over data fields and writes result into checksum (out param).
-      "update_checksum" -> {
+      // update_checksum[_with_payload](condition, data, checksum, algo): v1model §14.
+      // Computes hash over data fields (and optionally the unparsed packet body) and
+      // writes result into checksum (out param).
+      "update_checksum",
+      "update_checksum_with_payload" -> {
         val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
         if (condition) {
           val data = evalExpr(call.argsList[1], env) as StructVal
           val algo = (evalExpr(call.argsList[3], env) as EnumVal).member
-          val computed = computeHash(algo, data)
+          val payload =
+            if (funcName.endsWith("_with_payload")) packet.peekRemainingInput() else ByteArray(0)
+          val computed = computeHashWithPayload(algo, data, payload)
           val checksumWidth = call.argsList[2].type.bit.width
           setLValue(call.argsList[2], BitVal(BitVector(computed, checksumWidth)), env)
         }
@@ -969,7 +976,12 @@ class Interpreter(
     val result = mutableMapOf<String, Value>()
     var bitOffset = 0
     for ((field, width) in fields.zip(widths)) {
-      if (width == 0) continue
+      if (width == 0) {
+        // Zero-width varbit fields still need a map entry so checksum StructExprs
+        // can reference them (e.g. hdr.ipv4.options when IHL=5).
+        if (field.type.hasVarbit()) result[field.name] = BitVal(BitVector(BigInteger.ZERO, 0))
+        continue
+      }
       val mask = BigInteger.ONE.shiftLeft(width) - BigInteger.ONE
       val raw = (allBits shr (totalBits - bitOffset - width)) and mask
       result[field.name] = bitsToValue(field.type, raw, width)

--- a/simulator/InterpreterPacketTest.kt
+++ b/simulator/InterpreterPacketTest.kt
@@ -27,6 +27,7 @@ import fourward.ir.v1.P4BehavioralConfig
 import fourward.ir.v1.StructDecl
 import fourward.ir.v1.Type
 import fourward.ir.v1.TypeDecl
+import fourward.ir.v1.VarbitType
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -492,5 +493,83 @@ class InterpreterPacketTest {
     assertThrows(PacketTooShortException::class.java) {
       interp(pktCtx, type).evalExpr(advanceCall(16), env)
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // varbit extract with zero-length varbit field
+  // ---------------------------------------------------------------------------
+
+  private fun varbitType(maxWidth: Int): Type =
+    Type.newBuilder().setVarbit(VarbitType.newBuilder().setMaxWidth(maxWidth)).build()
+
+  /** Builds a header TypeDecl with a trailing varbit field. */
+  private fun headerTypeWithVarbit(
+    typeName: String,
+    fixedFields: List<Pair<String, Int>>,
+    varbitFieldName: String,
+    varbitMaxWidth: Int,
+  ): TypeDecl =
+    TypeDecl.newBuilder()
+      .setName(typeName)
+      .setHeader(
+        HeaderDecl.newBuilder().also { hdr ->
+          for ((name, width) in fixedFields) {
+            hdr.addFields(FieldDecl.newBuilder().setName(name).setType(bitType(width)))
+          }
+          hdr.addFields(
+            FieldDecl.newBuilder().setName(varbitFieldName).setType(varbitType(varbitMaxWidth))
+          )
+        }
+      )
+      .build()
+
+  /** Builds a 2-arg extract call: `pkt.extract(headerVarName, varbitBits)`. */
+  private fun varbitExtractCall(headerVarName: String, varbitBits: Int): Expr =
+    Expr.newBuilder()
+      .setMethodCall(
+        MethodCall.newBuilder()
+          .setTarget(nameRef("pkt"))
+          .setMethod("extract")
+          .addArgs(nameRef(headerVarName))
+          .addArgs(
+            Expr.newBuilder()
+              .setLiteral(Literal.newBuilder().setInteger(varbitBits.toLong()))
+              .setType(bitType(32))
+          )
+      )
+      .build()
+
+  @Test
+  fun `extract with zero-length varbit stores field as BitVal(0, 0)`() {
+    // Simplified IPv4-like header: 8-bit fixed field + varbit<320> options.
+    // When varbitBits=0, the varbit field should still exist in the header's fields map.
+    val type = headerTypeWithVarbit("ipv4_t", listOf("ihl" to 8), "options", 320)
+    val pktCtx = PacketContext(byteArrayOf(0x05))
+    val env = Environment()
+    val header = HeaderVal(typeName = "ipv4_t", valid = false)
+    env.define("hdr", header)
+
+    interp(pktCtx, type).evalExpr(varbitExtractCall("hdr", 0), env)
+
+    assertTrue(header.valid)
+    assertEquals(BitVal(5, 8), header.fields["ihl"])
+    // The varbit field must be present even with width 0.
+    assertEquals(BitVal(0, 0), header.fields["options"])
+  }
+
+  @Test
+  fun `extract with non-zero varbit stores field with correct width`() {
+    // 8-bit fixed + 16-bit varbit options.
+    val type = headerTypeWithVarbit("ipv4_t", listOf("ihl" to 8), "options", 320)
+    val pktCtx = PacketContext(byteArrayOf(0x06, 0xAB.toByte(), 0xCD.toByte()))
+    val env = Environment()
+    val header = HeaderVal(typeName = "ipv4_t", valid = false)
+    env.define("hdr", header)
+
+    interp(pktCtx, type).evalExpr(varbitExtractCall("hdr", 16), env)
+
+    assertTrue(header.valid)
+    assertEquals(BitVal(6, 8), header.fields["ihl"])
+    assertEquals(BitVal(0xABCD, 16), header.fields["options"])
   }
 }


### PR DESCRIPTION
## Summary

Unblocks **checksum1-bmv2** and **checksum-l4-bmv2**, bringing the corpus from 181 → 183 passing tests.

Two independent issues were preventing these tests from passing:

1. **Zero-width varbit fields were missing from the header fields map.** When `varbitBits=0` (e.g. IPv4 with IHL=5, no options), `unpackFields` skipped the varbit field entirely. Checksum `StructExpr`s that reference `hdr.ipv4.options` then fail with "field not found". Fix: store `BitVal(0, 0)` for zero-width varbit fields — `BitVector` now allows width 0, and `concat` is a no-op for zero-width values.

2. **`verify_checksum_with_payload` / `update_checksum_with_payload` weren't implemented.** These `_with_payload` variants are identical to the non-payload checksum externs but include the unparsed packet body in the hash. Fix: add `peekRemainingInput()` to `PacketContext` and `computeHashWithPayload()` to `Hash.kt`, with the non-payload `computeHash` delegating to avoid duplicating the algorithm dispatch.

## Test plan

- [x] New unit tests for zero-width and non-zero varbit extract
- [x] `bazel test //...` — 30/30 pass (183 corpus tests)
- [x] `tools/format.sh` clean
- [x] `tools/lint.sh` clean (detekt; clang-tidy N/A — no C++ changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)