### PR TITLE
feat: support sdn_string in P4Runtime message translation

### DIFF
--- a/p4runtime/TypeTranslator.kt
+++ b/p4runtime/TypeTranslator.kt
@@ -53,6 +53,7 @@ private constructor(
   private val paramUris: Map<Long, String>,
   private val matchFieldUris: Map<Long, String>,
   private val packetMetadataUris: Map<Int, String>,
+  private val stringUris: Set<String>,
 ) {
 
   /** True if this translator has any translated types to handle. */
@@ -175,7 +176,7 @@ private constructor(
         val uri = paramUris[packKey(actionId, param.paramId)]
         if (uri != null) {
           changed = true
-          val translated = translateValue(getOrCreateTable(uri), param.value, toDataplane)
+          val translated = translateValue(getOrCreateTable(uri), param.value, toDataplane, uri)
           param.toBuilder().setValue(translated).build()
         } else {
           param
@@ -198,7 +199,7 @@ private constructor(
           val table = getOrCreateTable(uri)
           when {
             match.hasExact() -> {
-              val translated = translateValue(table, match.exact.value, toDataplane)
+              val translated = translateValue(table, match.exact.value, toDataplane, uri)
               match
                 .toBuilder()
                 .setExact(
@@ -207,7 +208,7 @@ private constructor(
                 .build()
             }
             match.hasOptional() -> {
-              val translated = translateValue(table, match.optional.value, toDataplane)
+              val translated = translateValue(table, match.optional.value, toDataplane, uri)
               match
                 .toBuilder()
                 .setOptional(
@@ -235,7 +236,7 @@ private constructor(
         val uri = packetMetadataUris[meta.metadataId]
         if (uri != null) {
           changed = true
-          val translated = translateValue(getOrCreateTable(uri), meta.value, toDataplane)
+          val translated = translateValue(getOrCreateTable(uri), meta.value, toDataplane, uri)
           meta.toBuilder().setValue(translated).build()
         } else {
           meta
@@ -244,21 +245,28 @@ private constructor(
     return if (changed) result else null
   }
 
-  /** Translates a single ByteString value forward (SDN→DP) or reverse (DP→SDN). */
+  /**
+   * Translates a single ByteString value forward (SDN→DP) or reverse (DP→SDN).
+   *
+   * For `sdn_string` URIs, the SDN value is a UTF-8 string encoded in the proto `bytes` field (per
+   * P4Runtime spec §8.3 — there is no separate string field).
+   */
   private fun translateValue(
     table: TranslationTable,
     value: ByteString,
     toDataplane: Boolean,
+    uri: String,
   ): ByteString =
     if (toDataplane) {
-      table.lookupOrAllocateBitstring(value)
+      if (uri in stringUris) {
+        table.lookupOrAllocateString(value.toStringUtf8())
+      } else {
+        table.lookupOrAllocateBitstring(value)
+      }
     } else {
       when (val sdnValue = table.reverseLookup(value)) {
         is SdnValue.Bitstring -> sdnValue.value
-        // sdn_string values can't be encoded as bytes — the P4Runtime spec has no
-        // mechanism to return string values inside match fields or action parameters.
-        is SdnValue.Str ->
-          throw TranslationException("Cannot encode sdn_string value '${sdnValue.value}' as bytes")
+        is SdnValue.Str -> ByteString.copyFromUtf8(sdnValue.value)
       }
     }
 
@@ -276,6 +284,7 @@ private constructor(
         paramUris = emptyMap(),
         matchFieldUris = emptyMap(),
         packetMetadataUris = emptyMap(),
+        stringUris = emptySet(),
       )
 
     /**
@@ -315,11 +324,18 @@ private constructor(
         }
       }
 
+      val stringUris =
+        translatedTypes.values
+          .filter { it.translatedType.hasSdnString() }
+          .map { it.translatedType.uri }
+          .toSet()
+
       return TypeTranslator(
         buildTables(translations),
         paramUris,
         matchFieldUris,
         packetMetadataUris,
+        stringUris,
       )
     }
 

--- a/p4runtime/TypeTranslator.kt
+++ b/p4runtime/TypeTranslator.kt
@@ -53,7 +53,6 @@ private constructor(
   private val paramUris: Map<Long, String>,
   private val matchFieldUris: Map<Long, String>,
   private val packetMetadataUris: Map<Int, String>,
-  private val stringUris: Set<String>,
 ) {
 
   /** True if this translator has any translated types to handle. */
@@ -176,7 +175,7 @@ private constructor(
         val uri = paramUris[packKey(actionId, param.paramId)]
         if (uri != null) {
           changed = true
-          val translated = translateValue(getOrCreateTable(uri), param.value, toDataplane, uri)
+          val translated = translateValue(getOrCreateTable(uri), param.value, toDataplane)
           param.toBuilder().setValue(translated).build()
         } else {
           param
@@ -199,7 +198,7 @@ private constructor(
           val table = getOrCreateTable(uri)
           when {
             match.hasExact() -> {
-              val translated = translateValue(table, match.exact.value, toDataplane, uri)
+              val translated = translateValue(table, match.exact.value, toDataplane)
               match
                 .toBuilder()
                 .setExact(
@@ -208,7 +207,7 @@ private constructor(
                 .build()
             }
             match.hasOptional() -> {
-              val translated = translateValue(table, match.optional.value, toDataplane, uri)
+              val translated = translateValue(table, match.optional.value, toDataplane)
               match
                 .toBuilder()
                 .setOptional(
@@ -236,7 +235,7 @@ private constructor(
         val uri = packetMetadataUris[meta.metadataId]
         if (uri != null) {
           changed = true
-          val translated = translateValue(getOrCreateTable(uri), meta.value, toDataplane, uri)
+          val translated = translateValue(getOrCreateTable(uri), meta.value, toDataplane)
           meta.toBuilder().setValue(translated).build()
         } else {
           meta
@@ -248,17 +247,16 @@ private constructor(
   /**
    * Translates a single ByteString value forward (SDN→DP) or reverse (DP→SDN).
    *
-   * For `sdn_string` URIs, the SDN value is a UTF-8 string encoded in the proto `bytes` field (per
-   * P4Runtime spec §8.3 — there is no separate string field).
+   * For `sdn_string` tables, the SDN value is a UTF-8 string encoded in the proto `bytes` field
+   * (per P4Runtime spec §8.3 — there is no separate string field).
    */
   private fun translateValue(
     table: TranslationTable,
     value: ByteString,
     toDataplane: Boolean,
-    uri: String,
   ): ByteString =
     if (toDataplane) {
-      if (uri in stringUris) {
+      if (table.isStringType) {
         table.lookupOrAllocateString(value.toStringUtf8())
       } else {
         table.lookupOrAllocateBitstring(value)
@@ -284,7 +282,6 @@ private constructor(
         paramUris = emptyMap(),
         matchFieldUris = emptyMap(),
         packetMetadataUris = emptyMap(),
-        stringUris = emptySet(),
       )
 
     /**
@@ -327,24 +324,26 @@ private constructor(
       val stringUris =
         translatedTypes.values
           .filter { it.translatedType.hasSdnString() }
-          .map { it.translatedType.uri }
-          .toSet()
+          .mapTo(mutableSetOf()) { it.translatedType.uri }
 
-      return TypeTranslator(
-        buildTables(translations),
-        paramUris,
-        matchFieldUris,
-        packetMetadataUris,
-        stringUris,
-      )
+      val tables = buildTables(translations, stringUris)
+      // Pre-create tables for string URIs that have no translation config,
+      // so getOrCreateTable finds them with the correct isStringType.
+      for (uri in stringUris) {
+        tables.computeIfAbsent(uri) { TranslationTable(autoAllocate = true, isStringType = true) }
+      }
+
+      return TypeTranslator(tables, paramUris, matchFieldUris, packetMetadataUris)
     }
 
     private fun buildTables(
-      translations: List<TypeTranslation>
+      translations: List<TypeTranslation>,
+      stringUris: Set<String> = emptySet(),
     ): ConcurrentHashMap<String, TranslationTable> {
       val tables = ConcurrentHashMap<String, TranslationTable>()
       for (translation in translations) {
-        tables[translation.uri] = TranslationTable.fromProto(translation)
+        tables[translation.uri] =
+          TranslationTable.fromProto(translation, isStringType = translation.uri in stringUris)
       }
       return tables
     }
@@ -360,7 +359,11 @@ private constructor(
  *
  * Thread-safe: all mutating operations are synchronized.
  */
-internal class TranslationTable(private val autoAllocate: Boolean) {
+internal class TranslationTable(
+  private val autoAllocate: Boolean,
+  /** True if this table's SDN values are strings (UTF-8 encoded in proto bytes fields). */
+  val isStringType: Boolean = false,
+) {
 
   // Forward maps: SDN → data-plane.
   private val bitstringForward = mutableMapOf<ByteString, ByteString>()
@@ -427,8 +430,8 @@ internal class TranslationTable(private val autoAllocate: Boolean) {
 
   companion object {
     /** Builds a TranslationTable from a proto config, pre-populating explicit entries. */
-    fun fromProto(proto: TypeTranslation): TranslationTable {
-      val table = TranslationTable(autoAllocate = proto.autoAllocate)
+    fun fromProto(proto: TypeTranslation, isStringType: Boolean = false): TranslationTable {
+      val table = TranslationTable(autoAllocate = proto.autoAllocate, isStringType = isStringType)
       for (entry in proto.entriesList) {
         val dp = entry.dataplaneValue
         table.reservedValues.add(dp)

--- a/p4runtime/TypeTranslatorTest.kt
+++ b/p4runtime/TypeTranslatorTest.kt
@@ -654,16 +654,17 @@ class TypeTranslatorTest {
     private const val STRING_TYPE_URI = "sai.port"
   }
 
-  private fun portNameStringTypeInfo(): P4Types.P4TypeInfo =
+  /** Builds a single-entry P4TypeInfo for a translated type. */
+  private fun typeInfo(
+    typeName: String,
+    uri: String,
+    sdnType: P4Types.P4NewTypeTranslation.Builder.() -> Unit,
+  ): P4Types.P4TypeInfo =
     P4Types.P4TypeInfo.newBuilder()
       .putNewTypes(
-        STRING_TYPE_NAME,
+        typeName,
         P4Types.P4NewTypeSpec.newBuilder()
-          .setTranslatedType(
-            P4Types.P4NewTypeTranslation.newBuilder()
-              .setUri(STRING_TYPE_URI)
-              .setSdnString(P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance())
-          )
+          .setTranslatedType(P4Types.P4NewTypeTranslation.newBuilder().setUri(uri).apply(sdnType))
           .build(),
       )
       .build()
@@ -693,7 +694,7 @@ class TypeTranslatorTest {
                 .setTypeName(P4Types.P4NamedType.newBuilder().setName(STRING_TYPE_NAME))
             )
         )
-        .setTypeInfo(portNameStringTypeInfo())
+        .setTypeInfo(stringTypeInfo())
         .build()
     return TypeTranslator.create(p4info)
   }
@@ -713,7 +714,7 @@ class TypeTranslatorTest {
                 .setTypeName(P4Types.P4NamedType.newBuilder().setName(STRING_TYPE_NAME))
             )
         )
-        .setTypeInfo(portNameStringTypeInfo())
+        .setTypeInfo(stringTypeInfo())
         .build()
     return TypeTranslator.create(p4info)
   }
@@ -721,26 +722,7 @@ class TypeTranslatorTest {
   /** Builds a TypeTranslator with both sdn_string and sdn_bitwidth match fields. */
   private fun buildP4InfoTranslatorWithMixedTypes(): TypeTranslator {
     val typeInfo =
-      P4Types.P4TypeInfo.newBuilder()
-        .putNewTypes(
-          STRING_TYPE_NAME,
-          P4Types.P4NewTypeSpec.newBuilder()
-            .setTranslatedType(
-              P4Types.P4NewTypeTranslation.newBuilder()
-                .setUri(STRING_TYPE_URI)
-                .setSdnString(P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance())
-            )
-            .build(),
-        )
-        .putNewTypes(
-          TYPE_NAME,
-          P4Types.P4NewTypeSpec.newBuilder()
-            .setTranslatedType(
-              P4Types.P4NewTypeTranslation.newBuilder().setUri(TYPE_URI).setSdnBitwidth(32)
-            )
-            .build(),
-        )
-        .build()
+      bitstringTypeInfo().toBuilder().putAllNewTypes(stringTypeInfo().newTypesMap).build()
     val p4info =
       P4InfoOuterClass.P4Info.newBuilder()
         .addTables(
@@ -776,17 +758,12 @@ class TypeTranslatorTest {
     return TypeTranslator.create(p4info)
   }
 
-  private fun portIdTypeInfo(): P4Types.P4TypeInfo =
-    P4Types.P4TypeInfo.newBuilder()
-      .putNewTypes(
-        TYPE_NAME,
-        P4Types.P4NewTypeSpec.newBuilder()
-          .setTranslatedType(
-            P4Types.P4NewTypeTranslation.newBuilder().setUri(TYPE_URI).setSdnBitwidth(32)
-          )
-          .build(),
-      )
-      .build()
+  private fun bitstringTypeInfo() = typeInfo(TYPE_NAME, TYPE_URI) { setSdnBitwidth(32) }
+
+  private fun stringTypeInfo() =
+    typeInfo(STRING_TYPE_NAME, STRING_TYPE_URI) {
+      setSdnString(P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance())
+    }
 
   /** Builds a TypeTranslator from synthetic p4info with a translated match field. */
   private fun buildP4InfoTranslator(): TypeTranslator {
@@ -819,7 +796,7 @@ class TypeTranslatorTest {
                 .setTypeName(P4Types.P4NamedType.newBuilder().setName(TYPE_NAME))
             )
         )
-        .setTypeInfo(portIdTypeInfo())
+        .setTypeInfo(bitstringTypeInfo())
         .build()
     return TypeTranslator.create(p4info)
   }
@@ -845,7 +822,7 @@ class TypeTranslatorTest {
                 .setBitwidth(7)
             )
         )
-        .setTypeInfo(portIdTypeInfo())
+        .setTypeInfo(bitstringTypeInfo())
         .build()
     return TypeTranslator.create(p4info)
   }

--- a/p4runtime/TypeTranslatorTest.kt
+++ b/p4runtime/TypeTranslatorTest.kt
@@ -415,6 +415,119 @@ class TypeTranslatorTest {
     assertEquals(ByteString.copyFromUtf8("Ethernet1"), param.value)
   }
 
+  @Test
+  fun `sdn_string optional match field is translated on write`() {
+    val translator = buildP4InfoTranslatorWithStringType()
+
+    val sdnBytes = "Ethernet0".toByteArray(Charsets.UTF_8)
+    val update =
+      writeUpdateOptionalMatch(TABLE_ID, MATCH_FIELD_ID, sdnBytes, ACTION_ID, PARAM_ID, sdnBytes)
+    val translated = translator.translateForWrite(update)
+    val match = translated.entity.tableEntry.matchList.first()
+    assertEquals(ByteString.copyFrom(dpBytes(0)), match.optional.value)
+  }
+
+  // ===========================================================================
+  // Mixed sdn_bitwidth and sdn_string in the same p4info
+  // ===========================================================================
+
+  @Test
+  fun `mixed sdn_bitwidth and sdn_string types are partitioned correctly`() {
+    val translator = buildP4InfoTranslatorWithMixedTypes()
+
+    // Field 1 is sdn_string (port_name_t), field 3 is sdn_bitwidth (port_id_t).
+    val stringBytes = "Ethernet0".toByteArray(Charsets.UTF_8)
+    val bitstringBytes = sdnBytes(5000)
+
+    // Write with both match fields.
+    val entry =
+      P4RuntimeOuterClass.TableEntry.newBuilder()
+        .setTableId(TABLE_ID)
+        .addMatch(
+          P4RuntimeOuterClass.FieldMatch.newBuilder()
+            .setFieldId(MATCH_FIELD_ID)
+            .setExact(
+              P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+                .setValue(ByteString.copyFrom(stringBytes))
+            )
+        )
+        .addMatch(
+          P4RuntimeOuterClass.FieldMatch.newBuilder()
+            .setFieldId(BITWIDTH_FIELD_ID)
+            .setExact(
+              P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+                .setValue(ByteString.copyFrom(bitstringBytes))
+            )
+        )
+        .setAction(
+          P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(
+              P4RuntimeOuterClass.Action.newBuilder()
+                .setActionId(ACTION_ID)
+                .addParams(
+                  P4RuntimeOuterClass.Action.Param.newBuilder()
+                    .setParamId(PARAM_ID)
+                    .setValue(ByteString.copyFrom(stringBytes))
+                )
+            )
+        )
+        .build()
+    val update =
+      P4RuntimeOuterClass.Update.newBuilder()
+        .setType(P4RuntimeOuterClass.Update.Type.INSERT)
+        .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry))
+        .build()
+
+    val translated = translator.translateForWrite(update)
+    val matches = translated.entity.tableEntry.matchList
+
+    // String field → auto-allocated dp=0.
+    assertEquals(ByteString.copyFrom(dpBytes(0)), matches[0].exact.value)
+    // Bitwidth field → also auto-allocated dp=0 (independent table).
+    assertEquals(ByteString.copyFrom(dpBytes(0)), matches[1].exact.value)
+
+    // Read back: string field returns UTF-8, bitwidth field returns raw bytes.
+    val dpEntity =
+      P4RuntimeOuterClass.Entity.newBuilder()
+        .setTableEntry(
+          P4RuntimeOuterClass.TableEntry.newBuilder()
+            .setTableId(TABLE_ID)
+            .addMatch(
+              P4RuntimeOuterClass.FieldMatch.newBuilder()
+                .setFieldId(MATCH_FIELD_ID)
+                .setExact(
+                  P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+                    .setValue(ByteString.copyFrom(dpBytes(0)))
+                )
+            )
+            .addMatch(
+              P4RuntimeOuterClass.FieldMatch.newBuilder()
+                .setFieldId(BITWIDTH_FIELD_ID)
+                .setExact(
+                  P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+                    .setValue(ByteString.copyFrom(dpBytes(0)))
+                )
+            )
+            .setAction(
+              P4RuntimeOuterClass.TableAction.newBuilder()
+                .setAction(
+                  P4RuntimeOuterClass.Action.newBuilder()
+                    .setActionId(ACTION_ID)
+                    .addParams(
+                      P4RuntimeOuterClass.Action.Param.newBuilder()
+                        .setParamId(PARAM_ID)
+                        .setValue(ByteString.copyFrom(dpBytes(0)))
+                    )
+                )
+            )
+        )
+        .build()
+    val sdnEntity = translator.translateForRead(dpEntity)
+    val sdnMatches = sdnEntity.tableEntry.matchList
+    assertEquals(ByteString.copyFromUtf8("Ethernet0"), sdnMatches[0].exact.value)
+    assertEquals(ByteString.copyFrom(bitstringBytes), sdnMatches[1].exact.value)
+  }
+
   // ===========================================================================
   // PacketIO metadata translation via P4Info
   // ===========================================================================
@@ -536,6 +649,7 @@ class TypeTranslatorTest {
     private const val NON_TRANSLATED_METADATA_ID = 2
     private const val TYPE_NAME = "port_id_t"
     private const val TYPE_URI = "test.port_id"
+    private const val BITWIDTH_FIELD_ID = 3
     private const val STRING_TYPE_NAME = "port_name_t"
     private const val STRING_TYPE_URI = "sai.port"
   }
@@ -600,6 +714,64 @@ class TypeTranslatorTest {
             )
         )
         .setTypeInfo(portNameStringTypeInfo())
+        .build()
+    return TypeTranslator.create(p4info)
+  }
+
+  /** Builds a TypeTranslator with both sdn_string and sdn_bitwidth match fields. */
+  private fun buildP4InfoTranslatorWithMixedTypes(): TypeTranslator {
+    val typeInfo =
+      P4Types.P4TypeInfo.newBuilder()
+        .putNewTypes(
+          STRING_TYPE_NAME,
+          P4Types.P4NewTypeSpec.newBuilder()
+            .setTranslatedType(
+              P4Types.P4NewTypeTranslation.newBuilder()
+                .setUri(STRING_TYPE_URI)
+                .setSdnString(P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance())
+            )
+            .build(),
+        )
+        .putNewTypes(
+          TYPE_NAME,
+          P4Types.P4NewTypeSpec.newBuilder()
+            .setTranslatedType(
+              P4Types.P4NewTypeTranslation.newBuilder().setUri(TYPE_URI).setSdnBitwidth(32)
+            )
+            .build(),
+        )
+        .build()
+    val p4info =
+      P4InfoOuterClass.P4Info.newBuilder()
+        .addTables(
+          P4InfoOuterClass.Table.newBuilder()
+            .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(TABLE_ID))
+            .addMatchFields(
+              P4InfoOuterClass.MatchField.newBuilder()
+                .setId(MATCH_FIELD_ID)
+                .setBitwidth(32)
+                .setMatchType(P4InfoOuterClass.MatchField.MatchType.EXACT)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(STRING_TYPE_NAME))
+            )
+            .addMatchFields(
+              P4InfoOuterClass.MatchField.newBuilder()
+                .setId(BITWIDTH_FIELD_ID)
+                .setBitwidth(32)
+                .setMatchType(P4InfoOuterClass.MatchField.MatchType.EXACT)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(TYPE_NAME))
+            )
+        )
+        .addActions(
+          P4InfoOuterClass.Action.newBuilder()
+            .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(ACTION_ID))
+            .addParams(
+              P4InfoOuterClass.Action.Param.newBuilder()
+                .setId(PARAM_ID)
+                .setBitwidth(32)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(STRING_TYPE_NAME))
+            )
+        )
+        .setTypeInfo(typeInfo)
         .build()
     return TypeTranslator.create(p4info)
   }

--- a/p4runtime/TypeTranslatorTest.kt
+++ b/p4runtime/TypeTranslatorTest.kt
@@ -355,6 +355,67 @@ class TypeTranslatorTest {
   }
 
   // ===========================================================================
+  // Match field and action param translation: sdn_string via P4Info
+  // ===========================================================================
+
+  @Test
+  fun `sdn_string match field write decodes UTF-8 and allocates`() {
+    val translator = buildP4InfoTranslatorWithStringType()
+
+    val sdnBytes = "Ethernet0".toByteArray(Charsets.UTF_8)
+    val update = writeUpdate(TABLE_ID, MATCH_FIELD_ID, sdnBytes, ACTION_ID, PARAM_ID, sdnBytes)
+    val translated = translator.translateForWrite(update)
+    val match = translated.entity.tableEntry.matchList.first()
+    assertEquals(ByteString.copyFrom(dpBytes(0)), match.exact.value)
+  }
+
+  @Test
+  fun `sdn_string match field round-trips through read`() {
+    val translator = buildP4InfoTranslatorWithStringType()
+
+    // Write to install the mapping.
+    val sdnBytes = "Ethernet0".toByteArray(Charsets.UTF_8)
+    translator.translateForWrite(
+      writeUpdate(TABLE_ID, MATCH_FIELD_ID, sdnBytes, ACTION_ID, PARAM_ID, sdnBytes)
+    )
+
+    // Read back.
+    val dpEntity = readEntity(TABLE_ID, MATCH_FIELD_ID, dpBytes(0), ACTION_ID, PARAM_ID, dpBytes(0))
+    val sdnEntity = translator.translateForRead(dpEntity)
+    val match = sdnEntity.tableEntry.matchList.first()
+    assertEquals(ByteString.copyFromUtf8("Ethernet0"), match.exact.value)
+  }
+
+  @Test
+  fun `sdn_string action param write decodes UTF-8`() {
+    val translator = buildP4InfoTranslatorWithStringType()
+
+    val matchBytes = "Ethernet0".toByteArray(Charsets.UTF_8)
+    val paramBytes = "Ethernet1".toByteArray(Charsets.UTF_8)
+    val update = writeUpdate(TABLE_ID, MATCH_FIELD_ID, matchBytes, ACTION_ID, PARAM_ID, paramBytes)
+    val translated = translator.translateForWrite(update)
+    val param = translated.entity.tableEntry.action.action.paramsList.first()
+    // Match allocated "Ethernet0" → dp=0; param allocates "Ethernet1" → dp=1.
+    assertEquals(ByteString.copyFrom(dpBytes(1)), param.value)
+  }
+
+  @Test
+  fun `sdn_string action param round-trips through read`() {
+    val translator = buildP4InfoTranslatorWithStringType()
+
+    val matchBytes = "Ethernet0".toByteArray(Charsets.UTF_8)
+    val paramBytes = "Ethernet1".toByteArray(Charsets.UTF_8)
+    translator.translateForWrite(
+      writeUpdate(TABLE_ID, MATCH_FIELD_ID, matchBytes, ACTION_ID, PARAM_ID, paramBytes)
+    )
+
+    val dpEntity = readEntity(TABLE_ID, MATCH_FIELD_ID, dpBytes(0), ACTION_ID, PARAM_ID, dpBytes(1))
+    val sdnEntity = translator.translateForRead(dpEntity)
+    val param = sdnEntity.tableEntry.action.action.paramsList.first()
+    assertEquals(ByteString.copyFromUtf8("Ethernet1"), param.value)
+  }
+
+  // ===========================================================================
   // PacketIO metadata translation via P4Info
   // ===========================================================================
 
@@ -410,6 +471,38 @@ class TypeTranslatorTest {
   }
 
   @Test
+  fun `sdn_string packet metadata round-trips through packet out and in`() {
+    val translator = buildP4InfoTranslatorWithStringPacketIO()
+
+    val packetOut =
+      P4RuntimeOuterClass.PacketOut.newBuilder()
+        .setPayload(ByteString.copyFrom(byteArrayOf(0x00)))
+        .addMetadata(
+          P4RuntimeOuterClass.PacketMetadata.newBuilder()
+            .setMetadataId(PACKET_METADATA_ID)
+            .setValue(ByteString.copyFromUtf8("Ethernet0"))
+        )
+        .build()
+
+    val translatedOut = translator.translatePacketOut(packetOut)
+    assertEquals(ByteString.copyFrom(dpBytes(0)), translatedOut.metadataList.first().value)
+
+    // Reverse: data-plane → SDN.
+    val packetIn =
+      P4RuntimeOuterClass.PacketIn.newBuilder()
+        .setPayload(ByteString.copyFrom(byteArrayOf(0x00)))
+        .addMetadata(
+          P4RuntimeOuterClass.PacketMetadata.newBuilder()
+            .setMetadataId(PACKET_METADATA_ID)
+            .setValue(ByteString.copyFrom(dpBytes(0)))
+        )
+        .build()
+
+    val translatedIn = translator.translatePacketIn(packetIn)
+    assertEquals(ByteString.copyFromUtf8("Ethernet0"), translatedIn.metadataList.first().value)
+  }
+
+  @Test
   fun `non-translated packet metadata passes through unchanged`() {
     val translator = buildP4InfoTranslatorWithPacketIO()
 
@@ -443,6 +536,72 @@ class TypeTranslatorTest {
     private const val NON_TRANSLATED_METADATA_ID = 2
     private const val TYPE_NAME = "port_id_t"
     private const val TYPE_URI = "test.port_id"
+    private const val STRING_TYPE_NAME = "port_name_t"
+    private const val STRING_TYPE_URI = "sai.port"
+  }
+
+  private fun portNameStringTypeInfo(): P4Types.P4TypeInfo =
+    P4Types.P4TypeInfo.newBuilder()
+      .putNewTypes(
+        STRING_TYPE_NAME,
+        P4Types.P4NewTypeSpec.newBuilder()
+          .setTranslatedType(
+            P4Types.P4NewTypeTranslation.newBuilder()
+              .setUri(STRING_TYPE_URI)
+              .setSdnString(P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance())
+          )
+          .build(),
+      )
+      .build()
+
+  /** Builds a TypeTranslator with sdn_string translated match field and action param. */
+  private fun buildP4InfoTranslatorWithStringType(): TypeTranslator {
+    val p4info =
+      P4InfoOuterClass.P4Info.newBuilder()
+        .addTables(
+          P4InfoOuterClass.Table.newBuilder()
+            .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(TABLE_ID))
+            .addMatchFields(
+              P4InfoOuterClass.MatchField.newBuilder()
+                .setId(MATCH_FIELD_ID)
+                .setBitwidth(32)
+                .setMatchType(P4InfoOuterClass.MatchField.MatchType.EXACT)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(STRING_TYPE_NAME))
+            )
+        )
+        .addActions(
+          P4InfoOuterClass.Action.newBuilder()
+            .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(ACTION_ID))
+            .addParams(
+              P4InfoOuterClass.Action.Param.newBuilder()
+                .setId(PARAM_ID)
+                .setBitwidth(32)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(STRING_TYPE_NAME))
+            )
+        )
+        .setTypeInfo(portNameStringTypeInfo())
+        .build()
+    return TypeTranslator.create(p4info)
+  }
+
+  /** Builds a TypeTranslator with sdn_string translated PacketIO metadata. */
+  private fun buildP4InfoTranslatorWithStringPacketIO(): TypeTranslator {
+    val p4info =
+      P4InfoOuterClass.P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          P4InfoOuterClass.ControllerPacketMetadata.newBuilder()
+            .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(1).setName("packet_out"))
+            .addMetadata(
+              P4InfoOuterClass.ControllerPacketMetadata.Metadata.newBuilder()
+                .setId(PACKET_METADATA_ID)
+                .setName("ingress_port")
+                .setBitwidth(32)
+                .setTypeName(P4Types.P4NamedType.newBuilder().setName(STRING_TYPE_NAME))
+            )
+        )
+        .setTypeInfo(portNameStringTypeInfo())
+        .build()
+    return TypeTranslator.create(p4info)
   }
 
   private fun portIdTypeInfo(): P4Types.P4TypeInfo =


### PR DESCRIPTION
## Summary

Completes `sdn_string` support in the P4Runtime message translation layer.
The mapping infrastructure already handled string values (`lookupOrAllocateString`,
`SdnValue.Str`), but the write path always called `lookupOrAllocateBitstring()` and
the read path threw on `SdnValue.Str`. Now both paths work correctly for
`sdn_string` URIs like SAI P4's port names.

Key design: the `TranslationTable` carries its own `isStringType` flag, so
`translateValue` dispatches on the table's type — no parallel data structures,
no extra parameters. On write, string tables decode the proto `bytes` field as
UTF-8; on read, `SdnValue.Str` encodes back to UTF-8 `ByteString`.

7 new unit tests cover `sdn_string` round-trips for exact and optional match
fields, action params, PacketIO metadata, and mixed `sdn_bitwidth`/`sdn_string`
p4info.

## Test plan

- [ ] CI passes (`bazel test //...`)
- [ ] New `sdn_string` tests cover all three translation surfaces
- [ ] Mixed-type test verifies correct partitioning
- [ ] Existing `sdn_bitwidth` tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)