### PR TITLE
docs: add runnable trace tree example with PRINT_TRACE flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ clones a packet and forwards the original and clone out of two different ports:
 
 ```sh
 bazel test //e2e_tests/trace_tree:golden_trace_tree_test \
-  --test_filter=clone_with_egress --test_output=all
+  --test_filter=clone_with_egress --test_output=all \
+  --test_env=PRINT_TRACE=1
 ```
 
-One packet goes in, two come out — here's the trace
+One packet goes in, two come out — here's what you'll see
 ([full version](e2e_tests/trace_tree/clone_with_egress.golden.txtpb)):
 
 ```protobuf
@@ -151,7 +152,7 @@ ergonomics (sealed classes, pattern matching).
 - **Rust?** Borrow checker is overkill — we don't need manual memory control.
 - **Go?** Weaker type system — no algebraic data types, no pattern matching.
 - **Python?** Weak type system, slow test execution.
-- **Java?** Kotlin, but worse. Verbose, no sealed `when`, no data classes.
+- **Java?** Kotlin, but worse.
 
 **You don't need to know Kotlin to contribute to 4ward!**
 [The AI writes the code](docs/AI_WORKFLOW.md) — you just need to know your

--- a/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
+++ b/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
@@ -53,6 +53,11 @@ class GoldenTraceTreeTest(private val testName: String) {
 
     val expected = loadGoldenTraceTree(goldenPath)
     val actual = captureTraceTree(r, configPath, stfPath)
+    if (System.getenv("PRINT_TRACE") != null) {
+      println("--- Trace tree for $testName ---")
+      print(TextFormat.printer().printToString(actual))
+      println("--- End trace tree ---")
+    }
     if (expected != actual) {
       fail(
         "Trace tree mismatch for $testName.\n" +


### PR DESCRIPTION
## Summary

- Add `PRINT_TRACE` env var to golden trace tree tests — when set, prints the
  actual trace tree to stdout so readers can see what 4ward produces
- Replace the old "See what your packets are up to" section with a real runnable
  example (`clone_with_egress`) that demonstrates the core value prop: one packet
  in, two branches out

## Test plan

- `bazel test //e2e_tests/trace_tree:golden_trace_tree_test` — all pass, no output
- Same with `--test_env=PRINT_TRACE=1 --test_output=all` — traces printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)