### PR TITLE
p4runtime: GetForwardingPipelineConfig, Capabilities, and Read filtering

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -29,16 +29,14 @@ guilt — just write it down so someone can find it later.
 
 - **Single controller only.** No multi-controller arbitration or election ID
   tracking. The first connection is master unconditionally.
-- **Wildcard reads only.** `Read` returns all table entries regardless of the
-  request's entity filter. Per-table and per-entry reads are not implemented.
+- **No per-entry reads.** `Read` supports wildcard (all tables) and per-table
+  filtering, but not per-entry reads with specific match keys.
 - **No p4-constraints validation.** `Write` does not enforce `@entry_restriction`
   or `@action_restriction` annotations from the P4 source.
 - **`@p4runtime_translation`: `sdn_bitwidth` only.** Bitwidth-based translation
   (e.g. 9-bit port → 32-bit SDN) is implemented. String-based translation
   (`sdn_string`) is not — SAI P4 programs that translate IDs to strings will
   not work correctly.
-- **Missing RPCs.** `GetForwardingPipelineConfig` and `Capabilities` return
-  UNIMPLEMENTED.
 - **No counters, meters, or registers via P4Runtime.** These work via the
   simulator protocol but cannot be managed through the gRPC server.
 - **No action profiles or groups via P4Runtime.** Action selector tables and

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -8,11 +8,14 @@ import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
 import io.grpc.Status
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.ReadRequest
 
 /**
  * P4Runtime conformance tests.
@@ -205,5 +208,79 @@ class P4RuntimeConformanceTest {
       assertEquals(com.google.protobuf.ByteString.copyFrom(payload1), pkt1.packet.payload)
       assertEquals(com.google.protobuf.ByteString.copyFrom(payload2), pkt2.packet.payload)
     }
+  }
+
+  // =========================================================================
+  // GetForwardingPipelineConfig (scenarios 16-18)
+  // =========================================================================
+
+  @Test
+  fun `16 - getForwardingPipelineConfig returns loaded p4info`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val resp = harness.getConfig()
+    assertEquals(config.p4Info, resp.config.p4Info)
+  }
+
+  @Test
+  fun `17 - getForwardingPipelineConfig without pipeline returns error`() {
+    assertGrpcError(Status.Code.FAILED_PRECONDITION) { harness.getConfig() }
+  }
+
+  @Test
+  fun `18 - getForwardingPipelineConfig P4INFO_AND_COOKIE omits device config`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val resp = harness.getConfig(GetForwardingPipelineConfigRequest.ResponseType.P4INFO_AND_COOKIE)
+    assertTrue("p4info should be present", resp.config.hasP4Info())
+    assertTrue("device config should be empty", resp.config.p4DeviceConfig.isEmpty)
+  }
+
+  // =========================================================================
+  // Capabilities (scenario 19)
+  // =========================================================================
+
+  @Test
+  fun `19 - capabilities returns API version`() {
+    val resp = harness.capabilities()
+    assertEquals("1.5.0", resp.p4RuntimeApiVersion)
+  }
+
+  // =========================================================================
+  // Read filtering (scenarios 20-21)
+  // =========================================================================
+
+  @Test
+  fun `20 - read with table filter returns only matching entries`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    harness.installEntry(buildExactEntry(config, matchValue = 0x0800, port = 1))
+
+    val tableId = config.p4Info.tablesList.first().preamble.id
+    assertEquals("matching table ID", 1, harness.readTableEntries(tableId).size)
+    assertTrue("non-matching table ID", harness.readTableEntries(99999).isEmpty())
+  }
+
+  @Test
+  fun `21 - read with empty entity filter returns nothing`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    harness.installEntry(buildExactEntry(config, matchValue = 0x0800, port = 1))
+
+    // P4Runtime spec §11.1: empty entity list = no filters = no results.
+    val request = ReadRequest.newBuilder().setDeviceId(1).build()
+    assertTrue("empty filter should return nothing", harness.readEntries(request).isEmpty())
+  }
+
+  // =========================================================================
+  // GetForwardingPipelineConfig response types (scenario 22)
+  // =========================================================================
+
+  @Test
+  fun `22 - getForwardingPipelineConfig DEVICE_CONFIG_AND_COOKIE omits p4info`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val resp =
+      harness.getConfig(GetForwardingPipelineConfigRequest.ResponseType.DEVICE_CONFIG_AND_COOKIE)
+    assertFalse("p4info should be absent", resp.config.hasP4Info())
+    assertFalse("device config should be present", resp.config.p4DeviceConfig.isEmpty)
   }
 }

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.flow
 import p4.v1.P4RuntimeGrpcKt
 import p4.v1.P4RuntimeOuterClass.CapabilitiesRequest
 import p4.v1.P4RuntimeOuterClass.CapabilitiesResponse
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
 import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigRequest
 import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigResponse
 import p4.v1.P4RuntimeOuterClass.MasterArbitrationUpdate
@@ -41,14 +42,12 @@ class P4RuntimeService(private val simulator: Simulator) :
   @Volatile private var currentConfig: PipelineConfig? = null
   @Volatile private var typeTranslator: TypeTranslator? = null
 
-  private fun requirePipeline() {
-    if (currentConfig == null) {
-      throw Status.FAILED_PRECONDITION.withDescription(
+  private fun requirePipeline(): PipelineConfig =
+    currentConfig
+      ?: throw Status.FAILED_PRECONDITION.withDescription(
           "No pipeline loaded; call SetForwardingPipelineConfig first"
         )
         .asException()
-    }
-  }
 
   // ---------------------------------------------------------------------------
   // SetForwardingPipelineConfig
@@ -238,21 +237,42 @@ class P4RuntimeService(private val simulator: Simulator) :
   override suspend fun getForwardingPipelineConfig(
     request: GetForwardingPipelineConfigRequest
   ): GetForwardingPipelineConfigResponse {
-    throw Status.UNIMPLEMENTED.withDescription("GetForwardingPipelineConfig not yet implemented")
-      .asException()
+    val config = requirePipeline()
+
+    val fwdConfig = ForwardingPipelineConfig.newBuilder()
+    when (request.responseType) {
+      GetForwardingPipelineConfigRequest.ResponseType.ALL,
+      GetForwardingPipelineConfigRequest.ResponseType.UNRECOGNIZED -> {
+        fwdConfig.setP4Info(config.p4Info)
+        fwdConfig.setP4DeviceConfig(config.behavioral.toByteString())
+      }
+      GetForwardingPipelineConfigRequest.ResponseType.COOKIE_ONLY -> {
+        // No cookie support — return empty config.
+      }
+      GetForwardingPipelineConfigRequest.ResponseType.P4INFO_AND_COOKIE -> {
+        fwdConfig.setP4Info(config.p4Info)
+      }
+      GetForwardingPipelineConfigRequest.ResponseType.DEVICE_CONFIG_AND_COOKIE -> {
+        fwdConfig.setP4DeviceConfig(config.behavioral.toByteString())
+      }
+    }
+
+    return GetForwardingPipelineConfigResponse.newBuilder().setConfig(fwdConfig).build()
   }
 
   // ---------------------------------------------------------------------------
   // Capabilities
   // ---------------------------------------------------------------------------
 
-  override suspend fun capabilities(request: CapabilitiesRequest): CapabilitiesResponse {
-    throw Status.UNIMPLEMENTED.withDescription("Capabilities not yet implemented").asException()
-  }
+  override suspend fun capabilities(request: CapabilitiesRequest): CapabilitiesResponse =
+    CapabilitiesResponse.newBuilder().setP4RuntimeApiVersion(P4RUNTIME_API_VERSION).build()
 
   companion object {
     // Well-known metadata IDs for v1model packet_in/packet_out headers.
     private const val INGRESS_PORT_METADATA_ID = 1
     private const val EGRESS_PORT_METADATA_ID = 2
+
+    // Matches the p4runtime proto version declared in MODULE.bazel.
+    private const val P4RUNTIME_API_VERSION = "1.5.0"
   }
 }

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -20,8 +20,12 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import p4.v1.P4RuntimeGrpcKt.P4RuntimeCoroutineStub
+import p4.v1.P4RuntimeOuterClass.CapabilitiesRequest
+import p4.v1.P4RuntimeOuterClass.CapabilitiesResponse
 import p4.v1.P4RuntimeOuterClass.Entity
 import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigResponse
 import p4.v1.P4RuntimeOuterClass.MasterArbitrationUpdate
 import p4.v1.P4RuntimeOuterClass.PacketOut
 import p4.v1.P4RuntimeOuterClass.ReadRequest
@@ -29,6 +33,7 @@ import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
 import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigResponse
 import p4.v1.P4RuntimeOuterClass.StreamMessageRequest
 import p4.v1.P4RuntimeOuterClass.StreamMessageResponse
+import p4.v1.P4RuntimeOuterClass.TableEntry
 import p4.v1.P4RuntimeOuterClass.Uint128
 import p4.v1.P4RuntimeOuterClass.Update
 import p4.v1.P4RuntimeOuterClass.WriteRequest
@@ -78,6 +83,22 @@ class P4RuntimeTestHarness : Closeable {
     return loadPipeline(builder.build())
   }
 
+  fun getConfig(
+    responseType: GetForwardingPipelineConfigRequest.ResponseType =
+      GetForwardingPipelineConfigRequest.ResponseType.ALL
+  ): GetForwardingPipelineConfigResponse = runBlocking {
+    stub.getForwardingPipelineConfig(
+      GetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setResponseType(responseType)
+        .build()
+    )
+  }
+
+  fun capabilities(): CapabilitiesResponse = runBlocking {
+    stub.capabilities(CapabilitiesRequest.getDefaultInstance())
+  }
+
   // ---------------------------------------------------------------------------
   // Table entry management
   // ---------------------------------------------------------------------------
@@ -109,12 +130,29 @@ class P4RuntimeTestHarness : Closeable {
     )
   }
 
-  fun readEntries(request: ReadRequest = ReadRequest.getDefaultInstance()): List<Entity> =
-    runBlocking {
-      val entities = mutableListOf<Entity>()
-      stub.read(request).collect { response -> entities.addAll(response.entitiesList) }
-      entities
-    }
+  /** Wildcard read: returns all table entries. */
+  fun readEntries(): List<Entity> =
+    readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(Entity.newBuilder().setTableEntry(TableEntry.getDefaultInstance()))
+        .build()
+    )
+
+  /** Per-table read: returns entries from a single table (or all tables if tableId is 0). */
+  fun readTableEntries(tableId: Int): List<Entity> =
+    readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(tableId)))
+        .build()
+    )
+
+  fun readEntries(request: ReadRequest): List<Entity> = runBlocking {
+    val entities = mutableListOf<Entity>()
+    stub.read(request).collect { response -> entities.addAll(response.entitiesList) }
+    entities
+  }
 
   // ---------------------------------------------------------------------------
   // StreamChannel helpers

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -130,14 +130,8 @@ class P4RuntimeTestHarness : Closeable {
     )
   }
 
-  /** Wildcard read: returns all table entries. */
-  fun readEntries(): List<Entity> =
-    readEntries(
-      ReadRequest.newBuilder()
-        .setDeviceId(1)
-        .addEntities(Entity.newBuilder().setTableEntry(TableEntry.getDefaultInstance()))
-        .build()
-    )
+  /** Wildcard read: returns all table entries (table_id=0 is the P4Runtime wildcard). */
+  fun readEntries(): List<Entity> = readTableEntries(0)
 
   /** Per-table read: returns entries from a single table (or all tables if tableId is 0). */
   fun readTableEntries(tableId: Int): List<Entity> =

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -154,9 +154,17 @@ class Simulator {
     }
   }
 
-  @Suppress("UnusedParameter") // will be used when read filters are implemented
   private fun handleReadEntries(req: fourward.sim.v1.ReadEntriesRequest): SimResponse {
-    val entities = tableStore.readAllEntities()
+    // P4Runtime spec §11.1: each entity in the ReadRequest is a filter; the response is the union.
+    // A TableEntry with table_id=0 is a wildcard (all tables). An empty entity list returns
+    // nothing.
+    val entities =
+      req.request.entitiesList.flatMap { filter ->
+        when {
+          filter.hasTableEntry() -> tableStore.readEntities(filter.tableEntry.tableId)
+          else -> emptyList()
+        }
+      }
     return SimResponse.newBuilder()
       .setReadEntries(ReadEntriesResponse.newBuilder().addAllEntities(entities))
       .build()

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -157,14 +157,14 @@ class Simulator {
   private fun handleReadEntries(req: fourward.sim.v1.ReadEntriesRequest): SimResponse {
     // P4Runtime spec §11.1: each entity in the ReadRequest is a filter; the response is the union.
     // A TableEntry with table_id=0 is a wildcard (all tables). An empty entity list returns
-    // nothing.
+    // nothing. Deduplicate table IDs so overlapping filters don't produce duplicate entities.
+    val tableIds =
+      req.request.entitiesList
+        .mapNotNull { filter -> if (filter.hasTableEntry()) filter.tableEntry.tableId else null }
+        .toSet()
     val entities =
-      req.request.entitiesList.flatMap { filter ->
-        when {
-          filter.hasTableEntry() -> tableStore.readEntities(filter.tableEntry.tableId)
-          else -> emptyList()
-        }
-      }
+      if (0 in tableIds) tableStore.readEntities()
+      else tableIds.flatMap { tableStore.readEntities(it) }
     return SimResponse.newBuilder()
       .setReadEntries(ReadEntriesResponse.newBuilder().addAllEntities(entities))
       .build()

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -229,15 +229,10 @@ class TableStore {
    * returns only entries from the specified table.
    */
   fun readEntities(tableId: Int = 0): List<P4RuntimeOuterClass.Entity> {
-    val entities = mutableListOf<P4RuntimeOuterClass.Entity>()
-    for (entries in tables.values) {
-      for (entry in entries) {
-        if (tableId == 0 || entry.tableId == tableId) {
-          entities += P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry).build()
-        }
-      }
+    val sources = if (tableId == 0) tables.values else listOfNotNull(tables[tableNameById[tableId]])
+    return sources.flatMap { entries ->
+      entries.map { P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(it).build() }
     }
-    return entities
   }
 
   // -------------------------------------------------------------------------

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -222,12 +222,19 @@ class TableStore {
   // Read
   // -------------------------------------------------------------------------
 
-  /** Returns all stored entities as P4Runtime Entity protos. */
-  fun readAllEntities(): List<P4RuntimeOuterClass.Entity> {
+  /**
+   * Returns table entries as P4Runtime Entity protos.
+   *
+   * If [tableId] is 0 (the default), returns entries from all tables (wildcard read). If non-zero,
+   * returns only entries from the specified table.
+   */
+  fun readEntities(tableId: Int = 0): List<P4RuntimeOuterClass.Entity> {
     val entities = mutableListOf<P4RuntimeOuterClass.Entity>()
     for (entries in tables.values) {
       for (entry in entries) {
-        entities += P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry).build()
+        if (tableId == 0 || entry.tableId == tableId) {
+          entities += P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry).build()
+        }
       }
     }
     return entities


### PR DESCRIPTION
## Summary

Implements three P4Runtime RPCs and shrinks the limitations list:

- **GetForwardingPipelineConfig**: returns the loaded pipeline config, respecting
  the `ResponseType` filter (ALL, P4INFO_AND_COOKIE, DEVICE_CONFIG_AND_COOKIE,
  COOKIE_ONLY). Returns FAILED_PRECONDITION if no pipeline loaded.
- **Capabilities**: returns P4Runtime API version `"1.5.0"`.
- **Read filtering**: `Read` now respects entity filters per P4Runtime spec §11.1 —
  wildcard (`table_id=0`), per-table, or empty filter (returns nothing). Previously
  returned all entries unconditionally. Per-table reads use O(1) table lookup
  instead of scanning all tables, and overlapping filters are deduplicated.

Also refactors `requirePipeline()` to return the config directly, removing a
duplicated null-check pattern.

7 new conformance tests (scenarios 16–22), bringing the total to 28 across three
test suites.

## Test plan

- [x] All 3 P4Runtime test suites pass (Conformance, WriteError, Translation)
- [x] All 13 simulator unit tests pass
- [x] Lint clean
- [x] LIMITATIONS.md updated: removed "Missing RPCs" and "Wildcard reads only",
  replaced with narrower "No per-entry reads"

🤖 Generated with [Claude Code](https://claude.com/claude-code)