### PR TITLE
p4runtime: action profile members and groups via Read/Write RPCs

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -39,8 +39,6 @@ guilt — just write it down so someone can find it later.
   UNIMPLEMENTED.
 - **No counters, meters, or registers via P4Runtime.** These work via the
   simulator protocol but cannot be managed through the gRPC server.
-- **No action profiles or groups via P4Runtime.** Action selector tables and
-  group management are not implemented.
 - **No digests, idle timeouts, or atomic write batches.**
 
 ## Simulator

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -4,6 +4,8 @@ import fourward.ir.v1.PipelineConfig
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.assertGrpcError
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildEthernetFrame
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildExactEntry
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildGroupEntity
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildMemberEntity
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
 import io.grpc.Status
 import org.junit.After
@@ -338,6 +340,73 @@ class P4RuntimeConformanceTest {
       entry.tableEntry.action.action.paramsList,
       results[0].tableEntry.action.action.paramsList,
     )
+  }
+
+  // =========================================================================
+  // Action profile members (scenarios 26-28)
+  // =========================================================================
+
+  @Test
+  fun `26 - write and read back action profile member`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val member = buildMemberEntity(actionProfileId = 1, memberId = 1, actionId = 1)
+    harness.installEntry(member)
+    val results = harness.readProfileMembers(actionProfileId = 1)
+    assertEquals(1, results.size)
+    assertTrue(results[0].hasActionProfileMember())
+    assertEquals(1, results[0].actionProfileMember.memberId)
+  }
+
+  @Test
+  fun `27 - insert duplicate member returns ALREADY_EXISTS`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val member = buildMemberEntity(actionProfileId = 1, memberId = 1, actionId = 1)
+    harness.installEntry(member)
+    assertGrpcError(Status.Code.ALREADY_EXISTS) { harness.installEntry(member) }
+  }
+
+  @Test
+  fun `28 - delete member then read returns empty`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val member = buildMemberEntity(actionProfileId = 1, memberId = 1, actionId = 1)
+    harness.installEntry(member)
+    harness.deleteEntry(member)
+    assertTrue(harness.readProfileMembers(actionProfileId = 1).isEmpty())
+  }
+
+  // =========================================================================
+  // Action profile groups (scenarios 29-31)
+  // =========================================================================
+
+  @Test
+  fun `29 - write and read back action profile group`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val group = buildGroupEntity(actionProfileId = 1, groupId = 1, memberIds = listOf(1, 2))
+    harness.installEntry(group)
+    val results = harness.readProfileGroups(actionProfileId = 1)
+    assertEquals(1, results.size)
+    assertTrue(results[0].hasActionProfileGroup())
+    assertEquals(1, results[0].actionProfileGroup.groupId)
+    assertEquals(2, results[0].actionProfileGroup.membersCount)
+  }
+
+  @Test
+  fun `30 - modify group with different members succeeds`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val group = buildGroupEntity(actionProfileId = 1, groupId = 1, memberIds = listOf(1))
+    harness.installEntry(group)
+    val modified = buildGroupEntity(actionProfileId = 1, groupId = 1, memberIds = listOf(1, 2, 3))
+    harness.modifyEntry(modified)
+    val results = harness.readProfileGroups(actionProfileId = 1)
+    assertEquals(1, results.size)
+    assertEquals(3, results[0].actionProfileGroup.membersCount)
+  }
+
+  @Test
+  fun `31 - delete non-existent group returns NOT_FOUND`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val group = buildGroupEntity(actionProfileId = 1, groupId = 99, memberIds = listOf(1))
+    assertGrpcError(Status.Code.NOT_FOUND) { harness.deleteEntry(group) }
   }
 
   // ---------------------------------------------------------------------------

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -152,6 +152,36 @@ class P4RuntimeTestHarness : Closeable {
     entities
   }
 
+  /** Reads action profile members, optionally filtered by profile ID. */
+  fun readProfileMembers(actionProfileId: Int = 0): List<Entity> =
+    readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setActionProfileMember(
+              p4.v1.P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+                .setActionProfileId(actionProfileId)
+            )
+        )
+        .build()
+    )
+
+  /** Reads action profile groups, optionally filtered by profile ID. */
+  fun readProfileGroups(actionProfileId: Int = 0): List<Entity> =
+    readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setActionProfileGroup(
+              p4.v1.P4RuntimeOuterClass.ActionProfileGroup.newBuilder()
+                .setActionProfileId(actionProfileId)
+            )
+        )
+        .build()
+    )
+
   // ---------------------------------------------------------------------------
   // StreamChannel helpers
   // ---------------------------------------------------------------------------
@@ -369,5 +399,34 @@ class P4RuntimeTestHarness : Closeable {
       }
       return bytes
     }
+
+    /** Builds an Entity wrapping an ActionProfileMember with a single action param. */
+    fun buildMemberEntity(actionProfileId: Int, memberId: Int, actionId: Int): Entity =
+      Entity.newBuilder()
+        .setActionProfileMember(
+          p4.v1.P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+            .setActionProfileId(actionProfileId)
+            .setMemberId(memberId)
+            .setAction(p4.v1.P4RuntimeOuterClass.Action.newBuilder().setActionId(actionId))
+        )
+        .build()
+
+    /** Builds an Entity wrapping an ActionProfileGroup with the given member IDs. */
+    fun buildGroupEntity(actionProfileId: Int, groupId: Int, memberIds: List<Int>): Entity =
+      Entity.newBuilder()
+        .setActionProfileGroup(
+          p4.v1.P4RuntimeOuterClass.ActionProfileGroup.newBuilder()
+            .setActionProfileId(actionProfileId)
+            .setGroupId(groupId)
+            .addAllMembers(
+              memberIds.map { mid ->
+                p4.v1.P4RuntimeOuterClass.ActionProfileGroup.Member.newBuilder()
+                  .setMemberId(mid)
+                  .setWeight(1)
+                  .build()
+              }
+            )
+        )
+        .build()
   }
 }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -157,9 +157,15 @@ class Simulator {
   private fun handleReadEntries(req: fourward.sim.v1.ReadEntriesRequest): SimResponse {
     // P4Runtime spec §11.1: each entity in the ReadRequest is a filter; the response is the union.
     val entities =
-      req.request.entitiesList
-        .filter { it.hasTableEntry() }
-        .flatMap { tableStore.readEntities(it.tableEntry) }
+      req.request.entitiesList.flatMap { entity ->
+        when {
+          entity.hasTableEntry() -> tableStore.readEntities(entity.tableEntry)
+          entity.hasActionProfileMember() ->
+            tableStore.readProfileMembers(entity.actionProfileMember)
+          entity.hasActionProfileGroup() -> tableStore.readProfileGroups(entity.actionProfileGroup)
+          else -> emptyList()
+        }
+      }
     return SimResponse.newBuilder()
       .setReadEntries(ReadEntriesResponse.newBuilder().addAllEntities(entities))
       .build()

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -135,14 +135,8 @@ class TableStore {
   fun write(update: Update): WriteResult {
     val entity = update.entity
     return when {
-      entity.hasActionProfileMember() -> {
-        writeProfileMember(entity.actionProfileMember)
-        WriteResult.Success
-      }
-      entity.hasActionProfileGroup() -> {
-        writeProfileGroup(entity.actionProfileGroup)
-        WriteResult.Success
-      }
+      entity.hasActionProfileMember() -> writeProfileMember(update.type, entity.actionProfileMember)
+      entity.hasActionProfileGroup() -> writeProfileGroup(update.type, entity.actionProfileGroup)
       entity.hasPacketReplicationEngineEntry() -> {
         writePreEntry(entity.packetReplicationEngineEntry)
         WriteResult.Success
@@ -193,12 +187,80 @@ class TableStore {
     }
   }
 
-  private fun writeProfileMember(member: P4RuntimeOuterClass.ActionProfileMember) {
-    profileMembers.getOrPut(member.actionProfileId) { mutableMapOf() }[member.memberId] = member
+  private fun writeProfileMember(
+    type: Update.Type,
+    member: P4RuntimeOuterClass.ActionProfileMember,
+  ): WriteResult {
+    val members = profileMembers.getOrPut(member.actionProfileId) { mutableMapOf() }
+    val exists = member.memberId in members
+    return when (type) {
+      Update.Type.INSERT ->
+        if (exists)
+          WriteResult.AlreadyExists(
+            "action profile ${member.actionProfileId} already contains member ${member.memberId}"
+          )
+        else {
+          members[member.memberId] = member
+          WriteResult.Success
+        }
+      Update.Type.MODIFY ->
+        if (!exists)
+          WriteResult.NotFound(
+            "action profile ${member.actionProfileId} has no member ${member.memberId}"
+          )
+        else {
+          members[member.memberId] = member
+          WriteResult.Success
+        }
+      Update.Type.DELETE ->
+        if (!exists)
+          WriteResult.NotFound(
+            "action profile ${member.actionProfileId} has no member ${member.memberId}"
+          )
+        else {
+          members.remove(member.memberId)
+          WriteResult.Success
+        }
+      else -> WriteResult.InvalidArgument("unsupported update type: $type")
+    }
   }
 
-  private fun writeProfileGroup(group: P4RuntimeOuterClass.ActionProfileGroup) {
-    profileGroups.getOrPut(group.actionProfileId) { mutableMapOf() }[group.groupId] = group
+  private fun writeProfileGroup(
+    type: Update.Type,
+    group: P4RuntimeOuterClass.ActionProfileGroup,
+  ): WriteResult {
+    val groups = profileGroups.getOrPut(group.actionProfileId) { mutableMapOf() }
+    val exists = group.groupId in groups
+    return when (type) {
+      Update.Type.INSERT ->
+        if (exists)
+          WriteResult.AlreadyExists(
+            "action profile ${group.actionProfileId} already contains group ${group.groupId}"
+          )
+        else {
+          groups[group.groupId] = group
+          WriteResult.Success
+        }
+      Update.Type.MODIFY ->
+        if (!exists)
+          WriteResult.NotFound(
+            "action profile ${group.actionProfileId} has no group ${group.groupId}"
+          )
+        else {
+          groups[group.groupId] = group
+          WriteResult.Success
+        }
+      Update.Type.DELETE ->
+        if (!exists)
+          WriteResult.NotFound(
+            "action profile ${group.actionProfileId} has no group ${group.groupId}"
+          )
+        else {
+          groups.remove(group.groupId)
+          WriteResult.Success
+        }
+      else -> WriteResult.InvalidArgument("unsupported update type: $type")
+    }
   }
 
   private fun writePreEntry(pre: P4RuntimeOuterClass.PacketReplicationEngineEntry) {
@@ -241,6 +303,47 @@ class TableStore {
         if (hasMatchFilter) listOfNotNull(entries.find { it.sameKey(filter) }) else entries
       }
       .map { P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(it).build() }
+  }
+
+  /**
+   * Returns action profile members as P4Runtime Entity protos, filtered by [filter].
+   * - `action_profile_id=0` → wildcard: all members from all profiles.
+   * - `action_profile_id=N, member_id=0` → all members from profile N.
+   * - `action_profile_id=N, member_id=M` → single member (N, M).
+   */
+  fun readProfileMembers(
+    filter: P4RuntimeOuterClass.ActionProfileMember =
+      P4RuntimeOuterClass.ActionProfileMember.getDefaultInstance()
+  ): List<P4RuntimeOuterClass.Entity> {
+    val sources =
+      if (filter.actionProfileId == 0) profileMembers.values.flatMap { it.values }
+      else {
+        val members = profileMembers[filter.actionProfileId] ?: return emptyList()
+        if (filter.memberId != 0) listOfNotNull(members[filter.memberId])
+        else members.values.toList()
+      }
+    return sources.map {
+      P4RuntimeOuterClass.Entity.newBuilder().setActionProfileMember(it).build()
+    }
+  }
+
+  /**
+   * Returns action profile groups as P4Runtime Entity protos, filtered by [filter].
+   * - `action_profile_id=0` → wildcard: all groups from all profiles.
+   * - `action_profile_id=N, group_id=0` → all groups from profile N.
+   * - `action_profile_id=N, group_id=G` → single group (N, G).
+   */
+  fun readProfileGroups(
+    filter: P4RuntimeOuterClass.ActionProfileGroup =
+      P4RuntimeOuterClass.ActionProfileGroup.getDefaultInstance()
+  ): List<P4RuntimeOuterClass.Entity> {
+    val sources =
+      if (filter.actionProfileId == 0) profileGroups.values.flatMap { it.values }
+      else {
+        val groups = profileGroups[filter.actionProfileId] ?: return emptyList()
+        if (filter.groupId != 0) listOfNotNull(groups[filter.groupId]) else groups.values.toList()
+      }
+    return sources.map { P4RuntimeOuterClass.Entity.newBuilder().setActionProfileGroup(it).build() }
   }
 
   // -------------------------------------------------------------------------

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -187,81 +187,59 @@ class TableStore {
     }
   }
 
-  private fun writeProfileMember(
+  /** Generic INSERT/MODIFY/DELETE for a keyed map entry. */
+  private fun <V> writeProfileEntity(
     type: Update.Type,
-    member: P4RuntimeOuterClass.ActionProfileMember,
-  ): WriteResult {
-    val members = profileMembers.getOrPut(member.actionProfileId) { mutableMapOf() }
-    val exists = member.memberId in members
-    return when (type) {
+    map: MutableMap<Int, V>,
+    key: Int,
+    value: V,
+    desc: String,
+  ): WriteResult =
+    when (type) {
       Update.Type.INSERT ->
-        if (exists)
-          WriteResult.AlreadyExists(
-            "action profile ${member.actionProfileId} already contains member ${member.memberId}"
-          )
+        if (key in map) WriteResult.AlreadyExists("$desc already exists")
         else {
-          members[member.memberId] = member
+          map[key] = value
           WriteResult.Success
         }
       Update.Type.MODIFY ->
-        if (!exists)
-          WriteResult.NotFound(
-            "action profile ${member.actionProfileId} has no member ${member.memberId}"
-          )
+        if (key !in map) WriteResult.NotFound("$desc not found")
         else {
-          members[member.memberId] = member
+          map[key] = value
           WriteResult.Success
         }
       Update.Type.DELETE ->
-        if (!exists)
-          WriteResult.NotFound(
-            "action profile ${member.actionProfileId} has no member ${member.memberId}"
-          )
+        if (key !in map) WriteResult.NotFound("$desc not found")
         else {
-          members.remove(member.memberId)
+          map.remove(key)
           WriteResult.Success
         }
       else -> WriteResult.InvalidArgument("unsupported update type: $type")
     }
-  }
+
+  private fun writeProfileMember(
+    type: Update.Type,
+    member: P4RuntimeOuterClass.ActionProfileMember,
+  ): WriteResult =
+    writeProfileEntity(
+      type,
+      profileMembers.getOrPut(member.actionProfileId) { mutableMapOf() },
+      member.memberId,
+      member,
+      "member ${member.memberId} in action profile ${member.actionProfileId}",
+    )
 
   private fun writeProfileGroup(
     type: Update.Type,
     group: P4RuntimeOuterClass.ActionProfileGroup,
-  ): WriteResult {
-    val groups = profileGroups.getOrPut(group.actionProfileId) { mutableMapOf() }
-    val exists = group.groupId in groups
-    return when (type) {
-      Update.Type.INSERT ->
-        if (exists)
-          WriteResult.AlreadyExists(
-            "action profile ${group.actionProfileId} already contains group ${group.groupId}"
-          )
-        else {
-          groups[group.groupId] = group
-          WriteResult.Success
-        }
-      Update.Type.MODIFY ->
-        if (!exists)
-          WriteResult.NotFound(
-            "action profile ${group.actionProfileId} has no group ${group.groupId}"
-          )
-        else {
-          groups[group.groupId] = group
-          WriteResult.Success
-        }
-      Update.Type.DELETE ->
-        if (!exists)
-          WriteResult.NotFound(
-            "action profile ${group.actionProfileId} has no group ${group.groupId}"
-          )
-        else {
-          groups.remove(group.groupId)
-          WriteResult.Success
-        }
-      else -> WriteResult.InvalidArgument("unsupported update type: $type")
-    }
-  }
+  ): WriteResult =
+    writeProfileEntity(
+      type,
+      profileGroups.getOrPut(group.actionProfileId) { mutableMapOf() },
+      group.groupId,
+      group,
+      "group ${group.groupId} in action profile ${group.actionProfileId}",
+    )
 
   private fun writePreEntry(pre: P4RuntimeOuterClass.PacketReplicationEngineEntry) {
     when {
@@ -306,45 +284,41 @@ class TableStore {
   }
 
   /**
-   * Returns action profile members as P4Runtime Entity protos, filtered by [filter].
-   * - `action_profile_id=0` → wildcard: all members from all profiles.
-   * - `action_profile_id=N, member_id=0` → all members from profile N.
-   * - `action_profile_id=N, member_id=M` → single member (N, M).
+   * Generic read for a two-level profile map (profile_id → entry_id → value).
+   * - `profileId=0` → wildcard: all values from all profiles.
+   * - `profileId=N, entryId=0` → all values from profile N.
+   * - `profileId=N, entryId=M` → single value (N, M).
    */
+  private fun <V> readProfileEntities(
+    storage: Map<Int, Map<Int, V>>,
+    profileId: Int,
+    entryId: Int,
+    toEntity: (V) -> P4RuntimeOuterClass.Entity,
+  ): List<P4RuntimeOuterClass.Entity> {
+    val sources =
+      if (profileId == 0) storage.values.flatMap { it.values }
+      else {
+        val entries = storage[profileId] ?: return emptyList()
+        if (entryId != 0) listOfNotNull(entries[entryId]) else entries.values.toList()
+      }
+    return sources.map(toEntity)
+  }
+
   fun readProfileMembers(
     filter: P4RuntimeOuterClass.ActionProfileMember =
       P4RuntimeOuterClass.ActionProfileMember.getDefaultInstance()
-  ): List<P4RuntimeOuterClass.Entity> {
-    val sources =
-      if (filter.actionProfileId == 0) profileMembers.values.flatMap { it.values }
-      else {
-        val members = profileMembers[filter.actionProfileId] ?: return emptyList()
-        if (filter.memberId != 0) listOfNotNull(members[filter.memberId])
-        else members.values.toList()
-      }
-    return sources.map {
+  ): List<P4RuntimeOuterClass.Entity> =
+    readProfileEntities(profileMembers, filter.actionProfileId, filter.memberId) {
       P4RuntimeOuterClass.Entity.newBuilder().setActionProfileMember(it).build()
     }
-  }
 
-  /**
-   * Returns action profile groups as P4Runtime Entity protos, filtered by [filter].
-   * - `action_profile_id=0` → wildcard: all groups from all profiles.
-   * - `action_profile_id=N, group_id=0` → all groups from profile N.
-   * - `action_profile_id=N, group_id=G` → single group (N, G).
-   */
   fun readProfileGroups(
     filter: P4RuntimeOuterClass.ActionProfileGroup =
       P4RuntimeOuterClass.ActionProfileGroup.getDefaultInstance()
-  ): List<P4RuntimeOuterClass.Entity> {
-    val sources =
-      if (filter.actionProfileId == 0) profileGroups.values.flatMap { it.values }
-      else {
-        val groups = profileGroups[filter.actionProfileId] ?: return emptyList()
-        if (filter.groupId != 0) listOfNotNull(groups[filter.groupId]) else groups.values.toList()
-      }
-    return sources.map { P4RuntimeOuterClass.Entity.newBuilder().setActionProfileGroup(it).build() }
-  }
+  ): List<P4RuntimeOuterClass.Entity> =
+    readProfileEntities(profileGroups, filter.actionProfileId, filter.groupId) {
+      P4RuntimeOuterClass.Entity.newBuilder().setActionProfileGroup(it).build()
+    }
 
   // -------------------------------------------------------------------------
   // Lookup

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -440,10 +440,16 @@ class TableStoreTest {
     return store
   }
 
-  private fun writeMember(store: TableStore, memberId: Int, actionId: Int, paramValue: Byte) {
+  private fun writeMember(
+    store: TableStore,
+    memberId: Int,
+    actionId: Int,
+    paramValue: Byte,
+    type: Update.Type = Update.Type.INSERT,
+  ): WriteResult =
     store.write(
       Update.newBuilder()
-        .setType(Update.Type.INSERT)
+        .setType(type)
         .setEntity(
           Entity.newBuilder()
             .setActionProfileMember(
@@ -463,12 +469,16 @@ class TableStoreTest {
         )
         .build()
     )
-  }
 
-  private fun writeGroup(store: TableStore, groupId: Int, memberIds: List<Int>) {
+  private fun writeGroup(
+    store: TableStore,
+    groupId: Int,
+    memberIds: List<Int>,
+    type: Update.Type = Update.Type.INSERT,
+  ): WriteResult =
     store.write(
       Update.newBuilder()
-        .setType(Update.Type.INSERT)
+        .setType(type)
         .setEntity(
           Entity.newBuilder()
             .setActionProfileGroup(
@@ -487,7 +497,6 @@ class TableStoreTest {
         )
         .build()
     )
-  }
 
   private fun writeGroupEntry(store: TableStore, fieldValue: Byte, groupId: Int) {
     store.write(
@@ -683,6 +692,194 @@ class TableStoreTest {
 
     assertNull(store.getCloneSession(1))
     assertNull(store.getMulticastGroup(1))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Action profile write semantics
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `insert duplicate member returns AlreadyExists`() {
+    val s = storeWithProfile()
+    assertEquals(WriteResult.Success, writeMember(s, memberId = 1, actionId = 10, paramValue = 1))
+    assertTrue(
+      writeMember(s, memberId = 1, actionId = 20, paramValue = 2) is WriteResult.AlreadyExists
+    )
+  }
+
+  @Test
+  fun `modify existing member succeeds`() {
+    val s = storeWithProfile()
+    writeMember(s, memberId = 1, actionId = 10, paramValue = 1)
+    assertEquals(
+      WriteResult.Success,
+      writeMember(s, memberId = 1, actionId = 20, paramValue = 2, type = Update.Type.MODIFY),
+    )
+  }
+
+  @Test
+  fun `modify non-existent member returns NotFound`() {
+    val s = storeWithProfile()
+    assertTrue(
+      writeMember(s, memberId = 99, actionId = 10, paramValue = 1, type = Update.Type.MODIFY)
+        is WriteResult.NotFound
+    )
+  }
+
+  @Test
+  fun `delete existing member succeeds`() {
+    val s = storeWithProfile()
+    writeMember(s, memberId = 1, actionId = 10, paramValue = 1)
+    assertEquals(
+      WriteResult.Success,
+      writeMember(s, memberId = 1, actionId = 10, paramValue = 1, type = Update.Type.DELETE),
+    )
+  }
+
+  @Test
+  fun `delete non-existent member returns NotFound`() {
+    val s = storeWithProfile()
+    assertTrue(
+      writeMember(s, memberId = 99, actionId = 10, paramValue = 1, type = Update.Type.DELETE)
+        is WriteResult.NotFound
+    )
+  }
+
+  @Test
+  fun `insert duplicate group returns AlreadyExists`() {
+    val s = storeWithProfile()
+    assertEquals(WriteResult.Success, writeGroup(s, groupId = 1, memberIds = listOf(0)))
+    assertTrue(writeGroup(s, groupId = 1, memberIds = listOf(0)) is WriteResult.AlreadyExists)
+  }
+
+  @Test
+  fun `modify existing group succeeds`() {
+    val s = storeWithProfile()
+    writeGroup(s, groupId = 1, memberIds = listOf(0))
+    assertEquals(
+      WriteResult.Success,
+      writeGroup(s, groupId = 1, memberIds = listOf(0, 1), type = Update.Type.MODIFY),
+    )
+  }
+
+  @Test
+  fun `modify non-existent group returns NotFound`() {
+    val s = storeWithProfile()
+    assertTrue(
+      writeGroup(s, groupId = 99, memberIds = listOf(0), type = Update.Type.MODIFY)
+        is WriteResult.NotFound
+    )
+  }
+
+  @Test
+  fun `delete existing group succeeds`() {
+    val s = storeWithProfile()
+    writeGroup(s, groupId = 1, memberIds = listOf(0))
+    assertEquals(
+      WriteResult.Success,
+      writeGroup(s, groupId = 1, memberIds = listOf(0), type = Update.Type.DELETE),
+    )
+  }
+
+  @Test
+  fun `delete non-existent group returns NotFound`() {
+    val s = storeWithProfile()
+    assertTrue(
+      writeGroup(s, groupId = 99, memberIds = listOf(0), type = Update.Type.DELETE)
+        is WriteResult.NotFound
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Action profile reads
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `readProfileMembers wildcard returns all members`() {
+    val s = storeWithProfile()
+    writeMember(s, memberId = 1, actionId = 10, paramValue = 1)
+    writeMember(s, memberId = 2, actionId = 20, paramValue = 2)
+    val results = s.readProfileMembers()
+    assertEquals(2, results.size)
+    assertTrue(results.all { it.hasActionProfileMember() })
+  }
+
+  @Test
+  fun `readProfileMembers with profile filter returns only that profile`() {
+    val s = storeWithProfile()
+    writeMember(s, memberId = 1, actionId = 10, paramValue = 1)
+    // Members from a different profile (id=999) should not be returned.
+    s.write(
+      Update.newBuilder()
+        .setType(Update.Type.INSERT)
+        .setEntity(
+          Entity.newBuilder()
+            .setActionProfileMember(
+              P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+                .setActionProfileId(999)
+                .setMemberId(1)
+                .setAction(Action.newBuilder().setActionId(10))
+            )
+        )
+        .build()
+    )
+    val filter =
+      P4RuntimeOuterClass.ActionProfileMember.newBuilder().setActionProfileId(PROFILE_ID).build()
+    val results = s.readProfileMembers(filter)
+    assertEquals(1, results.size)
+    assertEquals(PROFILE_ID, results[0].actionProfileMember.actionProfileId)
+  }
+
+  @Test
+  fun `readProfileMembers with member filter returns single member`() {
+    val s = storeWithProfile()
+    writeMember(s, memberId = 1, actionId = 10, paramValue = 1)
+    writeMember(s, memberId = 2, actionId = 20, paramValue = 2)
+    val filter =
+      P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+        .setActionProfileId(PROFILE_ID)
+        .setMemberId(1)
+        .build()
+    val results = s.readProfileMembers(filter)
+    assertEquals(1, results.size)
+    assertEquals(1, results[0].actionProfileMember.memberId)
+  }
+
+  @Test
+  fun `readProfileMembers non-matching returns empty`() {
+    val s = storeWithProfile()
+    writeMember(s, memberId = 1, actionId = 10, paramValue = 1)
+    val filter =
+      P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+        .setActionProfileId(PROFILE_ID)
+        .setMemberId(99)
+        .build()
+    assertTrue(s.readProfileMembers(filter).isEmpty())
+  }
+
+  @Test
+  fun `readProfileGroups wildcard returns all groups`() {
+    val s = storeWithProfile()
+    writeGroup(s, groupId = 1, memberIds = listOf(0))
+    writeGroup(s, groupId = 2, memberIds = listOf(0))
+    val results = s.readProfileGroups()
+    assertEquals(2, results.size)
+    assertTrue(results.all { it.hasActionProfileGroup() })
+  }
+
+  @Test
+  fun `readProfileGroups with group filter returns single group`() {
+    val s = storeWithProfile()
+    writeGroup(s, groupId = 1, memberIds = listOf(0))
+    writeGroup(s, groupId = 2, memberIds = listOf(0))
+    val filter =
+      P4RuntimeOuterClass.ActionProfileGroup.newBuilder()
+        .setActionProfileId(PROFILE_ID)
+        .setGroupId(1)
+        .build()
+    val results = s.readProfileGroups(filter)
+    assertEquals(1, results.size)
+    assertEquals(1, results[0].actionProfileGroup.groupId)
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Action profiles are now first-class citizens in the P4Runtime server. Members and groups support full CRUD through Write/Read RPCs with proper INSERT/MODIFY/DELETE semantics — the same error handling table entries get. The simulator's internal action profile machinery was already in place; this wires it up to the gRPC interface.

- **Write semantics**: INSERT fails on duplicate, MODIFY/DELETE fail on missing (matching table entry behavior)
- **Read filtering**: wildcard (all profiles), per-profile, and per-member/group lookup
- **Simulator dispatch**: `handleReadEntries` now routes `ActionProfileMember` and `ActionProfileGroup` entity filters alongside table entries

## Test plan

- [x] 10 unit tests for write semantics (INSERT/MODIFY/DELETE for both members and groups)
- [x] 6 unit tests for read filtering (wildcard, per-profile, per-member/group, non-matching)
- [x] 6 conformance tests through gRPC (scenarios 26-31)
- [x] Full `bazel test //...` green (206 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)