### PR TITLE
ci: fix BMv2 build on Ubuntu — install system deps, bust stale cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,11 @@ jobs:
             bazel-${{ matrix.os }}-
             ${{ matrix.os == 'ubuntu-24.04' && 'bazel-coverage-' || '' }}
 
+      # BMv2 links against system libgmp and libpcap.
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libgmp-dev libpcap-dev
+
       - name: Save start time
         run: echo "START_TIME=$(date +%s)" >> "$GITHUB_ENV"
 
@@ -163,8 +168,8 @@ jobs:
       - name: Save start time
         run: echo "START_TIME=$(date +%s)" >> "$GITHUB_ENV"
 
-      - name: Install lcov
-        run: sudo apt install -y lcov
+      - name: Install system dependencies
+        run: sudo apt-get install -y lcov libgmp-dev libpcap-dev
 
       - name: Fetch gh-pages
         run: git fetch --depth=1 origin gh-pages || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/bazel
-          key: bazel-ubuntu-24.04-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-ubuntu-24.04-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}
           restore-keys: bazel-ubuntu-24.04-
 
       - name: Install clang tools
@@ -100,7 +100,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.BAZEL_CACHE }}
-          key: bazel-${{ matrix.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-${{ matrix.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}
           restore-keys: |
             bazel-${{ matrix.os }}-
             ${{ matrix.os == 'ubuntu-24.04' && 'bazel-coverage-' || '' }}
@@ -133,7 +133,7 @@ jobs:
         if: always() && (github.ref_name == 'main' || env.DURATION > 300)
         with:
           path: ${{ env.BAZEL_CACHE }}
-          key: bazel-${{ matrix.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}-${{ github.run_id }}
+          key: bazel-${{ matrix.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}-${{ github.run_id }}
 
 
   coverage:
@@ -160,7 +160,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/bazel
-          key: bazel-coverage-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-coverage-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}
           restore-keys: |
             bazel-coverage-
             bazel-ubuntu-24.04-
@@ -207,7 +207,7 @@ jobs:
         if: always() && (github.ref_name == 'main' || env.DURATION > 300)
         with:
           path: ~/.cache/bazel
-          key: bazel-coverage-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}-${{ github.run_id }}
+          key: bazel-coverage-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}-${{ github.run_id }}
 
       - name: Publish mainline report
         if: github.event_name == 'push'

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 # --- Core build rules ---
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")

--- a/bazel/behavioral_model.patch
+++ b/bazel/behavioral_model.patch
@@ -1,7 +1,7 @@
 diff --color -ruN a/BUILD.bazel b/BUILD.bazel
 --- a/BUILD.bazel	2026-03-06 06:27:42
 +++ b/BUILD.bazel	2026-03-06 06:47:28
-@@ -0,0 +1,208 @@
+@@ -0,0 +1,211 @@
 +# Native Bazel build for behavioral-model (BMv2).
 +# Minimal build: no Thrift, no nanomsg, no debugger, no PI.
 +
@@ -27,6 +27,8 @@ diff --color -ruN a/BUILD.bazel b/BUILD.bazel
 +        '([ -f {p}/gmp.h ] && cp {p}/gmp.h $@)'.format(p = p)
 +        for p in _GMP_SEARCH_PATHS
 +    ]) + ' || (echo "#error gmp.h not found -- install libgmp-dev" > $@)',
++    # System header presence depends on host state, not build inputs.
++    tags = ["no-cache", "no-remote-cache"],
 +)
 +
 +genrule(
@@ -36,6 +38,7 @@ diff --color -ruN a/BUILD.bazel b/BUILD.bazel
 +        '([ -f {p}/gmpxx.h ] && cp {p}/gmpxx.h $@)'.format(p = p)
 +        for p in _GMP_SEARCH_PATHS
 +    ]) + ' || (echo "#error gmpxx.h not found -- install libgmp-dev" > $@)',
++    tags = ["no-cache", "no-remote-cache"],
 +)
 +
 +cc_library(

--- a/bazel/behavioral_model.patch
+++ b/bazel/behavioral_model.patch
@@ -1,7 +1,7 @@
 diff --color -ruN a/BUILD.bazel b/BUILD.bazel
 --- a/BUILD.bazel	2026-03-06 06:27:42
 +++ b/BUILD.bazel	2026-03-06 06:47:28
-@@ -0,0 +1,211 @@
+@@ -0,0 +1,212 @@
 +# Native Bazel build for behavioral-model (BMv2).
 +# Minimal build: no Thrift, no nanomsg, no debugger, no PI.
 +
@@ -17,7 +17,8 @@ diff --color -ruN a/BUILD.bazel b/BUILD.bazel
 +_GMP_SEARCH_PATHS = [
 +    "/opt/homebrew/include",  # macOS (Apple Silicon Homebrew)
 +    "/usr/local/include",  # macOS (Intel Homebrew)
-+    "/usr/include",  # Linux
++    "/usr/include/x86_64-linux-gnu",  # Ubuntu/Debian multiarch
++    "/usr/include",  # Linux (non-multiarch)
 +]
 +
 +genrule(
@@ -26,8 +27,8 @@ diff --color -ruN a/BUILD.bazel b/BUILD.bazel
 +    cmd = " || ".join([
 +        '([ -f {p}/gmp.h ] && cp {p}/gmp.h $@)'.format(p = p)
 +        for p in _GMP_SEARCH_PATHS
-+    ]) + ' || (echo "#error gmp.h not found -- install libgmp-dev" > $@)',
-+    # System header presence depends on host state, not build inputs.
++    ]) + ' || { echo "ERROR: gmp.h not found -- install libgmp-dev" >&2; exit 1; }',
++    # No build inputs capture host state; must re-run every time.
 +    tags = ["no-cache", "no-remote-cache"],
 +)
 +
@@ -37,7 +38,7 @@ diff --color -ruN a/BUILD.bazel b/BUILD.bazel
 +    cmd = " || ".join([
 +        '([ -f {p}/gmpxx.h ] && cp {p}/gmpxx.h $@)'.format(p = p)
 +        for p in _GMP_SEARCH_PATHS
-+    ]) + ' || (echo "#error gmpxx.h not found -- install libgmp-dev" > $@)',
++    ]) + ' || { echo "ERROR: gmpxx.h not found -- install libgmp-dev" >&2; exit 1; }',
 +    tags = ["no-cache", "no-remote-cache"],
 +)
 +

--- a/e2e_tests/bmv2_diff/BUILD.bazel
+++ b/e2e_tests/bmv2_diff/BUILD.bazel
@@ -5,6 +5,11 @@ cc_binary(
     name = "bmv2_driver",
     srcs = ["bmv2_driver.cpp"],
     copts = ["-std=c++17"],
+    # BMv2 uses 128-bit atomics; clang on Linux needs -latomic explicitly.
+    linkopts = select({
+        "@platforms//os:linux": ["-latomic"],
+        "//conditions:default": [],
+    }),
     deps = ["@behavioral_model//:simple_switch_lib"],
 )
 


### PR DESCRIPTION
## Summary

Ubuntu CI has been broken since PR #173 (BMv2 differential testing) landed.
Three root causes, all fixed:

1. **Multiarch search paths.** Ubuntu puts `gmp.h` in
   `/usr/include/x86_64-linux-gnu/`, not `/usr/include/`. Added the
   multiarch path to the genrule search list.

2. **Poisoned cache.** The genrules produced `#error` placeholder headers
   when deps were missing. These got cached in BuildBuddy, persisting even
   after the deps were installed. Genrules now `exit 1` instead — missing
   deps are build failures, never cacheable artifacts. CI cache key now
   includes `bazel/*.patch` to bust stale caches on patch changes.

3. **Missing `-latomic`.** BMv2 uses 128-bit atomics; clang on Linux needs
   `-latomic` explicitly. Added a platform-conditional linker flag (required
   adding `platforms` to `MODULE.bazel`).

Supersedes PR #180 (includes its `apt-get install` + `no-cache` tags).

## Test plan

- [x] `bazel build @behavioral_model//:bm_sim` passes locally (macOS)
- [x] `bazel build //e2e_tests/bmv2_diff:bmv2_driver` passes locally
- [ ] Ubuntu CI passes (the whole point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)