### PR TITLE
feat: extend @p4runtime_translation to match fields and PacketIO metadata

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -31,10 +31,11 @@ guilt — just write it down so someone can find it later.
   tracking. The first connection is master unconditionally.
 - **No p4-constraints validation.** `Write` does not enforce `@entry_restriction`
   or `@action_restriction` annotations from the P4 source.
-- **`@p4runtime_translation`: mapping table, not yet integrated end-to-end.**
-  The `TypeTranslator` supports `sdn_bitwidth` and `sdn_string` with explicit,
-  auto-allocate, and hybrid mapping modes. Integration with match fields and
-  PacketIO metadata translation is not yet implemented.
+- **`@p4runtime_translation`: fully integrated for action params, match fields,
+  and PacketIO metadata.** The `TypeTranslator` supports `sdn_bitwidth` and
+  `sdn_string` with explicit, auto-allocate, and hybrid mapping modes.
+  Note: v1model `p4c` does not emit `controller_packet_metadata` with
+  `type_name`, so PacketIO translation is exercised via unit tests only.
 - **Missing RPCs.** `GetForwardingPipelineConfig` and `Capabilities` return
   UNIMPLEMENTED.
 - **No counters, meters, or registers via P4Runtime.** These work via the

--- a/e2e_tests/translated_type/translated_type.p4
+++ b/e2e_tests/translated_type/translated_type.p4
@@ -2,7 +2,7 @@
  *
  * Uses a translated port type (sdn_bitwidth=32 for a 9-bit field) to verify
  * that the P4Runtime server correctly converts between controller and
- * dataplane representations.
+ * dataplane representations in action params and match fields.
  */
 
 #include <core.p4>
@@ -23,6 +23,7 @@ struct metadata_t { port_id_t ingress_port; }
 parser MyParser(packet_in pkt, out headers_t hdr,
                 inout metadata_t meta, inout standard_metadata_t smeta) {
     state start {
+        meta.ingress_port = (port_id_t)smeta.ingress_port;
         pkt.extract(hdr.ethernet);
         transition accept;
     }
@@ -43,7 +44,18 @@ control MyIngress(inout headers_t hdr, inout metadata_t meta,
         default_action = drop();
     }
 
-    apply { forwarding.apply(); }
+    // Second table: match field uses the translated port_id_t type.
+    // p4info will emit type_name on this match field, exercising match translation.
+    table port_forward {
+        key = { meta.ingress_port : exact; }
+        actions = { forward; drop; NoAction; }
+        default_action = NoAction;
+    }
+
+    apply {
+        forwarding.apply();
+        port_forward.apply();
+    }
 }
 
 control MyEgress(inout headers_t hdr, inout metadata_t meta,

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -128,6 +128,8 @@ kt_jvm_test(
     srcs = ["TypeTranslatorTest.kt"],
     test_class = "fourward.p4runtime.TypeTranslatorTest",
     deps = [
+        ":p4info_java_proto",
+        ":p4runtime_java_proto",
         ":p4runtime_lib",
         "//simulator:ir_java_proto",
         "@maven//:com_google_protobuf_protobuf_java",

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -175,8 +175,8 @@ class P4RuntimeService(private val simulator: Simulator) :
             )
           }
           msg.hasPacket() -> {
-            val packetOut = msg.packet
-            // Extract ingress port from packet_out metadata (field "ingress_port", ID 0 or 1).
+            val translator = typeTranslator?.takeIf { it.hasTranslations }
+            val packetOut = translator?.translatePacketOut(msg.packet) ?: msg.packet
             val ingressPort = extractIngressPort(packetOut.metadataList)
 
             val simRequest =
@@ -195,17 +195,18 @@ class P4RuntimeService(private val simulator: Simulator) :
 
             // Convert output packets to PacketIn messages.
             for (outputPacket in simResponse.processPacket.outputPacketsList) {
+              val rawPacketIn =
+                PacketIn.newBuilder()
+                  .setPayload(outputPacket.payload)
+                  .addMetadata(
+                    p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
+                      .setMetadataId(EGRESS_PORT_METADATA_ID)
+                      .setValue(encodeMinWidth(outputPacket.egressPort))
+                  )
+                  .build()
               emit(
                 StreamMessageResponse.newBuilder()
-                  .setPacket(
-                    PacketIn.newBuilder()
-                      .setPayload(outputPacket.payload)
-                      .addMetadata(
-                        p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
-                          .setMetadataId(EGRESS_PORT_METADATA_ID)
-                          .setValue(encodeMinWidth(outputPacket.egressPort))
-                      )
-                  )
+                  .setPacket(translator?.translatePacketIn(rawPacketIn) ?: rawPacketIn)
                   .build()
               )
             }

--- a/p4runtime/P4RuntimeTranslationTest.kt
+++ b/p4runtime/P4RuntimeTranslationTest.kt
@@ -140,9 +140,7 @@ class P4RuntimeTranslationTest {
   @Test
   fun `forwarding to translated port 2 works`() {
     // SDN port 2 is auto-allocated to the first available data-plane value (0),
-    // since no explicit translation mappings are configured. The simulator forwards
-    // on data-plane port 0, which is what PacketIn metadata reports (PacketIn
-    // metadata translation is not yet implemented).
+    // since no explicit translation mappings are configured.
     val entry = buildEntry(matchValue = 0x0800, portValue = byteArrayOf(0, 0, 0, 2))
     harness.installEntry(entry)
 
@@ -157,14 +155,51 @@ class P4RuntimeTranslationTest {
   }
 
   // =========================================================================
+  // Match field translation: port_forward table with translated match key
+  // =========================================================================
+
+  @Test
+  fun `translated match field round-trips through write and read`() {
+    // port_forward table matches on meta.ingress_port (port_id_t, SDN bitwidth=32).
+    // Write with SDN port value 42 and read back — should get 42 back.
+    val portForwardEntry =
+      buildPortForwardEntry(sdnPort = 42, forwardPort = byteArrayOf(0, 0, 0, 1))
+    harness.installEntry(portForwardEntry)
+
+    val portForwardTable =
+      config.p4Info.tablesList.find { it.preamble.name.contains("port_forward") }!!
+    val entities = harness.readTableEntries(portForwardTable.preamble.id)
+    assertEquals("expected one entity in port_forward", 1, entities.size)
+
+    val matchField = entities[0].tableEntry.matchList.first()
+    val matchValue =
+      matchField.exact.value.toByteArray().fold(0L) { acc, b ->
+        (acc shl 8) or (b.toLong() and 0xFF)
+      }
+    assertEquals("match field should round-trip as SDN value", 42L, matchValue)
+  }
+
+  // =========================================================================
   // Helpers
   // =========================================================================
 
-  /** Builds a table entry for the translated_type fixture's forwarding table. */
+  private fun buildPortForwardEntry(sdnPort: Int, forwardPort: ByteArray): Entity =
+    buildEntry(tableName = "port_forward", matchValue = sdnPort.toLong(), portValue = forwardPort)
+
+  /** Builds a table entry: exact match on the first field → forward(port). */
   @Suppress("MagicNumber")
-  private fun buildEntry(matchValue: Long = 0x0800, portValue: ByteArray): Entity {
+  private fun buildEntry(
+    matchValue: Long = 0x0800,
+    portValue: ByteArray,
+    tableName: String? = null,
+  ): Entity {
     val p4info = config.p4Info
-    val table = p4info.tablesList.first()
+    val table =
+      if (tableName != null) {
+        p4info.tablesList.find { it.preamble.name.contains(tableName) }!!
+      } else {
+        p4info.tablesList.first()
+      }
     val forwardAction = p4info.actionsList.find { it.preamble.name.contains("forward") }!!
     val matchField = table.matchFieldsList.first()
 

--- a/p4runtime/TypeTranslator.kt
+++ b/p4runtime/TypeTranslator.kt
@@ -6,6 +6,8 @@ import fourward.ir.v1.TypeTranslation
 import java.util.concurrent.ConcurrentHashMap
 import p4.config.v1.P4InfoOuterClass.P4Info
 import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.PacketIn
+import p4.v1.P4RuntimeOuterClass.PacketOut
 import p4.v1.P4RuntimeOuterClass.Update
 
 /**
@@ -42,16 +44,23 @@ class TranslationException(message: String) : RuntimeException(message)
  * - **Hybrid**: explicit pins for known values, auto-allocate for the rest.
  *
  * When no [TypeTranslation] is provided for a URI, auto-allocation is used by default.
+ *
+ * Translates action parameters, match fields (exact/optional), and PacketIO metadata.
  */
 class TypeTranslator
 private constructor(
   private val tables: ConcurrentHashMap<String, TranslationTable>,
   private val paramUris: Map<Long, String>,
+  private val matchFieldUris: Map<Long, String>,
+  private val packetMetadataUris: Map<Int, String>,
 ) {
 
-  /** Returns true if this translator has any translated types to handle. */
-  val hasTranslations: Boolean
-    get() = tables.isNotEmpty() || paramUris.isNotEmpty()
+  /** True if this translator has any translated types to handle. */
+  val hasTranslations: Boolean =
+    tables.isNotEmpty() ||
+      paramUris.isNotEmpty() ||
+      matchFieldUris.isNotEmpty() ||
+      packetMetadataUris.isNotEmpty()
 
   /**
    * Translates an SDN bitstring value to its data-plane representation.
@@ -82,66 +91,78 @@ private constructor(
     tables.computeIfAbsent(uri) { TranslationTable(autoAllocate = true) }
 
   // ---------------------------------------------------------------------------
-  // P4Runtime Write/Read translation (delegates to per-param URI lookup)
+  // P4Runtime Write/Read translation
   // ---------------------------------------------------------------------------
 
-  /**
-   * Translates a Write update from SDN to data-plane representation.
-   *
-   * For each action parameter that uses a translated type, looks up the SDN value in the mapping
-   * table and replaces it with the corresponding data-plane value.
-   */
+  /** Translates a Write update from SDN to data-plane representation. */
   fun translateForWrite(update: Update): Update {
     if (!update.entity.hasTableEntry()) return update
-    val entry = update.entity.tableEntry
-    if (!entry.hasAction() || !entry.action.hasAction()) return update
-    val action = entry.action.action
-    val translatedParams = translateParams(action.actionId, action.paramsList, toDataplane = true)
-    translatedParams ?: return update
-    return update
-      .toBuilder()
-      .setEntity(
-        update.entity
-          .toBuilder()
-          .setTableEntry(
-            entry
-              .toBuilder()
-              .setAction(
-                entry.action
-                  .toBuilder()
-                  .setAction(action.toBuilder().clearParams().addAllParams(translatedParams))
-              )
-          )
-      )
-      .build()
+    val translated =
+      translateTableEntry(update.entity.tableEntry, toDataplane = true) ?: return update
+    return update.toBuilder().setEntity(update.entity.toBuilder().setTableEntry(translated)).build()
+  }
+
+  /** Translates a Read entity from data-plane to SDN representation. */
+  fun translateForRead(entity: Entity): Entity {
+    if (!entity.hasTableEntry()) return entity
+    val translated = translateTableEntry(entity.tableEntry, toDataplane = false) ?: return entity
+    return entity.toBuilder().setTableEntry(translated).build()
   }
 
   /**
-   * Translates a Read entity from data-plane to SDN representation.
-   *
-   * For each action parameter that uses a translated type, looks up the data-plane value and
-   * replaces it with the corresponding SDN value.
+   * Translates match field values and action parameter values in a table entry. Returns null if
+   * nothing was translated.
    */
-  fun translateForRead(entity: Entity): Entity {
-    if (!entity.hasTableEntry()) return entity
-    val entry = entity.tableEntry
-    if (!entry.hasAction() || !entry.action.hasAction()) return entity
-    val action = entry.action.action
-    val translatedParams = translateParams(action.actionId, action.paramsList, toDataplane = false)
-    translatedParams ?: return entity
-    return entity
-      .toBuilder()
-      .setTableEntry(
-        entry
+  private fun translateTableEntry(
+    entry: p4.v1.P4RuntimeOuterClass.TableEntry,
+    toDataplane: Boolean,
+  ): p4.v1.P4RuntimeOuterClass.TableEntry? {
+    val translatedMatches = translateMatchFields(entry.tableId, entry.matchList, toDataplane)
+    val translatedParams =
+      if (entry.hasAction() && entry.action.hasAction()) {
+        val action = entry.action.action
+        translateParams(action.actionId, action.paramsList, toDataplane)
+      } else {
+        null
+      }
+    if (translatedMatches == null && translatedParams == null) return null
+    val builder = entry.toBuilder()
+    if (translatedMatches != null) {
+      builder.clearMatch().addAllMatch(translatedMatches)
+    }
+    if (translatedParams != null) {
+      builder.setAction(
+        entry.action
           .toBuilder()
-          .setAction(
-            entry.action
-              .toBuilder()
-              .setAction(action.toBuilder().clearParams().addAllParams(translatedParams))
-          )
+          .setAction(entry.action.action.toBuilder().clearParams().addAllParams(translatedParams))
       )
-      .build()
+    }
+    return builder.build()
   }
+
+  // ---------------------------------------------------------------------------
+  // PacketIO metadata translation
+  // ---------------------------------------------------------------------------
+
+  /** Translates PacketOut metadata from SDN to data-plane representation. */
+  fun translatePacketOut(packetOut: PacketOut): PacketOut {
+    if (packetMetadataUris.isEmpty()) return packetOut
+    val translated =
+      translateMetadata(packetOut.metadataList, toDataplane = true) ?: return packetOut
+    return packetOut.toBuilder().clearMetadata().addAllMetadata(translated).build()
+  }
+
+  /** Translates PacketIn metadata from data-plane to SDN representation. */
+  fun translatePacketIn(packetIn: PacketIn): PacketIn {
+    if (packetMetadataUris.isEmpty()) return packetIn
+    val translated =
+      translateMetadata(packetIn.metadataList, toDataplane = false) ?: return packetIn
+    return packetIn.toBuilder().clearMetadata().addAllMetadata(translated).build()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal translation helpers
+  // ---------------------------------------------------------------------------
 
   private fun translateParams(
     actionId: Int,
@@ -151,26 +172,10 @@ private constructor(
     var changed = false
     val result =
       params.map { param ->
-        val uri = paramUris[paramKey(actionId, param.paramId)]
+        val uri = paramUris[packKey(actionId, param.paramId)]
         if (uri != null) {
           changed = true
-          val table = getOrCreateTable(uri)
-          // Operate on ByteString directly — param.value is already ByteString,
-          // so we avoid unnecessary ByteArray↔ByteString round-trips.
-          val translated =
-            if (toDataplane) {
-              table.lookupOrAllocateBitstring(param.value)
-            } else {
-              when (val sdnValue = table.reverseLookup(param.value)) {
-                is SdnValue.Bitstring -> sdnValue.value
-                // sdn_string values can't be encoded as action param bytes — the P4Runtime
-                // spec has no mechanism to return string values inside action parameters.
-                is SdnValue.Str ->
-                  throw TranslationException(
-                    "Cannot encode sdn_string value '${sdnValue.value}' as action param bytes"
-                  )
-              }
-            }
+          val translated = translateValue(getOrCreateTable(uri), param.value, toDataplane)
           param.toBuilder().setValue(translated).build()
         } else {
           param
@@ -179,22 +184,105 @@ private constructor(
     return if (changed) result else null
   }
 
+  private fun translateMatchFields(
+    tableId: Int,
+    matches: List<p4.v1.P4RuntimeOuterClass.FieldMatch>,
+    toDataplane: Boolean,
+  ): List<p4.v1.P4RuntimeOuterClass.FieldMatch>? {
+    var changed = false
+    val result =
+      matches.map { match ->
+        val uri = matchFieldUris[packKey(tableId, match.fieldId)]
+        if (uri != null) {
+          changed = true
+          val table = getOrCreateTable(uri)
+          when {
+            match.hasExact() -> {
+              val translated = translateValue(table, match.exact.value, toDataplane)
+              match
+                .toBuilder()
+                .setExact(
+                  p4.v1.P4RuntimeOuterClass.FieldMatch.Exact.newBuilder().setValue(translated)
+                )
+                .build()
+            }
+            match.hasOptional() -> {
+              val translated = translateValue(table, match.optional.value, toDataplane)
+              match
+                .toBuilder()
+                .setOptional(
+                  p4.v1.P4RuntimeOuterClass.FieldMatch.Optional.newBuilder().setValue(translated)
+                )
+                .build()
+            }
+            // Ternary/LPM/Range on translated types is nonsensical — pass through.
+            else -> match
+          }
+        } else {
+          match
+        }
+      }
+    return if (changed) result else null
+  }
+
+  private fun translateMetadata(
+    metadata: List<p4.v1.P4RuntimeOuterClass.PacketMetadata>,
+    toDataplane: Boolean,
+  ): List<p4.v1.P4RuntimeOuterClass.PacketMetadata>? {
+    var changed = false
+    val result =
+      metadata.map { meta ->
+        val uri = packetMetadataUris[meta.metadataId]
+        if (uri != null) {
+          changed = true
+          val translated = translateValue(getOrCreateTable(uri), meta.value, toDataplane)
+          meta.toBuilder().setValue(translated).build()
+        } else {
+          meta
+        }
+      }
+    return if (changed) result else null
+  }
+
+  /** Translates a single ByteString value forward (SDN→DP) or reverse (DP→SDN). */
+  private fun translateValue(
+    table: TranslationTable,
+    value: ByteString,
+    toDataplane: Boolean,
+  ): ByteString =
+    if (toDataplane) {
+      table.lookupOrAllocateBitstring(value)
+    } else {
+      when (val sdnValue = table.reverseLookup(value)) {
+        is SdnValue.Bitstring -> sdnValue.value
+        // sdn_string values can't be encoded as bytes — the P4Runtime spec has no
+        // mechanism to return string values inside match fields or action parameters.
+        is SdnValue.Str ->
+          throw TranslationException("Cannot encode sdn_string value '${sdnValue.value}' as bytes")
+      }
+    }
+
   companion object {
     /**
      * Creates a TypeTranslator from translation configurations.
      *
      * For use without p4info — the translator supports direct URI-based lookups via
-     * [sdnToDataplane] and [dataplaneToSdn], but not [translateForWrite]/[translateForRead] (which
-     * require p4info to map action param IDs to URIs).
+     * [sdnToDataplane] and [dataplaneToSdn], but not message-level translation methods (which
+     * require p4info to map field IDs to URIs).
      */
     fun create(translations: List<TypeTranslation> = emptyList()): TypeTranslator =
-      TypeTranslator(buildTables(translations), paramUris = emptyMap())
+      TypeTranslator(
+        buildTables(translations),
+        paramUris = emptyMap(),
+        matchFieldUris = emptyMap(),
+        packetMetadataUris = emptyMap(),
+      )
 
     /**
      * Creates a TypeTranslator from p4info and translation configurations.
      *
-     * Discovers translated types from p4info and maps (actionId, paramId) pairs to URIs, enabling
-     * [translateForWrite] and [translateForRead] on P4Runtime messages.
+     * Discovers translated types from p4info and maps field IDs to URIs, enabling translation of
+     * action parameters, match fields, and PacketIO metadata in P4Runtime messages.
      */
     fun create(p4info: P4Info, translations: List<TypeTranslation> = emptyList()): TypeTranslator {
       val translatedTypes =
@@ -205,11 +293,34 @@ private constructor(
         for (param in action.paramsList) {
           if (!param.hasTypeName()) continue
           val typeSpec = translatedTypes[param.typeName.name] ?: continue
-          paramUris[paramKey(action.preamble.id, param.id)] = typeSpec.translatedType.uri
+          paramUris[packKey(action.preamble.id, param.id)] = typeSpec.translatedType.uri
         }
       }
 
-      return TypeTranslator(buildTables(translations), paramUris)
+      val matchFieldUris = mutableMapOf<Long, String>()
+      for (table in p4info.tablesList) {
+        for (matchField in table.matchFieldsList) {
+          if (!matchField.hasTypeName()) continue
+          val typeSpec = translatedTypes[matchField.typeName.name] ?: continue
+          matchFieldUris[packKey(table.preamble.id, matchField.id)] = typeSpec.translatedType.uri
+        }
+      }
+
+      val packetMetadataUris = mutableMapOf<Int, String>()
+      for (controllerMeta in p4info.controllerPacketMetadataList) {
+        for (metadata in controllerMeta.metadataList) {
+          if (!metadata.hasTypeName()) continue
+          val typeSpec = translatedTypes[metadata.typeName.name] ?: continue
+          packetMetadataUris[metadata.id] = typeSpec.translatedType.uri
+        }
+      }
+
+      return TypeTranslator(
+        buildTables(translations),
+        paramUris,
+        matchFieldUris,
+        packetMetadataUris,
+      )
     }
 
     private fun buildTables(
@@ -222,9 +333,9 @@ private constructor(
       return tables
     }
 
-    /** Encodes (actionId, paramId) as a single Long for fast lookup. */
-    private fun paramKey(actionId: Int, paramId: Int): Long =
-      (actionId.toLong() shl 32) or (paramId.toLong() and 0xFFFFFFFFL)
+    /** Packs two IDs into a single Long for fast compound-key lookup. */
+    private fun packKey(high: Int, low: Int): Long =
+      (high.toLong() shl 32) or (low.toLong() and 0xFFFFFFFFL)
   }
 }
 

--- a/p4runtime/TypeTranslatorTest.kt
+++ b/p4runtime/TypeTranslatorTest.kt
@@ -7,6 +7,9 @@ import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
+import p4.config.v1.P4InfoOuterClass
+import p4.config.v1.P4Types
+import p4.v1.P4RuntimeOuterClass
 
 /**
  * Unit tests for [TypeTranslator]'s core mapping logic.
@@ -288,6 +291,321 @@ class TypeTranslatorTest {
   }
 
   // ===========================================================================
+  // Match field translation via P4Info
+  // ===========================================================================
+
+  @Test
+  fun `match field with translated type is discovered from p4info`() {
+    val translator = buildP4InfoTranslator()
+
+    // Forward: SDN exact match value → data-plane value.
+    val update =
+      writeUpdate(TABLE_ID, MATCH_FIELD_ID, sdnBytes(5000), ACTION_ID, PARAM_ID, sdnBytes(1))
+    val translated = translator.translateForWrite(update)
+    val match = translated.entity.tableEntry.matchList.first()
+    assertEquals(ByteString.copyFrom(dpBytes(0)), match.exact.value)
+  }
+
+  @Test
+  fun `match field translation round-trips through read`() {
+    val translator = buildP4InfoTranslator()
+
+    // Forward translate to install the mapping.
+    translator.translateForWrite(
+      writeUpdate(TABLE_ID, MATCH_FIELD_ID, sdnBytes(5000), ACTION_ID, PARAM_ID, sdnBytes(1))
+    )
+
+    // Reverse: simulate reading back a data-plane entity.
+    val dpEntity = readEntity(TABLE_ID, MATCH_FIELD_ID, dpBytes(0), ACTION_ID, PARAM_ID, dpBytes(0))
+    val sdnEntity = translator.translateForRead(dpEntity)
+    val match = sdnEntity.tableEntry.matchList.first()
+    assertEquals(ByteString.copyFrom(sdnBytes(5000)), match.exact.value)
+  }
+
+  @Test
+  fun `optional match field with translated type is translated`() {
+    val translator = buildP4InfoTranslator()
+
+    val update =
+      writeUpdateOptionalMatch(
+        TABLE_ID,
+        MATCH_FIELD_ID,
+        sdnBytes(5000),
+        ACTION_ID,
+        PARAM_ID,
+        sdnBytes(1),
+      )
+    val translated = translator.translateForWrite(update)
+    val match = translated.entity.tableEntry.matchList.first()
+    assertEquals(ByteString.copyFrom(dpBytes(0)), match.optional.value)
+  }
+
+  @Test
+  fun `non-translated match field passes through unchanged`() {
+    val translator = buildP4InfoTranslator()
+
+    // Use a match field ID that has no type_name in p4info.
+    val rawValue = sdnBytes(42)
+    val update =
+      writeUpdate(TABLE_ID, NON_TRANSLATED_FIELD_ID, rawValue, ACTION_ID, PARAM_ID, sdnBytes(1))
+    val translated = translator.translateForWrite(update)
+    val match = translated.entity.tableEntry.matchList.first()
+    // Match value should be unchanged.
+    assertEquals(ByteString.copyFrom(rawValue), match.exact.value)
+  }
+
+  // ===========================================================================
+  // PacketIO metadata translation via P4Info
+  // ===========================================================================
+
+  @Test
+  fun `packet metadata with translated type is translated for packet out`() {
+    val translator = buildP4InfoTranslatorWithPacketIO()
+
+    val packetOut =
+      P4RuntimeOuterClass.PacketOut.newBuilder()
+        .setPayload(ByteString.copyFrom(byteArrayOf(0x00)))
+        .addMetadata(
+          P4RuntimeOuterClass.PacketMetadata.newBuilder()
+            .setMetadataId(PACKET_METADATA_ID)
+            .setValue(ByteString.copyFrom(sdnBytes(5000)))
+        )
+        .build()
+
+    val translated = translator.translatePacketOut(packetOut)
+    val meta = translated.metadataList.first()
+    assertEquals(ByteString.copyFrom(dpBytes(0)), meta.value)
+  }
+
+  @Test
+  fun `packet metadata with translated type is translated for packet in`() {
+    val translator = buildP4InfoTranslatorWithPacketIO()
+
+    // Install forward mapping first.
+    val packetOut =
+      P4RuntimeOuterClass.PacketOut.newBuilder()
+        .setPayload(ByteString.copyFrom(byteArrayOf(0x00)))
+        .addMetadata(
+          P4RuntimeOuterClass.PacketMetadata.newBuilder()
+            .setMetadataId(PACKET_METADATA_ID)
+            .setValue(ByteString.copyFrom(sdnBytes(5000)))
+        )
+        .build()
+    translator.translatePacketOut(packetOut)
+
+    // Reverse: data-plane → SDN.
+    val packetIn =
+      P4RuntimeOuterClass.PacketIn.newBuilder()
+        .setPayload(ByteString.copyFrom(byteArrayOf(0x00)))
+        .addMetadata(
+          P4RuntimeOuterClass.PacketMetadata.newBuilder()
+            .setMetadataId(PACKET_METADATA_ID)
+            .setValue(ByteString.copyFrom(dpBytes(0)))
+        )
+        .build()
+
+    val translated = translator.translatePacketIn(packetIn)
+    val meta = translated.metadataList.first()
+    assertEquals(ByteString.copyFrom(sdnBytes(5000)), meta.value)
+  }
+
+  @Test
+  fun `non-translated packet metadata passes through unchanged`() {
+    val translator = buildP4InfoTranslatorWithPacketIO()
+
+    val rawValue = ByteString.copyFrom(sdnBytes(42))
+    val packetOut =
+      P4RuntimeOuterClass.PacketOut.newBuilder()
+        .setPayload(ByteString.copyFrom(byteArrayOf(0x00)))
+        .addMetadata(
+          P4RuntimeOuterClass.PacketMetadata.newBuilder()
+            .setMetadataId(NON_TRANSLATED_METADATA_ID)
+            .setValue(rawValue)
+        )
+        .build()
+
+    val translated = translator.translatePacketOut(packetOut)
+    val meta = translated.metadataList.first()
+    assertEquals(rawValue, meta.value)
+  }
+
+  // ===========================================================================
+  // P4Info test constants and builders
+  // ===========================================================================
+
+  companion object {
+    private const val TABLE_ID = 100
+    private const val MATCH_FIELD_ID = 1
+    private const val NON_TRANSLATED_FIELD_ID = 2
+    private const val ACTION_ID = 200
+    private const val PARAM_ID = 1
+    private const val PACKET_METADATA_ID = 1
+    private const val NON_TRANSLATED_METADATA_ID = 2
+    private const val TYPE_NAME = "port_id_t"
+    private const val TYPE_URI = "test.port_id"
+  }
+
+  private fun portIdTypeInfo(): P4Types.P4TypeInfo =
+    P4Types.P4TypeInfo.newBuilder()
+      .putNewTypes(
+        TYPE_NAME,
+        P4Types.P4NewTypeSpec.newBuilder()
+          .setTranslatedType(
+            P4Types.P4NewTypeTranslation.newBuilder().setUri(TYPE_URI).setSdnBitwidth(32)
+          )
+          .build(),
+      )
+      .build()
+
+  /** Builds a TypeTranslator from synthetic p4info with a translated match field. */
+  private fun buildP4InfoTranslator(): TypeTranslator {
+    val p4info =
+      P4InfoOuterClass.P4Info.newBuilder()
+        .addTables(
+          P4InfoOuterClass.Table.newBuilder()
+            .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(TABLE_ID))
+            .addMatchFields(
+              P4InfoOuterClass.MatchField.newBuilder()
+                .setId(MATCH_FIELD_ID)
+                .setBitwidth(32)
+                .setMatchType(P4InfoOuterClass.MatchField.MatchType.EXACT)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(TYPE_NAME))
+            )
+            .addMatchFields(
+              P4InfoOuterClass.MatchField.newBuilder()
+                .setId(NON_TRANSLATED_FIELD_ID)
+                .setBitwidth(16)
+                .setMatchType(P4InfoOuterClass.MatchField.MatchType.EXACT)
+            )
+        )
+        .addActions(
+          P4InfoOuterClass.Action.newBuilder()
+            .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(ACTION_ID))
+            .addParams(
+              P4InfoOuterClass.Action.Param.newBuilder()
+                .setId(PARAM_ID)
+                .setBitwidth(32)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(TYPE_NAME))
+            )
+        )
+        .setTypeInfo(portIdTypeInfo())
+        .build()
+    return TypeTranslator.create(p4info)
+  }
+
+  /** Builds a TypeTranslator from synthetic p4info with translated PacketIO metadata. */
+  private fun buildP4InfoTranslatorWithPacketIO(): TypeTranslator {
+    val p4info =
+      P4InfoOuterClass.P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          P4InfoOuterClass.ControllerPacketMetadata.newBuilder()
+            .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(1).setName("packet_out"))
+            .addMetadata(
+              P4InfoOuterClass.ControllerPacketMetadata.Metadata.newBuilder()
+                .setId(PACKET_METADATA_ID)
+                .setName("ingress_port")
+                .setBitwidth(32)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(TYPE_NAME))
+            )
+            .addMetadata(
+              P4InfoOuterClass.ControllerPacketMetadata.Metadata.newBuilder()
+                .setId(NON_TRANSLATED_METADATA_ID)
+                .setName("padding")
+                .setBitwidth(7)
+            )
+        )
+        .setTypeInfo(portIdTypeInfo())
+        .build()
+    return TypeTranslator.create(p4info)
+  }
+
+  /** Builds an Update wrapping a table entry with an exact match. */
+  private fun writeUpdate(
+    tableId: Int,
+    fieldId: Int,
+    matchValue: ByteArray,
+    actionId: Int,
+    paramId: Int,
+    paramValue: ByteArray,
+  ): P4RuntimeOuterClass.Update {
+    val match = exactMatch(fieldId, matchValue)
+    return wrapUpdate(buildTableEntry(tableId, match, actionId, paramId, paramValue))
+  }
+
+  /** Builds an Update wrapping a table entry with an optional match. */
+  private fun writeUpdateOptionalMatch(
+    tableId: Int,
+    fieldId: Int,
+    matchValue: ByteArray,
+    actionId: Int,
+    paramId: Int,
+    paramValue: ByteArray,
+  ): P4RuntimeOuterClass.Update {
+    val match =
+      P4RuntimeOuterClass.FieldMatch.newBuilder()
+        .setFieldId(fieldId)
+        .setOptional(
+          P4RuntimeOuterClass.FieldMatch.Optional.newBuilder()
+            .setValue(ByteString.copyFrom(matchValue))
+        )
+        .build()
+    return wrapUpdate(buildTableEntry(tableId, match, actionId, paramId, paramValue))
+  }
+
+  /** Builds an Entity with exact match and action param (simulates a read response). */
+  private fun readEntity(
+    tableId: Int,
+    fieldId: Int,
+    matchValue: ByteArray,
+    actionId: Int,
+    paramId: Int,
+    paramValue: ByteArray,
+  ): P4RuntimeOuterClass.Entity {
+    val match = exactMatch(fieldId, matchValue)
+    return P4RuntimeOuterClass.Entity.newBuilder()
+      .setTableEntry(buildTableEntry(tableId, match, actionId, paramId, paramValue))
+      .build()
+  }
+
+  private fun exactMatch(fieldId: Int, value: ByteArray): P4RuntimeOuterClass.FieldMatch =
+    P4RuntimeOuterClass.FieldMatch.newBuilder()
+      .setFieldId(fieldId)
+      .setExact(
+        P4RuntimeOuterClass.FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(value))
+      )
+      .build()
+
+  private fun buildTableEntry(
+    tableId: Int,
+    match: P4RuntimeOuterClass.FieldMatch,
+    actionId: Int,
+    paramId: Int,
+    paramValue: ByteArray,
+  ): P4RuntimeOuterClass.TableEntry =
+    P4RuntimeOuterClass.TableEntry.newBuilder()
+      .setTableId(tableId)
+      .addMatch(match)
+      .setAction(
+        P4RuntimeOuterClass.TableAction.newBuilder()
+          .setAction(
+            P4RuntimeOuterClass.Action.newBuilder()
+              .setActionId(actionId)
+              .addParams(
+                P4RuntimeOuterClass.Action.Param.newBuilder()
+                  .setParamId(paramId)
+                  .setValue(ByteString.copyFrom(paramValue))
+              )
+          )
+      )
+      .build()
+
+  private fun wrapUpdate(entry: P4RuntimeOuterClass.TableEntry): P4RuntimeOuterClass.Update =
+    P4RuntimeOuterClass.Update.newBuilder()
+      .setType(P4RuntimeOuterClass.Update.Type.INSERT)
+      .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry))
+      .build()
+
+  // ===========================================================================
   // Helpers
   // ===========================================================================
 
@@ -313,7 +631,6 @@ class TypeTranslatorTest {
       .setDataplaneValue(ByteString.copyFrom(dataplaneValue))
       .build()
 
-  /** Minimum-width big-endian encoding of a non-negative integer. */
   private fun sdnBytes(value: Int): ByteArray = encodeMinWidth(value)
 
   private fun dpBytes(value: Int): ByteArray = encodeMinWidth(value)


### PR DESCRIPTION
## Summary

Closes the last gap in `@p4runtime_translation` support — **match fields** and **PacketIO metadata** now go through the same bidirectional SDN↔dataplane mapping as action parameters.

- Match fields with `type_name` in p4info (exact and optional) are translated on Write and Read
- PacketIO metadata with `type_name` is translated on PacketOut (SDN→DP) and PacketIn (DP→SDN)
- Exercised end-to-end via a new `port_forward` table matching on `port_id_t`
- 7 new unit tests with synthetic P4Info protos (match field discovery, optional match, PacketIO forward/reverse, passthrough)
- 1 new E2E test verifying match field round-trip through a real pipeline

Note: v1model `p4c` doesn't emit `controller_packet_metadata` with `type_name`, so PacketIO translation is unit-tested only. Works for SAI P4 and similar programs.

## Test plan

- [x] `bazel test //...` — 203 tests pass
- [x] `./tools/format.sh` clean
- [x] `./tools/lint.sh` clean (detekt; clang-tidy N/A locally)
- [x] Unit tests cover match field + PacketIO translation with synthetic P4Info
- [x] E2E test verifies translated match field round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)