### PR TITLE
p4runtime: per-entry reads with match key filtering

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -29,8 +29,6 @@ guilt — just write it down so someone can find it later.
 
 - **Single controller only.** No multi-controller arbitration or election ID
   tracking. The first connection is master unconditionally.
-- **No per-entry reads.** `Read` supports wildcard (all tables) and per-table
-  filtering, but not per-entry reads with specific match keys.
 - **No p4-constraints validation.** `Write` does not enforce `@entry_restriction`
   or `@action_restriction` annotations from the P4 source.
 - **`@p4runtime_translation`: `sdn_bitwidth` only.** Bitwidth-based translation

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -283,4 +283,92 @@ class P4RuntimeConformanceTest {
     assertFalse("p4info should be absent", resp.config.hasP4Info())
     assertFalse("device config should be present", resp.config.p4DeviceConfig.isEmpty)
   }
+
+  // =========================================================================
+  // Per-entry reads (scenarios 23-25)
+  // =========================================================================
+
+  @Test
+  fun `23 - read with match key filter returns only matching entry`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry1 = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    val entry2 = buildExactEntry(config, matchValue = 0x0806, port = 2)
+    harness.installEntry(entry1)
+    harness.installEntry(entry2)
+
+    // Read with a filter that matches only entry1's match key.
+    val filter = buildReadFilter(config, matchValue = 0x0800)
+    val results = harness.readEntry(filter)
+    assertEquals("should return exactly one entry", 1, results.size)
+    assertEquals(
+      "returned entry should match the filter",
+      entry1.tableEntry.matchList,
+      results[0].tableEntry.matchList,
+    )
+  }
+
+  @Test
+  fun `24 - read with non-matching key returns empty`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    harness.installEntry(buildExactEntry(config, matchValue = 0x0800, port = 1))
+
+    val filter = buildReadFilter(config, matchValue = 0x9999)
+    assertTrue("non-matching key should return nothing", harness.readEntry(filter).isEmpty())
+  }
+
+  @Test
+  fun `25 - per-entry read preserves action parameters`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(entry)
+
+    val filter = buildReadFilter(config, matchValue = 0x0800)
+    val results = harness.readEntry(filter)
+    assertEquals(1, results.size)
+    // The returned entry should have the same action as what was installed.
+    assertTrue("should have action set", results[0].tableEntry.action.hasAction())
+    assertEquals(
+      entry.tableEntry.action.action.actionId,
+      results[0].tableEntry.action.action.actionId,
+    )
+    assertEquals(
+      entry.tableEntry.action.action.paramsList,
+      results[0].tableEntry.action.action.paramsList,
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds a read filter entity: table_id + match key, no action (used as a ReadRequest filter).
+   */
+  @Suppress("MagicNumber")
+  private fun buildReadFilter(config: PipelineConfig, matchValue: Long): Entity {
+    val table = config.p4Info.tablesList.first()
+    val matchField = table.matchFieldsList.first()
+    val fieldMatch =
+      p4.v1.P4RuntimeOuterClass.FieldMatch.newBuilder()
+        .setFieldId(matchField.id)
+        .setExact(
+          p4.v1.P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+            .setValue(
+              com.google.protobuf.ByteString.copyFrom(
+                P4RuntimeTestHarness.longToBytes(matchValue, (matchField.bitwidth + 7) / 8)
+              )
+            )
+        )
+        .build()
+    return Entity.newBuilder()
+      .setTableEntry(
+        p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder()
+          .setTableId(table.preamble.id)
+          .addMatch(fieldMatch)
+      )
+      .build()
+  }
 }

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -344,31 +344,6 @@ class P4RuntimeConformanceTest {
   // Test helpers
   // ---------------------------------------------------------------------------
 
-  /**
-   * Builds a read filter entity: table_id + match key, no action (used as a ReadRequest filter).
-   */
-  @Suppress("MagicNumber")
-  private fun buildReadFilter(config: PipelineConfig, matchValue: Long): Entity {
-    val table = config.p4Info.tablesList.first()
-    val matchField = table.matchFieldsList.first()
-    val fieldMatch =
-      p4.v1.P4RuntimeOuterClass.FieldMatch.newBuilder()
-        .setFieldId(matchField.id)
-        .setExact(
-          p4.v1.P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
-            .setValue(
-              com.google.protobuf.ByteString.copyFrom(
-                P4RuntimeTestHarness.longToBytes(matchValue, (matchField.bitwidth + 7) / 8)
-              )
-            )
-        )
-        .build()
-    return Entity.newBuilder()
-      .setTableEntry(
-        p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder()
-          .setTableId(table.preamble.id)
-          .addMatch(fieldMatch)
-      )
-      .build()
-  }
+  private fun buildReadFilter(config: PipelineConfig, matchValue: Long): Entity =
+    P4RuntimeTestHarness.buildMatchFilter(config, matchValue)
 }

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -268,16 +268,13 @@ class P4RuntimeTestHarness : Closeable {
     }
 
     /**
-     * Builds a table entry for the basic_table fixture: exact match on the table's first match
-     * field → forward(port).
+     * Builds a read-filter entity: table_id + exact match key, no action. Useful as a ReadRequest
+     * filter for per-entry reads.
      */
     @Suppress("MagicNumber")
-    fun buildExactEntry(config: PipelineConfig, matchValue: Long, port: Int): Entity {
-      val p4info = config.p4Info
-      val table = p4info.tablesList.first()
-      val forwardAction = p4info.actionsList.find { it.preamble.name.contains("forward") }!!
+    fun buildMatchFilter(config: PipelineConfig, matchValue: Long): Entity {
+      val table = config.p4Info.tablesList.first()
       val matchField = table.matchFieldsList.first()
-
       val fieldMatch =
         p4.v1.P4RuntimeOuterClass.FieldMatch.newBuilder()
           .setFieldId(matchField.id)
@@ -286,7 +283,26 @@ class P4RuntimeTestHarness : Closeable {
               .setValue(ByteString.copyFrom(longToBytes(matchValue, (matchField.bitwidth + 7) / 8)))
           )
           .build()
+      return Entity.newBuilder()
+        .setTableEntry(
+          p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder()
+            .setTableId(table.preamble.id)
+            .addMatch(fieldMatch)
+        )
+        .build()
+    }
 
+    /**
+     * Builds a table entry for the basic_table fixture: exact match on the table's first match
+     * field → forward(port).
+     */
+    @Suppress("MagicNumber")
+    fun buildExactEntry(config: PipelineConfig, matchValue: Long, port: Int): Entity {
+      val p4info = config.p4Info
+      val table = p4info.tablesList.first()
+      val forwardAction = p4info.actionsList.find { it.preamble.name.contains("forward") }!!
+
+      val filter = buildMatchFilter(config, matchValue)
       val actionParam =
         p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
           .setParamId(forwardAction.paramsList.first().id)
@@ -297,21 +313,20 @@ class P4RuntimeTestHarness : Closeable {
           )
           .build()
 
-      val tableEntry =
-        p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder()
-          .setTableId(table.preamble.id)
-          .addMatch(fieldMatch)
-          .setAction(
-            p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
-              .setAction(
-                p4.v1.P4RuntimeOuterClass.Action.newBuilder()
-                  .setActionId(forwardAction.preamble.id)
-                  .addParams(actionParam)
-              )
-          )
-          .build()
-
-      return Entity.newBuilder().setTableEntry(tableEntry).build()
+      return Entity.newBuilder()
+        .setTableEntry(
+          filter.tableEntry
+            .toBuilder()
+            .setAction(
+              p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
+                .setAction(
+                  p4.v1.P4RuntimeOuterClass.Action.newBuilder()
+                    .setActionId(forwardAction.preamble.id)
+                    .addParams(actionParam)
+                )
+            )
+        )
+        .build()
     }
 
     /** Minimum-width unsigned big-endian encoding of a port number. */

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -142,6 +142,10 @@ class P4RuntimeTestHarness : Closeable {
         .build()
     )
 
+  /** Per-entry read: uses the entity's match fields as a filter. */
+  fun readEntry(entity: Entity): List<Entity> =
+    readEntries(ReadRequest.newBuilder().setDeviceId(1).addEntities(entity).build())
+
   fun readEntries(request: ReadRequest): List<Entity> = runBlocking {
     val entities = mutableListOf<Entity>()
     stub.read(request).collect { response -> entities.addAll(response.entitiesList) }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -156,12 +156,10 @@ class Simulator {
 
   private fun handleReadEntries(req: fourward.sim.v1.ReadEntriesRequest): SimResponse {
     // P4Runtime spec §11.1: each entity in the ReadRequest is a filter; the response is the union.
-    // A TableEntry with table_id=0 is a wildcard (all tables). An empty entity list returns
-    // nothing. Filters with match fields perform per-entry lookup.
-    val filters = req.request.entitiesList.filter { it.hasTableEntry() }.map { it.tableEntry }
     val entities =
-      if (filters.any { it.tableId == 0 && it.matchCount == 0 }) tableStore.readEntities()
-      else filters.flatMap { tableStore.readEntities(it) }
+      req.request.entitiesList
+        .filter { it.hasTableEntry() }
+        .flatMap { tableStore.readEntities(it.tableEntry) }
     return SimResponse.newBuilder()
       .setReadEntries(ReadEntriesResponse.newBuilder().addAllEntities(entities))
       .build()

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -157,14 +157,11 @@ class Simulator {
   private fun handleReadEntries(req: fourward.sim.v1.ReadEntriesRequest): SimResponse {
     // P4Runtime spec §11.1: each entity in the ReadRequest is a filter; the response is the union.
     // A TableEntry with table_id=0 is a wildcard (all tables). An empty entity list returns
-    // nothing. Deduplicate table IDs so overlapping filters don't produce duplicate entities.
-    val tableIds =
-      req.request.entitiesList
-        .mapNotNull { filter -> if (filter.hasTableEntry()) filter.tableEntry.tableId else null }
-        .toSet()
+    // nothing. Filters with match fields perform per-entry lookup.
+    val filters = req.request.entitiesList.filter { it.hasTableEntry() }.map { it.tableEntry }
     val entities =
-      if (0 in tableIds) tableStore.readEntities()
-      else tableIds.flatMap { tableStore.readEntities(it) }
+      if (filters.any { it.tableId == 0 && it.matchCount == 0 }) tableStore.readEntities()
+      else filters.flatMap { tableStore.readEntities(it) }
     return SimResponse.newBuilder()
       .setReadEntries(ReadEntriesResponse.newBuilder().addAllEntities(entities))
       .build()

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -223,15 +223,26 @@ class TableStore {
   // -------------------------------------------------------------------------
 
   /**
-   * Returns table entries as P4Runtime Entity protos.
-   *
-   * If [tableId] is 0 (the default), returns entries from all tables (wildcard read). If non-zero,
-   * returns only entries from the specified table.
+   * Returns table entries as P4Runtime Entity protos, filtered by [filter].
+   * - `table_id=0`, no match fields → wildcard: returns all entries from all tables.
+   * - `table_id=N`, no match fields → returns all entries from table N.
+   * - `table_id=N` with match fields → returns only the entry whose match key matches the filter
+   *   (P4Runtime spec §11.1: match fields in the filter act as an exact key lookup).
    */
-  fun readEntities(tableId: Int = 0): List<P4RuntimeOuterClass.Entity> {
-    val sources = if (tableId == 0) tables.values else listOfNotNull(tables[tableNameById[tableId]])
+  fun readEntities(
+    filter: P4RuntimeOuterClass.TableEntry = P4RuntimeOuterClass.TableEntry.getDefaultInstance()
+  ): List<P4RuntimeOuterClass.Entity> {
+    val sources =
+      if (filter.tableId == 0) tables.values
+      else listOfNotNull(tables[tableNameById[filter.tableId]])
+    val hasMatchFilter = filter.matchCount > 0
     return sources.flatMap { entries ->
-      entries.map { P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(it).build() }
+      entries
+        .filter { entry ->
+          !hasMatchFilter ||
+            (entry.matchList == filter.matchList && entry.priority == filter.priority)
+        }
+        .map { P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(it).build() }
     }
   }
 

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -13,7 +13,7 @@ private fun ByteString.toUnsignedBigInteger(): BigInteger = BigInteger(1, toByte
 // P4Runtime spec §9.1: two entries are the same iff they have the same match key
 // AND the same priority (priority is part of the key for ternary/range tables).
 private fun TableEntry.sameKey(other: TableEntry): Boolean =
-  tableId == other.tableId && matchList == other.matchList && priority == other.priority
+  tableId == other.tableId && priority == other.priority && matchList == other.matchList
 
 /** Result of a [TableStore.write] operation. */
 sealed class WriteResult {
@@ -234,11 +234,13 @@ class TableStore {
       if (filter.tableId == 0) tables.values
       else listOfNotNull(tables[tableNameById[filter.tableId]])
     val hasMatchFilter = filter.matchCount > 0
-    return sources.flatMap { entries ->
-      entries
-        .filter { !hasMatchFilter || it.sameKey(filter) }
-        .map { P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(it).build() }
-    }
+    return sources
+      .flatMap { entries ->
+        // P4Runtime spec §9.1: match key + priority uniquely identify an entry,
+        // so at most one entry can match a filter with match fields.
+        if (hasMatchFilter) listOfNotNull(entries.find { it.sameKey(filter) }) else entries
+      }
+      .map { P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(it).build() }
   }
 
   // -------------------------------------------------------------------------

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -10,6 +10,11 @@ import p4.v1.P4RuntimeOuterClass.Update
 /** Interprets a protobuf [ByteString] as an unsigned big-endian integer. */
 private fun ByteString.toUnsignedBigInteger(): BigInteger = BigInteger(1, toByteArray())
 
+// P4Runtime spec §9.1: two entries are the same iff they have the same match key
+// AND the same priority (priority is part of the key for ternary/range tables).
+private fun TableEntry.sameKey(other: TableEntry): Boolean =
+  tableId == other.tableId && matchList == other.matchList && priority == other.priority
+
 /** Result of a [TableStore.write] operation. */
 sealed class WriteResult {
   data object Success : WriteResult()
@@ -153,14 +158,7 @@ class TableStore {
         ?: return WriteResult.NotFound("unknown table ID: ${entry.tableId}")
 
     val entries = tables.getOrPut(tableName) { mutableListOf() }
-    // P4Runtime spec §9.1: two entries are the same iff they have the same match key
-    // AND the same priority (priority is part of the key for ternary/range tables).
-    val existingIndex =
-      entries.indexOfFirst {
-        it.tableId == entry.tableId &&
-          it.matchList == entry.matchList &&
-          it.priority == entry.priority
-      }
+    val existingIndex = entries.indexOfFirst { it.sameKey(entry) }
 
     // P4Runtime spec §9.1: INSERT requires the entry not to exist, MODIFY and DELETE
     // require it to exist.
@@ -238,10 +236,7 @@ class TableStore {
     val hasMatchFilter = filter.matchCount > 0
     return sources.flatMap { entries ->
       entries
-        .filter { entry ->
-          !hasMatchFilter ||
-            (entry.matchList == filter.matchList && entry.priority == filter.priority)
-        }
+        .filter { !hasMatchFilter || it.sameKey(filter) }
         .map { P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(it).build() }
     }
   }

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -686,6 +686,58 @@ class TableStoreTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Per-entry reads
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `readEntities with match filter returns only matching entry`() {
+    val entry1 = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
+    val entry2 = exactEntry(fieldId = 1, value = byteArrayOf(200.toByte()), actionId = 20)
+    store.write(insertUpdate(entry1))
+    store.write(insertUpdate(entry2))
+
+    val filter = TableEntry.newBuilder().setTableId(TABLE_ID).addMatch(entry1.getMatch(0)).build()
+    val results = store.readEntities(filter)
+    assertEquals("should return exactly one entry", 1, results.size)
+    assertEquals(entry1.matchList, results[0].tableEntry.matchList)
+  }
+
+  @Test
+  fun `readEntities with non-matching filter returns empty`() {
+    val entry = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
+    store.write(insertUpdate(entry))
+
+    val noMatchFilter =
+      TableEntry.newBuilder()
+        .setTableId(TABLE_ID)
+        .addMatch(
+          FieldMatch.newBuilder()
+            .setFieldId(1)
+            .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(99))))
+        )
+        .build()
+    assertTrue(store.readEntities(noMatchFilter).isEmpty())
+  }
+
+  @Test
+  fun `readEntities with table-only filter returns all entries in table`() {
+    val entry1 = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
+    val entry2 = exactEntry(fieldId = 1, value = byteArrayOf(200.toByte()), actionId = 20)
+    store.write(insertUpdate(entry1))
+    store.write(insertUpdate(entry2))
+
+    // Filter with table_id only, no match fields → returns all entries in the table.
+    val tableOnlyFilter = TableEntry.newBuilder().setTableId(TABLE_ID).build()
+    assertEquals(2, store.readEntities(tableOnlyFilter).size)
+  }
+
+  private fun insertUpdate(entry: TableEntry): Update =
+    Update.newBuilder()
+      .setType(Update.Type.INSERT)
+      .setEntity(Entity.newBuilder().setTableEntry(entry))
+      .build()
+
+  // ---------------------------------------------------------------------------
   // Constants
   // ---------------------------------------------------------------------------
 

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -731,6 +731,64 @@ class TableStoreTest {
     assertEquals(2, store.readEntities(tableOnlyFilter).size)
   }
 
+  @Test
+  fun `readEntities distinguishes ternary entries by priority`() {
+    // Two ternary entries with the same match key but different priorities are distinct.
+    val entry1 =
+      ternaryEntry(
+        fieldId = 1,
+        value = byteArrayOf(0x0A),
+        mask = byteArrayOf(0xFF.toByte()),
+        priority = 10,
+        actionId = 10,
+      )
+    val entry2 =
+      ternaryEntry(
+        fieldId = 1,
+        value = byteArrayOf(0x0A),
+        mask = byteArrayOf(0xFF.toByte()),
+        priority = 20,
+        actionId = 20,
+      )
+    store.write(insertUpdate(entry1))
+    store.write(insertUpdate(entry2))
+
+    // Filter for priority=10 should return only entry1.
+    val filter =
+      TableEntry.newBuilder()
+        .setTableId(TABLE_ID)
+        .addMatch(entry1.getMatch(0))
+        .setPriority(10)
+        .build()
+    val results = store.readEntities(filter)
+    assertEquals("should return exactly one entry", 1, results.size)
+    assertEquals(10, results[0].tableEntry.priority)
+  }
+
+  @Test
+  fun `readEntities wildcard returns all entries across tables`() {
+    store.loadMappings(
+      tableNameById = mapOf(TABLE_ID to TABLE_NAME, 3 to "otherTable"),
+      actionNameById = ACTION_ID_TO_NAME,
+    )
+    val entry1 = exactEntry(fieldId = 1, value = byteArrayOf(1), actionId = 10)
+    val entry2 =
+      TableEntry.newBuilder()
+        .setTableId(3)
+        .addMatch(
+          FieldMatch.newBuilder()
+            .setFieldId(1)
+            .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(2))))
+        )
+        .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(10)))
+        .build()
+    store.write(insertUpdate(entry1))
+    store.write(insertUpdate(entry2))
+
+    // Default filter (table_id=0, no match fields) → wildcard.
+    assertEquals(2, store.readEntities().size)
+  }
+
   private fun insertUpdate(entry: TableEntry): Update =
     Update.newBuilder()
       .setType(Update.Type.INSERT)


### PR DESCRIPTION
## Summary

Per-entry reads with match key filtering — the last missing Read RPC feature. The P4Runtime server now supports all three filtering levels specified in §11.1: wildcard (all tables), per-table, and per-entry.

- `TableStore.readEntities` accepts a full `TableEntry` filter: match fields act as an exact key lookup, short-circuiting after the first match (keys are unique per §9.1)
- `TableEntry.sameKey()` extracted as a single source of truth for entry identity (match key + priority)
- Wildcard semantics consolidated inside `TableStore` — the `Simulator` caller is now a simple pass-through
- Shared `buildMatchFilter` helper eliminates duplication between test harness and conformance tests

## Test plan

- [x] 3 conformance tests: match filter returns single entry, non-matching key returns empty, action params preserved
- [x] 5 unit tests: match/non-match/table-only filters, ternary priority distinction, cross-table wildcard
- [x] Full `bazel test //...` green (202 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)