### PR TITLE
p4testgen: add include support and expand to 46 passing programs

### DIFF
--- a/e2e_tests/p4testgen.bzl
+++ b/e2e_tests/p4testgen.bzl
@@ -4,9 +4,12 @@ Usage in e2e_tests/p4testgen/BUILD.bazel:
 
     load("//e2e_tests:p4testgen.bzl", "p4_testgen_test")
 
+    p4_testgen_test(name = "opassign1-bmv2")
+
+    # For programs that #include skeleton headers:
     p4_testgen_test(
-        name = "opassign1-bmv2",
-        src_p4 = "@p4c//testdata/p4_16_samples:opassign1-bmv2.p4",
+        name = "arith1-bmv2",
+        includes = ["@p4c//testdata/p4_16_samples:arith-skeleton.p4"],
     )
 
 This creates:
@@ -23,11 +26,13 @@ def _p4testgen_stfs_impl(ctx):
     p4testgen = ctx.executable._p4testgen
 
     out_dir = ctx.actions.declare_directory(ctx.label.name)
+    include_flags = ["-I " + f.dirname for f in ctx.files.includes]
     args = " ".join([
         "--target bmv2 --arch v1model --test-backend stf",
         "--max-tests " + str(ctx.attr.max_tests),
         "--seed " + str(ctx.attr.seed),
         "-I " + ctx.file._core_p4.dirname,
+    ] + include_flags + [
         ctx.file.src_p4.path,
         "--out-dir " + out_dir.path,
     ])
@@ -45,7 +50,7 @@ def _p4testgen_stfs_impl(ctx):
             p4testgen = p4testgen.path,
             args = args,
         ),
-        inputs = [ctx.file.src_p4] + ctx.files._p4include,
+        inputs = [ctx.file.src_p4] + ctx.files._p4include + ctx.files.includes,
         outputs = [out_dir],
         tools = depset(
             direct = [p4testgen],
@@ -61,6 +66,7 @@ _p4testgen_stfs = rule(
     implementation = _p4testgen_stfs_impl,
     attrs = {
         "src_p4": attr.label(allow_single_file = [".p4"]),
+        "includes": attr.label_list(allow_files = [".p4"]),
         "max_tests": attr.int(default = 0),
         "seed": attr.int(default = 0),
         "_p4testgen": attr.label(
@@ -80,12 +86,14 @@ _p4testgen_stfs = rule(
     fragments = ["cpp"],
 )
 
-def p4_testgen_test(name, src_p4 = None, max_tests = 0, seed = 0, tags = []):
+def p4_testgen_test(name, src_p4 = None, includes = [], max_tests = 0, seed = 0, tags = []):
     """Generates p4testgen STF tests and runs them against the 4ward simulator.
 
     Args:
         name: base name; also used to derive the src_p4 filename.
         src_p4: P4 source file (default: @p4c//testdata/p4_16_samples:<name>.p4).
+        includes: extra P4 file labels needed as #include dependencies (e.g.
+                  skeleton headers). Their directory is added to the include path.
         max_tests: upper bound on STF tests to generate (default: 0 = unlimited).
                    p4testgen explores paths until exhausted or the limit is hit.
         seed: random seed for p4testgen's path exploration (default: 0).
@@ -101,17 +109,20 @@ def p4_testgen_test(name, src_p4 = None, max_tests = 0, seed = 0, tags = []):
     _p4testgen_stfs(
         name = stfs_name,
         src_p4 = src_p4,
+        includes = includes,
         max_tests = max_tests,
         seed = seed,
         tags = tags,
     )
 
+    include_flags = "".join([" -I $$(dirname $(execpath " + inc + "))" for inc in includes])
+
     # Compile P4 → PipelineConfig txtpb (same as corpus.bzl).
     native.genrule(
         name = pb_name,
-        srcs = [src_p4],
+        srcs = [src_p4] + includes,
         outs = [name + ".txtpb"],
-        cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
+        cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flags + " -o $@ $(execpath " + src_p4 + ")",
         tools = [
             "//p4c_backend:p4c-4ward",
             "@p4c//:core_p4",

--- a/e2e_tests/p4testgen/BUILD.bazel
+++ b/e2e_tests/p4testgen/BUILD.bazel
@@ -15,6 +15,50 @@ kt_jvm_library(
 # + Z3) on a P4 program from the p4c test corpus to generate test cases, then
 # runs them against the simulator.
 
+_ARITH_SKELETON = ["@p4c//testdata/p4_16_samples:arith-skeleton.p4"]
+
+_ARITH_INLINE_SKELETON = ["@p4c//testdata/p4_16_samples:arith-inline-skeleton.p4"]
+
+p4_testgen_test(
+    name = "arith-bmv2",
+    includes = _ARITH_SKELETON,
+)
+
+p4_testgen_test(
+    name = "arith-inline-bmv2",
+    includes = _ARITH_INLINE_SKELETON,
+)
+
+p4_testgen_test(
+    name = "arith1-bmv2",
+    includes = _ARITH_SKELETON,
+)
+
+p4_testgen_test(
+    name = "arith2-bmv2",
+    includes = _ARITH_SKELETON,
+)
+
+p4_testgen_test(
+    name = "arith2-inline-bmv2",
+    includes = _ARITH_INLINE_SKELETON,
+)
+
+p4_testgen_test(
+    name = "arith3-bmv2",
+    includes = _ARITH_SKELETON,
+)
+
+p4_testgen_test(
+    name = "arith4-bmv2",
+    includes = _ARITH_SKELETON,
+)
+
+p4_testgen_test(
+    name = "arith5-bmv2",
+    includes = _ARITH_SKELETON,
+)
+
 p4_testgen_test(name = "array-copy-bmv2")
 
 p4_testgen_test(name = "bvec-hdr-bmv2")
@@ -53,6 +97,32 @@ p4_testgen_test(name = "gauntlet_exit_combination_7-bmv2")
 p4_testgen_test(name = "gauntlet_exit_combination_8-bmv2")
 
 p4_testgen_test(name = "gauntlet_exit_combination_9-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_10-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_11-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_13-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_14-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_15-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_16-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_17-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_18-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_19-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_20-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_21-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_22-bmv2")
+
+p4_testgen_test(name = "gauntlet_exit_combination_23-bmv2")
 
 p4_testgen_test(name = "gauntlet_hdr_assign_1-bmv2")
 


### PR DESCRIPTION
## Summary

p4testgen grows from 25 → 46 passing programs (4.6x the original 10).

Two wins in one PR:

1. **`includes` parameter for `p4_testgen_test`** — mirrors the `corpus.bzl` pattern so
   programs that `#include` skeleton headers can be tested. Unlocks an entire
   category of programs that was previously inaccessible.

2. **21 new programs**, all passing full symbolic path exploration:
   - **arith family (8)**: arith, arith-inline, arith1-5, arith2-inline — all using
     the new includes support
   - **gauntlet_exit_combination 10-23 (13)**: completes the full family (12 doesn't
     exist upstream)

## Test plan

- [x] `bazel test //...` — 70 tests pass
- [x] All 21 new p4testgen tests verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)