### PR TITLE
docs: address why not OCaml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ ergonomics (sealed classes, pattern matching).
 - **Go?** Weaker type system — no algebraic data types, no pattern matching.
 - **Python?** Weak type system, slow test execution.
 - **Java?** Kotlin, but worse.
-- **OCaml?** Excellent fit, but not supported by Google's ecosystem :(
+- **OCaml?** Excellent fit, but not supported within Google's ecosystem :(
 
 **You don't need to know Kotlin to contribute to 4ward!**
 [The AI writes the code](docs/AI_WORKFLOW.md) — you just need to know your

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ ergonomics (sealed classes, pattern matching).
 - **Go?** Weaker type system — no algebraic data types, no pattern matching.
 - **Python?** Weak type system, slow test execution.
 - **Java?** Kotlin, but worse.
+- **OCaml?** Excellent fit, but not supported by Google's ecosystem :(
 
 **You don't need to know Kotlin to contribute to 4ward!**
 [The AI writes the code](docs/AI_WORKFLOW.md) — you just need to know your


### PR DESCRIPTION
Closes #165.

Adds OCaml to the "Why not…" list in the README — being transparent about the
Google ecosystem constraint as a practical reason for choosing Kotlin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)