### PR TITLE
p4runtime: add strict Write validation at the P4Runtime layer

### DIFF
--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -128,6 +128,20 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "WriteValidatorTest",
+    srcs = ["WriteValidatorTest.kt"],
+    test_class = "fourward.p4runtime.WriteValidatorTest",
+    deps = [
+        ":p4info_java_proto",
+        ":p4runtime_java_proto",
+        ":p4runtime_lib",
+        "@grpc-java//api",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "TypeTranslatorTest",
     srcs = ["TypeTranslatorTest.kt"],
     test_class = "fourward.p4runtime.TypeTranslatorTest",

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -42,12 +42,18 @@ class P4RuntimeService(
   private val constraintValidatorBinary: Path? = null,
 ) : P4RuntimeGrpcKt.P4RuntimeCoroutineImplBase(), Closeable {
 
-  @Volatile private var currentConfig: PipelineConfig? = null
-  @Volatile private var typeTranslator: TypeTranslator? = null
-  @Volatile private var constraintValidator: ConstraintValidator? = null
+  /** Bundled pipeline state — atomically swapped on pipeline load to avoid torn reads. */
+  private data class PipelineState(
+    val config: PipelineConfig,
+    val typeTranslator: TypeTranslator?,
+    val writeValidator: WriteValidator,
+    val constraintValidator: ConstraintValidator?,
+  )
 
-  private fun requirePipeline(): PipelineConfig =
-    currentConfig
+  @Volatile private var pipeline: PipelineState? = null
+
+  private fun requirePipeline(): PipelineState =
+    pipeline
       ?: throw Status.FAILED_PRECONDITION.withDescription(
           "No pipeline loaded; call SetForwardingPipelineConfig first"
         )
@@ -94,11 +100,15 @@ class P4RuntimeService(
         .asException()
     }
 
-    currentConfig = pipelineConfig
-    typeTranslator = TypeTranslator.create(fwdConfig.p4Info, deviceConfig.translationsList)
-    constraintValidator?.close()
-    constraintValidator =
-      constraintValidatorBinary?.let { ConstraintValidator.create(fwdConfig.p4Info, it) }
+    pipeline?.constraintValidator?.close()
+    pipeline =
+      PipelineState(
+        config = pipelineConfig,
+        typeTranslator = TypeTranslator.create(fwdConfig.p4Info, deviceConfig.translationsList),
+        writeValidator = WriteValidator(pipelineConfig.p4Info),
+        constraintValidator =
+          constraintValidatorBinary?.let { ConstraintValidator.create(fwdConfig.p4Info, it) },
+      )
     return SetForwardingPipelineConfigResponse.getDefaultInstance()
   }
 
@@ -107,10 +117,15 @@ class P4RuntimeService(
   // ---------------------------------------------------------------------------
 
   override suspend fun write(request: WriteRequest): WriteResponse {
-    requirePipeline()
-    val translator = typeTranslator?.takeIf { it.hasTranslations }
-    val validator = constraintValidator
+    val state = requirePipeline()
+    val translator = state.typeTranslator?.takeIf { it.hasTranslations }
+    val validator = state.constraintValidator
     for (rawUpdate in request.updatesList) {
+      // Validate against p4info before type translation so SDN-visible values
+      // are checked at canonical widths (P4Runtime spec §8.3, §9.1).
+      if (rawUpdate.entity.hasTableEntry()) {
+        state.writeValidator.validate(rawUpdate)
+      }
       val update = translator?.translateForWrite(rawUpdate) ?: rawUpdate
 
       // Validate constraints before forwarding to the simulator.
@@ -153,7 +168,7 @@ class P4RuntimeService(
   // ---------------------------------------------------------------------------
 
   override fun read(request: ReadRequest): Flow<ReadResponse> = flow {
-    requirePipeline()
+    val state = requirePipeline()
     val simRequest =
       SimRequest.newBuilder()
         .setReadEntries(ReadEntriesRequest.newBuilder().setRequest(request))
@@ -164,7 +179,7 @@ class P4RuntimeService(
         .asException()
     }
     if (simResponse.readEntries.entitiesCount > 0) {
-      val translator = typeTranslator?.takeIf { it.hasTranslations }
+      val translator = state.typeTranslator?.takeIf { it.hasTranslations }
       val entities =
         if (translator != null) {
           simResponse.readEntries.entitiesList.map { translator.translateForRead(it) }
@@ -198,7 +213,7 @@ class P4RuntimeService(
             )
           }
           msg.hasPacket() -> {
-            val translator = typeTranslator?.takeIf { it.hasTranslations }
+            val translator = pipeline?.typeTranslator?.takeIf { it.hasTranslations }
             val packetOut = translator?.translatePacketOut(msg.packet) ?: msg.packet
             val ingressPort = extractIngressPort(packetOut.metadataList)
 
@@ -252,7 +267,7 @@ class P4RuntimeService(
   override suspend fun getForwardingPipelineConfig(
     request: GetForwardingPipelineConfigRequest
   ): GetForwardingPipelineConfigResponse {
-    val config = requirePipeline()
+    val config = requirePipeline().config
 
     val fwdConfig = ForwardingPipelineConfig.newBuilder()
     when (request.responseType) {
@@ -283,7 +298,7 @@ class P4RuntimeService(
     CapabilitiesResponse.newBuilder().setP4RuntimeApiVersion(P4RUNTIME_API_VERSION).build()
 
   override fun close() {
-    constraintValidator?.close()
+    pipeline?.constraintValidator?.close()
   }
 
   companion object {

--- a/p4runtime/P4RuntimeWriteErrorTest.kt
+++ b/p4runtime/P4RuntimeWriteErrorTest.kt
@@ -1,5 +1,6 @@
 package fourward.p4runtime
 
+import com.google.protobuf.ByteString
 import fourward.ir.v1.PipelineConfig
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.assertGrpcError
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildExactEntry
@@ -114,5 +115,98 @@ class P4RuntimeWriteErrorTest {
     harness.deleteEntry(entry)
 
     assertGrpcError(Status.Code.NOT_FOUND) { harness.deleteEntry(entry) }
+  }
+
+  // =========================================================================
+  // Write validation errors
+  // =========================================================================
+
+  /** Builds a valid exact entry and applies a mutation to produce an invalid one. */
+  private fun buildInvalidEntry(config: PipelineConfig, mutate: (Entity.Builder) -> Unit): Entity {
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    return valid.toBuilder().apply(mutate).build()
+  }
+
+  // P4Runtime spec §9.1.2: action_id must be in the table's action_refs.
+  @Test
+  fun `insert with unknown action ID returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entity =
+      buildInvalidEntry(config) { b ->
+        b.tableEntryBuilder.actionBuilder.actionBuilder.setActionId(99999).clearParams()
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "unknown action ID") {
+      harness.installEntry(entity)
+    }
+  }
+
+  // P4Runtime spec §9.1.2: action parameters must match the p4info schema.
+  @Test
+  fun `insert with wrong param count returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    // forward expects 1 param (port); send 0 params.
+    val entity =
+      buildInvalidEntry(config) { b ->
+        b.tableEntryBuilder.actionBuilder.actionBuilder.clearParams()
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "expects") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §9.1.1: exact-only tables must have priority == 0.
+  @Test
+  fun `insert with nonzero priority on exact table returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entity = buildInvalidEntry(config) { b -> b.tableEntryBuilder.setPriority(10) }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "priority") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §8.3: match field value must have canonical byte width.
+  @Test
+  fun `insert with wrong match value width returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    // etherType is 16-bit (2 bytes); send 1 byte.
+    val entity =
+      buildInvalidEntry(config) { b ->
+        b.tableEntryBuilder
+          .getMatchBuilder(0)
+          .exactBuilder
+          .setValue(ByteString.copyFrom(byteArrayOf(0x08)))
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "bytes") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §9.1.1: match field kind must match p4info.
+  @Test
+  fun `insert with ternary encoding on exact field returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val matchField = config.p4Info.tablesList.first().matchFieldsList.first()
+    val byteWidth = (matchField.bitwidth + 7) / 8
+    val entity =
+      buildInvalidEntry(config) { b ->
+        b.tableEntryBuilder.setPriority(1)
+        b.tableEntryBuilder
+          .getMatchBuilder(0)
+          .clearExact()
+          .setFieldId(matchField.id)
+          .ternaryBuilder
+          .setValue(ByteString.copyFrom(P4RuntimeTestHarness.longToBytes(0x0800, byteWidth)))
+          .setMask(ByteString.copyFrom(P4RuntimeTestHarness.longToBytes(0xFFFF, byteWidth)))
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "EXACT") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §9.1.1: exact match fields are required (cannot be omitted).
+  @Test
+  fun `insert with missing exact match field returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    // No match fields at all — the table requires an exact match.
+    val entity = buildInvalidEntry(config) { b -> b.tableEntryBuilder.clearMatch() }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "missing") { harness.installEntry(entity) }
   }
 }

--- a/p4runtime/WriteValidator.kt
+++ b/p4runtime/WriteValidator.kt
@@ -1,0 +1,222 @@
+package fourward.p4runtime
+
+import io.grpc.Status
+import io.grpc.StatusException
+import p4.config.v1.P4InfoOuterClass
+import p4.v1.P4RuntimeOuterClass
+
+/**
+ * Validates P4Runtime Write updates against the p4info schema.
+ *
+ * Enforces P4Runtime spec §9.1: action IDs/refs, action parameter count/IDs/byte widths, match
+ * field IDs/kinds/byte widths, required exact fields, and priority rules.
+ *
+ * All lookup maps are pre-computed at construction time so [validate] does zero allocations.
+ * Constructed once per pipeline load; call [validate] for each update before type translation so
+ * SDN-visible values are checked at canonical widths (§8.3).
+ */
+class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
+
+  private val tableInfoById = p4Info.tablesList.associateBy { it.preamble.id }
+  private val actionInfoById = p4Info.actionsList.associateBy { it.preamble.id }
+
+  // Pre-computed per-table: valid action IDs, match field lookup, priority requirement.
+  private val actionRefIdsByTable: Map<Int, Set<Int>> =
+    p4Info.tablesList.associate { it.preamble.id to it.actionRefsList.map { r -> r.id }.toSet() }
+
+  private val fieldInfoByTable: Map<Int, Map<Int, P4InfoOuterClass.MatchField>> =
+    p4Info.tablesList.associate { it.preamble.id to it.matchFieldsList.associateBy { f -> f.id } }
+
+  private val tableRequiresPriority: Map<Int, Boolean> =
+    p4Info.tablesList.associate {
+      it.preamble.id to it.matchFieldsList.any { f -> f.matchType in PRIORITY_MATCH_TYPES }
+    }
+
+  // Pre-computed per-action: param lookup.
+  private val paramInfoByAction: Map<Int, Map<Int, P4InfoOuterClass.Action.Param>> =
+    p4Info.actionsList.associate { it.preamble.id to it.paramsList.associateBy { p -> p.id } }
+
+  /** Validates a table entry update. Throws [StatusException] on spec violations. */
+  fun validate(update: P4RuntimeOuterClass.Update) {
+    val entry = update.entity.tableEntry
+    val tableInfo =
+      tableInfoById[entry.tableId] ?: throw notFound("unknown table ID: ${entry.tableId}")
+
+    // P4Runtime spec §9.1: DELETE only needs the match key; skip content validation.
+    if (update.type == P4RuntimeOuterClass.Update.Type.DELETE) return
+
+    if (entry.hasAction() && entry.action.hasAction()) {
+      validateAction(entry.action.action, tableInfo)
+    }
+    validateMatchFields(entry, tableInfo)
+    validatePriority(entry, tableInfo)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Action validation (§9.1.2)
+  // ---------------------------------------------------------------------------
+
+  private fun validateAction(
+    action: P4RuntimeOuterClass.Action,
+    tableInfo: P4InfoOuterClass.Table,
+  ) {
+    val actionInfo =
+      actionInfoById[action.actionId] ?: throw invalidArg("unknown action ID: ${action.actionId}")
+
+    if (action.actionId !in (actionRefIdsByTable[tableInfo.preamble.id] ?: emptySet())) {
+      throw invalidArg(
+        "action ID ${action.actionId} is not valid for table '${tableInfo.tableName}'"
+      )
+    }
+
+    validateActionParams(action, actionInfo)
+  }
+
+  private fun validateActionParams(
+    action: P4RuntimeOuterClass.Action,
+    actionInfo: P4InfoOuterClass.Action,
+  ) {
+    val expected = actionInfo.paramsList
+    if (action.paramsCount != expected.size) {
+      throw invalidArg(
+        "action '${actionInfo.preamble.name}' expects ${expected.size} params, " +
+          "got ${action.paramsCount}"
+      )
+    }
+    val paramLookup = paramInfoByAction[action.actionId] ?: return
+    for (param in action.paramsList) {
+      val paramInfo =
+        paramLookup[param.paramId]
+          ?: throw invalidArg(
+            "unknown param ID ${param.paramId} for action '${actionInfo.preamble.name}'"
+          )
+      // §8.3: canonical byte width. Skip if bitwidth is 0
+      // (e.g. @p4runtime_translation with sdn_string).
+      checkWidth(paramInfo.bitwidth, param.value.size(), "param '${paramInfo.name}'")
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Match field validation (§9.1.1)
+  // ---------------------------------------------------------------------------
+
+  private fun validateMatchFields(
+    entry: P4RuntimeOuterClass.TableEntry,
+    tableInfo: P4InfoOuterClass.Table,
+  ) {
+    val expectedFields = tableInfo.matchFieldsList
+    if (expectedFields.isEmpty()) return
+
+    val fieldLookup = fieldInfoByTable[tableInfo.preamble.id] ?: return
+    val presentFieldIds = mutableSetOf<Int>()
+    for (fm in entry.matchList) {
+      val fieldInfo =
+        fieldLookup[fm.fieldId]
+          ?: throw invalidArg(
+            "unknown match field ID ${fm.fieldId} in table '${tableInfo.tableName}'"
+          )
+      validateMatchKind(fm, fieldInfo)
+      validateMatchWidth(fm, fieldInfo)
+      presentFieldIds.add(fm.fieldId)
+    }
+
+    // EXACT fields must be present; omission is not allowed.
+    for (fieldInfo in expectedFields) {
+      if (
+        fieldInfo.matchType == P4InfoOuterClass.MatchField.MatchType.EXACT &&
+          fieldInfo.id !in presentFieldIds
+      ) {
+        throw invalidArg(
+          "missing required exact match field '${fieldInfo.name}' in table '${tableInfo.tableName}'"
+        )
+      }
+    }
+  }
+
+  private fun validateMatchKind(
+    fm: P4RuntimeOuterClass.FieldMatch,
+    fieldInfo: P4InfoOuterClass.MatchField,
+  ) {
+    val actual =
+      when {
+        fm.hasExact() -> P4InfoOuterClass.MatchField.MatchType.EXACT
+        fm.hasTernary() -> P4InfoOuterClass.MatchField.MatchType.TERNARY
+        fm.hasLpm() -> P4InfoOuterClass.MatchField.MatchType.LPM
+        fm.hasRange() -> P4InfoOuterClass.MatchField.MatchType.RANGE
+        fm.hasOptional() -> P4InfoOuterClass.MatchField.MatchType.OPTIONAL
+        else -> throw invalidArg("match field '${fieldInfo.name}' has no value set")
+      }
+    if (actual != fieldInfo.matchType) {
+      throw invalidArg(
+        "match field '${fieldInfo.name}' expects ${fieldInfo.matchType.name} but got ${actual.name}"
+      )
+    }
+  }
+
+  private fun validateMatchWidth(
+    fm: P4RuntimeOuterClass.FieldMatch,
+    fieldInfo: P4InfoOuterClass.MatchField,
+  ) {
+    val w = fieldInfo.bitwidth
+    val f = fieldInfo.name
+    when {
+      fm.hasExact() -> checkWidth(w, fm.exact.value.size(), "match field '$f' value")
+      fm.hasTernary() -> {
+        checkWidth(w, fm.ternary.value.size(), "match field '$f' value")
+        checkWidth(w, fm.ternary.mask.size(), "match field '$f' mask")
+      }
+      fm.hasLpm() -> checkWidth(w, fm.lpm.value.size(), "match field '$f' value")
+      fm.hasRange() -> {
+        checkWidth(w, fm.range.low.size(), "match field '$f' low")
+        checkWidth(w, fm.range.high.size(), "match field '$f' high")
+      }
+      fm.hasOptional() -> checkWidth(w, fm.optional.value.size(), "match field '$f' value")
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Priority validation (§9.1.1)
+  // ---------------------------------------------------------------------------
+
+  private fun validatePriority(
+    entry: P4RuntimeOuterClass.TableEntry,
+    tableInfo: P4InfoOuterClass.Table,
+  ) {
+    val hasPriorityFields = tableRequiresPriority[tableInfo.preamble.id] ?: false
+    val name = tableInfo.tableName
+    if (hasPriorityFields && entry.priority <= 0) {
+      throw invalidArg(
+        "table '$name' requires priority > 0 (has ternary/range/optional match fields)"
+      )
+    }
+    if (!hasPriorityFields && entry.priority != 0) {
+      throw invalidArg("table '$name' must have priority == 0 (exact/LPM match only)")
+    }
+  }
+
+  companion object {
+    private val PRIORITY_MATCH_TYPES =
+      setOf(
+        P4InfoOuterClass.MatchField.MatchType.TERNARY,
+        P4InfoOuterClass.MatchField.MatchType.RANGE,
+        P4InfoOuterClass.MatchField.MatchType.OPTIONAL,
+      )
+
+    /** §8.3: values must be exactly ceil(bitwidth/8) bytes. Skips if bitwidth is 0. */
+    private fun checkWidth(bitwidth: Int, actual: Int, label: String) {
+      val expected = (bitwidth + 7) / 8
+      if (expected > 0 && actual != expected) {
+        throw invalidArg("$label expects $expected bytes, got $actual")
+      }
+    }
+
+    private val P4InfoOuterClass.Table.tableName: String
+      get() = preamble.alias.ifEmpty { preamble.name }
+
+    private fun invalidArg(msg: String): StatusException =
+      Status.INVALID_ARGUMENT.withDescription(msg).asException()
+
+    private fun notFound(msg: String): StatusException =
+      Status.NOT_FOUND.withDescription(msg).asException()
+  }
+}

--- a/p4runtime/WriteValidatorTest.kt
+++ b/p4runtime/WriteValidatorTest.kt
@@ -1,0 +1,514 @@
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import io.grpc.Status
+import io.grpc.StatusException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import p4.config.v1.P4InfoOuterClass
+import p4.v1.P4RuntimeOuterClass
+
+/**
+ * Unit tests for [WriteValidator].
+ *
+ * Tests validation logic directly without the gRPC service or simulator. Each test constructs a
+ * synthetic p4info and checks that the validator accepts valid updates and rejects invalid ones
+ * with the correct gRPC status code.
+ */
+class WriteValidatorTest {
+
+  // =========================================================================
+  // Valid updates — should not throw
+  // =========================================================================
+
+  @Test
+  fun `valid insert passes validation`() {
+    val v = validator()
+    v.validate(insertUpdate(EXACT_TABLE_ID, exactMatch(MATCH_FIELD_ID, bytes(2)), action()))
+  }
+
+  @Test
+  fun `delete skips content validation`() {
+    // DELETE with a bogus action ID — should pass because DELETE only needs the match key.
+    val v = validator()
+    v.validate(
+      deleteUpdate(EXACT_TABLE_ID, exactMatch(MATCH_FIELD_ID, bytes(2)), action(actionId = 99999))
+    )
+  }
+
+  // =========================================================================
+  // Table ID validation
+  // =========================================================================
+
+  @Test
+  fun `unknown table ID returns NOT_FOUND`() {
+    val v = validator()
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(insertUpdate(99999, exactMatch(MATCH_FIELD_ID, bytes(2)), action()))
+      }
+    assertEquals(Status.Code.NOT_FOUND, e.status.code)
+  }
+
+  // =========================================================================
+  // Action validation (§9.1.2)
+  // =========================================================================
+
+  @Test
+  fun `unknown action ID returns INVALID_ARGUMENT`() {
+    val v = validator()
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(EXACT_TABLE_ID, exactMatch(MATCH_FIELD_ID, bytes(2)), action(actionId = 99))
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+  }
+
+  @Test
+  fun `action not in table action_refs returns INVALID_ARGUMENT`() {
+    val v = validator()
+    // OTHER_ACTION_ID exists in p4info but is not in the exact table's action_refs.
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(
+            EXACT_TABLE_ID,
+            exactMatch(MATCH_FIELD_ID, bytes(2)),
+            action(actionId = OTHER_ACTION_ID),
+          )
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("not valid for table"))
+  }
+
+  @Test
+  fun `wrong param count returns INVALID_ARGUMENT`() {
+    val v = validator()
+    // forward expects 1 param; send 0.
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(
+            EXACT_TABLE_ID,
+            exactMatch(MATCH_FIELD_ID, bytes(2)),
+            action(params = emptyList()),
+          )
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("expects"))
+  }
+
+  @Test
+  fun `unknown param ID returns INVALID_ARGUMENT`() {
+    val v = validator()
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(
+            EXACT_TABLE_ID,
+            exactMatch(MATCH_FIELD_ID, bytes(2)),
+            action(params = listOf(param(paramId = 99, value = bytes(2)))),
+          )
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("unknown param ID"))
+  }
+
+  @Test
+  fun `wrong param byte width returns INVALID_ARGUMENT`() {
+    val v = validator()
+    // Param is 16-bit (2 bytes); send 1 byte.
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(
+            EXACT_TABLE_ID,
+            exactMatch(MATCH_FIELD_ID, bytes(2)),
+            action(params = listOf(param(value = bytes(1)))),
+          )
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("bytes"))
+  }
+
+  @Test
+  fun `zero-bitwidth param skips width check`() {
+    // Simulates @p4runtime_translation with sdn_string where bitwidth is 0.
+    val v = validatorWithZeroBitwidthParam()
+    v.validate(
+      insertUpdate(
+        EXACT_TABLE_ID,
+        exactMatch(MATCH_FIELD_ID, bytes(2)),
+        action(params = listOf(param(value = bytes(5)))),
+      )
+    )
+  }
+
+  // =========================================================================
+  // Match field validation (§9.1.1)
+  // =========================================================================
+
+  @Test
+  fun `unknown match field ID returns INVALID_ARGUMENT`() {
+    val v = validator()
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(insertUpdate(EXACT_TABLE_ID, exactMatch(fieldId = 99, bytes(2)), action()))
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("unknown match field ID"))
+  }
+
+  @Test
+  fun `wrong match kind returns INVALID_ARGUMENT`() {
+    val v = validator()
+    // Table expects EXACT; send TERNARY.
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(insertUpdate(EXACT_TABLE_ID, ternaryMatch(MATCH_FIELD_ID, bytes(2)), action()))
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("EXACT"))
+  }
+
+  @Test
+  fun `wrong match value width returns INVALID_ARGUMENT`() {
+    val v = validator()
+    // Match field is 16-bit (2 bytes); send 1 byte.
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(insertUpdate(EXACT_TABLE_ID, exactMatch(MATCH_FIELD_ID, bytes(1)), action()))
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("bytes"))
+  }
+
+  @Test
+  fun `missing required exact field returns INVALID_ARGUMENT`() {
+    val v = validator()
+    // No match fields at all.
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(insertUpdate(EXACT_TABLE_ID, matches = emptyList(), action = action()))
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("missing"))
+  }
+
+  @Test
+  fun `ternary match value and mask widths validated`() {
+    val v = validator()
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(
+            TERNARY_TABLE_ID,
+            ternaryMatch(TERNARY_FIELD_ID, value = bytes(1), mask = bytes(2)),
+            ternaryAction(),
+            priority = 1,
+          )
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("value"))
+  }
+
+  @Test
+  fun `LPM match value width validated`() {
+    val v = validator()
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(
+            LPM_TABLE_ID,
+            lpmMatch(LPM_FIELD_ID, value = bytes(1), prefixLen = 8),
+            ternaryAction(),
+          )
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+  }
+
+  // =========================================================================
+  // Priority validation (§9.1.1)
+  // =========================================================================
+
+  @Test
+  fun `exact table with nonzero priority returns INVALID_ARGUMENT`() {
+    val v = validator()
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(EXACT_TABLE_ID, exactMatch(MATCH_FIELD_ID, bytes(2)), action(), priority = 5)
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("priority"))
+  }
+
+  @Test
+  fun `ternary table with zero priority returns INVALID_ARGUMENT`() {
+    val v = validator()
+    val e =
+      assertThrows(StatusException::class.java) {
+        v.validate(
+          insertUpdate(
+            TERNARY_TABLE_ID,
+            ternaryMatch(TERNARY_FIELD_ID, bytes(2)),
+            ternaryAction(),
+            priority = 0,
+          )
+        )
+      }
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assert(e.status.description!!.contains("priority"))
+  }
+
+  @Test
+  fun `ternary table with positive priority passes`() {
+    val v = validator()
+    v.validate(
+      insertUpdate(
+        TERNARY_TABLE_ID,
+        ternaryMatch(TERNARY_FIELD_ID, bytes(2)),
+        ternaryAction(),
+        priority = 10,
+      )
+    )
+  }
+
+  // =========================================================================
+  // Test fixtures
+  // =========================================================================
+
+  companion object {
+    private const val EXACT_TABLE_ID = 1
+    private const val TERNARY_TABLE_ID = 2
+    private const val LPM_TABLE_ID = 3
+    private const val MATCH_FIELD_ID = 1
+    private const val TERNARY_FIELD_ID = 2
+    private const val LPM_FIELD_ID = 3
+    private const val ACTION_ID = 10
+    private const val OTHER_ACTION_ID = 11
+    private const val TERNARY_ACTION_ID = 12
+    private const val PARAM_ID = 1
+    private const val MATCH_BITWIDTH = 16
+    private const val PARAM_BITWIDTH = 16
+  }
+
+  private fun validator(): WriteValidator = WriteValidator(testP4Info())
+
+  private fun validatorWithZeroBitwidthParam(): WriteValidator =
+    WriteValidator(testP4InfoWithZeroBitwidthParam())
+
+  private fun testP4Info(): P4InfoOuterClass.P4Info =
+    P4InfoOuterClass.P4Info.newBuilder()
+      .addTables(
+        P4InfoOuterClass.Table.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder().setId(EXACT_TABLE_ID).setName("exact_table")
+          )
+          .addMatchFields(
+            P4InfoOuterClass.MatchField.newBuilder()
+              .setId(MATCH_FIELD_ID)
+              .setName("f1")
+              .setBitwidth(MATCH_BITWIDTH)
+              .setMatchType(P4InfoOuterClass.MatchField.MatchType.EXACT)
+          )
+          .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_ID))
+      )
+      .addTables(
+        P4InfoOuterClass.Table.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder().setId(TERNARY_TABLE_ID).setName("ternary_table")
+          )
+          .addMatchFields(
+            P4InfoOuterClass.MatchField.newBuilder()
+              .setId(TERNARY_FIELD_ID)
+              .setName("f2")
+              .setBitwidth(MATCH_BITWIDTH)
+              .setMatchType(P4InfoOuterClass.MatchField.MatchType.TERNARY)
+          )
+          .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(TERNARY_ACTION_ID))
+      )
+      .addTables(
+        P4InfoOuterClass.Table.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder().setId(LPM_TABLE_ID).setName("lpm_table")
+          )
+          .addMatchFields(
+            P4InfoOuterClass.MatchField.newBuilder()
+              .setId(LPM_FIELD_ID)
+              .setName("f3")
+              .setBitwidth(MATCH_BITWIDTH)
+              .setMatchType(P4InfoOuterClass.MatchField.MatchType.LPM)
+          )
+          .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(TERNARY_ACTION_ID))
+      )
+      .addActions(
+        P4InfoOuterClass.Action.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(ACTION_ID).setName("forward"))
+          .addParams(
+            P4InfoOuterClass.Action.Param.newBuilder()
+              .setId(PARAM_ID)
+              .setName("port")
+              .setBitwidth(PARAM_BITWIDTH)
+          )
+      )
+      .addActions(
+        P4InfoOuterClass.Action.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder().setId(OTHER_ACTION_ID).setName("other")
+          )
+      )
+      .addActions(
+        P4InfoOuterClass.Action.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder().setId(TERNARY_ACTION_ID).setName("drop")
+          )
+      )
+      .build()
+
+  private fun testP4InfoWithZeroBitwidthParam(): P4InfoOuterClass.P4Info =
+    P4InfoOuterClass.P4Info.newBuilder()
+      .addTables(
+        P4InfoOuterClass.Table.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder().setId(EXACT_TABLE_ID).setName("exact_table")
+          )
+          .addMatchFields(
+            P4InfoOuterClass.MatchField.newBuilder()
+              .setId(MATCH_FIELD_ID)
+              .setName("f1")
+              .setBitwidth(MATCH_BITWIDTH)
+              .setMatchType(P4InfoOuterClass.MatchField.MatchType.EXACT)
+          )
+          .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_ID))
+      )
+      .addActions(
+        P4InfoOuterClass.Action.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(ACTION_ID).setName("forward"))
+          .addParams(
+            P4InfoOuterClass.Action.Param.newBuilder()
+              .setId(PARAM_ID)
+              .setName("port")
+              .setBitwidth(0) // sdn_string translation — bitwidth 0
+          )
+      )
+      .build()
+
+  // =========================================================================
+  // Proto builders
+  // =========================================================================
+
+  private fun bytes(len: Int): ByteArray = ByteArray(len)
+
+  private fun exactMatch(
+    fieldId: Int = MATCH_FIELD_ID,
+    value: ByteArray,
+  ): P4RuntimeOuterClass.FieldMatch =
+    P4RuntimeOuterClass.FieldMatch.newBuilder()
+      .setFieldId(fieldId)
+      .setExact(
+        P4RuntimeOuterClass.FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(value))
+      )
+      .build()
+
+  private fun ternaryMatch(
+    fieldId: Int = TERNARY_FIELD_ID,
+    value: ByteArray,
+    mask: ByteArray = value,
+  ): P4RuntimeOuterClass.FieldMatch =
+    P4RuntimeOuterClass.FieldMatch.newBuilder()
+      .setFieldId(fieldId)
+      .setTernary(
+        P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
+          .setValue(ByteString.copyFrom(value))
+          .setMask(ByteString.copyFrom(mask))
+      )
+      .build()
+
+  private fun lpmMatch(
+    fieldId: Int,
+    value: ByteArray,
+    prefixLen: Int,
+  ): P4RuntimeOuterClass.FieldMatch =
+    P4RuntimeOuterClass.FieldMatch.newBuilder()
+      .setFieldId(fieldId)
+      .setLpm(
+        P4RuntimeOuterClass.FieldMatch.LPM.newBuilder()
+          .setValue(ByteString.copyFrom(value))
+          .setPrefixLen(prefixLen)
+      )
+      .build()
+
+  private fun param(
+    paramId: Int = PARAM_ID,
+    value: ByteArray = bytes(PARAM_BITWIDTH / 8),
+  ): P4RuntimeOuterClass.Action.Param =
+    P4RuntimeOuterClass.Action.Param.newBuilder()
+      .setParamId(paramId)
+      .setValue(ByteString.copyFrom(value))
+      .build()
+
+  private fun action(
+    actionId: Int = ACTION_ID,
+    params: List<P4RuntimeOuterClass.Action.Param> = listOf(param()),
+  ): P4RuntimeOuterClass.Action =
+    P4RuntimeOuterClass.Action.newBuilder().setActionId(actionId).addAllParams(params).build()
+
+  private fun ternaryAction(): P4RuntimeOuterClass.Action =
+    P4RuntimeOuterClass.Action.newBuilder().setActionId(TERNARY_ACTION_ID).build()
+
+  private fun insertUpdate(
+    tableId: Int,
+    match: P4RuntimeOuterClass.FieldMatch,
+    action: P4RuntimeOuterClass.Action,
+    priority: Int = 0,
+  ): P4RuntimeOuterClass.Update = insertUpdate(tableId, listOf(match), action, priority)
+
+  private fun insertUpdate(
+    tableId: Int,
+    matches: List<P4RuntimeOuterClass.FieldMatch>,
+    action: P4RuntimeOuterClass.Action,
+    priority: Int = 0,
+  ): P4RuntimeOuterClass.Update =
+    P4RuntimeOuterClass.Update.newBuilder()
+      .setType(P4RuntimeOuterClass.Update.Type.INSERT)
+      .setEntity(
+        P4RuntimeOuterClass.Entity.newBuilder()
+          .setTableEntry(
+            P4RuntimeOuterClass.TableEntry.newBuilder()
+              .setTableId(tableId)
+              .addAllMatch(matches)
+              .setPriority(priority)
+              .setAction(P4RuntimeOuterClass.TableAction.newBuilder().setAction(action))
+          )
+      )
+      .build()
+
+  private fun deleteUpdate(
+    tableId: Int,
+    match: P4RuntimeOuterClass.FieldMatch,
+    action: P4RuntimeOuterClass.Action,
+  ): P4RuntimeOuterClass.Update =
+    P4RuntimeOuterClass.Update.newBuilder()
+      .setType(P4RuntimeOuterClass.Update.Type.DELETE)
+      .setEntity(
+        P4RuntimeOuterClass.Entity.newBuilder()
+          .setTableEntry(
+            P4RuntimeOuterClass.TableEntry.newBuilder()
+              .setTableId(tableId)
+              .addMatch(match)
+              .setAction(P4RuntimeOuterClass.TableAction.newBuilder().setAction(action))
+          )
+      )
+      .build()
+}


### PR DESCRIPTION
## Summary

Adds P4Runtime spec §9.1 write validation so the server rejects malformed entries with proper gRPC errors instead of crashing the simulator.

- **New `WriteValidator` class** — self-contained validation constructed once per pipeline load from p4info, zero per-call allocations
- **Validates before type translation** — SDN-visible values checked at canonical p4info widths (§8.3)
- **Atomic `PipelineState`** — bundles config, translator, and validator into single `@Volatile` reference to prevent torn reads
- **18 unit tests** in `WriteValidatorTest` covering every validation path (table ID, action ID/refs, param count/IDs/widths, match field IDs/kinds/widths, required exact fields, priority rules, DELETE bypass, zero-bitwidth skip)
- **6 E2E tests** in `P4RuntimeWriteErrorTest` for gRPC-level error codes
- **Cleans up LIMITATIONS.md** — removes stale "Missing RPCs" entry

Key design: validation lives in `P4RuntimeService`, not `TableStore`. STF and p4testgen bypass the P4Runtime layer entirely, so strict spec checks don't affect them.

## Test plan

- [ ] CI passes (`bazel test //...`)
- [ ] 18 unit tests in `WriteValidatorTest`
- [ ] 6 E2E tests in `P4RuntimeWriteErrorTest`
- [ ] Existing P4Runtime conformance and translation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)