### PR TITLE
p4testgen: graceful clone/multicast handling, promote ipv6-switch-ml

### DIFF
--- a/e2e_tests/p4testgen/BUILD.bazel
+++ b/e2e_tests/p4testgen/BUILD.bazel
@@ -273,7 +273,6 @@ p4_testgen_test(name = "invalid-hdr-warnings3-bmv2")
 p4_testgen_test(
     name = "ipv6-switch-ml-bmv2",
     includes = _ML_HEADERS,
-    tags = ["manual"],  # unknown multicast group
 )
 
 p4_testgen_test(name = "issue-2123-2-bmv2")
@@ -447,5 +446,5 @@ p4_testgen_test(name = "v1model-const-entries-bmv2")
 p4_testgen_test(
     name = "v1model-special-ops-bmv2",
     max_tests = 20,
-    tags = ["manual"],  # unknown clone session: 5
+    tags = ["manual"],  # StackOverflowError from deep clone/recirculate fork trees
 )

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -345,10 +345,9 @@ class V1ModelArchitecture : Architecture {
     when (val mode = decisions.branchMode) {
       is BranchMode.I2EClone -> {
         // I2E clone branch: set up clone metadata and continue to egress.
-        val session =
-          ctx.tableStore.getCloneSession(mode.sessionId)
-            ?: error("unknown clone session: ${mode.sessionId}")
-        val clonePort = session.replicasList.firstOrNull()?.egressPort ?: 0
+        // BMv2 drops the clone if the session doesn't exist.
+        val session = ctx.tableStore.getCloneSession(mode.sessionId)
+        val clonePort = session?.replicasList?.firstOrNull()?.egressPort ?: DROP_PORT
         s.standardMetadata.fields["instance_type"] = BitVal(CLONE_I2E_INSTANCE_TYPE, INT32_BITS)
         s.standardMetadata.fields["egress_port"] = BitVal(clonePort.toLong(), PORT_BITS)
       }
@@ -371,12 +370,13 @@ class V1ModelArchitecture : Architecture {
         val mcastGrp =
           (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
         if (mcastGrp != 0) {
-          val group =
-            ctx.tableStore.getMulticastGroup(mcastGrp)
-              ?: error("unknown multicast group: $mcastGrp")
-          val replicas =
-            group.replicasList.map { r -> BranchMode.Replica(r.instance, r.egressPort) }
-          throw MulticastFork(replicas, s.packetCtx.getEvents())
+          // BMv2 silently ignores unknown multicast groups (no fork, no output).
+          val group = ctx.tableStore.getMulticastGroup(mcastGrp)
+          if (group != null) {
+            val replicas =
+              group.replicasList.map { r -> BranchMode.Replica(r.instance, r.egressPort) }
+            throw MulticastFork(replicas, s.packetCtx.getEvents())
+          }
         }
         // Normal unicast: copy egress_spec → egress_port for uniform read below.
         s.standardMetadata.fields["egress_port"] =
@@ -395,12 +395,9 @@ class V1ModelArchitecture : Architecture {
       is BranchMode.E2EClone -> {
         // E2E clone branch: after the original egress ran (giving us modified headers),
         // re-run egress with CLONE_E2E instance_type and the clone session's egress_port.
-        // This matches BMv2 semantics where the E2E clone re-enters egress with the
-        // post-egress packet state.
-        val session =
-          ctx.tableStore.getCloneSession(mode.sessionId)
-            ?: error("unknown clone session: ${mode.sessionId}")
-        val clonePort = session.replicasList.firstOrNull()?.egressPort ?: 0
+        // BMv2 drops the clone if the session doesn't exist.
+        val session = ctx.tableStore.getCloneSession(mode.sessionId)
+        val clonePort = session?.replicasList?.firstOrNull()?.egressPort ?: DROP_PORT
         s.standardMetadata.fields["instance_type"] = BitVal(CLONE_E2E_INSTANCE_TYPE, INT32_BITS)
         s.standardMetadata.fields["egress_port"] = BitVal(clonePort.toLong(), PORT_BITS)
         s.packetCtx.pendingEgressCloneSessionId = null

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -507,4 +507,57 @@ class V1ModelArchitectureTest {
     assertEquals(1, branches.size)
     assertEquals("recirculate", branches[0].label)
   }
+
+  @Test
+  fun `I2E clone with missing session drops clone branch`() {
+    // Clone session 99 is never installed — BMv2 drops the clone silently.
+    val config =
+      v1modelConfig(
+        externCall("clone", enumArg("I2E"), intArg(99, 32)),
+        assignField("sm", "egress_spec", 2, V1ModelArchitecture.PORT_BITS),
+      )
+
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+
+    assertTrue(result.trace.hasForkOutcome())
+    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    val outputs = collectOutputs(result.trace)
+    // Only the original branch produces output; the clone branch is dropped.
+    assertEquals(1, outputs.size)
+    assertEquals(2, outputs[0].egressPort)
+  }
+
+  @Test
+  fun `E2E clone with missing session drops clone branch`() {
+    val config =
+      v1modelConfig(
+        ingressStmts = listOf(assignField("sm", "egress_spec", 3, V1ModelArchitecture.PORT_BITS)),
+        egressStmts = listOf(externCall("clone", enumArg("E2E"), intArg(99, 32))),
+      )
+
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+
+    assertTrue(result.trace.hasForkOutcome())
+    val outputs = collectOutputs(result.trace)
+    // Only the original branch produces output.
+    assertEquals(1, outputs.size)
+    assertEquals(3, outputs[0].egressPort)
+  }
+
+  @Test
+  fun `unknown multicast group falls through to unicast`() {
+    // mcast_grp is set but the group isn't installed — BMv2 treats this as unicast/drop.
+    val config =
+      v1modelConfig(
+        assignField("sm", "mcast_grp", 42, 16),
+        assignField("sm", "egress_spec", 5, V1ModelArchitecture.PORT_BITS),
+      )
+
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+
+    // No fork — falls through to unicast path.
+    val outputs = collectOutputs(result.trace)
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].egressPort)
+  }
 }


### PR DESCRIPTION
## Summary

**156 p4testgen programs now pass** (was 155 after #181) — one more test
promoted by making the simulator match BMv2's behavior for missing PRE entries.

BMv2 silently drops clones when the session doesn't exist and ignores unknown
multicast groups. We were crashing with `error()` instead. Three changes:

1. **Missing I2E clone session** → clone branch routes to DROP_PORT (dropped)
2. **Missing E2E clone session** → same
3. **Missing multicast group** → skip fork, fall through to unicast/drop

Promoted: ipv6-switch-ml-bmv2 (was blocked on "unknown multicast group").
v1model-special-ops stays manual — the clone fix works but 7/20 generated
test cases hit JVM StackOverflowError from deep fork recursion.

## Test plan

- [x] Unit tests: missing clone session → drop, missing multicast group → no fork
- [x] ipv6-switch-ml-bmv2 passes
- [x] `bazel test //...` — 211 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)