### PR TITLE
p4runtime: register read/write via P4Runtime RPCs

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -36,10 +36,8 @@ guilt — just write it down so someone can find it later.
   `sdn_string` with explicit, auto-allocate, and hybrid mapping modes.
   Note: v1model `p4c` does not emit `controller_packet_metadata` with
   `type_name`, so PacketIO translation is exercised via unit tests only.
-- **Missing RPCs.** `GetForwardingPipelineConfig` and `Capabilities` return
-  UNIMPLEMENTED.
-- **No counters, meters, or registers via P4Runtime.** These work via the
-  simulator protocol but cannot be managed through the gRPC server.
+- **No counters or meters via P4Runtime.** These work via the simulator
+  protocol but cannot be managed through the gRPC server.
 - **No digests, idle timeouts, or atomic write batches.**
 
 ## Simulator

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -149,6 +149,26 @@ the others.
 
 ---
 
+## Pass `P4Info` directly to `TableStore.loadMappings`
+
+**Files**: `simulator/TableStore.kt`, `simulator/Simulator.kt`,
+`simulator/TableStoreTest.kt`
+
+**Problem**: `loadMappings` takes a growing list of parameters — one per
+entity type (`tableNameById`, `actionNameById`, `p4infoTables`,
+`p4infoRegisters`). Each new P4Runtime entity (counters, meters, digests)
+will add another parameter.
+
+**Fix**: Accept the `P4Info` proto directly (or a slim wrapper) and let
+`TableStore` extract what it needs internally. The two `Map<Int, String>`
+parameters are already derived from `P4Info` in `Simulator.kt` and could
+move inside `loadMappings`. This keeps the signature stable as entity
+coverage grows.
+
+**Trigger**: when counters or meters are wired through P4Runtime.
+
+---
+
 ## Upstream p4c backend
 
 Land the 4ward backend in the p4c repository. Blocked on upstream review.

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -409,10 +409,76 @@ class P4RuntimeConformanceTest {
     assertGrpcError(Status.Code.NOT_FOUND) { harness.deleteEntry(group) }
   }
 
+  // =========================================================================
+  // Register entries (scenarios 32-34)
+  // =========================================================================
+
+  private fun loadConfigWithRegister(): PipelineConfig {
+    val base = loadBasicTableConfig()
+    // Inject a register into the p4info so the simulator creates RegisterInfo.
+    val register =
+      p4.config.v1.P4InfoOuterClass.Register.newBuilder()
+        .setPreamble(
+          p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(REG_ID).setName("myReg")
+        )
+        .setTypeSpec(
+          p4.config.v1.P4Types.P4DataTypeSpec.newBuilder()
+            .setBitstring(
+              p4.config.v1.P4Types.P4BitstringLikeTypeSpec.newBuilder()
+                .setBit(p4.config.v1.P4Types.P4BitTypeSpec.newBuilder().setBitwidth(REG_BITWIDTH))
+            )
+        )
+        .setSize(REG_SIZE)
+        .build()
+    return base.toBuilder().setP4Info(base.p4Info.toBuilder().addRegisters(register)).build()
+  }
+
+  @Test
+  fun `32 - write register entry and read it back`() {
+    harness.loadPipeline(loadConfigWithRegister())
+    val entry = P4RuntimeTestHarness.buildRegisterEntry(REG_ID, 0, 0xCAFE)
+    harness.modifyEntry(entry)
+    val results = harness.readRegisterEntries(REG_ID)
+    // Should return all REG_SIZE entries; index 0 has our value.
+    assertEquals(REG_SIZE, results.size)
+    val written = results.find { it.registerEntry.index.index == 0L }!!
+    assertEquals(
+      com.google.protobuf.ByteString.copyFrom(
+        P4RuntimeTestHarness.longToBytes(0xCAFE, REG_BYTEWIDTH)
+      ),
+      written.registerEntry.data.bitstring,
+    )
+  }
+
+  @Test
+  fun `33 - read unwritten register entry returns zero`() {
+    harness.loadPipeline(loadConfigWithRegister())
+    val results = harness.readRegisterEntries(REG_ID)
+    assertEquals(REG_SIZE, results.size)
+    for (entity in results) {
+      val data = entity.registerEntry.data.bitstring.toByteArray()
+      assertTrue("unwritten register should be zero", data.all { it == 0.toByte() })
+    }
+  }
+
+  @Test
+  fun `34 - INSERT register entry returns INVALID_ARGUMENT`() {
+    harness.loadPipeline(loadConfigWithRegister())
+    val entry = P4RuntimeTestHarness.buildRegisterEntry(REG_ID, 0, 1)
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.installEntry(entry) }
+  }
+
   // ---------------------------------------------------------------------------
   // Test helpers
   // ---------------------------------------------------------------------------
 
   private fun buildReadFilter(config: PipelineConfig, matchValue: Long): Entity =
     P4RuntimeTestHarness.buildMatchFilter(config, matchValue)
+
+  companion object {
+    private const val REG_ID = 500
+    private const val REG_BITWIDTH = 32
+    private const val REG_BYTEWIDTH = REG_BITWIDTH / 8
+    private const val REG_SIZE = 4
+  }
 }

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -182,6 +182,20 @@ class P4RuntimeTestHarness : Closeable {
         .build()
     )
 
+  /** Reads register entries, filtered by register ID. */
+  fun readRegisterEntries(registerId: Int): List<Entity> =
+    readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setRegisterEntry(
+              p4.v1.P4RuntimeOuterClass.RegisterEntry.newBuilder().setRegisterId(registerId)
+            )
+        )
+        .build()
+    )
+
   // ---------------------------------------------------------------------------
   // StreamChannel helpers
   // ---------------------------------------------------------------------------
@@ -425,6 +439,21 @@ class P4RuntimeTestHarness : Closeable {
                   .setWeight(1)
                   .build()
               }
+            )
+        )
+        .build()
+
+    /** Builds an Entity wrapping a RegisterEntry. Value is encoded as 4-byte big-endian. */
+    @Suppress("MagicNumber")
+    fun buildRegisterEntry(registerId: Int, index: Long, value: Long): Entity =
+      Entity.newBuilder()
+        .setRegisterEntry(
+          p4.v1.P4RuntimeOuterClass.RegisterEntry.newBuilder()
+            .setRegisterId(registerId)
+            .setIndex(p4.v1.P4RuntimeOuterClass.Index.newBuilder().setIndex(index))
+            .setData(
+              p4.v1.P4DataOuterClass.P4Data.newBuilder()
+                .setBitstring(ByteString.copyFrom(longToBytes(value, 4)))
             )
         )
         .build()

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -443,9 +443,9 @@ class P4RuntimeTestHarness : Closeable {
         )
         .build()
 
-    /** Builds an Entity wrapping a RegisterEntry. Value is encoded as 4-byte big-endian. */
+    /** Builds an Entity wrapping a RegisterEntry. */
     @Suppress("MagicNumber")
-    fun buildRegisterEntry(registerId: Int, index: Long, value: Long): Entity =
+    fun buildRegisterEntry(registerId: Int, index: Long, value: Long, byteLen: Int = 4): Entity =
       Entity.newBuilder()
         .setRegisterEntry(
           p4.v1.P4RuntimeOuterClass.RegisterEntry.newBuilder()
@@ -453,7 +453,7 @@ class P4RuntimeTestHarness : Closeable {
             .setIndex(p4.v1.P4RuntimeOuterClass.Index.newBuilder().setIndex(index))
             .setData(
               p4.v1.P4DataOuterClass.P4Data.newBuilder()
-                .setBitstring(ByteString.copyFrom(longToBytes(value, 4)))
+                .setBitstring(ByteString.copyFrom(longToBytes(value, byteLen)))
             )
         )
         .build()

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -67,7 +67,17 @@ class Simulator {
         val alias = action.preamble.alias.ifEmpty { action.preamble.name }
         action.preamble.id to resolveName(alias, behavioralActions)
       }
-    tableStore.loadMappings(tableNameById, actionNameById, config.p4Info.tablesList)
+    val registerInfoById =
+      config.p4Info.registersList.associate { reg ->
+        val bitwidth = reg.typeSpec.bitstring.bit.bitwidth
+        reg.preamble.id to TableStore.RegisterInfo(reg.preamble.name, bitwidth, reg.size)
+      }
+    tableStore.loadMappings(
+      tableNameById,
+      actionNameById,
+      config.p4Info.tablesList,
+      registerInfoById,
+    )
 
     for (table in config.p4Info.tablesList) {
       // const_default_action_id: immutable default set in the P4 source with `const`.
@@ -163,6 +173,7 @@ class Simulator {
           entity.hasActionProfileMember() ->
             tableStore.readProfileMembers(entity.actionProfileMember)
           entity.hasActionProfileGroup() -> tableStore.readProfileGroups(entity.actionProfileGroup)
+          entity.hasRegisterEntry() -> tableStore.readRegisterEntries(entity.registerEntry)
           else -> emptyList()
         }
       }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -67,16 +67,11 @@ class Simulator {
         val alias = action.preamble.alias.ifEmpty { action.preamble.name }
         action.preamble.id to resolveName(alias, behavioralActions)
       }
-    val registerInfoById =
-      config.p4Info.registersList.associate { reg ->
-        val bitwidth = reg.typeSpec.bitstring.bit.bitwidth
-        reg.preamble.id to TableStore.RegisterInfo(reg.preamble.name, bitwidth, reg.size)
-      }
     tableStore.loadMappings(
       tableNameById,
       actionNameById,
       config.p4Info.tablesList,
-      registerInfoById,
+      config.p4Info.registersList,
     )
 
     for (table in config.p4Info.tablesList) {

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -10,6 +10,17 @@ import p4.v1.P4RuntimeOuterClass.Update
 /** Interprets a protobuf [ByteString] as an unsigned big-endian integer. */
 private fun ByteString.toUnsignedBigInteger(): BigInteger = BigInteger(1, toByteArray())
 
+/** Encodes a [BigInteger] as unsigned big-endian bytes with the given byte length. */
+private fun BigInteger.toByteString(byteLen: Int): ByteString {
+  val raw = toByteArray() // signed two's-complement, big-endian
+  val out = ByteArray(byteLen)
+  // Copy right-aligned, trimming any leading sign byte.
+  val srcStart = maxOf(0, raw.size - byteLen)
+  val dstStart = maxOf(0, byteLen - raw.size)
+  raw.copyInto(out, dstStart, srcStart)
+  return ByteString.copyFrom(out)
+}
+
 // P4Runtime spec §9.1: two entries are the same iff they have the same match key
 // AND the same priority (priority is part of the key for ternary/range tables).
 private fun TableEntry.sameKey(other: TableEntry): Boolean =
@@ -35,6 +46,9 @@ sealed class WriteResult {
  * Call [loadMappings] once per pipeline load before any [write] or [lookup] calls.
  */
 class TableStore {
+
+  /** P4Runtime register metadata: maps p4info ID to internal name, element bitwidth, and size. */
+  data class RegisterInfo(val name: String, val bitwidth: Int, val size: Int)
 
   // tableName -> list of entries, ordered by insertion (priority is explicit in the entry)
   private val tables: MutableMap<String, MutableList<TableEntry>> = mutableMapOf()
@@ -79,6 +93,7 @@ class TableStore {
   // Populated by loadMappings; used to resolve IDs to names in write() and lookup().
   private var tableNameById: Map<Int, String> = emptyMap()
   private var actionNameById: Map<Int, String> = emptyMap()
+  private var registerInfoById: Map<Int, RegisterInfo> = emptyMap()
 
   /**
    * Initialises the ID→name maps for the loaded pipeline and clears all table entries.
@@ -89,9 +104,11 @@ class TableStore {
     tableNameById: Map<Int, String>,
     actionNameById: Map<Int, String>,
     p4infoTables: List<P4InfoOuterClass.Table> = emptyList(),
+    registerInfoById: Map<Int, RegisterInfo> = emptyMap(),
   ) {
     this.tableNameById = tableNameById
     this.actionNameById = actionNameById
+    this.registerInfoById = registerInfoById
     tables.clear()
     forcedHits.clear()
     registers.clear()
@@ -128,6 +145,62 @@ class TableStore {
     registers.getOrPut(name) { mutableMapOf() }[index] = value
   }
 
+  // P4Runtime spec: RegisterEntry MODIFY only (statically allocated arrays).
+  private fun writeRegisterEntry(
+    type: Update.Type,
+    entry: P4RuntimeOuterClass.RegisterEntry,
+  ): WriteResult {
+    if (type != Update.Type.MODIFY)
+      return WriteResult.InvalidArgument("registers only support MODIFY, not $type")
+    val info =
+      registerInfoById[entry.registerId]
+        ?: return WriteResult.NotFound("unknown register ID: ${entry.registerId}")
+    val index = entry.index.index.toInt()
+    if (index < 0 || index >= info.size)
+      return WriteResult.InvalidArgument("register index $index out of bounds [0, ${info.size})")
+    val value = BitVal(BitVector(entry.data.bitstring.toUnsignedBigInteger(), info.bitwidth))
+    registerWrite(info.name, index, value)
+    return WriteResult.Success
+  }
+
+  /**
+   * Reads register entries as P4Runtime Entity protos, filtered by [filter].
+   * - `register_id=0` → wildcard: all indices of all registers.
+   * - `register_id=N`, no index → all indices for register N (0..size-1).
+   * - `register_id=N`, with index → single entry.
+   *
+   * Unwritten indices return the default value (zero).
+   */
+  fun readRegisterEntries(
+    filter: P4RuntimeOuterClass.RegisterEntry =
+      P4RuntimeOuterClass.RegisterEntry.getDefaultInstance()
+  ): List<P4RuntimeOuterClass.Entity> {
+    val infos =
+      if (filter.registerId == 0) registerInfoById
+      else {
+        val info = registerInfoById[filter.registerId] ?: return emptyList()
+        mapOf(filter.registerId to info)
+      }
+    val hasIndex = filter.hasIndex()
+    return infos.flatMap { (regId, info) ->
+      val indices =
+        if (hasIndex) listOf(filter.index.index.toInt()) else (0 until info.size).toList()
+      indices.map { idx ->
+        val value = registerRead(info.name, idx) as? BitVal
+        val byteLen = (info.bitwidth + 7) / 8
+        val data = (value?.bits?.value ?: BigInteger.ZERO).toByteString(byteLen)
+        P4RuntimeOuterClass.Entity.newBuilder()
+          .setRegisterEntry(
+            P4RuntimeOuterClass.RegisterEntry.newBuilder()
+              .setRegisterId(regId)
+              .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(idx.toLong()))
+              .setData(p4.v1.P4DataOuterClass.P4Data.newBuilder().setBitstring(data))
+          )
+          .build()
+      }
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Write
   // -------------------------------------------------------------------------
@@ -137,6 +210,7 @@ class TableStore {
     return when {
       entity.hasActionProfileMember() -> writeProfileMember(update.type, entity.actionProfileMember)
       entity.hasActionProfileGroup() -> writeProfileGroup(update.type, entity.actionProfileGroup)
+      entity.hasRegisterEntry() -> writeRegisterEntry(update.type, entity.registerEntry)
       entity.hasPacketReplicationEngineEntry() -> {
         writePreEntry(entity.packetReplicationEngineEntry)
         WriteResult.Success

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -10,17 +10,6 @@ import p4.v1.P4RuntimeOuterClass.Update
 /** Interprets a protobuf [ByteString] as an unsigned big-endian integer. */
 private fun ByteString.toUnsignedBigInteger(): BigInteger = BigInteger(1, toByteArray())
 
-/** Encodes a [BigInteger] as unsigned big-endian bytes with the given byte length. */
-private fun BigInteger.toByteString(byteLen: Int): ByteString {
-  val raw = toByteArray() // signed two's-complement, big-endian
-  val out = ByteArray(byteLen)
-  // Copy right-aligned, trimming any leading sign byte.
-  val srcStart = maxOf(0, raw.size - byteLen)
-  val dstStart = maxOf(0, byteLen - raw.size)
-  raw.copyInto(out, dstStart, srcStart)
-  return ByteString.copyFrom(out)
-}
-
 // P4Runtime spec §9.1: two entries are the same iff they have the same match key
 // AND the same priority (priority is part of the key for ternary/range tables).
 private fun TableEntry.sameKey(other: TableEntry): Boolean =
@@ -47,8 +36,7 @@ sealed class WriteResult {
  */
 class TableStore {
 
-  /** P4Runtime register metadata: maps p4info ID to internal name, element bitwidth, and size. */
-  data class RegisterInfo(val name: String, val bitwidth: Int, val size: Int)
+  private data class RegisterInfo(val name: String, val bitwidth: Int, val size: Int)
 
   // tableName -> list of entries, ordered by insertion (priority is explicit in the entry)
   private val tables: MutableMap<String, MutableList<TableEntry>> = mutableMapOf()
@@ -104,11 +92,15 @@ class TableStore {
     tableNameById: Map<Int, String>,
     actionNameById: Map<Int, String>,
     p4infoTables: List<P4InfoOuterClass.Table> = emptyList(),
-    registerInfoById: Map<Int, RegisterInfo> = emptyMap(),
+    p4infoRegisters: List<P4InfoOuterClass.Register> = emptyList(),
   ) {
     this.tableNameById = tableNameById
     this.actionNameById = actionNameById
-    this.registerInfoById = registerInfoById
+    this.registerInfoById =
+      p4infoRegisters.associate { reg ->
+        val bitwidth = reg.typeSpec.bitstring.bit.bitwidth
+        reg.preamble.id to RegisterInfo(reg.preamble.name, bitwidth, reg.size)
+      }
     tables.clear()
     forcedHits.clear()
     registers.clear()
@@ -183,11 +175,11 @@ class TableStore {
       }
     val hasIndex = filter.hasIndex()
     return infos.flatMap { (regId, info) ->
-      val byteLen = (info.bitwidth + 7) / 8
+      val zeroBits = BitVector(BigInteger.ZERO, info.bitwidth)
       val indices = if (hasIndex) listOf(filter.index.index.toInt()) else (0 until info.size)
       indices.map { idx ->
-        val value = registerRead(info.name, idx) as? BitVal
-        val data = (value?.bits?.value ?: BigInteger.ZERO).toByteString(byteLen)
+        val bits = (registerRead(info.name, idx) as? BitVal)?.bits ?: zeroBits
+        val data = ByteString.copyFrom(bits.toByteArray())
         P4RuntimeOuterClass.Entity.newBuilder()
           .setRegisterEntry(
             P4RuntimeOuterClass.RegisterEntry.newBuilder()

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -183,11 +183,10 @@ class TableStore {
       }
     val hasIndex = filter.hasIndex()
     return infos.flatMap { (regId, info) ->
-      val indices =
-        if (hasIndex) listOf(filter.index.index.toInt()) else (0 until info.size).toList()
+      val byteLen = (info.bitwidth + 7) / 8
+      val indices = if (hasIndex) listOf(filter.index.index.toInt()) else (0 until info.size)
       indices.map { idx ->
         val value = registerRead(info.name, idx) as? BitVal
-        val byteLen = (info.bitwidth + 7) / 8
         val data = (value?.bits?.value ?: BigInteger.ZERO).toByteString(byteLen)
         P4RuntimeOuterClass.Entity.newBuilder()
           .setRegisterEntry(

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -883,6 +883,158 @@ class TableStoreTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Register write semantics
+  // ---------------------------------------------------------------------------
+
+  /** Creates a TableStore with register metadata for register tests. */
+  private fun storeWithRegister(): TableStore {
+    val store = TableStore()
+    store.loadMappings(
+      tableNameById = mapOf(TABLE_ID to TABLE_NAME),
+      actionNameById = ACTION_ID_TO_NAME,
+      registerInfoById =
+        mapOf(
+          REGISTER_ID to TableStore.RegisterInfo(REGISTER_NAME, REGISTER_BITWIDTH, REGISTER_SIZE)
+        ),
+    )
+    return store
+  }
+
+  private fun registerUpdate(
+    type: Update.Type,
+    registerId: Int = REGISTER_ID,
+    index: Long = 0,
+    value: Long = 0,
+  ): Update {
+    val entry =
+      P4RuntimeOuterClass.RegisterEntry.newBuilder()
+        .setRegisterId(registerId)
+        .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(index))
+        .setData(
+          p4.v1.P4DataOuterClass.P4Data.newBuilder()
+            .setBitstring(ByteString.copyFrom(longToBytes(value, (REGISTER_BITWIDTH + 7) / 8)))
+        )
+        .build()
+    return Update.newBuilder()
+      .setType(type)
+      .setEntity(Entity.newBuilder().setRegisterEntry(entry))
+      .build()
+  }
+
+  private fun longToBytes(value: Long, byteLen: Int): ByteArray {
+    val bytes = ByteArray(byteLen)
+    for (i in 0 until byteLen) {
+      bytes[byteLen - 1 - i] = (value shr (i * 8) and 0xFF).toByte()
+    }
+    return bytes
+  }
+
+  @Test
+  fun `modify register entry persists value`() {
+    val s = storeWithRegister()
+    assertEquals(WriteResult.Success, s.write(registerUpdate(Update.Type.MODIFY, value = 42)))
+    val readBack = s.registerRead(REGISTER_NAME, 0)
+    assertNotNull(readBack)
+    assertEquals(BitVal(42, REGISTER_BITWIDTH), readBack)
+  }
+
+  @Test
+  fun `modify register entry at out-of-bounds index returns error`() {
+    val s = storeWithRegister()
+    val result = s.write(registerUpdate(Update.Type.MODIFY, index = REGISTER_SIZE.toLong()))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `insert register entry returns InvalidArgument`() {
+    val s = storeWithRegister()
+    val result = s.write(registerUpdate(Update.Type.INSERT))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `delete register entry returns InvalidArgument`() {
+    val s = storeWithRegister()
+    val result = s.write(registerUpdate(Update.Type.DELETE))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `modify register with unknown ID returns NotFound`() {
+    val s = storeWithRegister()
+    val result = s.write(registerUpdate(Update.Type.MODIFY, registerId = 999))
+    assertTrue("expected NotFound", result is WriteResult.NotFound)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Register reads
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `readRegisterEntries single index returns written value`() {
+    val s = storeWithRegister()
+    s.write(registerUpdate(Update.Type.MODIFY, index = 1, value = 0xABCD))
+    val filter =
+      P4RuntimeOuterClass.RegisterEntry.newBuilder()
+        .setRegisterId(REGISTER_ID)
+        .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(1))
+        .build()
+    val results = s.readRegisterEntries(filter)
+    assertEquals(1, results.size)
+    val entry = results[0].registerEntry
+    assertEquals(REGISTER_ID, entry.registerId)
+    assertEquals(1, entry.index.index)
+    assertEquals(
+      ByteString.copyFrom(longToBytes(0xABCD, (REGISTER_BITWIDTH + 7) / 8)),
+      entry.data.bitstring,
+    )
+  }
+
+  @Test
+  fun `readRegisterEntries all indices returns full array with defaults`() {
+    val s = storeWithRegister()
+    s.write(registerUpdate(Update.Type.MODIFY, index = 2, value = 99))
+    val filter = P4RuntimeOuterClass.RegisterEntry.newBuilder().setRegisterId(REGISTER_ID).build()
+    val results = s.readRegisterEntries(filter)
+    assertEquals(REGISTER_SIZE, results.size)
+    // Index 2 has value 99, others default to 0.
+    for (entity in results) {
+      val entry = entity.registerEntry
+      val expected = if (entry.index.index == 2L) 99L else 0L
+      assertEquals(
+        ByteString.copyFrom(longToBytes(expected, (REGISTER_BITWIDTH + 7) / 8)),
+        entry.data.bitstring,
+      )
+    }
+  }
+
+  @Test
+  fun `readRegisterEntries wildcard returns all registers`() {
+    val s = TableStore()
+    s.loadMappings(
+      tableNameById = emptyMap(),
+      actionNameById = emptyMap(),
+      registerInfoById =
+        mapOf(
+          REGISTER_ID to TableStore.RegisterInfo(REGISTER_NAME, REGISTER_BITWIDTH, 2),
+          REGISTER_ID + 1 to TableStore.RegisterInfo("otherRegister", 8, 1),
+        ),
+    )
+    s.write(registerUpdate(Update.Type.MODIFY, registerId = REGISTER_ID, index = 0, value = 1))
+    val filter = P4RuntimeOuterClass.RegisterEntry.getDefaultInstance()
+    val results = s.readRegisterEntries(filter)
+    // 2 entries from first register + 1 from second = 3
+    assertEquals(3, results.size)
+  }
+
+  @Test
+  fun `readRegisterEntries unknown register returns empty`() {
+    val s = storeWithRegister()
+    val filter = P4RuntimeOuterClass.RegisterEntry.newBuilder().setRegisterId(999).build()
+    assertTrue(s.readRegisterEntries(filter).isEmpty())
+  }
+
+  // ---------------------------------------------------------------------------
   // Per-entry reads
   // ---------------------------------------------------------------------------
 
@@ -1002,6 +1154,10 @@ class TableStoreTest {
     private const val PROFILE_TABLE_ID = 2
     private const val PROFILE_TABLE_NAME = "selectorTable"
     private const val PROFILE_ID = 100
+    private const val REGISTER_ID = 500
+    private const val REGISTER_NAME = "myRegister"
+    private const val REGISTER_BITWIDTH = 32
+    private const val REGISTER_SIZE = 4
     private val ACTION_ID_TO_NAME =
       listOf(10, 20, 42, 50, 77, 99, 100, 200).associateWith { "action$it" }
   }

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -892,13 +892,29 @@ class TableStoreTest {
     store.loadMappings(
       tableNameById = mapOf(TABLE_ID to TABLE_NAME),
       actionNameById = ACTION_ID_TO_NAME,
-      registerInfoById =
-        mapOf(
-          REGISTER_ID to TableStore.RegisterInfo(REGISTER_NAME, REGISTER_BITWIDTH, REGISTER_SIZE)
-        ),
+      p4infoRegisters =
+        listOf(buildRegisterProto(REGISTER_ID, REGISTER_NAME, REGISTER_BITWIDTH, REGISTER_SIZE)),
     )
     return store
   }
+
+  private fun buildRegisterProto(
+    id: Int,
+    name: String,
+    bitwidth: Int,
+    size: Int,
+  ): P4InfoOuterClass.Register =
+    P4InfoOuterClass.Register.newBuilder()
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName(name))
+      .setTypeSpec(
+        p4.config.v1.P4Types.P4DataTypeSpec.newBuilder()
+          .setBitstring(
+            p4.config.v1.P4Types.P4BitstringLikeTypeSpec.newBuilder()
+              .setBit(p4.config.v1.P4Types.P4BitTypeSpec.newBuilder().setBitwidth(bitwidth))
+          )
+      )
+      .setSize(size)
+      .build()
 
   private fun registerUpdate(
     type: Update.Type,
@@ -1014,10 +1030,10 @@ class TableStoreTest {
     s.loadMappings(
       tableNameById = emptyMap(),
       actionNameById = emptyMap(),
-      registerInfoById =
-        mapOf(
-          REGISTER_ID to TableStore.RegisterInfo(REGISTER_NAME, REGISTER_BITWIDTH, 2),
-          REGISTER_ID + 1 to TableStore.RegisterInfo("otherRegister", 8, 1),
+      p4infoRegisters =
+        listOf(
+          buildRegisterProto(REGISTER_ID, REGISTER_NAME, REGISTER_BITWIDTH, 2),
+          buildRegisterProto(REGISTER_ID + 1, "otherRegister", 8, 1),
         ),
     )
     s.write(registerUpdate(Update.Type.MODIFY, registerId = REGISTER_ID, index = 0, value = 1))


### PR DESCRIPTION
## Summary

Registers are now fully accessible through P4Runtime Read/Write RPCs, closing
another gap in the gRPC server's entity coverage.

- **Write**: `MODIFY` sets a register value at a given index; `INSERT`/`DELETE`
  return `INVALID_ARGUMENT` (registers are statically allocated arrays)
- **Read**: supports per-index, per-register, and wildcard filtering; unwritten
  indices return zero
- **LIMITATIONS cleanup**: removes two stale entries — `GetForwardingPipelineConfig`
  and `Capabilities` were implemented in PR #175 but never cleaned up

Design notes:
- `loadMappings` accepts `List<Register>` protos (consistent with `p4infoTables`)
  and builds the internal ID→metadata map itself; `RegisterInfo` is private
- Value serialization reuses `BitVector.toByteArray()` rather than duplicating
  the BigInteger→bytes logic
- Added `loadMappings` parameter sprawl to `REFACTORING.md` as future tech debt
  (trigger: when counters/meters are wired through P4Runtime)

## Test plan

- [x] 9 unit tests in `TableStoreTest` (write semantics + read filtering)
- [x] 3 conformance tests through gRPC (write/read round-trip, unwritten defaults,
      INSERT rejection)
- [x] Full `bazel build` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)