### PR TITLE
p4testgen: expand to 25 passing programs (batch 1)

### DIFF
--- a/e2e_tests/p4testgen/BUILD.bazel
+++ b/e2e_tests/p4testgen/BUILD.bazel
@@ -15,52 +15,57 @@ kt_jvm_library(
 # + Z3) on a P4 program from the p4c test corpus to generate test cases, then
 # runs them against the simulator.
 
-p4_testgen_test(
-    name = "flag_lost-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:flag_lost-bmv2.p4",
-)
+p4_testgen_test(name = "array-copy-bmv2")
+
+p4_testgen_test(name = "bvec-hdr-bmv2")
 
 p4_testgen_test(
-    name = "opassign1-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:opassign1-bmv2.p4",
+    name = "checksum1-bmv2",
+    tags = ["manual"],  # UnitVal→BitVal cast error in checksum extern
 )
 
-p4_testgen_test(
-    name = "gauntlet_nested_table_calls-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:gauntlet_nested_table_calls-bmv2.p4",
-)
+p4_testgen_test(name = "checksum2-bmv2")
 
-p4_testgen_test(
-    name = "issue2343-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:issue2343-bmv2.p4",
-)
+p4_testgen_test(name = "checksum3-bmv2")
 
-p4_testgen_test(
-    name = "gauntlet_exit_combination_1-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:gauntlet_exit_combination_1-bmv2.p4",
-)
+p4_testgen_test(name = "equality-bmv2")
 
-p4_testgen_test(
-    name = "gauntlet_exit_combination_2-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:gauntlet_exit_combination_2-bmv2.p4",
-)
+p4_testgen_test(name = "equality-varbit-bmv2")
 
-p4_testgen_test(
-    name = "gauntlet_action_mux-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:gauntlet_action_mux-bmv2.p4",
-)
+p4_testgen_test(name = "flag_lost-bmv2")
 
-p4_testgen_test(
-    name = "gauntlet_hdr_assign_1-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:gauntlet_hdr_assign_1-bmv2.p4",
-)
+p4_testgen_test(name = "gauntlet_action_mux-bmv2")
 
-p4_testgen_test(
-    name = "issue2170-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:issue2170-bmv2.p4",
-)
+p4_testgen_test(name = "gauntlet_exit_combination_1-bmv2")
 
-p4_testgen_test(
-    name = "issue2205-bmv2",
-    src_p4 = "@p4c//testdata/p4_16_samples:issue2205-bmv2.p4",
-)
+p4_testgen_test(name = "gauntlet_exit_combination_2-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_3-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_4-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_5-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_6-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_7-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_8-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_9-bmv2")
+
+p4_testgen_test(name = "gauntlet_hdr_assign_1-bmv2")
+
+p4_testgen_test(name = "gauntlet_nested_table_calls-bmv2")
+
+p4_testgen_test(name = "header-bool-bmv2")
+
+p4_testgen_test(name = "issue2170-bmv2")
+
+p4_testgen_test(name = "issue2205-bmv2")
+
+p4_testgen_test(name = "issue2343-bmv2")
+
+p4_testgen_test(name = "opassign1-bmv2")
+
+p4_testgen_test(name = "parser_error-bmv2")


### PR DESCRIPTION
## Summary

p4testgen coverage jumps from 10 → 25 passing programs with full symbolic path exploration.

**New programs (16):**
- **gauntlet_exit_combination 3-9** — completing the exit combination family (1 & 2 already passing)
- **8 standalone programs** — checksum2/3, bvec-hdr, equality, equality-varbit, array-copy, header-bool, parser_error

**Manual (1):** checksum1-bmv2 — hits a simulator bug (`UnitVal→BitVal` cast in checksum extern)

## Test plan

- [x] `bazel test //...` — 49 tests pass
- [x] All 15 new passing tests verified individually
- [x] checksum1 failure classified and tagged manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)