### PR TITLE
fix: set JAVA_RUNFILES in coverage.sh so tests find their data deps

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -229,6 +229,7 @@ for target in ${TARGETS}; do
   mkdir -p "${test_coverage_dir}"
 
   echo -n "RUN   ${target} ... "
+  JAVA_RUNFILES="${bin_path}.runfiles" \
   JAVA_COVERAGE_FILE="${test_coverage_dir}/jvcov.dat" \
   COVERAGE_DIR="${test_coverage_dir}" \
   COVERAGE=1 \


### PR DESCRIPTION
## Summary

`coverage.sh` invokes test binaries directly, bypassing Bazel's test runner
which normally sets `JAVA_RUNFILES`. Without it, tests that locate `.stf`/`.txtpb`
files via the runfiles tree fail with missing inputs. One-line fix: set
`JAVA_RUNFILES="${bin_path}.runfiles"` before invoking each binary.

Closes #42

## Test plan

- [ ] CI coverage job passes with all six previously-failing p4testgen tests now finding their data deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)