### PR TITLE
feat: SAI P4 E2E test — the capstone

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -58,16 +58,16 @@ complexity:
     thresholdInEnums: 11
     excludes: ['**/test/**', '**/*Test.kt']
 
+  # The default (4) is too low for work-stack interpreters like buildTraceTree,
+  # where an explicit stack loop naturally nests: while → when → branch → try/catch.
+  NestedBlockDepth:
+    threshold: 6
+
   # Protocol dispatch functions (Interpreter.evalExpr, evalBinaryOp) are large
   # `when` expressions whose cyclomatic complexity grows linearly with the number
   # of P4 language constructs — not a readability problem.
   CyclomaticComplexMethod:
     threshold: 29
-
-  # The iterative trace-tree builder (buildTraceTree) uses while → when → try/catch,
-  # naturally reaching depth 5. Flattening it would hurt readability.
-  NestedBlockDepth:
-    threshold: 5
 
   # 60 lines is too tight for sequential protocol handlers (e.g. StfRunner.run, which
   # encodes a strict request/response sequence that reads clearly as one function).

--- a/e2e_tests/sai_p4/BUILD.bazel
+++ b/e2e_tests/sai_p4/BUILD.bazel
@@ -1,0 +1,33 @@
+# SAI P4 (middleblock instantiation) — vendored from sonic-net/sonic-pins.
+# Used for E2E testing of the P4Runtime server with @p4runtime_translation.
+
+filegroup(
+    name = "sai_p4_srcs",
+    srcs = glob([
+        "fixed/*.p4",
+        "fixed/*.h",
+        "instantiations/google/*.p4",
+        "instantiations/google/*.h",
+    ]),
+)
+
+genrule(
+    name = "sai_middleblock_pb",
+    srcs = [
+        "instantiations/google/middleblock.p4",
+        ":sai_p4_srcs",
+    ],
+    outs = ["sai_middleblock.txtpb"],
+    cmd = " ".join([
+        "$(execpath //p4c_backend:p4c-4ward)",
+        "-I $$(dirname $(execpath @p4c//:core_p4))",
+        "-o $@",
+        "$(execpath instantiations/google/middleblock.p4)",
+    ]),
+    tools = [
+        "//p4c_backend:p4c-4ward",
+        "@p4c//:core_p4",
+        "@p4c//:p4include",
+    ],
+    visibility = ["//p4runtime:__pkg__"],
+)

--- a/e2e_tests/sai_p4/fixed/bitwidths.p4
+++ b/e2e_tests/sai_p4/fixed/bitwidths.p4
@@ -1,0 +1,54 @@
+#ifndef SAI_BITWIDTHS_P4_
+#define SAI_BITWIDTHS_P4_
+
+#ifndef PORT_BITWIDTH
+#define PORT_BITWIDTH 16
+#endif
+
+#ifndef VRF_BITWIDTH
+#define VRF_BITWIDTH 16
+#endif
+
+#ifndef NEXTHOP_ID_BITWIDTH
+#define NEXTHOP_ID_BITWIDTH 16
+#endif
+
+#ifndef ROUTER_INTERFACE_ID_BITWIDTH
+#define ROUTER_INTERFACE_ID_BITWIDTH 16
+#endif
+
+#ifndef WCMP_GROUP_ID_BITWIDTH
+#define WCMP_GROUP_ID_BITWIDTH 16
+#endif
+
+#ifndef MIRROR_SESSION_ID_BITWIDTH
+#define MIRROR_SESSION_ID_BITWIDTH 16
+#endif
+
+#ifndef QOS_QUEUE_BITWIDTH
+#define QOS_QUEUE_BITWIDTH 16
+#endif
+
+#ifndef WCMP_SELECTOR_INPUT_BITWIDTH
+#define WCMP_SELECTOR_INPUT_BITWIDTH 16
+#endif
+
+#ifndef ROUTE_METADATA_BITWIDTH
+#define ROUTE_METADATA_BITWIDTH 6
+#endif
+
+#ifndef ACL_METADATA_BITWIDTH
+#define ACL_METADATA_BITWIDTH 8
+#endif
+
+#ifndef TUNNEL_ID_BITWIDTH
+#define TUNNEL_ID_BITWIDTH 16
+#endif
+
+// Inherited from v1model, see `standard_metadata_t.mcast_grp`.
+#define MULTICAST_GROUP_ID_BITWIDTH 16
+
+// Inherited from v1model, see `standard_metadata_t.egress_rid`.
+#define REPLICA_INSTANCE_BITWIDTH 16
+
+#endif  // SAI_BITWIDTHS_P4_

--- a/e2e_tests/sai_p4/fixed/bmv2_intrinsics.h
+++ b/e2e_tests/sai_p4/fixed/bmv2_intrinsics.h
@@ -1,0 +1,15 @@
+#ifndef PINS_SAI_P4_FIXED_BMV2_INTRINSICS_H_
+#define PINS_SAI_P4_FIXED_BMV2_INTRINSICS_H_
+
+// Possible values of the v1model `standard_metadata_t` field `instance_type` in
+// BMv2. The semantics of these values is explained here:
+// https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md
+#define PKT_INSTANCE_TYPE_NORMAL 0
+#define PKT_INSTANCE_TYPE_INGRESS_CLONE 1
+#define PKT_INSTANCE_TYPE_EGRESS_CLONE 2
+#define PKT_INSTANCE_TYPE_COALESCED 3
+#define PKT_INSTANCE_TYPE_RECIRC 4
+#define PKT_INSTANCE_TYPE_REPLICATION 5
+#define PKT_INSTANCE_TYPE_RESUBMIT 6
+
+#endif  // PINS_SAI_P4_FIXED_BMV2_INTRINSICS_H_

--- a/e2e_tests/sai_p4/fixed/common_actions.p4
+++ b/e2e_tests/sai_p4/fixed/common_actions.p4
@@ -1,0 +1,14 @@
+#ifndef SAI_FIXED_COMMON_ACTIONS_P4_
+#define SAI_FIXED_COMMON_ACTIONS_P4_
+
+#include "ids.h"
+
+// This file lists common actions that may be used by multiple control blocks in
+// the fixed pipeline.
+
+// Action that does nothing. Like `NoAction` in `core.p4`, but following
+// Google's naming conventions.
+@id(SHARED_NO_ACTION_ACTION_ID)
+action no_action() {}
+
+#endif  // SAI_FIXED_COMMON_ACTIONS_P4_

--- a/e2e_tests/sai_p4/fixed/drop_martians.p4
+++ b/e2e_tests/sai_p4/fixed/drop_martians.p4
@@ -1,0 +1,138 @@
+#ifndef SAI_DROP_MARTIANS_P4_
+#define SAI_DROP_MARTIANS_P4_
+
+// Drop certain special-use (aka martian) addresses.
+
+const ipv6_addr_t IPV6_MULTICAST_MASK =
+  0xff00_0000_0000_0000_0000_0000_0000_0000;
+const ipv6_addr_t IPV6_MULTICAST_VALUE =
+  0xff00_0000_0000_0000_0000_0000_0000_0000;
+
+// ::1/128
+const ipv6_addr_t IPV6_LOOPBACK_MASK =
+  0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff;
+const ipv6_addr_t IPV6_LOOPBACK_VALUE =
+  0x0000_0000_0000_0000_0000_0000_0000_0001;
+
+const ipv4_addr_t IPV4_MULTICAST_MASK = 0xf0_00_00_00;
+const ipv4_addr_t IPV4_MULTICAST_VALUE = 0xe0_00_00_00;
+
+const ipv4_addr_t IPV4_BROADCAST_VALUE = 0xff_ff_ff_ff;
+
+// 127.0.0.0/8
+const ipv4_addr_t IPV4_LOOPBACK_MASK = 0xff_00_00_00;
+const ipv4_addr_t IPV4_LOOPBACK_VALUE = 0x7f_00_00_00;
+
+// 0.X.Y.Z/8
+const ipv4_addr_t IPV4_THIS_HOST_ON_THIS_NETWORK_MASK = 0xff_00_00_00;
+const ipv4_addr_t IPV4_THIS_HOST_ON_THIS_NETWORK_VALUE = 0x00_00_00_00;
+
+#define IS_MULTICAST_IPV6(address) \
+  (address & IPV6_MULTICAST_MASK == IPV6_MULTICAST_VALUE)
+
+#define IS_LOOPBACK_IPV6(address) \
+  (address & IPV6_LOOPBACK_MASK == IPV6_LOOPBACK_VALUE)
+
+#define IS_MULTICAST_IPV4(address) \
+  (address & IPV4_MULTICAST_MASK == IPV4_MULTICAST_VALUE)
+
+#define IS_BROADCAST_IPV4(address) \
+  (address == IPV4_BROADCAST_VALUE)
+
+#define IS_LOOPBACK_IPV4(address) \
+  (address & IPV4_LOOPBACK_MASK == IPV4_LOOPBACK_VALUE)
+
+#define IS_THIS_HOST_ON_THIS_NETWORK_IPV4(address) \
+  (address & IPV4_THIS_HOST_ON_THIS_NETWORK_MASK == IPV4_THIS_HOST_ON_THIS_NETWORK_VALUE)
+
+// I/G bit = 1 means multicast.
+#define IS_UNICAST_MAC(address) \
+  (address[40:40] == 0)
+
+#define IS_IPV4_MULTICAST_MAC(address) \
+  (address[47:24] == 0x01005E && address[23:23] == 0)
+
+#define IS_IPV6_MULTICAST_MAC(address) \
+  (address[47:32] == 0x3333)
+
+// TODO: If it turns out that this logic does not apply to ACL 
+// redirects, call logic after `routing_lookup` but before `acl_ingress`.
+control drop_martians(in headers_t headers,
+                      inout local_metadata_t local_metadata,
+                      inout standard_metadata_t standard_metadata) {
+  apply {
+    bool acl_l3_redirect =
+          (local_metadata.acl_ingress_ipmc_redirect ||
+          local_metadata.acl_ingress_nexthop_redirect);
+
+    // TODO: Remove the `acl_l3_redirect` check when the switch
+    // correctly handles martians during ACL redirection.
+    // Packets going through L2 multicast (and potentially other L2 forwarded
+    // packets) bypass the martian check.
+    bool bypass_martian_check =
+        acl_l3_redirect || local_metadata.acl_ingress_l2mc_redirect;
+
+    // Drop the packet if:
+    // - Packet is not redirected by ingress ACL; or
+    // - Src IPv6 address is in multicast range; or
+    // - Src IPv4 address is in multicast or broadcast range; or
+    // - Src/Dst IPv4/IPv6 address is a loopback address; or
+    // - Dst IPv4 address is 0.X.Y.Z; or
+    // - Src/Dst IPv4/IPv6 is the all-zero address.
+    // Rationale:
+    // Src IP multicast drop: https://www.rfc-editor.org/rfc/rfc1812#section-5.3.7
+    // Src/Dst IP loopback drop: https://en.wikipedia.org/wiki/Localhost#Packet_processing
+    //    "Packets received on a non-loopback interface with a loopback source
+    //     or destination address must be dropped."
+    // Drop Dst IP signifying "this host on this network" (i.e. 0.X.Y.Z):
+    //    https://datatracker.ietf.org/doc/html/rfc6890#section-2.2.2
+    // Dst IP all zeroes drop: https://en.wikipedia.org/wiki/0.0.0.0
+    //    "RFC 1122 [...] prohibits this as a destination address."
+    // Src IPv4 all zeros drop: https://www.rfc-editor.org/rfc/rfc1812#section-5.3.7
+    // Src IPv6 all zeros drop: https://www.rfc-editor.org/rfc/rfc4291#section-2.5.2
+    if (!bypass_martian_check &&
+        ((headers.ipv6.isValid() &&
+            (IS_MULTICAST_IPV6(headers.ipv6.src_addr) ||
+             IS_LOOPBACK_IPV6(headers.ipv6.src_addr) ||
+             IS_LOOPBACK_IPV6(headers.ipv6.dst_addr) ||
+             headers.ipv6.src_addr == 0 ||
+             headers.ipv6.dst_addr == 0)) ||
+        (headers.ipv4.isValid() &&
+            (IS_MULTICAST_IPV4(headers.ipv4.src_addr) ||
+             IS_BROADCAST_IPV4(headers.ipv4.src_addr) ||
+             IS_BROADCAST_IPV4(headers.ipv4.dst_addr) ||
+             IS_LOOPBACK_IPV4(headers.ipv4.src_addr) ||
+             IS_LOOPBACK_IPV4(headers.ipv4.dst_addr) ||
+             IS_THIS_HOST_ON_THIS_NETWORK_IPV4(headers.ipv4.dst_addr) ||
+             headers.ipv4.src_addr == 0 ||
+             headers.ipv4.dst_addr == 0)))
+       ) {
+        mark_to_drop(standard_metadata);
+    }
+
+// TODO: Remove guard once p4-symbolic suports assertions.
+#ifndef PLATFORM_P4SYMBOLIC
+    if(headers.hop_by_hop_options.isValid()) {
+        assert(headers.hop_by_hop_options.header_extension_length == 0);
+    }
+
+    if(headers.inner_hop_by_hop_options.isValid()) {
+        assert(headers.inner_hop_by_hop_options.header_extension_length == 0);
+    }
+#endif
+
+    // PINs switches drop packets with hop-by-hop options by choice, not by
+    // necessity. All expected packets should be punted, so we mark them all to
+    // drop by choice to get some deterministic behavior.
+    if (!bypass_martian_check &&
+        (headers.hop_by_hop_options.isValid() ||
+        headers.inner_hop_by_hop_options.isValid())) {
+        mark_to_drop(standard_metadata);
+    }
+
+    // TODO: Drop the rest of martian packets.
+  }
+}  // control drop_martians
+
+
+#endif  // SAI_DROP_MARTIANS_P4_

--- a/e2e_tests/sai_p4/fixed/headers.p4
+++ b/e2e_tests/sai_p4/fixed/headers.p4
@@ -1,0 +1,199 @@
+#ifndef SAI_HEADERS_P4_
+#define SAI_HEADERS_P4_
+
+#define ETHERTYPE_IPV4  0x0800
+#define ETHERTYPE_IPV6  0x86dd
+#define ETHERTYPE_ARP   0x0806
+#define ETHERTYPE_LLDP  0x88cc
+#define ETHERTYPE_8021Q 0x8100
+
+#define IP_PROTOCOL_IPV4   0x04
+#define IP_PROTOCOL_TCP    0x06
+#define IP_PROTOCOL_UDP    0x11
+#define IP_PROTOCOL_ICMP   0x01
+#define IP_PROTOCOL_ICMPV6 0x3a
+#define IP_PROTOCOL_IPV6   0x29
+#define IP_PROTOCOL_V6_EXTENSION_HOP_BY_HOP 0x00
+#define IP_PROTOCOLS_GRE   0x2f
+
+typedef bit<48> ethernet_addr_t;
+typedef bit<32> ipv4_addr_t;
+typedef bit<128> ipv6_addr_t;
+typedef bit<12> vlan_id_t;
+typedef bit<16> ether_type_t;
+
+// "The VID value 0xFFF is reserved for implementation use; it must not be
+// configured or transmitted." (https://en.wikipedia.org/wiki/IEEE_802.1Q).
+const vlan_id_t INTERNAL_VLAN_ID = 0xfff;
+// "The reserved value 0x000 indicates that the frame does not carry a VLAN ID;
+// in this case, the 802.1Q tag specifies only a priority"
+// (https://en.wikipedia.org/wiki/IEEE_802.1Q).
+const vlan_id_t NO_VLAN_ID = 0x000;
+
+#define IS_RESERVED_VLAN_ID(vlan_id) \
+    (vlan_id == NO_VLAN_ID || vlan_id == INTERNAL_VLAN_ID)
+
+// -- Protocol headers ---------------------------------------------------------
+
+#define ETHERNET_HEADER_BYTES 14
+
+header ethernet_t {
+  ethernet_addr_t dst_addr;
+  ethernet_addr_t src_addr;
+  ether_type_t ether_type;
+}
+
+header vlan_t {
+  // Note: Tag Protocol Identifier (TPID) will be parsed as the ether_type of
+  // the ethernet header. It is technically a part of the vlan header but is
+  // modeled like this to facilitate parsing and deparsing.
+  bit<3> priority_code_point;      // PCP
+  bit<1> drop_eligible_indicator;  // DEI
+  vlan_id_t vlan_id;               // VID
+  // Note: The next ether_type will be parsed as part of the vlan
+  // header. It is technically a part of the ethernet header but is modeled like
+  // this to facilitate parsing and deparsing.
+  ether_type_t ether_type;
+}
+
+#define IPV4_HEADER_BYTES 20
+
+header ipv4_t {
+  bit<4> version;
+  bit<4> ihl;
+  bit<6> dscp;  // The 6 most significant bits of the diff_serv field.
+  bit<2> ecn;   // The 2 least significant bits of the diff_serv field.
+  bit<16> total_len;
+  bit<16> identification;
+  bit<1> reserved;
+  bit<1> do_not_fragment;
+  bit<1> more_fragments;
+  bit<13> frag_offset;
+  bit<8> ttl;
+  bit<8> protocol;
+  bit<16> header_checksum;
+  ipv4_addr_t src_addr;
+  ipv4_addr_t dst_addr;
+}
+
+#define IPV6_HEADER_BYTES 40
+
+header ipv6_t {
+  bit<4> version;
+  bit<6> dscp;  // The 6 most significant bits of the traffic_class field.
+  bit<2> ecn;   // The 2 least significant bits of the traffic_class field.
+  bit<20> flow_label;
+  bit<16> payload_length;
+  bit<8> next_header;
+  bit<8> hop_limit;
+  ipv6_addr_t src_addr;
+  ipv6_addr_t dst_addr;
+}
+
+header hop_by_hop_options_t {
+  bit<8> next_header;
+  bit<8> header_extension_length;
+  // options and padding = 64 bits -  next_header - header_extension_length
+  // = 64 - 8 - 8 = 48
+  bit<48> options_and_padding;
+  // Currently, we do not support `more_options_and_padding`. See b/364617104
+  // for more information. So packets with a non-zero `header_extension_length`
+  // will be rejected by the parser.
+}
+
+#define UDP_HEADER_BYTES 8
+
+header udp_t {
+  bit<16> src_port;
+  bit<16> dst_port;
+  bit<16> hdr_length;
+  bit<16> checksum;
+}
+
+header tcp_t {
+  bit<16> src_port;
+  bit<16> dst_port;
+  bit<32> seq_no;
+  bit<32> ack_no;
+  bit<4> data_offset;
+  bit<4> res;
+  bit<8> flags;
+  bit<16> window;
+  bit<16> checksum;
+  bit<16> urgent_ptr;
+}
+
+header icmp_t {
+  bit<8> type;
+  bit<8> code;
+  bit<16> checksum;
+  bit<32> rest_of_header;
+}
+
+header arp_t {
+  bit<16> hw_type;
+  bit<16> proto_type;
+  bit<8> hw_addr_len;
+  bit<8> proto_addr_len;
+  bit<16> opcode;
+  bit<48> sender_hw_addr;
+  bit<32> sender_proto_addr;
+  bit<48> target_hw_addr;
+  bit<32> target_proto_addr;
+}
+
+#define GRE_HEADER_BYTES 4
+
+header gre_t {
+  bit<1> checksum_present;
+  bit<1> routing_present;
+  bit<1> key_present;
+  bit<1> sequence_present;
+  bit<1> strict_source_route;
+  bit<3> recursion_control;
+  bit<1> acknowledgement_present;
+  bit<4> flags;
+  bit<3> version;
+  bit<16> protocol;
+}
+
+#define IPFIX_HEADER_BYTES 16
+
+// IP Flow Information Export (IPFIX) header, pursuant to RFC 7011 section 3.1.
+header ipfix_t {
+  // Version of IPFIX to which this Message conforms.
+  bit<16> version_number;
+  // Total length of the IPFIX Message, measured in octets, including
+  // Message Header and Set(s).
+  bit<16> length;
+  // Time at which the IPFIX Message Header leaves the Exporter,
+  // expressed in seconds since the UNIX epoch.
+  bit<32> export_time;
+  // Incremental sequence counter modulo 2^32 of all IPFIX Data Records
+  // sent in the current stream.
+  bit<32> sequence_number;
+  // An identifier of the Observation Domain that is locally
+  // unique to the Exporting Process.
+  bit<32> observation_domain_id;
+}
+
+#define PSAMP_EXTENDED_BYTES 28
+// PSAMP extended header, pursuant to RFC5476.
+header psamp_extended_t {
+  bit<16> template_id;
+  bit<16> length;
+  // Ingress timestamp in nanoseconds.
+  bit<64> observation_time;
+  bit<16> flowset;
+  bit<16> next_hop_index;
+  bit<16> epoch;
+  bit<16> ingress_port;
+  bit<16> egress_port;
+  bit<16> user_meta_field;
+  bit<8> dlb_id;
+  bit<8> variable_length;
+  bit<16> packet_sampled_length;
+}
+
+
+#endif  // SAI_HEADERS_P4_

--- a/e2e_tests/sai_p4/fixed/ids.h
+++ b/e2e_tests/sai_p4/fixed/ids.h
@@ -1,0 +1,154 @@
+#ifndef SAI_IDS_H_
+#define SAI_IDS_H_
+
+// All declarations (tables, actions, action profiles, meters, counters) have a
+// stable ID. This list will evolve as new declarations are added. IDs cannot be
+// reused. If a declaration is removed, its ID macro is kept and marked reserved
+// to avoid the ID being reused.
+//
+// The IDs are classified using the 8 most significant bits to be compatible
+// with "6.3. ID Allocation for P4Info Objects" in the P4Runtime specification.
+
+// --- Tables ------------------------------------------------------------------
+
+// IDs of fixed SAI tables (8 most significant bits = 0x02).
+#define ROUTING_VRF_TABLE_ID 0x0200004A                         // 33554506
+#define ROUTING_NEIGHBOR_TABLE_ID 0x02000040                    // 33554496
+#define ROUTING_ROUTER_INTERFACE_TABLE_ID 0x02000041            // 33554497
+#define ROUTING_NEXTHOP_TABLE_ID 0x02000042                     // 33554498
+#define ROUTING_WCMP_GROUP_TABLE_ID 0x02000043                  // 33554499
+#define ROUTING_IPV4_TABLE_ID 0x02000044                        // 33554500
+#define ROUTING_IPV6_TABLE_ID 0x02000045                        // 33554501
+#define ROUTING_IPV4_MULTICAST_TABLE_ID 0x0200004E              // 33554510
+#define ROUTING_IPV6_MULTICAST_TABLE_ID 0x0200004F              // 33554511
+#define ROUTING_MULTICAST_ROUTER_INTERFACE_TABLE_ID 0x0200004C  // 33554508
+#define MIRROR_SESSION_TABLE_ID 0x02000046                      // 33554502
+#define L3_ADMIT_TABLE_ID 0x02000047                            // 33554503
+#define MIRROR_PORT_TO_PRE_SESSION_TABLE_ID 0x02000048          // 33554504
+#define ECMP_HASHING_TABLE_ID 0x02000049                        // 33554505
+#define ROUTING_TUNNEL_TABLE_ID 0x02000050                      // 33554512
+#define IPV6_TUNNEL_TERMINATION_TABLE_ID 0x0200004B             // 33554507
+#define DISABLE_VLAN_CHECKS_TABLE_ID 0x0200004D                 // 33554509
+#define INGRESS_CLONE_TABLE_ID 0x02000051                       // 33554513
+#define EGRESS_PORT_LOOPBACK_TABLE_ID 0x02000052                // 33554514
+#define VLAN_TABLE_ID 0x02000053                                // 33554515
+#define VLAN_MEMBERSHIP_TABLE_ID 0x02000054                     // 33554516
+#define DISABLE_INGRESS_VLAN_CHECKS_TABLE_ID 0x02000056         // 33554518
+#define DISABLE_EGRESS_VLAN_CHECKS_TABLE_ID 0x02000057          // 33554519
+// Next available table id: 0x02000058 (33554520)
+
+// --- Actions -----------------------------------------------------------------
+
+// IDs of fixed SAI actions (8 most significant bits = 0x01).
+#define SHARED_NO_ACTION_ACTION_ID 0x01798B9E              // 24742814
+#define ROUTING_SET_DST_MAC_ACTION_ID 0x01000001           // 16777217
+#define ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID 0x01000002  // 16777218
+#define ROUTING_UNICAST_SET_PORT_AND_SRC_MAC_AND_VLAN_ID_ACTION_ID \
+  0x0100001B                                                         // 16777243
+#define ROUTING_SET_IP_NEXTHOP_ACTION_ID 0x01000014                  // 16777236
+#define ROUTING_SET_WCMP_GROUP_ID_ACTION_ID 0x01000004               // 16777220
+#define ROUTING_SET_WCMP_GROUP_ID_AND_METADATA_ACTION_ID 0x01000011  // 16777233
+#define ROUTING_SET_NEXTHOP_ID_ACTION_ID 0x01000005                  // 16777221
+#define ROUTING_SET_IP_NEXTHOP_AND_DISABLE_REWRITES_ACTION_ID \
+  0x01000017                                                       // 16777239
+#define ROUTING_SET_NEXTHOP_ID_AND_METADATA_ACTION_ID 0x01000010   // 16777232
+#define ROUTING_DROP_ACTION_ID 0x01000006                          // 16777222
+#define ROUTING_SET_P2P_TUNNEL_ENCAP_NEXTHOP_ACTION_ID 0x01000012  // 16777234
+#define ROUTING_MARK_FOR_P2P_TUNNEL_ENCAP_ACTION_ID 0x01000013     // 16777235
+#define ROUTING_SET_MULTICAST_GROUP_ID_ACTION_ID 0x01000018        // 16777240
+#define ROUTING_SET_MULTICAST_SRC_MAC_ACTION_ID 0x01000019         // 16777241
+#define ROUTING_IP_MULTICAST_SET_SRC_MAC_ACTION_ID 0x01000020      // 16777248
+#define ROUTING_IP_MULTICAST_SET_SRC_MAC_AND_VLAN_ID_ACTION_ID \
+  0x01000021  // 16777249
+#define ROUTING_IP_MULTICAST_SET_SRC_MAC_AND_DST_MAC_AND_VLAN_ID_ACTION_ID \
+  0x01000022  // 16777250
+#define ROUTING_IP_MULTICAST_SET_SRC_MAC_AND_PRESERVE_INGRESS_VLAN_ID_ACTION_ID /*NOLINT*/ \
+  0x01000023                                                   // 16777251
+#define ROUTING_L2_MULTICAST_PASSTHROUGH_ACTION_ID 0x0100001F  // 16777247
+#define CLONING_INGRESS_CLONE_ACTION_ID 0x0100001C             // 16777244
+#define CLONING_MIRROR_WITH_VLAN_TAG_AND_IPFIX_ENCAPSULATION_ACTION_ID \
+  0x0100001D                                                // 16777245
+#define L3_ADMIT_ACTION_ID 0x01000008                       // 16777224
+#define MIRRORING_SET_PRE_SESSION_ACTION_ID 0x01000009      // 16777225
+#define SELECT_ECMP_HASH_ALGORITHM_ACTION_ID 0x010000A      // 16777226
+#define COMPUTE_ECMP_HASH_IPV4_ACTION_ID 0x0100000B         // 16777227
+#define COMPUTE_ECMP_HASH_IPV6_ACTION_ID 0x0100000C         // 16777228
+#define COMPUTE_LAG_HASH_IPV4_ACTION_ID 0x0100000D          // 16777229
+#define COMPUTE_LAG_HASH_IPV6_ACTION_ID 0x0100000E          // 16777230
+#define ROUTING_SET_METADATA_AND_DROP_ACTION_ID 0x01000015  // 16777237
+#define TUNNEL_DECAP_ACTION_ID 0x01000016                   // 16777238
+#define DISABLE_VLAN_CHECKS_ACTION_ID 0x0100001A            // 16777242
+#define EGRESS_LOOPBACK_ACTION_ID 0x0100001E                // 16777246
+#define VLAN_MAKE_TAGGED_MEMBER_ACTION_ID 0x01000024        // 16777252
+#define VLAN_MAKE_UNTAGGED_MEMBER_ACTION_ID 0x01000025      // 16777253
+#define DISABLE_INGRESS_VLAN_CHECKS_ACTION_ID 0x01000028    // 16777256
+#define DISABLE_EGRESS_VLAN_CHECKS_ACTION_ID 0x01000029     // 16777257
+#define UNICAST_SET_PORT_AND_SRC_MAC_ACTION_ID 0x01000030   // 16777264
+// Next available action id: 0x01000031 (16777259)
+
+// --- Action Profiles and Selectors (8 most significant bits = 0x11) ----------
+// This value should ideally be 0x11000001, but we currently have this value for
+// legacy reasons.
+#define ROUTING_WCMP_GROUP_SELECTOR_ACTION_PROFILE_ID 0x11DC4EC8  // 299650760
+
+// --- Intrinsic ports ---------------------------------------------------------
+
+// Port used for PacketIO. Packets sent to this port go to the CPU.
+// Packets received on this port come from the CPU.
+// TODO For simplicity, we went with 510/511 as CPU/drop port to
+// begin with, which are the values used by BMv2 by default, and the values
+// hard-coded in p4-symbolic. We should revisit these arbitrary values.
+#define SAI_P4_CPU_PORT 510
+
+// The port used by `mark_to_drop` from v1model.p4. For details, see the
+// documentation of `mark_to_drop`.
+#define SAI_P4_DROP_PORT 511
+
+// --- Copy to CPU session -----------------------------------------------------
+// TODO: Remove COPY_TO_CPU_SESSION_ID and this example comment.
+// The COPY_TO_CPU_SESSION_ID must be programmed in the target using P4Runtime:
+//
+// type: INSERT
+// entity {
+//   packet_replication_engine_entry {
+//     clone_session_entry {
+//       session_id: COPY_TO_CPU_SESSION_ID
+//       replicas {
+//        egress_port: SAI_P4_CPU_PORT
+//        instance: SAI_P4_REPLICA_INSTANCE_PACKET_IN
+//       }
+//     }
+//   }
+// }
+#define COPY_TO_CPU_SESSION_ID 255
+
+// --- Packet-IO ---------------------------------------------------------------
+
+#define PACKET_IN_INGRESS_PORT_ID 1
+#define PACKET_IN_TARGET_EGRESS_PORT_ID 2
+#define PACKET_IN_UNUSED_PAD_ID 3
+
+#define PACKET_OUT_EGRESS_PORT_ID 1
+#define PACKET_OUT_SUBMIT_TO_INGRESS_ID 2
+#define PACKET_OUT_UNUSED_PAD_ID 3
+
+// Values for standard_metadata.egress_rid set by the packet replication engine
+// (PRE) in the V1Model architecture. These values are used by
+// p4::v1::Replica::instance to indicate whether the replicated packet is for
+// mirroring, punting or other purposes. However, these values are
+// not defined by the P4 specification. Here we define our own values.
+#define SAI_P4_REPLICA_INSTANCE_PACKET_IN 1
+#define SAI_P4_REPLICA_INSTANCE_MIRRORING 2
+
+// Macros to determine whether a packet is replicated due to packet in or
+// replicated due to mirroring.
+// The enclosing bracket pair allows the use of negation with the macros.
+#define IS_PACKET_IN_COPY(standard_metadata)                             \
+  (standard_metadata.instance_type == PKT_INSTANCE_TYPE_INGRESS_CLONE && \
+   standard_metadata.egress_rid == SAI_P4_REPLICA_INSTANCE_PACKET_IN)
+
+#define IS_MIRROR_COPY(standard_metadata)                                \
+  (standard_metadata.instance_type == PKT_INSTANCE_TYPE_INGRESS_CLONE && \
+   standard_metadata.egress_rid == SAI_P4_REPLICA_INSTANCE_MIRRORING)
+
+#endif  // SAI_IDS_H_

--- a/e2e_tests/sai_p4/fixed/ingress_cloning.p4
+++ b/e2e_tests/sai_p4/fixed/ingress_cloning.p4
@@ -1,0 +1,80 @@
+#ifndef SAI_INGRESS_CLONING_P4_
+#define SAI_INGRESS_CLONING_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "roles.h"
+#include "minimum_guaranteed_sizes.h"
+
+control ingress_cloning(inout headers_t headers,
+                        inout local_metadata_t local_metadata,
+                        inout standard_metadata_t standard_metadata) {
+
+  @id(CLONING_INGRESS_CLONE_ACTION_ID)
+  action ingress_clone(@id(1) bit<32> clone_session) {
+    clone_preserving_field_list(CloneType.I2E, clone_session,
+      PreservedFieldList.MIRROR_AND_PACKET_IN_COPY);
+  }
+
+// Logical table that calls the clone extern with an appropriate
+// `clone_session` to aggregate the effect of punt and mirror actions in the
+// ACL ingress stage.
+// On SAI targets (e.g. SONIC/PINS), this table does not exist and the logic it
+// performs is built in.
+// On V1Model targets (e.g. BMv2/P4TestGen) and P4-Symbolic, this table must be
+// populated with the following entries:
+  // ===========================================================================
+  // | type       | match fields             | action           | entry count  |
+  // ---------------------------------------------------------------------------
+  // | punt-only  | marked_to_copy: true     | ingress_clone(   | one          |
+  // |            | marked_to_mirror: false  |  punt_only_clone |              |
+  // |            |                          |  session)        |              |
+  // ---------------------------------------------------------------------------
+  // | mirror-only| marked_to_copy: false    | ingress_clone(   | one for each |
+  // |            | marked_to_mirror: true   |  mirror_only_    | port on the  |
+  // |            | mirror_egress_port: port |  clone_session)  | target       |
+  // ---------------------------------------------------------------------------
+  // | mirror-and | marked_to_copy: true     | ingress_clone(   | one for each |
+  // | -punt      | marked_to_mirror: true   |  punt_and_mirror_| port on the  |
+  // |            | mirror_egress_port: port |  clone_session)  | target       |
+  // ---------------------------------------------------------------------------
+  // The user also needs to install p4::v1::CloneSessionEntry for
+  // each `clone_session` and its p4::v1::Replicas need to reflect the action.
+  // For example, an entry to mirror_and_punt out of port `p`, its action must
+  // refer to a p4::v1::CloneSessionEntry with 2 Replicas, one for punting, one
+  // for mirroring out of port `p`.
+  // TODO: Remove @unsupported once we can ignore this table
+  // in P4Info verification.
+  @unsupported
+  @p4runtime_role(P4RUNTIME_ROLE_PACKET_REPLICATION_ENGINE)
+  @id(INGRESS_CLONE_TABLE_ID)
+  @entry_restriction("
+    // mirror_egress_port is present iff marked_to_mirror is true.
+    // Exact match indicating presence of mirror_egress_port.
+    marked_to_mirror == 1 -> mirror_egress_port::mask == -1;
+    // Wildcard match indicating abscence of mirror_egress_port.
+    marked_to_mirror == 0 -> mirror_egress_port::mask == 0;
+  ")
+  table ingress_clone_table {
+    key = {
+      local_metadata.marked_to_copy : exact
+        @id(1) @name("marked_to_copy");
+      local_metadata.marked_to_mirror : exact
+        @id(2) @name("marked_to_mirror");
+      local_metadata.mirror_egress_port : optional
+        @id(3) @name("mirror_egress_port");
+    }
+    actions = {
+      @proto_id(1) ingress_clone;
+    }
+  }
+
+  apply {
+    ingress_clone_table.apply();
+  }
+
+}  // control ingress_cloning
+
+#endif  // SAI_INGRESS_CLONING_P4_

--- a/e2e_tests/sai_p4/fixed/ipv4_checksum.p4
+++ b/e2e_tests/sai_p4/fixed/ipv4_checksum.p4
@@ -1,0 +1,53 @@
+#ifndef SAI_IPV4_CHECKSUM_H_
+#define SAI_IPV4_CHECKSUM_H_
+
+#include "headers.p4"
+#include "metadata.p4"
+
+// IPv6 does not have a checksum, so this code is only for IPv4.
+
+control verify_ipv4_checksum(inout headers_t headers,
+                             inout local_metadata_t local_metadata) {
+  apply {
+    verify_checksum(headers.ipv4.isValid(), {
+      headers.ipv4.version,
+      headers.ipv4.ihl,
+      headers.ipv4.dscp,
+      headers.ipv4.ecn,
+      headers.ipv4.total_len,
+      headers.ipv4.identification,
+      headers.ipv4.reserved,
+      headers.ipv4.do_not_fragment,
+      headers.ipv4.more_fragments,
+      headers.ipv4.frag_offset,
+      headers.ipv4.ttl,
+      headers.ipv4.protocol,
+      headers.ipv4.src_addr,
+      headers.ipv4.dst_addr
+    }, headers.ipv4.header_checksum, HashAlgorithm.csum16);
+  }
+}  // control verify_ipv4_checksum
+
+control compute_ipv4_checksum(inout headers_t headers,
+                              inout local_metadata_t local_metadata) {
+  apply {
+    update_checksum(headers.ipv4.isValid(), {
+        headers.ipv4.version,
+        headers.ipv4.ihl,
+        headers.ipv4.dscp,
+        headers.ipv4.ecn,
+        headers.ipv4.total_len,
+        headers.ipv4.identification,
+        headers.ipv4.reserved,
+        headers.ipv4.do_not_fragment,
+        headers.ipv4.more_fragments,
+        headers.ipv4.frag_offset,
+        headers.ipv4.ttl,
+        headers.ipv4.protocol,
+        headers.ipv4.src_addr,
+        headers.ipv4.dst_addr
+      }, headers.ipv4.header_checksum, HashAlgorithm.csum16);
+  }
+}  // control compute_ipv4_checksum
+
+#endif  // SAI_IPV4_CHECKSUM_H_

--- a/e2e_tests/sai_p4/fixed/l3_admit.p4
+++ b/e2e_tests/sai_p4/fixed/l3_admit.p4
@@ -1,0 +1,48 @@
+#ifndef SAI_L3_ADMIT_P4_
+#define SAI_L3_ADMIT_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "roles.h"
+#include "minimum_guaranteed_sizes.h"
+
+control l3_admit(in headers_t headers,
+                 inout local_metadata_t local_metadata,
+                 in standard_metadata_t standard_metadata) {
+  @id(L3_ADMIT_ACTION_ID)
+  action admit_to_l3() {
+    local_metadata.admit_to_l3 = true;
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(L3_ADMIT_TABLE_ID)
+  table l3_admit_table {
+    key = {
+      headers.ethernet.dst_addr : ternary @name("dst_mac") @id(1)
+                                          @format(MAC_ADDRESS);
+#if defined(L3_ADMIT_SUPPORTS_IN_PORT)
+      local_metadata.ingress_port : optional @name("in_port") @id(2);
+#endif
+    }
+    actions = {
+      @proto_id(1) admit_to_l3;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = L3_ADMIT_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    if (local_metadata.marked_to_drop_by_ingress_vlan_checks) {
+      // Explicitly reject VLAN tagged packets that fail ingress VLAN checks
+      // from L3 routing to cancel override in other parts of the code
+      local_metadata.admit_to_l3 = false;
+    } else {
+      l3_admit_table.apply();
+    }
+  }
+}  // control l3_admit
+
+#endif  // SAI_L3_ADMIT_P4_

--- a/e2e_tests/sai_p4/fixed/metadata.p4
+++ b/e2e_tests/sai_p4/fixed/metadata.p4
@@ -1,0 +1,379 @@
+#ifndef SAI_METADATA_P4_
+#define SAI_METADATA_P4_
+
+#include "ids.h"
+#include "headers.p4"
+#include "bitwidths.p4"
+
+// -- Preserved Field Lists ----------------------------------------------------
+
+// The field list numbers used in @field_list annotations to identify the fields
+// that need to be preserved during clone/recirculation/etc. operations.
+enum bit<8> PreservedFieldList {
+  MIRROR_AND_PACKET_IN_COPY = 8w1
+};
+
+// -- Translated Types ---------------------------------------------------------
+
+// BMv2 does not support @p4runtime_translation.
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+type bit<NEXTHOP_ID_BITWIDTH> nexthop_id_t;
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+type bit<TUNNEL_ID_BITWIDTH> tunnel_id_t;
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+type bit<WCMP_GROUP_ID_BITWIDTH> wcmp_group_id_t;
+
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+// TODO: The following annotation is not yet standard, and not yet
+// understood by p4-symbolic. Work with the P4Runtime WG to standardize the
+// annotation (or a similar annotation), and teach it to p4-symbolic.
+@p4runtime_translation_mappings({
+  // The "default VRF", 0, corresponds to the empty string, "", in P4Runtime.
+  {"", 0},
+})
+#endif
+type bit<VRF_BITWIDTH> vrf_id_t;
+
+const vrf_id_t kDefaultVrf = 0;
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+type bit<ROUTER_INTERFACE_ID_BITWIDTH> router_interface_id_t;
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+type bit<PORT_BITWIDTH> port_id_t;
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+type bit<MIRROR_SESSION_ID_BITWIDTH> mirror_session_id_t;
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+// TODO: Change this type to be called `cpu_queue_t`.
+type bit<QOS_QUEUE_BITWIDTH> cpu_queue_t;
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+type bit<QOS_QUEUE_BITWIDTH> unicast_queue_t;
+
+#ifndef PLATFORM_BMV2
+@p4runtime_translation("", string)
+#endif
+type bit<QOS_QUEUE_BITWIDTH> multicast_queue_t;
+
+// -- Untranslated Types -------------------------------------------------------
+
+typedef bit<ROUTE_METADATA_BITWIDTH> route_metadata_t;
+typedef bit<ACL_METADATA_BITWIDTH> acl_metadata_t;
+typedef bit<MULTICAST_GROUP_ID_BITWIDTH> multicast_group_id_t;
+typedef bit<REPLICA_INSTANCE_BITWIDTH> replica_instance_t;
+
+// -- Meters -------------------------------------------------------------------
+
+enum bit<2> MeterColor_t {
+  GREEN = 0,
+  YELLOW = 1,
+  RED = 2
+};
+
+// -- Packet IO headers --------------------------------------------------------
+
+@controller_header("packet_in")
+header packet_in_header_t {
+  // The port the packet ingressed on.
+  @id(PACKET_IN_INGRESS_PORT_ID)
+  port_id_t ingress_port;
+  // The initial intended egress port decided for the packet by the pipeline.
+  @id(PACKET_IN_TARGET_EGRESS_PORT_ID)
+  port_id_t target_egress_port;
+  // Padding field to align the header to 8-bit multiple, as required by BMv2.
+  // Carries no information.
+  //
+  // Contrary to the corresponding field in the `packet_out` header, we include
+  // this field only on BMv2, as clients will generally ignore this field anyhow
+  // and thus not observe this minor API deviation.
+  // TODO: Handle packet-in uniformly for all platforms.
+#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
+  @id(PACKET_IN_UNUSED_PAD_ID)
+  @padding
+  bit<6> unused_pad;
+#endif
+}
+
+@controller_header("packet_out")
+header packet_out_header_t {
+  // The port this packet should egress out of when `submit_to_ingress == 0`.
+  // Meaningless when `submit_to_ingress == 1`.
+  @id(PACKET_OUT_EGRESS_PORT_ID)
+  port_id_t egress_port;
+  // Indicates if the packet should go through the ingress pipeline like a
+  // dataplane packet, or be sent straight out of the given `egress_port`.
+  @id(PACKET_OUT_SUBMIT_TO_INGRESS_ID)
+  bit<1> submit_to_ingress;
+  // Padding field to align the header to 8-bit multiple, as required by BMv2.
+  // Carries no information.
+  //
+  // Technically this makes sense only for BMv2, but we include it on all
+  // platforms so clients don't have to make a distinction in packet-out
+  // requests.
+  @id(PACKET_OUT_UNUSED_PAD_ID)
+  @padding
+  bit<6> unused_pad;
+}
+
+// -- Per Packet State ---------------------------------------------------------
+
+// LINT.IfChange
+struct headers_t {
+// TODO: Clean up once we have better solution to handle packet-in
+// across platforms.
+#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
+  // Never extracted during parsing, but serialized during deparsing for packets
+  // punted to the controller.
+  packet_in_header_t packet_in_header;
+#endif
+
+  // PacketOut header; extracted only for packets received from the controller.
+  packet_out_header_t packet_out_header;
+
+  // -- mirroring encap headers ------------------------------------------------
+  ethernet_t mirror_encap_ethernet;
+  vlan_t mirror_encap_vlan;
+  ipv6_t mirror_encap_ipv6;
+  udp_t mirror_encap_udp;
+  ipfix_t mirror_encap_ipfix;
+  psamp_extended_t mirror_encap_psamp_extended;
+  // -- end of mirroring encap headers -----------------------------------------
+
+  ethernet_t ethernet;
+  vlan_t vlan;
+
+  // Not extracted during parsing.
+  ipv6_t tunnel_encap_ipv6;
+  gre_t tunnel_encap_gre;
+
+  ipv4_t ipv4;
+  ipv6_t ipv6;
+
+  // IPv6 extension headers.
+  hop_by_hop_options_t hop_by_hop_options;
+
+  // Inner IP-in-IP headers.
+  ipv4_t inner_ipv4;
+  ipv6_t inner_ipv6;
+
+  hop_by_hop_options_t inner_hop_by_hop_options;
+
+  icmp_t icmp;
+  tcp_t tcp;
+  udp_t udp;
+  arp_t arp;
+}
+// Headers are only useful if they are parsed and deparsed, therefore we add a
+// lint check ensuring that the parser and deparser are changed whenever the
+// header set is.
+// LINT.ThenChange(parser.p4:deparser, parser.p4:parser)
+
+// Header fields rewritten by the ingress pipeline. Rewrites are computed and
+// stored in this struct, but actual rewriting is dealyed until the egress
+// pipeline so that the original values aren't overridden and can be matched on.
+struct packet_rewrites_t {
+  ethernet_addr_t src_mac;
+  ethernet_addr_t dst_mac;
+  vlan_id_t vlan_id;
+  bit<6> dscp;
+}
+
+// LINT.IfChange
+// Local metadata for each packet being processed.
+struct local_metadata_t {
+  // When `enable_vlan_checks` is true, if the ingress/egress port is not a
+  // member of the VLAN in ingress/egress pipeline, the packet gets dropped
+  // except for reserved VIDs (0, 4095).
+  // This field is preserved after replication since VLAN checks should be
+  // applied regardless of instance type of a packet.
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  bool enable_vlan_checks;
+  
+  // If true, the packet does no go through L3 or IPMC lookup.
+  bool marked_to_drop_by_ingress_vlan_checks;
+ 
+  // If true, the egress packet goes out WITHOUT a VLAN tag, otherwise if the
+  // packet does not get dropped (e.g. by egress VLAN filtering, egress ACLs,
+  // etc) it goes out tagged with the VID in the egress pipeline (except for
+  // reserved VIDs 0 and 4095, which are always tagged).
+  bool omit_vlan_tag_on_egress_packet;
+
+  // The VLAN ID used for the packet throughout the pipeline. If the input
+  // packet has a VLAN tag, the VID from the outer VLAN tag is used
+  // (and the VLAN header gets invalidated at the beginning of the ingress
+  // pipeline). Otherwise, the ports' native VLAN ID (4095) is used.
+  // The pre-ingress stage can modify this value. The value is rewritten in
+  // router_interface table (unless VLAN rewrite is disabled). In that case,
+  // the actual rewrite takes place in the egress pipeline. This value is also
+  // used at the end of the egress pipeline to determine whether or not the
+  // packet should be VLAN tagged (if not dropped).
+  vlan_id_t vlan_id;
+  // This is used to model the behavior of SET_OUTER_VLAN_ID action in the
+  // pre-ingress ACL, which affects the packet if and only if the input packet
+  // is VLAN tagged.
+  bool input_packet_is_vlan_tagged;
+
+  bool admit_to_l3;
+  vrf_id_t vrf_id;
+
+  // Rewrite related fields.
+  bool enable_decrement_ttl;
+  bool enable_src_mac_rewrite;
+  bool enable_dst_mac_rewrite;
+  bool enable_vlan_rewrite;
+  bool enable_dscp_rewrite;
+  packet_rewrites_t packet_rewrites;
+
+  bit<16> l4_src_port;
+  bit<16> l4_dst_port;
+  bit<WCMP_SELECTOR_INPUT_BITWIDTH> wcmp_selector_input;
+
+  // Tunnel related fields.
+  bool apply_tunnel_decap_at_end_of_pre_ingress;
+  bool apply_tunnel_encap_at_egress;
+  ipv6_addr_t tunnel_encap_src_ipv6;
+  ipv6_addr_t tunnel_encap_dst_ipv6;
+
+  // If true, the packet needs to be copied to the CPU at the end of the ingress
+  // pipeline.
+  bool marked_to_copy;
+
+  // -- Mirroring related fields -----------------------------------------------
+  // We can't group them into a struct as BMv2 doesn't support passing structs
+  // into clone3.
+  // If true, the packet needs to be mirrored at the end of the ingress
+  // pipeline.
+  bool marked_to_mirror;
+  // Mirror session to mirror the packet.
+  // Valid iff marked_to_mirror is true.
+  mirror_session_id_t mirror_session_id;
+  port_id_t mirror_egress_port;
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  ethernet_addr_t mirror_encap_src_mac;
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  ethernet_addr_t mirror_encap_dst_mac;
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  vlan_id_t mirror_encap_vlan_id;
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  ipv6_addr_t mirror_encap_src_ip;
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  ipv6_addr_t mirror_encap_dst_ip;
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  bit<16> mirror_encap_udp_src_port;
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  bit<16> mirror_encap_udp_dst_port;
+  // -- end of mirroring related fields ----------------------------------------
+
+  // Packet-in related fields, which we can't group into a struct, because BMv2
+  // doesn't support passing structs in clone3.
+  // We model packet-in in SAI P4 by using the replication engine to make a
+  // clone of the punted packet and then send the clone to the controller. But
+  // the standard metadata of the packet clone will be empty, that's a problem
+  // because the controller needs to know the ingress port and expected egress
+  // port of the punted packet. To solve this problem, we save the targeted
+  // egress port and ingress port of the punted packet in local metadata and use
+  // clone_preserving_field_list to preserve these local metadata fields when
+  // cloning the punted packet.
+  // The value to be copied into the `ingress_port` field of packet_in_header on
+  // punted packets.
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  bit<PORT_BITWIDTH> packet_in_ingress_port;
+  // The value to be copied into the `target_egress_port` field of
+  // packet_in_header on punted packets.
+  @field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)
+  bit<PORT_BITWIDTH> packet_in_target_egress_port;
+ 
+  // When `redirect_port_valid` is true, the packet will be redirected to
+  // the port specified in `redirect_port`. Note that redirect to port cancels
+  // all forwarding decisions, except for nexthop. If the packet is assigned a
+  // nexthop, the packet rewrites are determined by the the nexthop but the
+  // egress port is determined by `redirect_port`.
+  bool redirect_port_valid;
+  bit<PORT_BITWIDTH> redirect_port;
+
+  MeterColor_t color;
+  // We consistently use local_metadata.ingress_port instead of
+  // standard_metadata.ingress_port in the P4 tables to ensure that the P4Info
+  // has port_id_t as the type for all fields that match on ports. This allows
+  // tools to treat ports specially (e.g. a fuzzer).
+  port_id_t ingress_port;
+  // The following field corresponds to SAI_ROUTE_ENTRY_ATTR_META_DATA/
+  // SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST_USER_META.
+  route_metadata_t route_metadata;
+  // ACL metadata can be set with SAI_ACL_ACTION_TYPE_SET_ACL_META_DATA, and
+  // read from SAI_ACL_TABLE_ATTR_FIELD_ACL_USER_META.
+  acl_metadata_t acl_metadata;
+
+  // Some special packets (packet-in, packet-out, mirroring) need to bypass the
+  // regular ingress/egress pipeline. This could be achieved using the `exit`
+  // command, but since p4-symbolic does not support it we use this metadata and
+  // explicit control flow instead.
+  // TODO: Clean up this workaround after 'exit' is supported in
+  // p4-symbolic.
+  bool bypass_ingress;
+  bool bypass_egress;
+
+  // Metadata shared between routing, acl_ingress, and routing_resolution
+  // control blocks.
+  bool wcmp_group_id_valid;
+  // Wcmp group id, only valid if `wcmp_group_id_valid` is true.
+  wcmp_group_id_t wcmp_group_id_value;
+  bool nexthop_id_valid;
+  // Nexthop id, only valid if `nexthop_id_valid` is true.
+  nexthop_id_t nexthop_id_value;
+  // After execution of the `routing_lookup` stage, indicates if an entry in one
+  // of the routing tables was hit
+  // (`ipv{4,6}_table` or `ipv{4,6}_multicast_table`).
+  bool route_hit;
+  // After execution of the `tunnel_termination` stage, indicates if an entry in
+  // the `tunnel_termination` table was hit.
+  bool tunnel_termination_table_hit;
+  // After execution of the `acl_ingress_mirror_and_redirect_table` stage,
+  // indicates if the packet was redirected to IPMC group. Needed to avoid drop
+  // on ttl=0 after rewrite.
+  // actions exhibit the same behavior.
+  bool acl_ingress_ipmc_redirect;
+  
+  // Indicates if the packet was redirected to an L2 multicast group in the ACL
+  // ingress stage. Used to bypass drop_martian for such packets.
+  bool acl_ingress_l2mc_redirect;
+  
+  // Indicates whether a packet was redirected from an ACL ingress entry to a
+  // Nexthop (rather than being directed through normal routing).
+  bool acl_ingress_nexthop_redirect;
+
+  // Determines if packet was dropped in ACL ingress/egress stage. If true, the
+  // actual call to mark_to_drop (that affects standard_metadata) takes place at
+  // the end of the respective pipeline.
+  // This is done this way because we want to call mark_to_drop after
+  // determining the target_egress_port through the value assigned to
+  // standard_metadata.egress_spec (which happens in routing_resolution *after*
+  // ACL ingress) for punted packets.
+  bool acl_drop;
+}
+// LINT.ThenChange(parser.p4:metadata_initialization)
+
+#endif  // SAI_METADATA_P4_

--- a/e2e_tests/sai_p4/fixed/minimum_guaranteed_sizes.h
+++ b/e2e_tests/sai_p4/fixed/minimum_guaranteed_sizes.h
@@ -1,0 +1,136 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+// A table's size specifies the minimum number of entries that must be supported
+// by the given table.
+//
+// Consider for example a hash table with 1024 buckets, where each bucket can
+// store two values. The table's size would be 2, because after installing
+// two entries that land in the same bucket B, the third entry will be rejected
+// if it also lands in B. Note that such collisions are unlikely, so the switch
+// will very likely accept a much larger number of table entries than 2.
+//
+// Instantiations of SAI P4 can override these sizes by defining the following
+// macros.
+
+#ifndef SAI_MINIMUM_GUARANTEED_SIZES_H_
+#define SAI_MINIMUM_GUARANTEED_SIZES_H_
+
+#ifndef IPV6_TUNNEL_TERMINATION_TABLE_MINIMUM_GUARANTEED_SIZE
+#define IPV6_TUNNEL_TERMINATION_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef NEXTHOP_TABLE_MINIMUM_GUARANTEED_SIZE
+#define NEXTHOP_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef NEIGHBOR_TABLE_MINIMUM_GUARANTEED_SIZE
+#define NEIGHBOR_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef ROUTER_INTERFACE_TABLE_MINIMUM_GUARANTEED_SIZE
+#define ROUTER_INTERFACE_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef MIRROR_SESSION_TABLE_MINIMUM_GUARANTEED_SIZE
+#define MIRROR_SESSION_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef ROUTING_VRF_TABLE_MINIMUM_GUARANTEED_SIZE
+#define ROUTING_VRF_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef ROUTING_IPV4_TABLE_MINIMUM_GUARANTEED_SIZE
+#define ROUTING_IPV4_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef ROUTING_IPV6_TABLE_MINIMUM_GUARANTEED_SIZE
+#define ROUTING_IPV6_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef ROUTING_TUNNEL_TABLE_MINIMUM_GUARANTEED_SIZE
+#define ROUTING_TUNNEL_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef ROUTING_IPV4_MULTICAST_TABLE_MINIMUM_GUARANTEED_SIZE
+#define ROUTING_IPV4_MULTICAST_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef ROUTING_IPV6_MULTICAST_TABLE_MINIMUM_GUARANTEED_SIZE
+#define ROUTING_IPV6_MULTICAST_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef ROUTING_MULTICAST_SOURCE_MAC_TABLE_MINIMUM_GUARANTEED_SIZE
+#define ROUTING_MULTICAST_SOURCE_MAC_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef L3_ADMIT_TABLE_MINIMUM_GUARANTEED_SIZE
+#define L3_ADMIT_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE
+#define WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_TOR
+#define WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_TOR 0
+#endif
+
+#ifndef VLAN_TABLE_MINIMUM_GUARANTEED_SIZE
+#define VLAN_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+#ifndef VLAN_MEMBERSHIP_TABLE_MINIMUM_GUARANTEED_SIZE
+#define VLAN_MEMBERSHIP_TABLE_MINIMUM_GUARANTEED_SIZE 0
+#endif
+
+// The size semantics for WCMP group selectors. Either SUM_OF_WEIGHTS or
+// SUM_OF_MEMBERS.
+#ifndef WCMP_GROUP_SELECTOR_SIZE_SEMANTICS
+#define WCMP_GROUP_SELECTOR_SIZE_SEMANTICS "SUM_OF_WEIGHTS"
+#endif
+
+// The size semantics for WCMP group selectors. Either SUM_OF_WEIGHTS or
+// SUM_OF_MEMBERS.
+#ifndef WCMP_GROUP_SELECTOR_SIZE_SEMANTICS_TOR
+#define WCMP_GROUP_SELECTOR_SIZE_SEMANTICS_TOR "SUM_OF_WEIGHTS"
+#endif
+
+// The maximum sum of weights or members across all wcmp groups.
+#ifndef WCMP_GROUP_SELECTOR_SIZE
+#define WCMP_GROUP_SELECTOR_SIZE 0
+#endif
+
+// The maximum sum of weights or members across all wcmp groups.
+#ifndef WCMP_GROUP_SELECTOR_SIZE_TOR
+#define WCMP_GROUP_SELECTOR_SIZE_TOR 0
+#endif
+
+// The maximum sum of weights or members for each wcmp group.
+#ifndef WCMP_GROUP_SELECTOR_MAX_GROUP_SIZE
+#define WCMP_GROUP_SELECTOR_MAX_GROUP_SIZE 0
+#endif
+
+// The maximum sum of weights or members for each wcmp group.
+#ifndef WCMP_GROUP_SELECTOR_MAX_GROUP_SIZE_TOR
+#define WCMP_GROUP_SELECTOR_MAX_GROUP_SIZE_TOR 0
+#endif
+
+// The max weight of an individual member when using the SUM_OF_MEMBERS size
+// semantics. This value is ignored in the SUM_OF_WEIGHTS semantics.
+#ifndef WCMP_GROUP_SELECTOR_MAX_MEMBER_WEIGHT
+#define WCMP_GROUP_SELECTOR_MAX_MEMBER_WEIGHT 0
+#endif
+
+#endif  // SAI_MINIMUM_GUARANTEED_SIZES_H_

--- a/e2e_tests/sai_p4/fixed/mirroring.p4
+++ b/e2e_tests/sai_p4/fixed/mirroring.p4
@@ -1,0 +1,147 @@
+#ifndef SAI_MIRRORING_P4_
+#define SAI_MIRRORING_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "minimum_guaranteed_sizes.h"
+#include "bmv2_intrinsics.h"
+
+control mirror_session_lookup(inout headers_t headers,
+                              inout local_metadata_t local_metadata,
+                              inout standard_metadata_t standard_metadata) {
+
+  // Sets
+  // * SAI_MIRROR_SESSION_ATTR_TYPE to SAI_MIRROR_SESSION_TYPE_IPFIX
+  // * SAI_MIRROR_SESSION_ATTR_IPFIX_ENCAPSULATION_TYPE to
+  //   SAI_IPFIX_ENCAPSULATION_TYPE_EXTENDED
+  // * SAI_MIRROR_SESSION_ATTR_MONITOR_PORT to `monitor_port`
+  // * SAI_MIRROR_SESSION_ATTR_SRC_MAC_ADDRESS
+  // * SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS
+  // * SAI_MIRROR_SESSION_ATTR_VLAN_TPID
+  // * SAI_MIRROR_SESSION_ATTR_VLAN_ID
+  // * SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS
+  // * SAI_MIRROR_SESSION_ATTR_DST_IP_ADDRESS
+  // * SAI_MIRROR_SESSION_ATTR_UDP_SRC_PORT
+  // * SAI_MIRROR_SESSION_ATTR_UDP_DST_PORT
+  //
+  // `monitor_failover_port` is used by OrchAgent to update
+  // SAI_MIRROR_SESSION_ATTR_MONITOR_PORT when `monitor_port` goes down.
+  // monitor_failover_port is not associated with any SAI ATTR But OrchAgent
+  // will switch to using it when `monitor_port` goes down.
+  // This is similar to how OrchAgent handles watch ports.
+  @id(CLONING_MIRROR_WITH_VLAN_TAG_AND_IPFIX_ENCAPSULATION_ACTION_ID)
+  action mirror_with_vlan_tag_and_ipfix_encapsulation(
+      @id(1) port_id_t monitor_port,
+      @id(2) port_id_t monitor_failover_port,
+      @id(3) @format(MAC_ADDRESS) ethernet_addr_t mirror_encap_src_mac,
+      @id(4) @format(MAC_ADDRESS) ethernet_addr_t mirror_encap_dst_mac,
+      @id(6) vlan_id_t mirror_encap_vlan_id,
+      @id(7) @format(IPV6_ADDRESS) ipv6_addr_t mirror_encap_src_ip,
+      @id(8) @format(IPV6_ADDRESS) ipv6_addr_t mirror_encap_dst_ip,
+      @id(9) bit<16> mirror_encap_udp_src_port,
+      @id(10) bit<16> mirror_encap_udp_dst_port) {
+    local_metadata.mirror_egress_port = monitor_port;
+    // monitor_failover_port's effect is not modeled.
+    local_metadata.mirror_encap_src_mac = mirror_encap_src_mac;
+    local_metadata.mirror_encap_dst_mac = mirror_encap_dst_mac;
+    local_metadata.mirror_encap_vlan_id = mirror_encap_vlan_id;
+    local_metadata.mirror_encap_src_ip = mirror_encap_src_ip;
+    local_metadata.mirror_encap_dst_ip = mirror_encap_dst_ip;
+    local_metadata.mirror_encap_udp_src_port = mirror_encap_udp_src_port;
+    local_metadata.mirror_encap_udp_dst_port = mirror_encap_udp_dst_port;
+  }
+
+  // Corresponding SAI object: SAI_OBJECT_TYPE_MIRROR_SESSION
+
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(MIRROR_SESSION_TABLE_ID)
+  table mirror_session_table {
+    key = {
+      local_metadata.mirror_session_id : exact
+        @id(1) @name("mirror_session_id");
+    }
+    actions = {
+      @proto_id(1) mirror_with_vlan_tag_and_ipfix_encapsulation;
+      @defaultonly NoAction;
+    }
+
+    const default_action = NoAction;
+    size = MIRROR_SESSION_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    // TODO: Consider unconditionally apply mirror_session_table.
+    if (local_metadata.marked_to_mirror) {
+      mirror_session_table.apply();
+    }
+  }
+}  // control mirror_session_lookup
+
+control mirror_encap(inout headers_t headers,
+                     inout local_metadata_t local_metadata,
+                     inout standard_metadata_t standard_metadata) {
+  apply {
+    // All mirrored packets are encapped with
+    // ==================================================================
+    // | Ethernet + vlan | IPv6 | UDP | IPFIX + PSAMP extended| payload |
+    // ==================================================================
+    // headers. Fields for headers mostly come from mirror-related
+    // local_metadata.
+    if (IS_MIRROR_COPY(standard_metadata)) {
+      // Mirrored packets do not traverse the usual egress pipeline.
+      local_metadata.bypass_egress = true;
+
+      headers.mirror_encap_ethernet.setValid();
+      headers.mirror_encap_ethernet.src_addr =
+       local_metadata.mirror_encap_src_mac;
+      headers.mirror_encap_ethernet.dst_addr =
+       local_metadata.mirror_encap_dst_mac;
+      headers.mirror_encap_ethernet.ether_type = ETHERTYPE_8021Q;  // VLAN
+
+      headers.mirror_encap_vlan.setValid();
+      headers.mirror_encap_vlan.ether_type = ETHERTYPE_IPV6;
+      headers.mirror_encap_vlan.vlan_id = local_metadata.mirror_encap_vlan_id;
+
+      headers.mirror_encap_ipv6.setValid();
+      headers.mirror_encap_ipv6.version = 4w6;
+      // Mirrored packets' traffic class is 0.
+      headers.mirror_encap_ipv6.dscp = 0;
+      headers.mirror_encap_ipv6.ecn = 0;
+      // Mirrored packets' hop_limit is harded-coded to 0 in OrchAgnet.
+      headers.mirror_encap_ipv6.hop_limit = 0;
+      headers.mirror_encap_ipv6.flow_label = 0;
+      // payload_lentgh for ipv6 packets is the byte length of headers after
+      // ipv6 + payload. in our case, that's the UDP, IPFIX and PSAMP headers.
+      // The mirror replicated packet becomes the new payload during mirror
+      // encap, so standard_metadata.packet_length becomes the payload length.
+      // contains the length of payload + all headers.
+      headers.mirror_encap_ipv6.payload_length =
+        (bit<16>)standard_metadata.packet_length
+        + UDP_HEADER_BYTES
+        + IPFIX_HEADER_BYTES
+        + PSAMP_EXTENDED_BYTES;
+      headers.mirror_encap_ipv6.next_header = IP_PROTOCOL_UDP;
+      headers.mirror_encap_ipv6.src_addr = local_metadata.mirror_encap_src_ip;
+      headers.mirror_encap_ipv6.dst_addr = local_metadata.mirror_encap_dst_ip;
+
+      headers.mirror_encap_udp.setValid();
+      headers.mirror_encap_udp.src_port =
+        local_metadata.mirror_encap_udp_src_port;
+      headers.mirror_encap_udp.dst_port =
+        local_metadata.mirror_encap_udp_dst_port;
+      headers.mirror_encap_udp.hdr_length =
+        headers.mirror_encap_ipv6.payload_length;
+      // Mirrored packets' UDP checksum is 0.
+      headers.mirror_encap_udp.checksum = 0;
+
+      // IPFIX and PSAMP fields are opaque to P4 so we only set their headers
+      // as valid.
+      headers.mirror_encap_ipfix.setValid();
+      headers.mirror_encap_psamp_extended.setValid();
+    }
+  }
+}  // control mirror_encap
+
+#endif  // SAI_MIRRORING_P4_

--- a/e2e_tests/sai_p4/fixed/packet_io.p4
+++ b/e2e_tests/sai_p4/fixed/packet_io.p4
@@ -1,0 +1,65 @@
+#ifndef SAI_PACKET_IO_P4_
+#define SAI_PACKET_IO_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "bmv2_intrinsics.h"
+
+// TODO: Clean up once we have better solution to handle packet-in
+// across platforms.
+control packet_in_encap(inout headers_t headers,
+                        inout local_metadata_t local_metadata,
+                        inout standard_metadata_t standard_metadata) {
+  apply {
+    // Ensure that packet-ins are headed to the CPU.
+    if (IS_PACKET_IN_COPY(standard_metadata)) {
+      // TODO: Remove guard once p4-symbolic supports assertions.
+#ifndef PLATFORM_P4SYMBOLIC
+      assert(standard_metadata.egress_port == SAI_P4_CPU_PORT);
+#endif
+    }
+
+    if (standard_metadata.egress_port == SAI_P4_CPU_PORT) {
+      // CPU-bound packets do not traverse the egress pipeline.
+      local_metadata.bypass_egress = true;
+
+#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
+      if (IS_PACKET_IN_COPY(standard_metadata)) {
+        headers.packet_out_header.setInvalid();
+        headers.packet_in_header = {
+          ingress_port = (port_id_t) local_metadata.packet_in_ingress_port,
+          target_egress_port =
+            (port_id_t) local_metadata.packet_in_target_egress_port,
+          unused_pad = 0
+        };
+      } else {
+        // CPU-bound packets that are not packet-ins get terminated by the
+        // local switch CPU.
+        // From a modeling perspective, this is like dropping the packet.
+        mark_to_drop(standard_metadata);
+      }    
+#endif
+    }
+  }
+}  // control populate_packet_in_header
+
+control packet_out_decap(inout headers_t headers,
+                         inout local_metadata_t local_metadata,
+                         inout standard_metadata_t standard_metadata){
+  apply {
+    if (headers.packet_out_header.isValid() &&
+        headers.packet_out_header.submit_to_ingress == 0) {
+      // Cast is necessary, because v1model does not define port using `type`.
+      standard_metadata.egress_spec =
+          (bit<PORT_BITWIDTH>) headers.packet_out_header.egress_port;
+      // Skip the rest of the ingress pipeline.
+      local_metadata.bypass_ingress = true;
+    }
+    // Set invalid as we don't need the packet out header in the output header.
+    headers.packet_out_header.setInvalid();
+  }
+}  // control packet_out_processing_ingress
+
+#endif  // SAI_PACKET_IO_P4_

--- a/e2e_tests/sai_p4/fixed/packet_rewrites.p4
+++ b/e2e_tests/sai_p4/fixed/packet_rewrites.p4
@@ -1,0 +1,267 @@
+#ifndef SAI_PACKET_REWRITES_P4_
+#define SAI_PACKET_REWRITES_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "metadata.p4"
+#include "minimum_guaranteed_sizes.h"
+#include "bmv2_intrinsics.h"
+#include "ids.h"
+
+// To be applied only for multicast-replicated packets, i.e. packets with
+// `standard_metadata.instance_type == PKT_INSTANCE_TYPE_REPLICATION`.
+// In P4Runtime, these are packets created by a `Replica` of a
+// `MulticastGroupEntry`.
+control multicast_rewrites(inout local_metadata_t local_metadata,
+                           in standard_metadata_t standard_metadata) {
+  // The egress port of the multicast-replicated packet.
+  // In P4Runtime, equal to the `port` value of the `Replica` of the
+  // `MulticastGroupEntry` that created this packet.
+  port_id_t multicast_replica_port = (port_id_t) standard_metadata.egress_port;
+
+  // The instance number of the multicast-replicated packet.
+  // In P4Runtime, equal to the `instance` value of the `Replica` of the
+  // `MulticastGroupEntry` that created this packet.
+  replica_instance_t multicast_replica_instance =
+      standard_metadata.egress_rid;
+
+  @id(ROUTING_SET_MULTICAST_SRC_MAC_ACTION_ID)
+  action set_multicast_src_mac(@id(1) @format(MAC_ADDRESS)
+                               ethernet_addr_t src_mac) {
+    local_metadata.enable_src_mac_rewrite = true;
+    local_metadata.packet_rewrites.src_mac = src_mac;
+
+    // By default VLAN is removed (if present). This is modeled by rewriting
+    // vlan_id to the INTERNAL_VLAN_ID.
+    local_metadata.enable_vlan_rewrite = true;
+    local_metadata.packet_rewrites.vlan_id = INTERNAL_VLAN_ID;
+  }
+
+  @id(ROUTING_IP_MULTICAST_SET_SRC_MAC_AND_VLAN_ID_ACTION_ID)
+  @action_restriction("
+    // Disallow invalid SRC MACs.
+    src_mac != 0;
+    // Disallow reserved VLAN IDs with implementation-defined semantics.
+    vlan_id != 0 && vlan_id != 4095;"
+    )
+  action multicast_set_src_mac_and_vlan_id(
+      @id(1) @format(MAC_ADDRESS) ethernet_addr_t src_mac,
+      @id(2) vlan_id_t vlan_id) {
+    local_metadata.enable_src_mac_rewrite = true;
+    local_metadata.packet_rewrites.src_mac = src_mac;
+
+    local_metadata.enable_vlan_rewrite = true;
+    local_metadata.packet_rewrites.vlan_id = vlan_id;
+  }
+
+  @id(ROUTING_IP_MULTICAST_SET_SRC_MAC_ACTION_ID)
+  @action_restriction("
+    // Disallow invalid SRC MACs.
+    src_mac != 0;"
+  )
+  action multicast_set_src_mac(@id(1) @format(MAC_ADDRESS)
+                               ethernet_addr_t src_mac) {
+    multicast_set_src_mac_and_vlan_id(src_mac, INTERNAL_VLAN_ID);
+  }
+
+  @id(ROUTING_IP_MULTICAST_SET_SRC_MAC_AND_DST_MAC_AND_VLAN_ID_ACTION_ID)
+  @action_restriction("
+    // Disallow invalid SRC MACs.
+    src_mac != 0;
+    // Disallow reserved VLAN IDs with implementation-defined semantics.
+    vlan_id != 0 && vlan_id != 4095;"
+  )
+  action multicast_set_src_mac_and_dst_mac_and_vlan_id(
+      @id(1) @format(MAC_ADDRESS) ethernet_addr_t src_mac,
+      @id(2) @format(MAC_ADDRESS) ethernet_addr_t dst_mac,
+      @id(3) vlan_id_t vlan_id) {
+    local_metadata.enable_src_mac_rewrite = true;
+    local_metadata.packet_rewrites.src_mac = src_mac;
+
+    local_metadata.enable_dst_mac_rewrite = true;
+    local_metadata.packet_rewrites.dst_mac = dst_mac;
+
+    local_metadata.enable_vlan_rewrite = true;
+    local_metadata.packet_rewrites.vlan_id = vlan_id;
+  }
+
+  @id(ROUTING_IP_MULTICAST_SET_SRC_MAC_AND_PRESERVE_INGRESS_VLAN_ID_ACTION_ID)
+  @action_restriction("
+    // Disallow invalid SRC MACs.
+    src_mac != 0;"
+  )
+  action multicast_set_src_mac_and_preserve_ingress_vlan_id(
+      @id(1) @format(MAC_ADDRESS) ethernet_addr_t src_mac) {
+    local_metadata.enable_src_mac_rewrite = true;
+    local_metadata.packet_rewrites.src_mac = src_mac;
+
+    local_metadata.enable_vlan_rewrite = false;
+  }
+
+  @id(ROUTING_L2_MULTICAST_PASSTHROUGH_ACTION_ID)
+  action l2_multicast_passthrough() {}
+
+  // This is a logical table that does not exist in SAI and instead is managed
+  // by the Orchagent. It is used to distinguish between L2 and IP
+  // multicast-replicated packets.
+  //  * L2MC packets will use the l2_multicast_passthrough action
+  //  * IPMC packets will use set_multicast_src_mac action.
+  //
+  // L2MC packets will not be modified in any way and simply duplicated to
+  // various output ports. IP packets will rewrite the source MAC.
+  //
+  // For IPMC there is a many-to-one correspondence between entries in this
+  // table and SAI Router Interfaces (RIFs). Each entry corresponds to a RIF
+  // with the following attributes:
+  // * `SAI_ROUTER_INTERFACE_ATTR_PORT_ID` is equal to `multicast_replica_port`.
+  // * `SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS` is equal to the `src_mac`
+  //   parameter of the `set_multicast_src_mac` action.
+  //
+  // Orchagent maintains a mapping from entries to RIFs, creating and destroying
+  // (possibly shared) RIFs as entries are inserted and deleted.
+  //
+  // When creating a multicast group member (`SAI_IPMC_GROUP_MEMBER`) from a
+  // P4Runtime `Replica`, Orchagent will use this table to set the value of the
+  // `SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID` attribute: it will expect to
+  // find an entry for the replica's port and instance in this table, and will
+  // use the ID of the RIF associated with that entry. This will cause the
+  // source MAC of packets generated by the group member to be rewritten to the
+  // `src_mac` of the `set_multicast_src_mac` action of the entry.
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_MULTICAST_ROUTER_INTERFACE_TABLE_ID)
+  table multicast_router_interface_table {
+    key = {
+      multicast_replica_port : exact
+        @referenced_by(builtin::multicast_group_table, replica.port)
+        @id(1);
+      multicast_replica_instance : exact
+        @referenced_by(builtin::multicast_group_table, replica.instance)
+        @id(2);
+    }
+    actions = {
+      @proto_id(2) l2_multicast_passthrough;
+#if defined(IP_MULTICAST_CAPABLE)
+      // TODO: Remove once no longer in use.
+      // Deprecated: use `multicast_set_src_mac` instead.
+      @proto_id(1) set_multicast_src_mac;
+      @proto_id(3) multicast_set_src_mac;
+      @proto_id(4) multicast_set_src_mac_and_vlan_id;
+      @proto_id(5) multicast_set_src_mac_and_dst_mac_and_vlan_id;
+      @proto_id(6) multicast_set_src_mac_and_preserve_ingress_vlan_id;
+#endif
+    }
+    size = ROUTING_MULTICAST_SOURCE_MAC_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    multicast_router_interface_table.apply();
+  }
+}  // control multicast_rewrites
+
+control ttl_logic(inout headers_t headers,
+                   in local_metadata_t local_metadata,
+                   inout standard_metadata_t standard_metadata) {
+  apply {
+    bool acl_l3_redirect =
+          (local_metadata.acl_ingress_ipmc_redirect ||
+          local_metadata.acl_ingress_nexthop_redirect);
+
+    // IPv4 TTL check.
+    if (headers.ipv4.isValid()) {
+      // Remove when switch correctly accepts TTL=1 packets.
+      if (headers.ipv4.ttl == 1 && !acl_l3_redirect) {
+          mark_to_drop(standard_metadata);
+      }
+
+      // Remove this clause and only decrement on TTL>0
+      // below when redirect to nexthop behavior correctly drops packets
+      // ingressing with TTL == 0.
+      if (headers.ipv4.ttl == 0 && !local_metadata.acl_ingress_nexthop_redirect) {
+          mark_to_drop(standard_metadata);
+      }
+
+      if (local_metadata.enable_decrement_ttl) {
+        // Note that this TTL can purposefully overflow when
+        // TTL == 0. The guard should be updated to preclude that when it is no
+        // longer the case.
+        headers.ipv4.ttl = headers.ipv4.ttl - 1;
+      }
+
+      // Remove ACL redirect check when redirection
+      // correctly drops TTL=0 packets.
+      // Note: This line is currently redundant, but will be needed when the
+      // bugs above are fixed and their related lines removed.
+      if (headers.ipv4.ttl == 0 && !acl_l3_redirect) {
+          mark_to_drop(standard_metadata);
+      }
+    }
+
+    // IPv6 TTL (aka hop limit) check.
+    if (headers.ipv6.isValid()) {
+      // Remove when switch correctly accepts TTL=1 packets.
+      if (headers.ipv6.hop_limit == 1 && !acl_l3_redirect) {
+          mark_to_drop(standard_metadata);
+      }
+
+      // Remove this clause and only decrement on TTL>0
+      // below when redirect to nexthop behavior correctly drops packets
+      // ingressing with TTL == 0.
+      if (headers.ipv6.hop_limit == 0 &&
+          !local_metadata.acl_ingress_nexthop_redirect) {
+          mark_to_drop(standard_metadata);
+      }
+
+      if (local_metadata.enable_decrement_ttl) {
+        // Note that this TTL can purposefully overflow when
+        // TTL == 0. The guard should be updated to preclude that when it is no
+        // longer the case.
+        headers.ipv6.hop_limit = headers.ipv6.hop_limit - 1;
+      }
+
+      // Remove ACL redirect check when redirection
+      // correctly drops TTL=0 packets.
+      // Note: This line is currently redundant, but will be needed when the
+      // bugs above are fixed and their related lines removed.
+      if (headers.ipv6.hop_limit == 0 && !acl_l3_redirect) {
+          mark_to_drop(standard_metadata);
+      }
+    }
+  }
+} // control ttl_logic
+
+// This control block applies the rewrites computed during the ingress
+// stage to the actual packet.
+control packet_rewrites(inout headers_t headers,
+                        inout local_metadata_t local_metadata,
+                        inout standard_metadata_t standard_metadata) {
+  apply {
+    if (standard_metadata.instance_type == PKT_INSTANCE_TYPE_REPLICATION) {
+      local_metadata.enable_decrement_ttl = true;
+      multicast_rewrites.apply(local_metadata, standard_metadata);
+    }
+    if (local_metadata.enable_src_mac_rewrite) {
+      headers.ethernet.src_addr = local_metadata.packet_rewrites.src_mac;
+    }
+    if (local_metadata.enable_dst_mac_rewrite) {
+      headers.ethernet.dst_addr = local_metadata.packet_rewrites.dst_mac;
+    }
+    if (local_metadata.enable_vlan_rewrite) {
+      // VLAN id is kept in local_metadata until the end of egress pipeline
+      // where depending on the value of VLAN id and VLAN configuration the
+      // packet might potentially get VLAN tagged with that VLAN id.
+      local_metadata.vlan_id = local_metadata.packet_rewrites.vlan_id;
+    }
+    if (local_metadata.enable_dscp_rewrite) {
+      if (headers.ipv4.isValid()) {
+        headers.ipv4.dscp = local_metadata.packet_rewrites.dscp;
+      }
+      if (headers.ipv6.isValid()) {
+        headers.ipv6.dscp = local_metadata.packet_rewrites.dscp;
+      }
+    }
+    // Perform TTL logic after all other packet rewrites have been applied.
+    ttl_logic.apply(headers, local_metadata, standard_metadata);
+  }
+}  // control packet_rewrites
+
+#endif  // SAI_PACKET_REWRITES_P4_

--- a/e2e_tests/sai_p4/fixed/parser.p4
+++ b/e2e_tests/sai_p4/fixed/parser.p4
@@ -1,0 +1,243 @@
+#ifndef SAI_PARSER_P4_
+#define SAI_PARSER_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "ids.h"
+#include "metadata.p4"
+
+// LINT.IfChange(parser)
+parser packet_parser(packet_in packet, out headers_t headers,
+                     inout local_metadata_t local_metadata,
+                     inout standard_metadata_t standard_metadata) {
+  // LINT.IfChange(metadata_initialization)
+  state start {
+    // Initialize local metadata fields.
+    local_metadata.enable_vlan_checks = false;
+    local_metadata.marked_to_drop_by_ingress_vlan_checks = false;
+    local_metadata.vlan_id = 0;
+    local_metadata.input_packet_is_vlan_tagged = false;
+    local_metadata.omit_vlan_tag_on_egress_packet = false;
+    local_metadata.admit_to_l3 = false;
+    local_metadata.vrf_id = kDefaultVrf;
+    local_metadata.enable_decrement_ttl = false;
+    local_metadata.enable_src_mac_rewrite = false;
+    local_metadata.enable_dst_mac_rewrite = false;
+    local_metadata.enable_vlan_rewrite = false;
+    local_metadata.enable_dscp_rewrite = false;
+    local_metadata.packet_rewrites.src_mac = 0;
+    local_metadata.packet_rewrites.dst_mac = 0;
+    local_metadata.packet_rewrites.dscp = 0;
+    local_metadata.l4_src_port = 0;
+    local_metadata.l4_dst_port = 0;
+    local_metadata.wcmp_selector_input = 0;
+    local_metadata.apply_tunnel_decap_at_end_of_pre_ingress = false;
+    local_metadata.apply_tunnel_encap_at_egress = false;
+    local_metadata.tunnel_encap_src_ipv6 = 0;
+    local_metadata.tunnel_encap_dst_ipv6 = 0;
+    local_metadata.marked_to_copy = false;
+    local_metadata.marked_to_mirror = false;
+    local_metadata.mirror_session_id = 0;
+    local_metadata.mirror_egress_port = 0;
+    local_metadata.color = MeterColor_t.GREEN;
+    local_metadata.ingress_port = (port_id_t)standard_metadata.ingress_port;
+    local_metadata.route_metadata = 0;
+    local_metadata.bypass_ingress = false;
+    local_metadata.bypass_egress = false; 
+    local_metadata.wcmp_group_id_valid = false;
+    local_metadata.wcmp_group_id_value = 0;
+    local_metadata.nexthop_id_valid = false;
+    local_metadata.acl_ingress_l2mc_redirect = false;
+    local_metadata.nexthop_id_value = 0;
+    local_metadata.route_hit = false;
+    local_metadata.acl_drop = false;
+    local_metadata.tunnel_termination_table_hit = false;
+    local_metadata.acl_ingress_ipmc_redirect = false;
+    local_metadata.redirect_port_valid = false;
+    local_metadata.redirect_port = 0;
+    local_metadata.acl_ingress_nexthop_redirect = false;
+    // LINT.ThenChange()
+    
+  transition select(standard_metadata.ingress_port) {
+      SAI_P4_CPU_PORT: parse_packet_out_header;
+      _              : parse_ethernet;
+    }
+  }
+
+  state parse_packet_out_header {
+    packet.extract(headers.packet_out_header);
+    transition parse_ethernet;
+  }
+
+  state parse_ethernet {
+    packet.extract(headers.ethernet);
+    transition select(headers.ethernet.ether_type) {
+      ETHERTYPE_IPV4: parse_ipv4;
+      ETHERTYPE_IPV6: parse_ipv6;
+      ETHERTYPE_ARP:  parse_arp;
+      // TODO: Parse 802.1Q VLAN-tagged packets correctly.
+      _:              accept;
+    }
+  }
+
+  state parse_ipv4 {
+    packet.extract(headers.ipv4);
+    transition select(headers.ipv4.protocol) {
+      IP_PROTOCOL_IPV4: parse_ipv4_in_ip;
+      IP_PROTOCOL_IPV6: parse_ipv6_in_ip;
+      IP_PROTOCOL_ICMP: parse_icmp;
+      IP_PROTOCOL_TCP:  parse_tcp;
+      IP_PROTOCOL_UDP:  parse_udp;
+      _:                accept;
+    }
+  }
+
+  state parse_ipv4_in_ip {
+    packet.extract(headers.inner_ipv4);
+    transition select(headers.inner_ipv4.protocol) {
+      IP_PROTOCOL_ICMP: parse_icmp;
+      IP_PROTOCOL_TCP:  parse_tcp;
+      IP_PROTOCOL_UDP:  parse_udp;
+      _:                accept;
+    }
+  }
+
+  state parse_ipv6 {
+    packet.extract(headers.ipv6);
+    transition select(headers.ipv6.next_header) {
+      IP_PROTOCOL_V6_EXTENSION_HOP_BY_HOP: parse_hop_by_hop_options;
+      IP_PROTOCOL_IPV4: parse_ipv4_in_ip;
+      IP_PROTOCOL_IPV6: parse_ipv6_in_ip;
+      IP_PROTOCOL_ICMPV6: parse_icmp;
+      IP_PROTOCOL_TCP:    parse_tcp;
+      IP_PROTOCOL_UDP:    parse_udp;
+      _:                  accept;
+    }
+  }
+
+  state parse_hop_by_hop_options {
+    packet.extract(headers.hop_by_hop_options);
+    // All packets with a non-zero `header_extension_length` in the hop-by-hop
+    // options header are rejected because P4-Symbolic does not support
+    // lookaheads, which are required to set the varbit's bitwidth to determine
+    // the amount of bits needed for `more_options_and_padding`.
+    // TODO: After the support for 'verify', 'reject', or
+    // or 'lookahead' to P4-Symbolic, update the program to reflect the comment
+    // above.
+     transition select(headers.hop_by_hop_options.header_extension_length) {
+        0: next_header_for_hop_by_hop_options;
+        _: accept;
+      }
+  }
+
+  state next_header_for_hop_by_hop_options {
+    transition select(headers.hop_by_hop_options.next_header) {
+      IP_PROTOCOL_IPV4: parse_ipv4_in_ip;
+      IP_PROTOCOL_IPV6: parse_ipv6_in_ip;
+      IP_PROTOCOL_ICMPV6: parse_icmp;
+      IP_PROTOCOL_TCP:    parse_tcp;
+      IP_PROTOCOL_UDP:    parse_udp;
+      _:                  accept;
+    }
+  }
+
+
+  state parse_ipv6_in_ip {
+    packet.extract(headers.inner_ipv6);
+    transition select(headers.inner_ipv6.next_header) {
+      IP_PROTOCOL_V6_EXTENSION_HOP_BY_HOP: parse_hop_by_hop_options_in_ip;
+      IP_PROTOCOL_ICMPV6: parse_icmp;
+      IP_PROTOCOL_TCP:    parse_tcp;
+      IP_PROTOCOL_UDP:    parse_udp;
+      _:                  accept;
+    }
+  }
+
+  state parse_hop_by_hop_options_in_ip {
+    packet.extract(headers.inner_hop_by_hop_options);
+    // All packets with a non-zero `header_extension_length` in the hop-by-hop
+    // options header are rejected because P4-Symbolic does not support
+    // lookaheads, which are required to set the varbit's bitwidth to determine
+    // the amount of bits needed for `more_options_and_padding`.
+    // TODO: Remove if support for `more_options_and_padding` is
+    // supported.
+    transition select(headers.inner_hop_by_hop_options.header_extension_length) {
+      0: next_header_for_hop_by_hop_options_in_ip;
+      _: accept;
+    }
+  }
+
+  state next_header_for_hop_by_hop_options_in_ip {
+    transition select(headers.inner_hop_by_hop_options.next_header) {
+      IP_PROTOCOL_ICMPV6: parse_icmp;
+      IP_PROTOCOL_TCP:    parse_tcp;
+      IP_PROTOCOL_UDP:    parse_udp;
+      _:                  accept;
+    }
+  }
+
+  state parse_tcp {
+    packet.extract(headers.tcp);
+    // Normalize TCP port metadata to common port metadata.
+    local_metadata.l4_src_port = headers.tcp.src_port;
+    local_metadata.l4_dst_port = headers.tcp.dst_port;
+    transition accept;
+  }
+
+  state parse_udp {
+    packet.extract(headers.udp);
+    // Normalize UDP port metadata to common port metadata.
+    local_metadata.l4_src_port = headers.udp.src_port;
+    local_metadata.l4_dst_port = headers.udp.dst_port;
+    transition accept;
+  }
+
+  state parse_icmp {
+    packet.extract(headers.icmp);
+    transition accept;
+  }
+
+  state parse_arp {
+    packet.extract(headers.arp);
+    transition accept;
+  }
+}  // parser packet_parser
+// The parser and the deparser need to roundtrip, so if you change the parser,
+// you often need to change the deparser too.
+// LINT.ThenChange(metadata.p4, :deparser)
+
+// LINT.IfChange(deparser)
+control packet_deparser(packet_out packet, in headers_t headers) {
+  apply {
+    // We always expect the packet_out_header to be invalid at the end of the
+    // pipeline, so this line has no effect on the output packet.
+    packet.emit(headers.packet_out_header);
+// TODO: Clean up once we have better solution to handle packet-in
+// across platforms.
+#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
+    packet.emit(headers.packet_in_header);
+#endif
+    packet.emit(headers.mirror_encap_ethernet);
+    packet.emit(headers.mirror_encap_vlan);
+    packet.emit(headers.mirror_encap_ipv6);
+    packet.emit(headers.mirror_encap_udp);
+    packet.emit(headers.mirror_encap_ipfix);
+    packet.emit(headers.mirror_encap_psamp_extended);
+    packet.emit(headers.ethernet);
+    packet.emit(headers.tunnel_encap_ipv6);
+    packet.emit(headers.tunnel_encap_gre);
+    packet.emit(headers.ipv4);
+    packet.emit(headers.ipv6);
+    packet.emit(headers.hop_by_hop_options);
+    packet.emit(headers.inner_ipv4);
+    packet.emit(headers.inner_ipv6);
+    packet.emit(headers.inner_hop_by_hop_options);
+    packet.emit(headers.arp);
+    packet.emit(headers.icmp);
+    packet.emit(headers.tcp);
+    packet.emit(headers.udp);
+  }
+}  // control packet_deparser
+// LINT.ThenChange(metadata.p4, :parser)
+
+#endif  // SAI_PARSER_P4_

--- a/e2e_tests/sai_p4/fixed/roles.h
+++ b/e2e_tests/sai_p4/fixed/roles.h
@@ -1,0 +1,21 @@
+#ifndef SAI_ROLES_P4_
+#define SAI_ROLES_P4_
+
+#define P4RUNTIME_ROLE_SDN_CONTROLLER "sdn_controller"
+
+// Instantiations of SAI P4 can override these roles by defining the macros.
+
+#ifndef P4RUNTIME_ROLE_ROUTING
+#define P4RUNTIME_ROLE_ROUTING P4RUNTIME_ROLE_SDN_CONTROLLER
+#endif
+
+#ifndef P4RUNTIME_ROLE_MIRRORING
+#define P4RUNTIME_ROLE_MIRRORING P4RUNTIME_ROLE_SDN_CONTROLLER
+#endif
+
+#ifndef P4RUNTIME_ROLE_PACKET_REPLICATION_ENGINE
+#define P4RUNTIME_ROLE_PACKET_REPLICATION_ENGINE \
+  "packet_replication_engine_manager"
+#endif
+
+#endif  // SAI_ROLES_P4_

--- a/e2e_tests/sai_p4/fixed/routing.p4
+++ b/e2e_tests/sai_p4/fixed/routing.p4
@@ -1,0 +1,643 @@
+#ifndef SAI_ROUTING_P4_
+#define SAI_ROUTING_P4_
+
+#include <v1model.p4>
+#include "common_actions.p4"
+#include "drop_martians.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "roles.h"
+#include "minimum_guaranteed_sizes.h"
+
+// This file contains two control blocks that together model the L3 routing
+// pipeline: routing_lookup and routing_resolution.
+//
+// --lookup---|A|------------------------resolution-----------------------------
+//            |C|
+// +-------+  |L|  +-------+ wcmp +---------+       +-----------+
+// |       |  | |  |       |----->|         |       |           |--> vlan_id
+// |  lpm  |--|i|->| group |----->| nexthop |----+->| router    |--> egress_port
+// |       |  |n|  |       |----->|         |-+  |  | interface |--> src_mac
+// +-------+  |g|  +-------+      +---------+ |  |  +-----------+
+//   |   |    |r|                     ^       |  |  +-----------+
+//   |   |    |e|                     |       |  +->| neighbor  |
+//   |   +----|s|---------------------+       +---->|           |--> dst_mac
+//   |        |s|                                   +-----------+
+//   +--------| |--------------------------------------------------> drop
+//
+// For packets that are admitted for L3 routing, the routing_lookup block
+// performs a longest prefix match on the packet's destination IP address (along
+// with an exact match on VRF id). The action associated with the
+// match then either drops the packet, points to a nexthop, or points to a WCMP
+// group, or multicast.
+// After the packet goes through the ACL ingress stage (which can potentially
+// change the nexthop or group set by LPM), the routing_resolution block
+// resolves the group/nexthop as follows:
+// A WCMP group uses a hash of the packet to choose from a set of nexthops. The
+// nexthop points to a router interface, which determines the packet's vlan_id,
+// src_mac, and the egress_port to forward the packet to. The nexthop also
+// points to a neighbor which together with the router_interface, determines the
+// packet's dst_mac.
+//
+// Note that routing_resolution does not rewrite any header field directly,
+// but only records rewrites in `local_metadata.packet_rewrites`, from where
+// they will be read and applied in the egress stage (dependeding on whether
+// the rewrites are disabled by the nexthop or not).
+// The following action is shared between routing_lookup and routing_resolution
+// control blocks and hence is defined in the outer scope.
+//
+// When called from a route, sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to
+// SAI_PACKET_ACTION_FORWARD, and SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID to a
+// SAI_OBJECT_TYPE_NEXT_HOP.
+//
+// When called from a group, sets SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID.
+// When called from a group, sets SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT.
+//
+// This action can only refer to `nexthop_id`s that are programmed in the
+// `nexthop_table`.
+@id(ROUTING_SET_NEXTHOP_ID_ACTION_ID)
+action set_nexthop_id(inout local_metadata_t local_metadata,
+                      @id(1) @refers_to(nexthop_table, nexthop_id)
+                      nexthop_id_t nexthop_id) {
+  local_metadata.nexthop_id_valid = true;
+  local_metadata.nexthop_id_value = nexthop_id;
+}
+
+control routing_lookup(in headers_t headers,
+                       inout local_metadata_t local_metadata,
+                       inout standard_metadata_t standard_metadata) {
+  // Programming this table does not affect packet forwarding directly -- the
+  // table performs no actions -- but results in the creation/deletion of VRFs.
+  // This is a prerequisite to using these VRFs, e.g. in the `ipv4_table` and
+  // `ipv6_table` below, as is indicated by the `@refers_to(vrf_table, vrf_id)`
+  // annotations.
+  // TODO: Currently we don't expose any `sai_virtual_router_attr_t`
+  // attributes here, but we may explore that in the future.
+  @entry_restriction("
+    // The VRF ID 0 (or '' in P4Runtime) encodes the default VRF, which cannot
+    // be read or written via this table, but is always present implicitly.
+    // TODO: This constraint should read `vrf_id != ''` (since
+    // constraints are a control plane (P4Runtime) concept), but
+    // p4-constraints does not currently support strings.
+    vrf_id != 0;
+  ")
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_VRF_TABLE_ID)
+  table vrf_table {
+    key = {
+      local_metadata.vrf_id : exact @id(1) @name("vrf_id");
+    }
+    actions = {
+      // TODO: Add support for CamlCase actions to the PD generator
+      // so we can use `NoAction` instead of `no_action`.
+      @proto_id(1) no_action;
+    }
+    const default_action = no_action;
+    size = ROUTING_VRF_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+  // Sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_DROP.
+  @id(ROUTING_DROP_ACTION_ID)
+  action drop() {
+    mark_to_drop(standard_metadata);
+  }
+  // Sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_FORWARD, and
+  // SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID to a SAI_OBJECT_TYPE_NEXT_HOP_GROUP.
+  //
+  // This action can only refer to `wcmp_group_id`s that are programmed in the
+  // `wcmp_group_table`.
+  @id(ROUTING_SET_WCMP_GROUP_ID_ACTION_ID)
+  action set_wcmp_group_id(@id(1) @refers_to(wcmp_group_table, wcmp_group_id)
+                           wcmp_group_id_t wcmp_group_id) {
+    local_metadata.wcmp_group_id_valid = true;
+    local_metadata.wcmp_group_id_value = wcmp_group_id;
+  }
+  // Sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_FORWARD, and
+  // SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID to a SAI_OBJECT_TYPE_NEXT_HOP_GROUP.
+  //
+  // This action can only refer to `wcmp_group_id`s that are programmed in the
+  // `wcmp_group_table`.
+  //
+  // Also sets the route metadata available for Ingress ACL lookup.
+  @id(ROUTING_SET_WCMP_GROUP_ID_AND_METADATA_ACTION_ID)
+  action set_wcmp_group_id_and_metadata(@id(1)
+                                        @refers_to(wcmp_group_table,
+                                        wcmp_group_id)
+                                        wcmp_group_id_t wcmp_group_id,
+                                        route_metadata_t route_metadata) {
+    set_wcmp_group_id(wcmp_group_id);
+    local_metadata.route_metadata = route_metadata;
+  }
+  // Set the metadata of the packet and mark the packet to drop at the end of
+  // the ingress pipeline.
+  @id(ROUTING_SET_METADATA_AND_DROP_ACTION_ID)
+  action set_metadata_and_drop(@id(1) route_metadata_t route_metadata) {
+    local_metadata.route_metadata = route_metadata;
+    mark_to_drop(standard_metadata);
+  }
+
+  // Can only be called form a route. Sets SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION to
+  // SAI_PACKET_ACTION_FORWARD, and SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID to a
+  // SAI_OBJECT_TYPE_NEXT_HOP.
+  // Also sets SAI_ROUTE_ENTRY_ATTR_META_DATA.
+  //
+  // This action can only refer to `nexthop_id`s that are programmed in the
+  // `nexthop_table`.
+  @id(ROUTING_SET_NEXTHOP_ID_AND_METADATA_ACTION_ID)
+  action set_nexthop_id_and_metadata(@id(1)
+                                     @refers_to(nexthop_table, nexthop_id)
+                                     nexthop_id_t nexthop_id,
+                                     route_metadata_t route_metadata) {
+    local_metadata.nexthop_id_valid = true;
+    local_metadata.nexthop_id_value = nexthop_id;
+    local_metadata.route_metadata = route_metadata;
+  }
+
+  // Sets the multicast group ID (SAI_IPMC_ENTRY_ATTR_OUTPUT_GROUP_ID).
+  // The ID will be looked up in the multicast group table after ingress
+  // processing. The group table will then make 0 or more copies of the packet
+  // and pass them to the egress pipeline.
+  //
+  // Calling this action will override unicast, and can itself be overriden by
+  // `mark_to_drop`.
+  //
+  @id(ROUTING_SET_MULTICAST_GROUP_ID_ACTION_ID)
+  @action_restriction("
+    // Disallow 0 since it encodes 'no multicast' in V1Model.
+    multicast_group_id != 0;
+  ")
+  action set_multicast_group_id(
+      @id(1)
+      @refers_to(builtin::multicast_group_table, multicast_group_id)
+      multicast_group_id_t multicast_group_id) {
+    standard_metadata.mcast_grp = multicast_group_id;
+  }
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_IPV4_TABLE_ID)
+  table ipv4_table {
+    key = {
+      // Sets `vr_id` in `sai_route_entry_t`.
+      local_metadata.vrf_id : exact
+        @id(1) @name("vrf_id") @refers_to(vrf_table, vrf_id);
+      // Sets `destination` in `sai_route_entry_t` to an IPv4 prefix.
+      headers.ipv4.dst_addr : lpm
+        @id(2) @name("ipv4_dst") @format(IPV4_ADDRESS);
+    }
+    actions = {
+      @proto_id(1) drop;
+      @proto_id(2) set_nexthop_id(local_metadata);
+      @proto_id(3) set_wcmp_group_id;
+      @proto_id(5) set_nexthop_id_and_metadata;
+      @proto_id(6) set_wcmp_group_id_and_metadata;
+      @proto_id(7) set_metadata_and_drop;
+    }
+    const default_action = drop;
+    size = ROUTING_IPV4_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_IPV6_TABLE_ID)
+  table ipv6_table {
+    key = {
+      // Sets `vr_id` in `sai_route_entry_t`.
+      local_metadata.vrf_id : exact
+        @id(1) @name("vrf_id") @refers_to(vrf_table, vrf_id);
+      // Sets `destination` in `sai_route_entry_t` to an IPv6 prefix.
+      headers.ipv6.dst_addr : lpm
+        @id(2)  @name("ipv6_dst") @format(IPV6_ADDRESS);
+    }
+    actions = {
+      @proto_id(1) drop;
+      @proto_id(2) set_nexthop_id(local_metadata);
+      @proto_id(3) set_wcmp_group_id;
+      @proto_id(5) set_nexthop_id_and_metadata;
+      @proto_id(6) set_wcmp_group_id_and_metadata;
+      @proto_id(7) set_metadata_and_drop;
+    }
+    const default_action = drop;
+    size = ROUTING_IPV6_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @entry_restriction("
+    // TODO: Use IPv4 address notation once it is supported.
+    // Only IPv4s in the multicast range 224.0.0.0/4 are supported.
+    ipv4_dst::value >= 0xe0000000;
+    ipv4_dst::value <= 0xefffffff;
+  ")
+  // Models SAI IPMC entries of type (*,G) whose destination is an IPv4 address.
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_IPV4_MULTICAST_TABLE_ID)
+  table ipv4_multicast_table {
+    key = {
+      // Sets `vr_id` in `sai_ipmc_entry_t`.
+      local_metadata.vrf_id : exact
+        @id(1) @name("vrf_id") @refers_to(vrf_table, vrf_id);
+      // Sets `destination` in `sai_ipmc_entry_t` to an IPv4 adress.
+      headers.ipv4.dst_addr : exact
+        @id(2) @name("ipv4_dst") @format(IPV4_ADDRESS);
+    }
+    actions = {
+      @proto_id(1) set_multicast_group_id;
+    }
+    size = ROUTING_IPV4_MULTICAST_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @entry_restriction("
+    // TODO: Use IPv4 address notation once it is supported.
+    // Only IPv6s in the multicast range ff00::/8 are supported.
+    ipv6_dst::value >= 0xff000000000000000000000000000000;
+    ipv6_dst::value <= 0xffffffffffffffffffffffffffffffff;
+  ")
+  // Models SAI IPMC entries of type (*,G) whose destination is an IPv6 address.
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_IPV6_MULTICAST_TABLE_ID)
+  table ipv6_multicast_table {
+    key = {
+      // Sets `vr_id` in `sai_ipmc_entry_t`.
+      local_metadata.vrf_id : exact
+        @id(1) @name("vrf_id") @refers_to(vrf_table, vrf_id);
+      // Sets `destination` in `sai_ipmc_entry_t` to an IPv6 adress.
+      headers.ipv6.dst_addr : exact
+        @id(2) @name("ipv6_dst") @format(IPV6_ADDRESS);
+    }
+    actions = {
+      @proto_id(1) set_multicast_group_id;
+    }
+    size = ROUTING_IPV6_MULTICAST_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    mark_to_drop(standard_metadata);
+    vrf_table.apply();
+
+    if (headers.ipv4.isValid()) {
+      if (IS_MULTICAST_IPV4(headers.ipv4.dst_addr)) {
+        if (IS_IPV4_MULTICAST_MAC(headers.ethernet.dst_addr)) {
+          // Packets failing ingress VLAN checks do not go through IPMC lookup
+          if (!local_metadata.marked_to_drop_by_ingress_vlan_checks) {
+#if defined(IP_MULTICAST_CAPABLE)
+            local_metadata.route_hit = ipv4_multicast_table.apply().hit;
+#endif
+          }
+        }
+      } else { // IPv4 unicast.
+        if (IS_UNICAST_MAC(headers.ethernet.dst_addr) &&
+            local_metadata.admit_to_l3) {
+          local_metadata.route_hit = ipv4_table.apply().hit;
+        }
+      }
+    } else if (headers.ipv6.isValid()) {
+      if (IS_MULTICAST_IPV6(headers.ipv6.dst_addr)) {
+        if (IS_IPV6_MULTICAST_MAC(headers.ethernet.dst_addr)) {
+          // Packets failing ingress VLAN checks do not go through IPMC lookup
+          if (!local_metadata.marked_to_drop_by_ingress_vlan_checks) {
+#if defined(IP_MULTICAST_CAPABLE)
+            local_metadata.route_hit = ipv6_multicast_table.apply().hit;
+#endif
+          }
+        }
+      } else { // IPv6 unicast.
+        if (IS_UNICAST_MAC(headers.ethernet.dst_addr) &&
+            local_metadata.admit_to_l3) {
+          local_metadata.route_hit = ipv6_table.apply().hit;
+        }
+      }
+    }
+  }
+}  // control routing_lookup
+control routing_resolution(in headers_t headers,
+                           inout local_metadata_t local_metadata,
+                           inout standard_metadata_t standard_metadata) {
+
+  // Tunnel id, only valid if `tunnel_id_valid` is true.
+  bool tunnel_id_valid = false;
+  tunnel_id_t tunnel_id_value;
+
+  // Router interface id, only valid if `router_interface_id_valid` is true.
+  bool router_interface_id_valid = false;
+  router_interface_id_t router_interface_id_value;
+
+  // Neighbor id, only valid if `neighbor_id_valid` is true.
+  bool neighbor_id_valid = false;
+  ipv6_addr_t neighbor_id_value;
+
+  // Sets SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS.
+  @id(ROUTING_SET_DST_MAC_ACTION_ID)
+  action set_dst_mac(@id(1) @format(MAC_ADDRESS) ethernet_addr_t dst_mac) {
+    local_metadata.packet_rewrites.dst_mac = dst_mac;
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_NEIGHBOR_TABLE_ID)
+  table neighbor_table {
+    key = {
+      // Sets rif_id in sai_neighbor_entry_t. Can only refer to values that are
+      // already programmed in the `router_interface_table`.
+      router_interface_id_value : exact @id(1) @name("router_interface_id")
+          @refers_to(router_interface_table, router_interface_id);
+      // Sets ip_address in sai_neighbor_entry_t.
+      neighbor_id_value : exact @id(2) @format(IPV6_ADDRESS)
+          @name("neighbor_id");
+    }
+    actions = {
+      @proto_id(1) set_dst_mac;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = NEIGHBOR_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  // Sets SAI_ROUTER_INTERFACE_ATTR_TYPE to SAI_ROUTER_INTERFACE_TYPE_SUB_PORT,
+  // and SAI_ROUTER_INTERFACE_ATTR_PORT_ID, and
+  // SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS, and
+  // SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID.
+  // Sets SAI_ROUTER_INTERFACE_ATTR_MY_MAC to a SAI_OBJECT_TYPE_MY_MAC, thus
+  // preventing the implicit creation of a MY_MAC entry in SAI (l3_admit_table
+  // at P4).
+  @id(ROUTING_UNICAST_SET_PORT_AND_SRC_MAC_AND_VLAN_ID_ACTION_ID)
+  // TODO: Remove @unsupported when the switch supports this
+  // action.
+  @unsupported
+  @action_restriction("
+    // Disallow invalid SRC MACs.
+    src_mac != 0;
+    // Disallow reserved VLAN IDs with implementation-defined semantics.
+    vlan_id != 0 && vlan_id != 4095;"
+  )
+  action unicast_set_port_and_src_mac_and_vlan_id(@id(1) port_id_t port,
+                                          @id(2) @format(MAC_ADDRESS)
+                                          ethernet_addr_t src_mac,
+                                          @id(3) vlan_id_t vlan_id) {
+    // Cast is necessary, because v1model does not define port using `type`.
+    standard_metadata.egress_spec = (bit<PORT_BITWIDTH>)port;
+    local_metadata.packet_rewrites.src_mac = src_mac;
+    local_metadata.packet_rewrites.vlan_id = vlan_id;
+  }
+
+  // Sets SAI_ROUTER_INTERFACE_ATTR_TYPE to SAI_ROUTER_INTERFACE_TYPE_PORT, and
+  // SAI_ROUTER_INTERFACE_ATTR_PORT_ID, and
+  // SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS.
+  // Implicitly creates a MY_MAC entry in SAI (l3_admit_table at P4) admitting
+  // packets with the same port and source mac address, though the given
+  // entry is not visible north of SAI.
+  @id(ROUTING_SET_PORT_AND_SRC_MAC_ACTION_ID)
+  @action_restriction("
+    // Disallow invalid SRC MACs.
+    src_mac != 0;"
+  )
+  action set_port_and_src_mac(@id(1) port_id_t port,
+                              @id(2) @format(MAC_ADDRESS)
+                              ethernet_addr_t src_mac) {
+    unicast_set_port_and_src_mac_and_vlan_id(port, src_mac, INTERNAL_VLAN_ID);
+  }
+
+  // Sets SAI_ROUTER_INTERFACE_ATTR_TYPE to SAI_ROUTER_INTERFACE_TYPE_PORT, and
+  // SAI_ROUTER_INTERFACE_ATTR_PORT_ID, and
+  // SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS.
+  // Sets SAI_ROUTER_INTERFACE_ATTR_MY_MAC to a SAI_OBJECT_TYPE_MY_MAC, thus
+  // preventing the implicit creation of a MY_MAC entry in SAI (l3_admit_table
+  // at P4).
+  @id(UNICAST_SET_PORT_AND_SRC_MAC_ACTION_ID)
+   @action_restriction("
+    // Disallow invalid SRC MACs.
+    src_mac != 0;"
+  )
+  action unicast_set_port_and_src_mac(@id(1) port_id_t port,
+                              @id(2) @format(MAC_ADDRESS)
+                              ethernet_addr_t src_mac) {
+    unicast_set_port_and_src_mac_and_vlan_id(port, src_mac, INTERNAL_VLAN_ID);
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_ROUTER_INTERFACE_TABLE_ID)
+  table router_interface_table {
+    key = {
+      router_interface_id_value : exact @id(1)
+                                        @name("router_interface_id");
+    }
+    actions = {
+#if defined(RIF_PROGRAMMING_MY_MAC_SUPPORTED)
+      // TODO: Remove once no longer in use on our switches.
+      @proto_id(1) set_port_and_src_mac;
+#endif
+      @proto_id(2) unicast_set_port_and_src_mac_and_vlan_id;
+      @proto_id(3) unicast_set_port_and_src_mac;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = ROUTER_INTERFACE_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  // Sets SAI_NEXT_HOP_ATTR_TYPE to SAI_NEXT_HOP_TYPE_IP. Also sets
+  // SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID, SAI_NEXT_HOP_ATTR_IP,
+  // SAI_NEXT_HOP_ATTR_DISABLE_SRC_MAC_REWRITE,
+  // SAI_NEXT_HOP_ATTR_DISABLE_DST_MAC_REWRITE,
+  // SAI_NEXT_HOP_ATTR_DISABLE_DECREMENT_TTL and
+  // SAI_NEXT_HOP_ATTR_DISABLE_VLAN_REWRITE based on action parameters.
+  @id(ROUTING_SET_IP_NEXTHOP_AND_DISABLE_REWRITES_ACTION_ID)
+  action set_ip_nexthop_and_disable_rewrites(
+      @id(1)
+      @refers_to(router_interface_table, router_interface_id)
+      @refers_to(neighbor_table, router_interface_id)
+      router_interface_id_t router_interface_id,
+      @id(2) @format(IPV6_ADDRESS)
+      @refers_to(neighbor_table, neighbor_id)
+      ipv6_addr_t neighbor_id,
+      // TODO: Use @format(BOOL) once PDPI
+      // supports it.
+      @id(3) bit<1> disable_decrement_ttl,
+      @id(4) bit<1> disable_src_mac_rewrite,
+      @id(5) bit<1> disable_dst_mac_rewrite,
+      @id(6) bit<1> disable_vlan_rewrite) {
+    router_interface_id_valid = true;
+    router_interface_id_value = router_interface_id;
+    neighbor_id_valid = true;
+    neighbor_id_value = neighbor_id;
+    local_metadata.enable_decrement_ttl = !(bool) disable_decrement_ttl;
+    local_metadata.enable_src_mac_rewrite = !(bool) disable_src_mac_rewrite;
+    local_metadata.enable_dst_mac_rewrite = !(bool) disable_dst_mac_rewrite;
+    local_metadata.enable_vlan_rewrite = !(bool) disable_vlan_rewrite;
+  }
+
+  // Sets SAI_NEXT_HOP_ATTR_TYPE to SAI_NEXT_HOP_TYPE_IP, and
+  // SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID, and SAI_NEXT_HOP_ATTR_IP.
+  //
+  // This action can only refer to `router_interface_id`s and `neighbor_id`s,
+  // if `router_interface_id` is a key in the `router_interface_table`, and
+  // the `(router_interface_id, neighbor_id)` pair is a key in the
+  // `neighbor_table`.
+  //
+  // Note that the @refers_to annotation could be more precise if it allowed
+  // specifying that the pair (router_interface_id, neighbor_id) refers to the
+  // two match fields in neighbor_table. This is still correct, but less
+  // precise.
+  @id(ROUTING_SET_IP_NEXTHOP_ACTION_ID)
+  action set_ip_nexthop(
+      @id(1)
+      @refers_to(router_interface_table, router_interface_id)
+      @refers_to(neighbor_table, router_interface_id)
+      router_interface_id_t router_interface_id,
+      @id(2) @format(IPV6_ADDRESS)
+      @refers_to(neighbor_table, neighbor_id)
+      ipv6_addr_t neighbor_id) {
+    set_ip_nexthop_and_disable_rewrites(router_interface_id, neighbor_id,
+      /*disable_decrement_ttl*/0x0, /*disable_src_mac_rewrite*/0x0,
+      /*disable_dst_mac_rewrite*/0x0, /*disable_vlan_rewrite*/0x0);
+  }
+
+  // Sets SAI_NEXT_HOP_ATTR_TYPE to SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP, and
+  // SAI_NEXT_HOP_ATTR_TUNNEL_ID and SAI_NEXT_HOP_ATTR_IP.
+  //
+  // This action encodes a SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP, which also has a
+  // SAI_NEXT_HOP_ATTR_IP, but does not take it as a parameter.
+  // Because we are using P2P tunnels, this information is stored in the tunnel
+  // referred to by the tunnel id, so we omit it here to avoid redundancy in our
+  // specification.
+  @id(ROUTING_SET_P2P_TUNNEL_ENCAP_NEXTHOP_ACTION_ID)
+  action set_p2p_tunnel_encap_nexthop(@id(1) @refers_to(tunnel_table, tunnel_id)
+                            tunnel_id_t tunnel_id) {
+    tunnel_id_valid = true;
+    tunnel_id_value = tunnel_id;
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_NEXTHOP_TABLE_ID)
+  table nexthop_table {
+    key = {
+      local_metadata.nexthop_id_value : exact @id(1) @name("nexthop_id");
+    }
+    actions = {
+      @proto_id(1) set_ip_nexthop;
+#if defined(TUNNEL_ENCAP_CAPABLE)
+      @proto_id(2) set_p2p_tunnel_encap_nexthop;
+#endif
+#if defined (NEXTHOP_DISABLE_REWRITES_CAPABLE)
+      @proto_id(3) set_ip_nexthop_and_disable_rewrites;
+#endif
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = NEXTHOP_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  // Sets SAI_TUNNEL_ATTR_TYPE to SAI_TUNNEL_TYPE_IPINIP_GRE,
+  // SAI_TUNNEL_PEER_MODE to SAI_TUNNEL_PEER_MODE_P2P and
+  // also sets SAI_TUNNEL_ATTR_ENCAP_SRC_IP, SAI_TUNNEL_ATTR_ENCAP_DST_IP
+  // and SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE.
+  //
+  // Because we are using P2P tunnels, this action requires an `encap_dst_ip`,
+  // which will also be the `neighbor_id` of an associated `neighbor_table`
+  // entry.
+  @id(ROUTING_MARK_FOR_P2P_TUNNEL_ENCAP_ACTION_ID)
+  action mark_for_p2p_tunnel_encap(
+      @id(1) @format(IPV6_ADDRESS)
+      ipv6_addr_t encap_src_ip,
+      @id(2) @format(IPV6_ADDRESS)
+      @refers_to(neighbor_table, neighbor_id)
+      ipv6_addr_t encap_dst_ip,
+      @id(3) @refers_to(neighbor_table, router_interface_id)
+      @refers_to(router_interface_table, router_interface_id)
+      router_interface_id_t router_interface_id) {
+    local_metadata.tunnel_encap_src_ipv6 = encap_src_ip;
+    local_metadata.tunnel_encap_dst_ipv6 = encap_dst_ip;
+    local_metadata.apply_tunnel_encap_at_egress = true;
+    set_ip_nexthop(router_interface_id, encap_dst_ip);
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_TUNNEL_TABLE_ID)
+  table tunnel_table {
+    key = {
+      tunnel_id_value : exact @id(1)
+                              @name("tunnel_id");
+    }
+    actions = {
+      @proto_id(1) mark_for_p2p_tunnel_encap;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = ROUTING_TUNNEL_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+#if defined(SAI_INSTANTIATION_TOR)
+  @selector_size_semantics(WCMP_GROUP_DEFAULT_SELECTOR_SIZE_SEMANTICS_TOR)
+#else
+  @selector_size_semantics(WCMP_GROUP_DEFAULT_SELECTOR_SIZE_SEMANTICS_NON_TOR)
+#endif
+  @max_member_weight(WCMP_GROUP_SELECTOR_SUM_OF_MEMBERS_MAX_MEMBER_WEIGHT)
+#if defined(SAI_INSTANTIATION_TOR) 
+  @max_group_size(WCMP_GROUP_SELECTOR_SUM_OF_WEIGHTS_MAX_GROUP_SIZE_TOR)
+#else
+  @max_group_size(WCMP_GROUP_SELECTOR_SUM_OF_WEIGHTS_MAX_GROUP_SIZE_NON_TOR)
+#endif
+  @id(ROUTING_WCMP_GROUP_SELECTOR_ACTION_PROFILE_ID)
+  action_selector(HashAlgorithm.identity,
+#if defined(SAI_INSTANTIATION_TOR) 
+ WCMP_GROUP_SUM_OF_WEIGHTS_SIZE_TOR,
+#else
+ WCMP_GROUP_SUM_OF_WEIGHTS_SIZE_NON_TOR,
+#endif
+                  WCMP_SELECTOR_INPUT_BITWIDTH)
+      wcmp_group_selector;
+
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(ROUTING_WCMP_GROUP_TABLE_ID)
+  @oneshot()
+  table wcmp_group_table {
+    key = {
+      local_metadata.wcmp_group_id_value : exact @id(1) @name("wcmp_group_id");
+      local_metadata.wcmp_selector_input : selector;
+    }
+    actions = {
+      @proto_id(1) set_nexthop_id(local_metadata);
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+        implementation = wcmp_group_selector;
+#if defined(SAI_INSTANTIATION_TOR)
+    size = WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_TOR;
+#else
+    size = WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_NON_TOR;
+#endif
+  }
+
+  apply {
+    // The lpm tables may not set a valid `wcmp_group_id`, e.g. they may drop.
+    if (local_metadata.wcmp_group_id_valid) {
+      wcmp_group_table.apply();
+    }
+
+    // The lpm tables may not set a valid `nexthop_id`, e.g. they may drop.
+    // The `wcmp_group_table` should always set a valid `nexthop_id`.
+    if (local_metadata.nexthop_id_valid) {
+      nexthop_table.apply();
+#if defined(TUNNEL_ENCAP_CAPABLE)
+      if (tunnel_id_valid) {
+        tunnel_table.apply();
+      }
+#endif
+      // The `nexthop_table` should always set a valid
+      // `router_interface_id` and `neighbor_id`.
+      if (router_interface_id_valid && neighbor_id_valid) {
+        router_interface_table.apply();
+        neighbor_table.apply();
+      }
+    }
+   
+    if (local_metadata.redirect_port_valid) {
+      standard_metadata.egress_spec = local_metadata.redirect_port;
+    }
+
+    // Add metadata that is relevant for punted packets.
+    local_metadata.packet_in_target_egress_port = standard_metadata.egress_spec;
+    local_metadata.packet_in_ingress_port = standard_metadata.ingress_port;
+
+    // Act on ACL drop after routing resolution. That way ACL drop has higher
+    // precedence than L3 routing or ACL ingress redirect actions, even if the
+    // redirect action comes from an ingress ACL table with higher priority.
+    if (local_metadata.acl_drop) {
+      mark_to_drop(standard_metadata);
+    }
+  }
+} // control routing_resolution.
+
+#endif  // SAI_ROUTING_P4_

--- a/e2e_tests/sai_p4/fixed/tunnel_termination.p4
+++ b/e2e_tests/sai_p4/fixed/tunnel_termination.p4
@@ -1,0 +1,119 @@
+// Tunnel termination aka decap, modeled after `saitunnel.h`,
+
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SAI_TUNNEL_TERMINATION_P4_
+#define SAI_TUNNEL_TERMINATION_P4_
+
+#include <v1model.p4>
+#include "headers.p4"
+#include "metadata.p4"
+#include "ids.h"
+#include "minimum_guaranteed_sizes.h"
+
+// Should be applied at the end of the pre-ingress stage.
+control tunnel_termination(inout headers_t headers,
+                                  inout local_metadata_t local_metadata) {
+  bool marked_for_ip_in_ipv6_decap = false;
+
+  @id(TUNNEL_DECAP_ACTION_ID)
+  action tunnel_decap() {
+    local_metadata.tunnel_termination_table_hit = true;
+  }
+
+  // Models SAI_TUNNEL_TERM_TABLE.
+  // Currently, we only model IPv6 decap of IP-in-IP packets
+  @p4runtime_role(P4RUNTIME_ROLE_ROUTING)
+  @id(IPV6_TUNNEL_TERMINATION_TABLE_ID)
+  @entry_restriction("
+    // TODO: Remove when switch supports priority as a key for
+    // this table.
+    // The switch does not support priority as a key. In order to avoid
+    // conflicts between entries where the only difference is the
+    // priority, we choose a fixed priority arbitrarily.
+    ::priority == 900;
+  ")
+  table ipv6_tunnel_termination_table {
+    key = {
+      // Sets `SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP[_MASK]`.
+      headers.ipv6.dst_addr : ternary
+        @id(1) @name("dst_ipv6") @format(IPV6_ADDRESS);
+      // Sets `SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_SRC_IP[_MASK]`.
+      headers.ipv6.src_addr : ternary
+        @id(2) @name("src_ipv6") @format(IPV6_ADDRESS);
+    }
+    actions = {
+      @proto_id(1) tunnel_decap;
+    }
+    size = IPV6_TUNNEL_TERMINATION_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    // Currently, we only model tunnel termination of IP-in-IPv6 packets
+    // (SAI_TUNNEL_TYPE_IPINIP).
+    if (headers.ipv6.isValid()) {
+      // IP-in-IP encapsulation: 4in6 or 6in6.
+      if (headers.ipv6.next_header == IP_PROTOCOL_IPV4 ||
+          headers.ipv6.next_header == IP_PROTOCOL_IPV6) {
+        ipv6_tunnel_termination_table.apply();
+      }
+    }
+
+    // Decap the packet only if BOTH tunnel termination and l3 admit tables
+    if(local_metadata.tunnel_termination_table_hit &&
+       local_metadata.admit_to_l3) {
+      // Currently, this should only ever be set for IP-in-IPv6 packets.
+      // TODO: Remove guard once p4-symbolic suports assertions.
+#ifndef PLATFORM_P4SYMBOLIC
+      assert(headers.ipv6.isValid());
+      assert((headers.inner_ipv4.isValid() && !headers.inner_ipv6.isValid()) ||
+             (!headers.inner_ipv4.isValid() && headers.inner_ipv6.isValid()));
+#endif
+
+      // Decap: strip outer header and replace with inner header.
+      headers.ipv6.setInvalid();
+      if (headers.inner_ipv4.isValid()) {
+        headers.ethernet.ether_type = ETHERTYPE_IPV4;
+        // In case of multicast inner header, the DMAC gets overwritten to a 
+        // multicast address drived from the destination IP address.
+        if (IS_MULTICAST_IPV4(headers.inner_ipv4.dst_addr)){
+          // MAC Address for IPv4 multicast is 01:00:5E:xx:xx:xx where the 24th
+          // LSB is 0 and the 23 LSBs are the 23 LSBs of IPv4 dst address.
+          // https://en.wikipedia.org/wiki/Multicast_address#Ethernet
+          headers.ethernet.dst_addr = (bit<24>)0x01005E++(bit<1>)0++
+              headers.inner_ipv4.dst_addr[22:0];
+        }
+        headers.ipv4 = headers.inner_ipv4;
+        headers.inner_ipv4.setInvalid();
+      }
+      if (headers.inner_ipv6.isValid()) {
+        headers.ethernet.ether_type = ETHERTYPE_IPV6;
+        // In case of multicast inner header, the DMAC gets overwritten to a 
+        // multicast address drived from the destination IP address.
+        if (IS_MULTICAST_IPV6(headers.inner_ipv6.dst_addr)){
+          // MAC Address for IPv6 multicast is 33:33:xx:xx:xx:xx where the 32
+          // LSBs are the 32 LSBs of the IPv6 dst address.
+          // https://en.wikipedia.org/wiki/Multicast_address#Ethernet
+          headers.ethernet.dst_addr = (bit<16>)0x3333++
+              headers.inner_ipv6.dst_addr[31:0];
+        }
+        headers.ipv6 = headers.inner_ipv6;
+        headers.inner_ipv6.setInvalid();
+      }
+    }
+  }
+}
+
+#endif  // SAI_TUNNEL_TERMINATION_P4_

--- a/e2e_tests/sai_p4/fixed/vlan.p4
+++ b/e2e_tests/sai_p4/fixed/vlan.p4
@@ -1,0 +1,268 @@
+// A preliminary, incomplete model of IEEE 802.1Q VLAN.
+
+#ifndef SAI_VLAN_P4_
+#define SAI_VLAN_P4_
+
+#include <v1model.p4>
+#include "common_actions.p4"
+#include "headers.p4"
+#include "metadata.p4"
+#include "minimum_guaranteed_sizes.h"
+
+
+control vlan_untag(inout headers_t headers,
+                   inout local_metadata_t local_metadata,
+                   inout standard_metadata_t standard_metadata) {
+
+  @id(DISABLE_VLAN_CHECKS_ACTION_ID)
+  action disable_vlan_checks() {
+    local_metadata.enable_vlan_checks = false;
+  }
+
+  // Models SAI_DISABLE_VLAN_CHECKS.
+  // If VLAN checks are enabled (i.e. if the table is empty), an ingress/egress
+  // packet with a VLAN tag containing a VID beside the reserved ones (0, 4095)
+  // gets dropped in ingress/egress pipelines, respectively (given the
+  // current switch configuration). With VLAN checks disabled, such drops do
+  // not happen.
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(DISABLE_VLAN_CHECKS_TABLE_ID)
+  @entry_restriction("
+    // Force the dummy_match to be wildcard.
+    dummy_match::mask == 0;
+  ")
+  table disable_vlan_checks_table {
+    key = {
+      // Note: In the P4_16 specification, a table with no match keys cannot have
+      // entries (only the default action can be programmed which does not fit
+      // well in our SDN ecosystem). To alleviate this, we add a dummy match but
+      // force it to always be wildcard.
+      1w1 : ternary @id(1) @name("dummy_match");
+    }
+    actions = {
+      @proto_id(1) disable_vlan_checks;
+    }
+    size = 1;
+  }
+
+  apply {
+     // Determine the vlan_id metadata.
+     if (headers.vlan.isValid()) {
+        // If input packet has a VLAN tag, use the VID from the tag.
+        local_metadata.vlan_id = headers.vlan.vlan_id;
+        // Invalidate the VLAN header. In doing so we move the ethertype placed
+        // after the VLAN tag (which we model as part of the VLAN tag due to P4
+        // language's limitations) to ethernet.ether_type.
+        headers.ethernet.ether_type = headers.vlan.ether_type;
+        headers.vlan.setInvalid();
+        // Store that the input packet has a VLAN tag. This is used to model the
+        // behavior of SET_OUTER_VLAN_ID action in the pre-ingress ACL.
+        local_metadata.input_packet_is_vlan_tagged = true;
+     } else {
+        // Otherwise, use native VID (4095 for all ports given the current
+        // configuration).
+        local_metadata.vlan_id = INTERNAL_VLAN_ID;
+     }
+
+     // VLAN checks are enabled by default.
+     local_metadata.enable_vlan_checks = true;
+     // Check if VLAN checks need to be disabled.
+     disable_vlan_checks_table.apply();
+  }
+}  // control vlan_untag
+
+// Apply VLAN checks for packets in ingress pipeline.
+// This control block assumes vlan_untag control block has been called
+// and VLAN-related information is stored in metadata instead of in headers.
+control ingress_vlan_checks(inout headers_t headers,
+                            inout local_metadata_t local_metadata,
+                            inout standard_metadata_t standard_metadata) {
+  // Ingress VLAN checks are enabled by default.
+  bool enable_ingress_vlan_checks = true;
+  bool ingress_port_is_member_of_vlan = false;
+
+  @id(DISABLE_INGRESS_VLAN_CHECKS_ACTION_ID)
+  action disable_ingress_vlan_checks() {
+    enable_ingress_vlan_checks = false;
+  }
+
+  // Models SAI_DISABLE_INGRESS_VLAN_CHECKS.
+  // If ingress VLAN checks are enabled (i.e. if the table is empty) and the
+  // ingress port is not a member of packet's VLAN at the end of the ingress
+  // pipeline, then the packet gets dropped (except for reserved VLANs 0 and
+  // 4095). With ingress VLAN checks disabled, such drops do not happen.
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(DISABLE_INGRESS_VLAN_CHECKS_TABLE_ID)
+  @entry_restriction("
+    // Force the dummy_match to be wildcard.
+    dummy_match::prefix_length == 0;
+  ")
+  table disable_ingress_vlan_checks_table {
+    key = {
+      // Note: In the P4_16 specification, a table with no match keys cannot
+      // have entries (only the default action can be programmed which does not
+      // fit well in our SDN ecosystem). To alleviate this, we add a dummy match
+      // but force it to always be wildcard. We use LPM as match type to prevent
+      // having multiple entires with different priorities.
+      1w1 : lpm
+        @id(1) @name("dummy_match");
+    }
+    actions = {
+      @proto_id(1) disable_ingress_vlan_checks;
+    }
+    size = 1;
+  }
+
+  apply {
+    // Ingress VLAN checks.
+    disable_ingress_vlan_checks_table.apply();
+    // TODO: Properly model the behavior for VIDs 0x001 and 0xFFF
+    // when Packet-IO is properly modeled.
+    // Failed ingress VLAN check should prevent packet from being admitted to
+    // L3 and IPMC lookup.Add commentMore actions
+    if (local_metadata.enable_vlan_checks &&
+        enable_ingress_vlan_checks &&
+        !ingress_port_is_member_of_vlan &&
+        !IS_RESERVED_VLAN_ID(local_metadata.vlan_id)) {
+      // Mark the packet as dropped by ingress VLAN checks.
+      local_metadata.marked_to_drop_by_ingress_vlan_checks = true;
+      mark_to_drop(standard_metadata);
+    }
+  }
+}  // control ingress_vlan_checks
+
+// Apply VLAN checks for packets in egress pipeline (except for punted packets).
+// This control block assumes vlan_tag control block has not been called and
+// VLAN-related information is stored in metadata, instead of in headers.
+control egress_vlan_checks(inout headers_t headers,
+                           inout local_metadata_t local_metadata,
+                           inout standard_metadata_t standard_metadata) {
+  port_id_t port = (port_id_t)standard_metadata.egress_port;
+  bool egress_port_is_member_of_vlan = false;
+  // Egress VLAN checks are enabled by default.
+  bool enable_egress_vlan_checks = true;
+
+  @id(DISABLE_EGRESS_VLAN_CHECKS_ACTION_ID)
+  action disable_egress_vlan_checks() {
+    enable_egress_vlan_checks = false;
+  }
+
+  // Models SAI_DISABLE_EGRESS_VLAN_CHECKS.
+  // If egress VLAN checks are enabled (i.e. if the table is empty) and the
+  // egress port is not a member of packet's VLAN at the end of the egress
+  // pipeline, then the packet gets dropped (except for reserved VLANs 0 and
+  // 4095). With egress VLAN checks disabled, such drops do not happen.
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(DISABLE_EGRESS_VLAN_CHECKS_TABLE_ID)
+  @entry_restriction("
+    // Force the dummy_match to be wildcard.
+    dummy_match::prefix_length == 0;
+  ")
+  table disable_egress_vlan_checks_table {
+    key = {
+      // Note: In the P4_16 specification, a table with no match keys cannot
+      // have entries (only the default action can be programmed which does not
+      // fit well in our SDN ecosystem). To alleviate this, we add a dummy match
+      // but force it to always be wildcard. We use LPM as match type to prevent
+      // having multiple entires with different priorities.
+      1w1 : lpm
+        @id(1) @name("dummy_match");
+    }
+    actions = {
+      @proto_id(1) disable_egress_vlan_checks;
+    }
+    size = 1;
+  }
+
+  @id(VLAN_MAKE_TAGGED_MEMBER_ACTION_ID)
+  action make_tagged_member() {
+    egress_port_is_member_of_vlan = true;
+  }
+
+  @id(VLAN_MAKE_UNTAGGED_MEMBER_ACTION_ID)
+  action make_untagged_member() {
+    egress_port_is_member_of_vlan = true;
+    local_metadata.omit_vlan_tag_on_egress_packet = true;
+  }
+
+  // Programming this table does not affect packet forwarding directly -- the
+  // table performs no actions -- but results in the creation/deletion of VLANs.
+  // This is a prerequisite to adding members to these VLANs in the
+  // `vlan_membership_table`, as is indicated by the
+  // `@refers_to(vlan_table, vlan_id)` annotations. Note that entries are ONLY
+  // needed for the VLAN membership table (e.g. matching on or setting VLAN
+  // does not require entries in this table).
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(VLAN_TABLE_ID)
+  @entry_restriction("
+    // Disallow creating reserved VLANs to rule out vendor specific behavior.
+    vlan_id != 0 && vlan_id != 4095;
+  ")
+  table vlan_table {
+    key = {
+      local_metadata.vlan_id : exact
+        @id(1) @name("vlan_id");
+    }
+    actions = {
+      @proto_id(1) no_action;
+    }
+    size = VLAN_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(VLAN_MEMBERSHIP_TABLE_ID)
+  table vlan_membership_table {
+    key = {
+      local_metadata.vlan_id : exact
+        @id(1) @name("vlan_id") @refers_to(vlan_table, vlan_id);
+      port: exact
+        @id(2) @name("port");
+    }
+    actions = {
+      @proto_id(1) make_tagged_member;
+      @proto_id(2) make_untagged_member;
+      @defaultonly NoAction;
+    }
+    size = VLAN_MEMBERSHIP_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    // Egress VLAN checks.
+    disable_egress_vlan_checks_table.apply();
+    vlan_table.apply();
+    if (!IS_PACKET_IN_COPY(standard_metadata) &&
+        !IS_MIRROR_COPY(standard_metadata)) {
+      vlan_membership_table.apply();
+      if (local_metadata.enable_vlan_checks &&
+          enable_egress_vlan_checks &&
+          !egress_port_is_member_of_vlan &&
+          !IS_RESERVED_VLAN_ID(local_metadata.vlan_id)) {
+        mark_to_drop(standard_metadata);
+      }
+    }
+  }
+} // control egress_vlan_checks
+
+// Add a VLAN tag for forwarded packets that have non-reserved vlan ids.
+control vlan_tag(inout headers_t headers,
+                 inout local_metadata_t local_metadata,
+                 inout standard_metadata_t standard_metadata) {
+  apply {
+    if (!IS_RESERVED_VLAN_ID(local_metadata.vlan_id) &&
+        !IS_MIRROR_COPY(standard_metadata) &&
+        !local_metadata.omit_vlan_tag_on_egress_packet) {
+      // Mirroring encapsulates a series of headers, including a VLAN header.
+      // To seperate concerns, vlan encapping for mirroring is skipped here.
+      headers.vlan.setValid();
+      headers.vlan.priority_code_point = 0;
+      headers.vlan.drop_eligible_indicator = 0;
+      headers.vlan.vlan_id = local_metadata.vlan_id;
+      // Move ethernet.ether_type to vlan.ether_type so that it can be
+      // placed after the VLAN tag during deparsing.
+      headers.vlan.ether_type = headers.ethernet.ether_type;
+      headers.ethernet.ether_type = ETHERTYPE_8021Q;
+    }
+  }
+}  // control vlan_tag
+
+#endif  // SAI_VLAN_P4_

--- a/e2e_tests/sai_p4/instantiations/google/acl_common_actions.p4
+++ b/e2e_tests/sai_p4/instantiations/google/acl_common_actions.p4
@@ -1,0 +1,13 @@
+#ifndef SAI_ACL_COMMON_ACTIONS_P4_
+#define SAI_ACL_COMMON_ACTIONS_P4_
+
+#include <v1model.p4>
+#include "ids.h"
+
+@id(ACL_DROP_ACTION_ID)
+@sai_action(SAI_PACKET_ACTION_DROP)
+action acl_drop(inout local_metadata_t local_metadata) {
+  local_metadata.acl_drop = true;
+}
+
+#endif  // SAI_ACL_COMMON_ACTIONS_P4_

--- a/e2e_tests/sai_p4/instantiations/google/acl_egress.p4
+++ b/e2e_tests/sai_p4/instantiations/google/acl_egress.p4
@@ -1,0 +1,189 @@
+#ifndef SAI_ACL_EGRESS_P4_
+#define SAI_ACL_EGRESS_P4_
+
+#include <v1model.p4>
+#include "../../fixed/headers.p4"
+#include "../../fixed/metadata.p4"
+#include "acl_common_actions.p4"
+#include "ids.h"
+#include "minimum_guaranteed_sizes.h"
+#include "roles.h"
+
+control acl_egress(in headers_t headers,
+                    inout local_metadata_t local_metadata,
+                    inout standard_metadata_t standard_metadata) {
+  // First 6 bits of IPv4 TOS or IPv6 traffic class (or 0, for non-IP packets)
+  bit<6> dscp = 0;
+  // IPv4 IP protocol or IPv6 next_header (or 0, for non-IP packets)
+  bit<8> ip_protocol = 0;
+
+  @id(ACL_EGRESS_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_egress_counter;
+
+  @id(ACL_EGRESS_L2_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_egress_l2_counter;
+
+  @id(ACL_EGRESS_DHCP_TO_HOST_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_egress_dhcp_to_host_counter;
+
+  // A forwarding action specific to the egress pipeline.
+  @id(ACL_EGRESS_FORWARD_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action acl_egress_forward() {
+    acl_egress_counter.count();
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(ACL_EGRESS_TABLE_ID)
+  @sai_acl(EGRESS)
+  @nonessential_for_upgrade
+  @entry_restriction("
+#ifdef SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).
+    ether_type != 0x0800 && ether_type != 0x86dd;
+    // Forbid match on ethertype if is_ip* is set.
+    (is_ip::mask != 0 || is_ipv4::mask != 0 || is_ipv6::mask != 0) -> ether_type::mask == 0;
+    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+#endif
+    // Only allow IP field matches for IP packets.
+    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+#if defined(SAI_INSTANTIATION_TOR) 
+    dst_ipv6::mask != 0 -> is_ipv6 == 1;
+#endif
+#ifdef SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+    // Only allow l4_dst_port matches for TCP/UDP packets.
+    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+#endif
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+  ")
+  table acl_egress_table {
+    key = {
+#ifdef SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+      headers.ethernet.ether_type : ternary @name("ether_type") @id(1)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE);
+#endif
+      ip_protocol : ternary @name("ip_protocol") @id(2)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL);
+#ifdef SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+      local_metadata.l4_dst_port : ternary @name("l4_dst_port") @id(3)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT);
+#endif
+      (port_id_t)standard_metadata.egress_port: optional @name("out_port")
+          @id(4) @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUT_PORT);
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional @name("is_ip")
+          @id(5) @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional @name("is_ipv4") @id(6)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional @name("is_ipv6") @id(7)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+#ifdef SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+      // Field for v4 and v6 DSCP bits.
+      dscp : ternary @name("dscp") @id(8)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP);
+#endif
+#if defined(SAI_INSTANTIATION_TOR) 
+      headers.ipv6.dst_addr[127:64] : ternary @name("dst_ipv6") @id(9)
+          @composite_field(
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD3),
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD2)
+          ) @format(IPV6_ADDRESS);
+#endif
+    }
+    actions = {
+      @proto_id(1) acl_drop(local_metadata);
+#if defined(SAI_INSTANTIATION_TOR) 
+      @proto_id(2) acl_egress_forward();
+#endif
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    counters = acl_egress_counter;
+    size = ACL_EGRESS_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @id(ACL_EGRESS_DHCP_TO_HOST_TABLE_ID)
+  @sai_acl(EGRESS)
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @nonessential_for_upgrade
+  @entry_restriction("
+    // Only allow IP field matches for IP packets.
+    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    // Only allow l4_dst_port matches for TCP/UDP packets.
+    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+  ")
+  table acl_egress_dhcp_to_host_table {
+    key = {
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional
+          @id(1) @name("is_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional
+          @id(2) @name("is_ipv4")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional
+          @id(3) @name("is_ipv6")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      ip_protocol : ternary
+          @id(5) @name("ip_protocol")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL);
+      local_metadata.l4_dst_port : ternary
+          @id(6) @name("l4_dst_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT);
+      (port_id_t)standard_metadata.egress_port: optional
+          @id(7) @name("out_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUT_PORT);
+    }
+    actions = {
+      @proto_id(1) acl_drop(local_metadata);
+      @proto_id(2) acl_egress_forward();
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    counters = acl_egress_dhcp_to_host_counter;
+    size = ACL_EGRESS_DHCP_TO_HOST_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    // We configure the hardware to explictly ignore the ACL egress tables for
+    // CPU traffic.
+    if (standard_metadata.egress_port != SAI_P4_CPU_PORT) {
+      if (headers.ipv4.isValid()) {
+        dscp = headers.ipv4.dscp;
+        ip_protocol = headers.ipv4.protocol;
+      } else if (headers.ipv6.isValid()) {
+        dscp = headers.ipv6.dscp;
+        if (headers.hop_by_hop_options.isValid()) {
+        ip_protocol = headers.hop_by_hop_options.next_header;
+      }
+      else {
+        ip_protocol = headers.ipv6.next_header;
+      }
+      } else {
+        ip_protocol = 0;
+      }
+
+      acl_egress_table.apply();
+#if defined(SAI_INSTANTIATION_TOR)
+      acl_egress_dhcp_to_host_table.apply();
+#endif
+    // Act on ACL drop metadata.
+      if (local_metadata.acl_drop) {
+        mark_to_drop(standard_metadata);
+      }
+    }
+  }
+}  // control ACL_EGRESS
+
+#endif  // SAI_ACL_EGRESS_P4_

--- a/e2e_tests/sai_p4/instantiations/google/acl_ingress.p4
+++ b/e2e_tests/sai_p4/instantiations/google/acl_ingress.p4
@@ -1,0 +1,918 @@
+#ifndef SAI_ACL_INGRESS_P4_
+#define SAI_ACL_INGRESS_P4_
+
+#include <v1model.p4>
+#include "../../fixed/headers.p4"
+#include "../../fixed/metadata.p4"
+#include "../../fixed/packet_io.p4"
+#include "acl_common_actions.p4"
+#include "ids.h"
+#include "minimum_guaranteed_sizes.h"
+
+control acl_ingress(in headers_t headers,
+                    inout local_metadata_t local_metadata,
+                    inout standard_metadata_t standard_metadata) {
+  // IPv4 TTL or IPv6 hoplimit bits (or 0, for non-IP packets)
+  bit<8> ttl = 0;
+  // First 6 bits of IPv4 TOS or IPv6 traffic class (or 0, for non-IP packets)
+  bit<6> dscp = 0;
+  // Last 2 bits of IPv4 TOS or IPv6 traffic class (or 0, for non-IP packets)
+  bit<2> ecn = 0;
+  // IPv4 IP protocol or IPv6 next_header (or 0, for non-IP packets)
+  bit<8> ip_protocol = 0;
+  // Cancels out local_metadata.marked_to_copy when true.
+  bool cancel_copy = false;
+  // Hop-by-hop options header used for ACL lookup (defaults to outer header).
+  hop_by_hop_options_t hop_by_hop_options = headers.hop_by_hop_options;
+
+  @id(ACL_INGRESS_METER_ID)
+  @mode(single_rate_two_color)
+  direct_meter<MeterColor_t>(MeterType.bytes) acl_ingress_meter;
+
+  @id(ACL_INGRESS_QOS_METER_ID)
+  @mode(single_rate_two_color)
+  direct_meter<MeterColor_t>(MeterType.bytes) acl_ingress_qos_meter;
+
+  @id(ACL_INGRESS_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_ingress_counter;
+
+  @id(ACL_INGRESS_QOS_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_ingress_qos_counter;
+
+  @id(ACL_INGRESS_COUNTING_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_ingress_counting_counter;
+
+  @id(ACL_INGRESS_SECURITY_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_ingress_security_counter;
+
+  // Copy the packet to the CPU, and forward the original packet.
+  @id(ACL_INGRESS_COPY_ACTION_ID)
+#if defined(SAI_INSTANTIATION_TOR)
+  // In ToRs, the acl_ingress_table copy action will not apply a rate limit.
+  // Rate limits will be applied by acl_ingress_qos_table cancel_copy actions.
+  @sai_action(SAI_PACKET_ACTION_COPY)
+  //TODO: Rename parameter to `cpu_queue`.
+  action acl_copy(@sai_action_param(QOS_QUEUE) @id(1) cpu_queue_t qos_queue) {
+    acl_ingress_counter.count();
+    local_metadata.marked_to_copy = true;
+  }
+#else
+  @sai_action(SAI_PACKET_ACTION_COPY, SAI_PACKET_COLOR_GREEN)
+  @sai_action(SAI_PACKET_ACTION_FORWARD, SAI_PACKET_COLOR_RED)
+  //TODO: Rename parameter to `cpu_queue`.
+  //TODO: Rename type to `cpu_queue_t`.
+  action acl_copy(@sai_action_param(QOS_QUEUE) @id(1) cpu_queue_t qos_queue) {
+    acl_ingress_counter.count();
+    acl_ingress_meter.read(local_metadata.color);
+
+    // We model the behavior for GREEN packets only.
+    // TODO: Branch on color and model behavior for all colors.
+    local_metadata.marked_to_copy = true;
+  }
+#endif
+  // Copy the packet to the CPU. The original packet is dropped.
+  @id(ACL_INGRESS_TRAP_ACTION_ID)
+#if defined(SAI_INSTANTIATION_TOR)
+  // In ToRs, the acl_ingress_table trap action will not apply a rate limit.
+  // Rate limits will be applied by acl_ingress_qos_table cancel_copy actions.
+  @sai_action(SAI_PACKET_ACTION_TRAP)
+#else
+  @sai_action(SAI_PACKET_ACTION_TRAP, SAI_PACKET_COLOR_GREEN)
+  @sai_action(SAI_PACKET_ACTION_DROP, SAI_PACKET_COLOR_RED)
+#endif
+  //TODO: Rename parameter to `cpu_queue`.
+  action acl_trap(@sai_action_param(QOS_QUEUE) @id(1) cpu_queue_t qos_queue) {
+    acl_copy(qos_queue);
+    // TODO: Use `acl_drop(local_metadata)` instead when supported
+    // in P4-Symbolic.
+    local_metadata.acl_drop = true;
+  }
+
+  // Forward the packet normally (i.e., perform no action). This is useful as
+  // the default action, and to specify a meter but not otherwise perform any
+  // action.
+  @id(ACL_INGRESS_FORWARD_ACTION_ID)
+#if defined(SAI_INSTANTIATION_TOR)
+  // ToRs rely on QoS queues to limit forwarded flows.
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action acl_forward() {
+  }
+#else
+  @sai_action(SAI_PACKET_ACTION_FORWARD, SAI_PACKET_COLOR_GREEN)
+  @sai_action(SAI_PACKET_ACTION_DROP, SAI_PACKET_COLOR_RED)
+  action acl_forward() {
+    acl_ingress_meter.read(local_metadata.color);
+    // We model the behavior for GREEN packes only here.
+    // TODO: Branch on color and model behavior for all colors.
+  }
+#endif
+
+  // Forward the packet normally (i.e., perform no action).
+  @id(ACL_INGRESS_COUNT_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action acl_count() {
+    acl_ingress_counting_counter.count();
+  }
+
+  @id(ACL_INGRESS_MIRROR_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action acl_mirror(
+      @id(1)
+      @refers_to(mirror_session_table, mirror_session_id)
+      @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS)
+      mirror_session_id_t mirror_session_id) {
+    acl_ingress_counter.count();
+    local_metadata.marked_to_mirror = true;
+    local_metadata.mirror_session_id = mirror_session_id;
+  }
+
+  @id(ACL_INGRESS_SET_QOS_QUEUE_AND_CANCEL_COPY_ABOVE_RATE_LIMIT_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD, SAI_PACKET_COLOR_GREEN)
+  @sai_action(SAI_PACKET_ACTION_COPY_CANCEL, SAI_PACKET_COLOR_RED)
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  @unsupported
+  // TODO: Rename qos queue to cpu queue, as per action below.
+  action set_qos_queue_and_cancel_copy_above_rate_limit(
+      @id(1) @sai_action_param(QOS_QUEUE) cpu_queue_t qos_queue) {
+    acl_ingress_qos_meter.read(local_metadata.color);
+    // TODO: Implement rate-limit flows for ToR use-case. Changes
+    // needed:
+    //  * acl_ingress.p4 shouldn't set rate limits.
+    //  * acl_ingress_qos.p4 should have a meter.
+    //  * This action should model behaviors.
+  }
+
+  @id(ACL_INGRESS_SET_CPU_QUEUE_AND_CANCEL_COPY_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_COPY_CANCEL)
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  @unsupported
+  action set_cpu_queue_and_cancel_copy(
+      @id(1) @sai_action_param(QOS_QUEUE) cpu_queue_t cpu_queue) {
+    cancel_copy = true;
+  }
+
+  // Forwards green packets normally and sets their DSCP to the given value.
+  // Otherwise, drops packets and ensures that they are not copied to the CPU.
+  // Also sets CPU queue, Multicast queue, and Unicast queue, with different
+  // multicast queues set depending on packet color.
+  @id(ACL_INGRESS_SET_DSCP_AND_QUEUES_AND_DENY_ABOVE_RATE_LIMIT_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD, SAI_PACKET_COLOR_GREEN)
+  @sai_action(SAI_PACKET_ACTION_DENY, SAI_PACKET_COLOR_RED)
+  // TODO: Remove @unsupported annotation.
+  @unsupported
+  action set_dscp_and_queues_and_deny_above_rate_limit(
+      @id(1) @sai_action_param(SAI_ACL_ACTION_TYPE_SET_DSCP) bit<6> dscp,
+      @id(2) @sai_action_param(QOS_QUEUE) cpu_queue_t cpu_queue,
+      @id(3) @sai_action_param(SAI_POLICER_ATTR_COLORED_PACKET_SET_MCAST_COS_QUEUE_ACTION, SAI_PACKET_COLOR_GREEN)
+        multicast_queue_t green_multicast_queue,
+      @id(4) @sai_action_param(SAI_POLICER_ATTR_COLORED_PACKET_SET_MCAST_COS_QUEUE_ACTION, SAI_PACKET_COLOR_RED)
+        multicast_queue_t red_multicast_queue,
+      @id(5) @sai_action_param(SAI_POLICER_ATTR_COLORED_PACKET_SET_UCAST_COS_QUEUE_ACTION, SAI_PACKET_COLOR_GREEN)
+        unicast_queue_t green_unicast_queue,
+      @id(6) @sai_action_param(SAI_POLICER_ATTR_COLORED_PACKET_SET_UCAST_COS_QUEUE_ACTION, SAI_PACKET_COLOR_RED)
+        unicast_queue_t red_unicast_queue) {
+    acl_ingress_qos_meter.read(local_metadata.color);
+    local_metadata.enable_dscp_rewrite = true;
+    local_metadata.packet_rewrites.dscp = dscp;
+    // We model the behavior for GREEN packes only here.
+    // TODO: Branch on color and model behavior for all colors.
+  }
+
+  // Forwards green packets normally. Otherwise, drops packets and ensures that
+  // they are not copied to the CPU.
+  @id(ACL_INGRESS_SET_CPU_QUEUE_AND_DENY_ABOVE_RATE_LIMIT_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD, SAI_PACKET_COLOR_GREEN)
+  @sai_action(SAI_PACKET_ACTION_DENY, SAI_PACKET_COLOR_RED)
+  action set_cpu_queue_and_deny_above_rate_limit(
+      @id(1) @sai_action_param(QOS_QUEUE) cpu_queue_t cpu_queue) {
+    acl_ingress_qos_meter.read(local_metadata.color);
+    // We model the behavior for GREEN packes only here.
+    // TODO: Branch on color and model behavior for all colors.
+  }
+
+  // Forwards packets normally. Sets CPU queue.
+  @id(ACL_INGRESS_SET_CPU_QUEUE_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action set_cpu_queue(
+      @id(1) @sai_action_param(QOS_QUEUE) cpu_queue_t cpu_queue) {
+  }
+
+  // Forwards packets normally. Sets Multicast and unicast queues depending on
+  // packet color.
+  @id(ACL_INGRESS_SET_FORWARDING_QUEUES_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action set_forwarding_queues(
+      @id(1) @sai_action_param(SAI_POLICER_ATTR_COLORED_PACKET_SET_MCAST_COS_QUEUE_ACTION, SAI_PACKET_COLOR_GREEN)
+        multicast_queue_t green_multicast_queue,
+      @id(2) @sai_action_param(SAI_POLICER_ATTR_COLORED_PACKET_SET_MCAST_COS_QUEUE_ACTION, SAI_PACKET_COLOR_RED)
+        multicast_queue_t red_multicast_queue,
+      @id(3) @sai_action_param(SAI_POLICER_ATTR_COLORED_PACKET_SET_UCAST_COS_QUEUE_ACTION, SAI_PACKET_COLOR_GREEN)
+        unicast_queue_t green_unicast_queue,
+      @id(4) @sai_action_param(SAI_POLICER_ATTR_COLORED_PACKET_SET_UCAST_COS_QUEUE_ACTION, SAI_PACKET_COLOR_RED)
+        unicast_queue_t red_unicast_queue) {
+    acl_ingress_qos_meter.read(local_metadata.color);
+  }
+
+  // Drops the packet at the end of the the pipeline and ensures that it is not
+  // copied to the CPU. See `acl_drop` for more information on the mechanism of
+  // the drop.
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  @unsupported
+  @id(ACL_INGRESS_DENY_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_DENY)
+  action acl_deny() {
+    cancel_copy = true;
+    // TODO: Use `acl_drop(local_metadata)` instead when supported
+    // in P4-Symbolic.
+    local_metadata.acl_drop = true;
+  }
+
+  @id(ACL_INGRESS_REDIRECT_TO_L2MC_GROUP_ACTION_ID)
+  @action_restriction("
+    // Disallow 0 since it encodes 'no multicast' in V1Model.
+    multicast_group_id != 0;
+  ")
+  action redirect_to_l2mc_group(
+    @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT)
+    @sai_action_param_object_type(SAI_OBJECT_TYPE_L2MC_GROUP)
+    @refers_to(builtin::multicast_group_table, multicast_group_id)
+    multicast_group_id_t multicast_group_id) {
+    // Mark that we are using ACLs to redirect the packet to an L2 multicast
+    // group.
+    local_metadata.acl_ingress_l2mc_redirect = true;
+
+    standard_metadata.mcast_grp = multicast_group_id;
+
+    // Cancel other forwarding decisions (if any).
+    local_metadata.nexthop_id_valid = false;
+    local_metadata.wcmp_group_id_valid = false;
+  }
+
+  @id(ACL_INGRESS_REDIRECT_TO_NEXTHOP_ACTION_ID)
+  action redirect_to_nexthop(
+    @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT)
+    @sai_action_param_object_type(SAI_OBJECT_TYPE_NEXT_HOP)
+    @refers_to(nexthop_table, nexthop_id)
+    nexthop_id_t nexthop_id) {
+    // Mark that we are using ACLs to redirect the packet to a nexthop.
+    local_metadata.acl_ingress_nexthop_redirect = true;
+
+    // Set nexthop id.
+    local_metadata.nexthop_id_valid = true;
+    local_metadata.nexthop_id_value = nexthop_id;
+
+    // Cancel other forwarding decisions (if any).
+    local_metadata.wcmp_group_id_valid = false;
+    standard_metadata.mcast_grp = 0;
+  }
+
+  @id(ACL_INGRESS_APPEND_INGRESS_AND_EGRESS_TIMESTAMP_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+#ifdef SAI_INSTANTIATION_TOR
+  // TODO: Remove unsupported from ToR when we order ACL
+  // insert/deletes during reconcile.
+#endif
+  @unsupported
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  action append_ingress_and_egress_timestamp(
+    @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_INSERT_INGRESS_TIMESTAMP)
+    bit<8> append_ingress_timestamp,
+    @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_INSERT_EGRESS_TIMESTAMP)
+    bit<8> append_egress_timestamp) {
+    // Treated as a noop in P4 since we can't predict the specific timestamp
+    // values.
+  }  
+
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(ACL_INGRESS_TABLE_ID)
+  @sai_acl(INGRESS)
+  @sai_acl_priority(5)
+  @nonessential_for_upgrade
+#if defined(SAI_INSTANTIATION_TOR)
+  @reinstall_during_upgrade
+#endif
+  @entry_restriction("
+    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).
+    ether_type != 0x0800 && ether_type != 0x86dd;
+    // Forbid match on ethertype if is_ip* is set.
+    (is_ip::mask != 0 || is_ipv4::mask != 0 || is_ipv6::mask != 0) -> ether_type::mask == 0;
+    // Only allow IP field matches for IP packets.
+    dst_ip::mask != 0 -> is_ipv4 == 1;
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK) || defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+    src_ip::mask != 0 -> is_ipv4 == 1;
+#endif
+    dst_ipv6::mask != 0 -> is_ipv6 == 1;
+    src_ipv6::mask != 0 -> is_ipv6 == 1;
+    ttl::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK) || defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+#endif
+    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.
+    l4_src_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK) || defined(SAI_INSTANTIATION_TOR)
+    // Only allow arp_tpa matches for ARP packets.
+    arp_tpa::mask != 0 -> ether_type == 0x0806;
+#endif
+#if defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER) || defined(SAI_INSTANTIATION_TOR)
+    // Only allow icmp_type matches for ICMP packets
+    icmp_type::mask != 0 -> ip_protocol == 1;
+#endif
+    icmpv6_type::mask != 0 -> ip_protocol == 58;
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+  ")
+  table acl_ingress_table {
+    key = {
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional @name("is_ip") @id(1)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional @name("is_ipv4") @id(2)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional @name("is_ipv6") @id(3)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      headers.ethernet.ether_type : ternary @name("ether_type") @id(4)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE);
+      headers.ethernet.dst_addr : ternary @name("dst_mac") @id(5)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_MAC) @format(MAC_ADDRESS);
+      headers.ipv4.src_addr : ternary @name("src_ip") @id(6)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_IP) @format(IPV4_ADDRESS);
+      headers.ipv4.dst_addr : ternary @name("dst_ip") @id(7)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IP) @format(IPV4_ADDRESS);
+      headers.ipv6.src_addr[127:64] : ternary @name("src_ipv6") @id(8)
+          @composite_field(
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6_WORD3),
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6_WORD2)
+          ) @format(IPV6_ADDRESS);
+      headers.ipv6.dst_addr[127:64] : ternary @name("dst_ipv6") @id(9)
+          @composite_field(
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD3),
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD2)
+          ) @format(IPV6_ADDRESS);
+      // Field for v4 TTL and v6 hop_limit
+      ttl : ternary @name("ttl") @id(10)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_TTL);
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK) || defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+      dscp : ternary @name("dscp") @id(11)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP);
+      // Field for v4 and v6 ECN bits.
+      ecn : ternary @name("ecn") @id(12)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ECN);
+#endif
+      // Field for v4 IP protocol and v6 next header.
+      ip_protocol : ternary
+          @id(13) @name("ip_protocol")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL);
+#if defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER) || defined(SAI_INSTANTIATION_TOR)
+      headers.icmp.type : ternary
+          @id(19) @name("icmp_type")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMP_TYPE);
+#endif
+      headers.icmp.type : ternary @name("icmpv6_type") @id(14)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE);
+      local_metadata.l4_src_port : ternary @name("l4_src_port") @id(20)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT);
+      local_metadata.l4_dst_port : ternary @name("l4_dst_port") @id(15)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT);
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK) || defined(SAI_INSTANTIATION_TOR)
+      headers.arp.target_proto_addr : ternary
+          @id(16) @name("arp_tpa")
+          @composite_field(
+              @sai_udf(base=SAI_UDF_BASE_L3, offset=24, length=2),
+              @sai_udf(base=SAI_UDF_BASE_L3, offset=26, length=2)
+          ) @format(IPV4_ADDRESS);
+#endif
+#if defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER) || defined(SAI_INSTANTIATION_TOR) 
+      local_metadata.ingress_port : optional @name("in_port") @id(17)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT);
+      local_metadata.route_metadata : optional @name("route_metadata") @id(18)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST_USER_META);
+#endif
+#if defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER) || defined(SAI_INSTANTIATION_TOR)
+      local_metadata.acl_metadata : ternary
+          @id(21) @name("acl_metadata")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_USER_META);
+#endif
+#if defined(SAI_INSTANTIATION_TOR)
+      local_metadata.vlan_id : ternary
+        @id(22) @name("vlan_id")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID);
+#endif
+    }
+    actions = {
+      @proto_id(1) acl_copy();
+      @proto_id(2) acl_trap();
+      @proto_id(3) acl_forward();
+#if defined(MIRROR_CAPABLE)
+      @proto_id(4) acl_mirror();
+#endif
+      @proto_id(5) acl_drop(local_metadata);
+      @proto_id(6) redirect_to_l2mc_group();
+#if defined(ACL_REDIRECT_TO_NEXTHOP_CAPABLE)
+      @proto_id(7) redirect_to_nexthop();
+#endif
+#if defined(TIMESTAMP_CAPABLE)
+      @proto_id(8) append_ingress_and_egress_timestamp();
+#endif
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK) || defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+    meters = acl_ingress_meter;
+    counters = acl_ingress_counter;
+#else
+    counters = acl_ingress_counter;
+#endif
+    size = ACL_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @id(ACL_INGRESS_QOS_TABLE_ID)
+  @sai_acl(INGRESS)
+  @sai_acl_priority(10)
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @nonessential_for_upgrade
+#if defined(SAI_INSTANTIATION_TOR)
+  @reinstall_during_upgrade
+#endif
+  @entry_restriction("
+    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).
+    ether_type != 0x0800 && ether_type != 0x86dd;
+    // Forbid match on ethertype if is_ip* is set.
+    (is_ip::mask != 0 || is_ipv4::mask != 0 || is_ipv6::mask != 0) -> ether_type::mask == 0;
+    // Only allow IP field matches for IP packets.
+    ttl::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    // Only allow l4_dst_port matches for TCP/UDP packets.
+    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+    // Only allow icmp_type matches for ICMP packets
+    icmpv6_type::mask != 0 -> ip_protocol == 58;
+#ifdef SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+    // Only allow l4_dst_port matches for TCP/UDP packets.
+    l4_src_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+    // Only allow icmp_type matches for ICMP packets
+    icmp_type::mask != 0 -> ip_protocol == 1;
+#endif
+#if defined(SAI_INSTANTIATION_TOR)
+    // Only allow arp_tpa matches for ARP packets.
+    arp_tpa::mask != 0 -> ether_type == 0x0806;
+#endif
+  ")
+  table acl_ingress_qos_table {
+    key = {
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional
+          @id(1) @name("is_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional
+          @id(2) @name("is_ipv4")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional
+          @id(3) @name("is_ipv6")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      headers.ethernet.ether_type : ternary
+          @id(4) @name("ether_type")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE);
+      ttl : ternary
+          @id(7) @name("ttl")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_TTL);
+      ip_protocol : ternary
+          @id(8) @name("ip_protocol")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL);
+      headers.icmp.type : ternary
+          @id(9) @name("icmpv6_type")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE);
+      local_metadata.l4_dst_port : ternary
+          @id(10) @name("l4_dst_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT);
+      local_metadata.acl_metadata : ternary
+          @id(13) @name("acl_metadata")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_USER_META);
+      local_metadata.route_metadata : ternary
+          @id(15) @name("route_metadata")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST_USER_META);
+#ifdef SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+      local_metadata.l4_src_port : ternary
+          @id(12) @name("l4_src_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT);
+      headers.icmp.type : ternary
+          @id(14) @name("icmp_type")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMP_TYPE);
+#endif
+#if defined(SAI_INSTANTIATION_TOR)
+      headers.ethernet.dst_addr : ternary
+          @id(5) @name("dst_mac")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_MAC) @format(MAC_ADDRESS);
+      headers.arp.target_proto_addr : ternary
+          @id(6) @name("arp_tpa")
+          @composite_field(
+              @sai_udf(base=SAI_UDF_BASE_L3, offset=24, length=2),
+              @sai_udf(base=SAI_UDF_BASE_L3, offset=26, length=2)
+          ) @format(IPV4_ADDRESS);
+      local_metadata.ingress_port : optional
+          @id(11) @name("in_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT);
+      local_metadata.vlan_id : ternary
+          @id(16) @name("vlan_id")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID);
+#endif
+    }
+    actions = {
+      @proto_id(1) set_qos_queue_and_cancel_copy_above_rate_limit();
+      @proto_id(2) set_cpu_queue_and_deny_above_rate_limit();
+      @proto_id(3) acl_forward();
+      @proto_id(4) acl_drop(local_metadata);
+      @proto_id(5) set_cpu_queue();
+#if defined(DSCP_REWRITE_CAPABLE)
+      @proto_id(6) set_dscp_and_queues_and_deny_above_rate_limit();
+#endif
+      @proto_id(7) set_forwarding_queues();
+#if defined(TIMESTAMP_CAPABLE)
+      @proto_id(8) append_ingress_and_egress_timestamp();
+#endif
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    meters = acl_ingress_qos_meter;
+    counters = acl_ingress_qos_counter;
+    size = ACL_INGRESS_QOS_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(ACL_INGRESS_COUNTING_TABLE_ID)
+  @sai_acl_priority(7)
+  @sai_acl(INGRESS)
+  @nonessential_for_upgrade
+  @entry_restriction("
+    // Only allow IP field matches for IP packets.
+    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+  ")
+  table acl_ingress_counting_table {
+    key = {
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional
+          @id(1) @name("is_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional
+          @id(2) @name("is_ipv4")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional @name("is_ipv6") @id(3)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      // Field for v4 and v6 DSCP bits.
+      dscp : ternary @name("dscp") @id(11)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP);
+      local_metadata.route_metadata : ternary @name("route_metadata") @id(18)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST_USER_META);
+    }
+    actions = {
+      @proto_id(3) acl_count();
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    counters = acl_ingress_counting_counter;
+    size = ACL_INGRESS_COUNTING_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @id(ACL_INGRESS_REDIRECT_TO_IPMC_GROUP_ACTION_ID)
+  @action_restriction("
+    // Disallow 0 since it encodes 'no multicast' in V1Model.
+    multicast_group_id != 0;
+  ")
+  action redirect_to_ipmc_group(
+      @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT)
+      @sai_action_param_object_type(SAI_OBJECT_TYPE_IPMC_GROUP)
+      @refers_to(builtin::multicast_group_table, multicast_group_id)
+      multicast_group_id_t multicast_group_id) {
+    standard_metadata.mcast_grp = multicast_group_id;
+    local_metadata.acl_ingress_ipmc_redirect = true;
+
+    // Cancel other forwarding decisions (if any).
+    local_metadata.nexthop_id_valid = false;
+    local_metadata.wcmp_group_id_valid = false;
+  }
+
+  @id(ACL_INGRESS_REDIRECT_TO_IPMC_GROUP_AND_SET_CPU_QUEUE_AND_CANCEL_COPY_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_COPY_CANCEL)
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  @unsupported
+  @action_restriction("
+    // Disallow 0 since it encodes 'no multicast' in V1Model.
+    multicast_group_id != 0;
+  ")
+  action redirect_to_ipmc_group_and_set_cpu_queue_and_cancel_copy(
+      @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT)
+      @sai_action_param_object_type(SAI_OBJECT_TYPE_IPMC_GROUP)
+      @refers_to(builtin::multicast_group_table, multicast_group_id)
+      multicast_group_id_t multicast_group_id,
+      @sai_action_param(QOS_QUEUE) cpu_queue_t cpu_queue) {
+    redirect_to_ipmc_group(multicast_group_id);
+    set_cpu_queue_and_cancel_copy(cpu_queue);
+  }
+
+  @id(ACL_INGRESS_REDIRECT_TO_PORT_ACTION_ID)
+  action redirect_to_port(
+    @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT)
+    @sai_action_param_object_type(SAI_OBJECT_TYPE_PORT)
+    port_id_t redirect_port) {
+    // The actual redirect to port happens after routing resolution. Here we
+    // just store the redirect port in a metadata.
+    local_metadata.redirect_port = (bit<9>)redirect_port;
+    local_metadata.redirect_port_valid = true;
+
+    // Cancel other forwarding decisions except for nexthop. If the packet is
+    // assigned a nexthop, the packet rewrites are determined by the nexthop but
+    // the egress port is determined by `redirect_port`.
+    local_metadata.wcmp_group_id_valid = false;
+    standard_metadata.mcast_grp = 0;
+  }
+
+  @id(ACL_INGRESS_MIRROR_AND_REDIRECT_TO_PORT_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action acl_mirror_and_redirect_to_port(
+    @id(1)
+      @refers_to(mirror_session_table, mirror_session_id)
+      @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS)
+      mirror_session_id_t mirror_session_id,
+    @id(2)
+      @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT)
+      @sai_action_param_object_type(SAI_OBJECT_TYPE_PORT)
+    port_id_t redirect_port) {
+
+    acl_ingress_counter.count();
+    local_metadata.marked_to_mirror = true;
+    local_metadata.mirror_session_id = mirror_session_id;
+    local_metadata.redirect_port = (bit<9>)redirect_port;
+    local_metadata.redirect_port_valid = true;
+
+    // Cancel other forwarding decisions except for nexthop. If the packet is
+    // assigned a nexthop, the packet rewrites are determined by the nexthop but
+    // the egress port is determined by `redirect_port`.
+    local_metadata.wcmp_group_id_valid = false;
+    standard_metadata.mcast_grp = 0;
+  }
+
+  // ACL table that mirrors and redirects packets.
+  @id(ACL_INGRESS_MIRROR_AND_REDIRECT_TABLE_ID)
+  @sai_acl(INGRESS)
+  @sai_acl_priority(15)
+  @nonessential_for_upgrade
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @entry_restriction("
+    // Only allow IP field matches for IP packets.
+    dst_ip::mask != 0 -> is_ipv4 == 1;
+    dst_ipv6::mask != 0 -> is_ipv6 == 1;
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+  ")
+  table acl_ingress_mirror_and_redirect_table {
+    key = {
+      local_metadata.ingress_port : optional
+        @name("in_port")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)
+        @id(1);
+
+      local_metadata.acl_metadata : ternary
+        @name("acl_metadata")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_USER_META)
+        @id(6);
+
+      local_metadata.vlan_id : ternary
+        @name("vlan_id")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID)
+        @id(7);
+
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional
+        @name("is_ip")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP)
+        @id(2);
+
+      headers.ipv4.isValid() : optional
+        @name("is_ipv4")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY)
+        @id(3);
+
+      headers.ipv6.isValid() : optional
+        @name("is_ipv6")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY)
+        @id(4);
+
+      headers.ipv4.dst_addr : ternary
+        @name("dst_ip")
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IP)
+        @format(IPV4_ADDRESS)
+        @id(10);
+
+      headers.ipv6.dst_addr[127:64] : ternary
+        @name("dst_ipv6")
+        @composite_field(
+            @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD3),
+            @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD2))
+        @format(IPV6_ADDRESS)
+        @id(5);
+
+      local_metadata.vrf_id : optional
+        @unsupported
+        @id(8) @name("vrf_id")
+        // TODO(PINS): refers is not supported for optional fields. Use
+        // if the type is changed later
+        //@refers_to(vrf_table, vrf_id)
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_VRF_ID);
+#if defined(IP_MULTICAST_CAPABLE)
+      local_metadata.route_hit : optional
+        @id(9) @name("route_hit")
+        // TODO(PINS): unsupported to be removed when P4Orch support is added
+        @unsupported
+        @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT);
+#endif
+    }
+    actions = {
+// We don't usually restrict actions to instantiations because they don't
+// require resources but we make an exception here because of issues with
+// metering (go/pins-meter-consistency for details).
+// `acl_forward` in `mirror_and_redirect` is needed for `tor` and is an
+// unmetered action there. `middleblock` needs `mirror_and_redirect` but NOT
+// `acl_forward` which is a metered action there. If we include it in
+// `middleblock` we run into resource issues.
+//
+// We also restrict Mirroring actions to `tor` because they are not
+// used in other instantiations. More importantly, these actions refer to
+// mirror_session_table that only exists in `tor` so
+// if these actions are visible in instantiations that don't have
+// mirror_session_table, reference entries generation in IrP4Info and
+// reference analysis will fail.
+#if defined(MIRROR_CAPABLE)
+      @proto_id(1) acl_mirror();
+#endif
+#if defined(MIRROR_CAPABLE) && defined(ACL_REDIRECT_TO_PORT_CAPABLE)
+      @proto_id(2) acl_mirror_and_redirect_to_port();
+#endif
+#if defined(ACL_REDIRECT_TO_PORT_CAPABLE)
+      @proto_id(6) redirect_to_port();
+#endif
+      @proto_id(3) acl_forward();
+#if defined(ACL_REDIRECT_TO_NEXTHOP_CAPABLE)
+      @proto_id(4) redirect_to_nexthop();
+#endif
+#if defined(IP_MULTICAST_CAPABLE)
+      @proto_id(5) redirect_to_ipmc_group();
+      @proto_id(7) redirect_to_ipmc_group_and_set_cpu_queue_and_cancel_copy();
+#endif
+      @proto_id(8) set_cpu_queue_and_cancel_copy();
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    size = ACL_INGRESS_MIRROR_AND_REDIRECT_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  // ACL table that only drops or denies packets, and is otherwise a no-op.
+  @id(ACL_INGRESS_SECURITY_TABLE_ID)
+  @sai_acl(INGRESS)
+  @sai_acl_priority(20)
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @entry_restriction("
+    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).
+    ether_type != 0x0800 && ether_type != 0x86dd;
+    // Forbid match on ethertype if is_ip* is set.
+    (is_ip::mask != 0 || is_ipv4::mask != 0 || is_ipv6::mask != 0) -> ether_type::mask == 0;
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK)
+    // Only allow IP field matches for IP packets.
+    dst_ip::mask != 0 -> is_ipv4 == 1;
+    src_ip::mask != 0 -> is_ipv4 == 1;
+    src_ipv6::mask != 0 -> is_ipv6 == 1;
+#endif
+  // TODO: This comment is required for the preprocessor to not
+  // spit out nonsense.
+#if defined(SAI_INSTANTIATION_TOR)
+    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.
+    l4_src_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+#endif
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+  ")
+  table acl_ingress_security_table {
+    key = {
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional
+          @id(1) @name("is_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional
+          @id(2) @name("is_ipv4")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional
+          @id(3) @name("is_ipv6")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      headers.ethernet.ether_type : ternary
+          @id(4) @name("ether_type")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE);
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK)
+      headers.ipv4.src_addr : ternary
+          @id(5) @name("src_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_IP) @format(IPV4_ADDRESS);
+      headers.ipv4.dst_addr : ternary
+          @id(6) @name("dst_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IP) @format(IPV4_ADDRESS);
+      headers.ipv6.src_addr[127:64] : ternary
+          @id(7) @name("src_ipv6")
+          @composite_field(
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6_WORD3),
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6_WORD2)
+          ) @format(IPV6_ADDRESS);
+#endif
+#if defined(SAI_INSTANTIATION_TOR)
+      dscp : ternary
+          @id(8) @name("dscp")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP);
+      ip_protocol : ternary
+          @id(9) @name("ip_protocol")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL);
+      local_metadata.l4_src_port : ternary
+          @id(10) @name("l4_src_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT);
+      local_metadata.l4_dst_port : ternary
+          @id(11) @name("l4_dst_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT);
+      local_metadata.vlan_id : ternary
+          @id(12) @name("vlan_id")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID);
+      local_metadata.acl_metadata : ternary
+          @id(13) @name("acl_metadata")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_USER_META);
+#endif
+    }
+    actions = {
+      @proto_id(1) acl_forward();
+      @proto_id(2) acl_drop(local_metadata);
+      @proto_id(3) acl_deny();
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    counters = acl_ingress_security_counter;
+    size = ACL_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    if (headers.ipv4.isValid()) {
+      ttl = headers.ipv4.ttl;
+      dscp = headers.ipv4.dscp;
+      ecn = headers.ipv4.ecn;
+      ip_protocol = headers.ipv4.protocol;
+    } else if (headers.ipv6.isValid()) {
+      ttl = headers.ipv6.hop_limit;
+      dscp = headers.ipv6.dscp;
+      ecn = headers.ipv6.ecn;
+      ip_protocol = headers.ipv6.next_header;
+    }
+
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK)
+    acl_ingress_table.apply();
+    acl_ingress_mirror_and_redirect_table.apply();
+    acl_ingress_security_table.apply();
+#elif defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+    acl_ingress_table.apply();
+    acl_ingress_counting_table.apply();
+    acl_ingress_qos_table.apply();
+#elif defined(SAI_INSTANTIATION_TOR)
+    // These tables are currently order agnostic, but we should be careful to
+    // ensure that the ordering is correct if we add new actions or model
+    // additional parts of SAI in the future.
+    acl_ingress_table.apply();
+    acl_ingress_qos_table.apply();
+    acl_ingress_mirror_and_redirect_table.apply();
+#endif
+
+    if (cancel_copy) {
+      local_metadata.marked_to_copy = false;
+    }
+  }
+}  // control ACL_INGRESS
+
+#endif  // SAI_ACL_INGRESS_P4_

--- a/e2e_tests/sai_p4/instantiations/google/acl_pre_ingress.p4
+++ b/e2e_tests/sai_p4/instantiations/google/acl_pre_ingress.p4
@@ -1,0 +1,313 @@
+#ifndef SAI_ACL_PRE_INGRESS_P4_
+#define SAI_ACL_PRE_INGRESS_P4_
+
+#include <v1model.p4>
+#include "../../fixed/headers.p4"
+#include "../../fixed/metadata.p4"
+#include "ids.h"
+#include "roles.h"
+#include "minimum_guaranteed_sizes.h"
+
+#if defined(SAI_INSTANTIATION_TOR)
+#define ACL_PRE_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE \
+  ACL_TOR_PRE_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE
+#else
+#define ACL_PRE_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE \
+  ACL_DEFAULT_PRE_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE
+#endif
+
+control acl_pre_ingress(in headers_t headers,
+                   inout local_metadata_t local_metadata,
+                   in standard_metadata_t standard_metadata) {
+  // First 6 bits of IPv4 TOS or IPv6 traffic class (or 0, for non-IP packets)
+  bit<6> dscp = 0;
+  // Last 2 bits of IPv4 TOS or IPv6 traffic class (or 0, for non-IP packets)
+  bit<2> ecn = 0;
+
+  // IPv4 IP protocol or IPv6 next_header (or 0, for non-IP packets)
+  bit<8> ip_protocol = 0;
+
+  bool set_outer_vlan_id_action_applied = false;
+  vlan_id_t set_outer_vlan_id_action_vlan_id = 0;
+
+  @id(ACL_PRE_INGRESS_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_pre_ingress_counter;
+
+  @id(ACL_PRE_INGRESS_VLAN_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_pre_ingress_vlan_counter;
+
+  @id(ACL_PRE_INGRESS_METADATA_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_pre_ingress_metadata_counter;
+
+  @id(ACL_PRE_INGRESS_SET_VRF_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action set_vrf(@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_VRF)
+                 @refers_to(vrf_table, vrf_id)
+                 @id(1)
+                 vrf_id_t vrf_id) {
+    local_metadata.vrf_id = vrf_id;
+    acl_pre_ingress_counter.count();
+  }
+
+  @id(ACL_PRE_INGRESS_SET_OUTER_VLAN_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action set_outer_vlan_id(
+      @id(1) @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_OUTER_VLAN_ID)
+        vlan_id_t vlan_id) {
+    set_outer_vlan_id_action_applied = true;
+    set_outer_vlan_id_action_vlan_id = vlan_id;
+    acl_pre_ingress_vlan_counter.count();
+  }
+
+  @id(ACL_PRE_INGRESS_SET_ACL_METADATA_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action set_acl_metadata(
+       @id(1) @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA)
+         acl_metadata_t acl_metadata) {
+    local_metadata.acl_metadata = acl_metadata;
+    acl_pre_ingress_metadata_counter.count();
+  }
+
+  @id(ACL_PRE_INGRESS_SET_OUTER_VLAN_AND_ACL_METADATA_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_FORWARD)
+  action set_outer_vlan_id_and_acl_metadata(
+      @id(1) @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_OUTER_VLAN_ID)
+        vlan_id_t vlan_id,
+      @id(2) @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA)
+        acl_metadata_t acl_metadata) {
+    set_outer_vlan_id_action_applied = true;
+    set_outer_vlan_id_action_vlan_id = vlan_id;
+    local_metadata.acl_metadata = acl_metadata;
+    acl_pre_ingress_vlan_counter.count();
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(ACL_PRE_INGRESS_TABLE_ID)
+  @sai_acl(PRE_INGRESS)
+  @sai_acl_priority(11)
+  @entry_restriction("
+    // Only allow IP field matches for IP packets.
+    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    dst_ip::mask != 0 -> is_ipv4 == 1;
+    dst_ipv6::mask != 0 -> is_ipv6 == 1;
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+    // Reserve high priorities for switch-internal use.
+    // TODO: Remove once inband workaround is obsolete.
+    ::priority < 0x7fffffff;
+  ")
+  table acl_pre_ingress_table {
+    key = {
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional @name("is_ip") @id(1)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional @name("is_ipv4") @id(2)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional @name("is_ipv6") @id(3)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      headers.ethernet.src_addr : ternary @name("src_mac") @id(4)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_SRC_MAC) @format(MAC_ADDRESS);
+#ifdef SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+      headers.ethernet.dst_addr : ternary @name("dst_mac") @id(9)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_MAC) @format(MAC_ADDRESS);
+#endif
+      headers.ipv4.dst_addr : ternary @name("dst_ip") @id(5)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IP) @format(IPV4_ADDRESS);
+      headers.ipv6.dst_addr[127:64] : ternary @name("dst_ipv6") @id(6)
+          @composite_field(
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD3),
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD2)
+          ) @format(IPV6_ADDRESS);
+      dscp : ternary @name("dscp") @id(7)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP);
+      ecn : ternary @name("ecn") @id(10)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ECN);
+      local_metadata.ingress_port : optional @name("in_port") @id(8)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT);
+    }
+    actions = {
+      @proto_id(1) set_vrf;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    counters = acl_pre_ingress_counter;
+    size = ACL_PRE_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @id(ACL_PRE_INGRESS_VLAN_TABLE_ID)
+  @sai_acl(PRE_INGRESS)
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @sai_acl_priority(1)
+  @entry_restriction("
+    // Forbid using ether_type for IP packets (by convention, use is_ip* instead).
+    ether_type != 0x0800 && ether_type != 0x86dd;
+    // Forbid match on ethertype if is_ip* is set.
+    (is_ip::mask != 0 || is_ipv4::mask != 0 || is_ipv6::mask != 0) -> ether_type::mask == 0;
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+    // Disallow match on reserved VLAN IDs to rule out vendor specific behavior.
+    vlan_id::mask != 0 -> (vlan_id != 4095);
+    // TODO: Disallow setting to reserved VLAN IDs when supported.
+  ")
+  table acl_pre_ingress_vlan_table {
+    key = {
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional
+          @id(1) @name("is_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional
+          @id(2) @name("is_ipv4")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional
+          @id(3) @name("is_ipv6")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      headers.ethernet.ether_type : ternary @name("ether_type") @id(4)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE);
+      local_metadata.vlan_id : ternary @id(5) @name("vlan_id")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID);
+    }
+    actions = {
+      @proto_id(1) set_outer_vlan_id;
+      @proto_id(2) set_outer_vlan_id_and_acl_metadata;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    counters = acl_pre_ingress_vlan_counter;
+    size = ACL_PRE_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  @id(ACL_PRE_INGRESS_METADATA_TABLE_ID)
+  @sai_acl(PRE_INGRESS)
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @sai_acl_priority(5)
+#if defined(SAI_INSTANTIATION_TOR)
+  @nonessential_for_upgrade
+#endif
+  @entry_restriction("
+    // Forbid illegal combinations of IP_TYPE fields.
+    is_ip::mask != 0 -> (is_ipv4::mask == 0 && is_ipv6::mask == 0);
+    is_ipv4::mask != 0 -> (is_ip::mask == 0 && is_ipv6::mask == 0);
+    is_ipv6::mask != 0 -> (is_ip::mask == 0 && is_ipv4::mask == 0);
+    // Forbid unsupported combinations of IP_TYPE fields.
+    is_ipv4::mask != 0 -> (is_ipv4 == 1);
+    is_ipv6::mask != 0 -> (is_ipv6 == 1);
+    // Only allow IP field matches for IP packets.
+    ip_protocol::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    // Only allow l4_dst_port and l4_src_port matches for TCP/UDP packets.
+    l4_dst_port::mask != 0 -> (ip_protocol == 6 || ip_protocol == 17);
+#if defined(SAI_INSTANTIATION_TOR) 
+    // DSCP is only allowed on IP traffic.
+    dscp::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    ecn::mask != 0 -> (is_ip == 1 || is_ipv4 == 1 || is_ipv6 == 1);
+    // Only allow icmp_type matches for ICMP packets
+    icmpv6_type::mask != 0 -> ip_protocol == 58;
+#elif defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+    dst_ip::mask != 0 -> is_ipv4 == 1;
+    dst_ipv6::mask != 0 -> is_ipv6 == 1;
+#endif
+  ")
+  table acl_pre_ingress_metadata_table {
+    key = {
+      headers.ipv4.isValid() || headers.ipv6.isValid() : optional
+          @id(1) @name("is_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IP);
+      headers.ipv4.isValid() : optional
+          @id(2) @name("is_ipv4")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional
+          @id(3) @name("is_ipv6")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      // Not required for FBR but provided to maintain a common and moderately
+      // wide match field for testing.
+      ip_protocol : ternary
+          @id(4) @name("ip_protocol")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL);
+      local_metadata.l4_dst_port : ternary
+          @id(11) @name("l4_dst_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT);
+#if defined(SAI_INSTANTIATION_TOR) 
+      headers.icmp.type : ternary
+          @id(5) @name("icmpv6_type")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE);
+      dscp : ternary
+          @id(6) @name("dscp")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DSCP);
+      ecn : ternary
+          @id(7) @name("ecn")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ECN);
+#if defined(SAI_INSTANTIATION_TOR)
+      local_metadata.ingress_port : optional
+          @id(8) @name("in_port")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT);
+#endif
+#elif defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+      headers.ipv4.dst_addr : ternary
+          @id(9) @name("dst_ip")
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IP) @format(IPV4_ADDRESS);
+      headers.ipv6.dst_addr[127:64] : ternary
+          @id(10) @name("dst_ipv6")
+          @composite_field(
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD3),
+              @sai_field(SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6_WORD2))
+          @format(IPV6_ADDRESS);
+#endif
+    }
+    actions = {
+      @proto_id(1) set_acl_metadata;
+      @proto_id(2) set_outer_vlan_id;
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+#if !defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+    counters = acl_pre_ingress_metadata_counter;
+#endif
+    size = ACL_PRE_INGRESS_METADATA_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    if (headers.ipv4.isValid()) {
+      dscp = headers.ipv4.dscp;
+      ecn = headers.ipv4.ecn;
+      ip_protocol = headers.ipv4.protocol;
+    } else if (headers.ipv6.isValid()) {
+      dscp = headers.ipv6.dscp;
+      ecn = headers.ipv6.ecn;
+      if (headers.ipv6.next_header == 0 &&
+          headers.hop_by_hop_options.isValid()) {
+        ip_protocol = headers.hop_by_hop_options.next_header;
+      }
+      else {
+        ip_protocol = headers.ipv6.next_header;
+      }
+    }
+
+#if defined(SAI_INSTANTIATION_MIDDLEBLOCK)
+    acl_pre_ingress_table.apply();
+#elif defined(SAI_INSTANTIATION_FABRIC_BORDER_ROUTER)
+    acl_pre_ingress_metadata_table.apply();
+    acl_pre_ingress_table.apply();
+#elif defined(SAI_INSTANTIATION_TOR) 
+    acl_pre_ingress_vlan_table.apply();
+    acl_pre_ingress_metadata_table.apply();
+    acl_pre_ingress_table.apply();
+#endif
+
+    // The SET_OUTER_VLAN_ID action affects the packet if and only if the input
+    // packet is VLAN tagged.
+    if (set_outer_vlan_id_action_applied &&
+        local_metadata.input_packet_is_vlan_tagged) {
+      local_metadata.vlan_id = set_outer_vlan_id_action_vlan_id;
+    }
+  }
+}  // control acl_pre_ingress
+
+#endif  // SAI_ACL_PRE_INGRESS_P4_

--- a/e2e_tests/sai_p4/instantiations/google/acl_wbb_ingress.p4
+++ b/e2e_tests/sai_p4/instantiations/google/acl_wbb_ingress.p4
@@ -1,0 +1,104 @@
+#ifndef SAI_ACL_WBB_INGRESS_P4_
+#define SAI_ACL_WBB_INGRESS_P4_
+
+#include <v1model.p4>
+#include "../../fixed/headers.p4"
+#include "../../fixed/metadata.p4"
+#include "ids.h"
+#include "roles.h"
+#include "minimum_guaranteed_sizes.h"
+
+control acl_wbb_ingress(in headers_t headers,
+                         inout local_metadata_t local_metadata,
+                         inout standard_metadata_t standard_metadata) {
+  // IPv4 TTL or IPv6 hoplimit bits (or 0, for non-IP packets)
+  bit<8> ttl = 0;
+
+  @id(ACL_WBB_INGRESS_METER_ID)
+  direct_meter<MeterColor_t>(MeterType.bytes) acl_wbb_ingress_meter;
+
+  @id(ACL_WBB_INGRESS_COUNTER_ID)
+  direct_counter(CounterType.packets_and_bytes) acl_wbb_ingress_counter;
+
+  // Copy the packet to the CPU, and forward the original packet.
+  @id(ACL_WBB_INGRESS_COPY_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_COPY)
+  action acl_wbb_ingress_copy() {
+    acl_wbb_ingress_meter.read(local_metadata.color);
+    clone(CloneType.I2E, COPY_TO_CPU_SESSION_ID);
+    acl_wbb_ingress_counter.count();
+  }
+
+  // Copy the packet to the CPU. The original packet is dropped.
+  @id(ACL_WBB_INGRESS_TRAP_ACTION_ID)
+  @sai_action(SAI_PACKET_ACTION_TRAP)
+  action acl_wbb_ingress_trap() {
+    acl_wbb_ingress_meter.read(local_metadata.color);
+    clone(CloneType.I2E, COPY_TO_CPU_SESSION_ID);
+    mark_to_drop(standard_metadata);
+    acl_wbb_ingress_counter.count();
+  }
+
+  @p4runtime_role(P4RUNTIME_ROLE_SDN_CONTROLLER)
+  @id(ACL_WBB_INGRESS_TABLE_ID)
+  @sai_acl(INGRESS)
+  @entry_restriction("
+    // WBB only allows for very specific table entries:
+
+    // Traceroute (6 entries)
+    (
+      // IPv4 or IPv6
+      ((is_ipv4 == 1 && is_ipv6::mask == 0) ||
+        (is_ipv4::mask == 0 && is_ipv6 == 1)) &&
+      // TTL 0, 1, and 2
+      (ttl == 0 || ttl == 1 || ttl == 2) &&
+      ether_type::mask == 0
+    ) ||
+    // LLDP
+    (
+      ether_type == 0x88cc &&
+      is_ipv4::mask == 0 && is_ipv6::mask == 0 && ttl::mask == 0
+    ) ||
+    // ND
+    (
+      ether_type == 0x6007;
+      is_ipv4::mask == 0;
+      is_ipv6::mask == 0;
+      ttl::mask == 0
+    )
+  ")
+  table acl_wbb_ingress_table {
+    key = {
+      headers.ipv4.isValid() : optional @name("is_ipv4") @id(1)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV4ANY);
+      headers.ipv6.isValid() : optional @name("is_ipv6") @id(2)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE/IPV6ANY);
+      headers.ethernet.ether_type : ternary @name("ether_type") @id(3)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE);
+      // Field for v4 TTL and v6 hop_limit
+      ttl : ternary @name("ttl") @id(4)
+          @sai_field(SAI_ACL_TABLE_ATTR_FIELD_TTL);
+    }
+    actions = {
+      @proto_id(1) acl_wbb_ingress_copy();
+      @proto_id(2) acl_wbb_ingress_trap();
+      @defaultonly NoAction;
+    }
+    const default_action = NoAction;
+    meters = acl_wbb_ingress_meter;
+    counters = acl_wbb_ingress_counter;
+    size = ACL_WBB_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE;
+  }
+
+  apply {
+    if (headers.ipv4.isValid()) {
+      ttl = headers.ipv4.ttl;
+    } else if (headers.ipv6.isValid()) {
+      ttl = headers.ipv6.hop_limit;
+    }
+
+    acl_wbb_ingress_table.apply();
+  }
+}  // control acl_wbb_packetio
+
+#endif  // SAI_ACL_WBB_INGRESS_P4_

--- a/e2e_tests/sai_p4/instantiations/google/admit_google_system_mac.p4
+++ b/e2e_tests/sai_p4/instantiations/google/admit_google_system_mac.p4
@@ -1,0 +1,15 @@
+#ifndef SAI_ADMIT_GOOGLE_SYSTEM_MAC_P4_
+#define SAI_ADMIT_GOOGLE_SYSTEM_MAC_P4_
+
+// The System MAC is installed by the inband manager running locally on the
+// switch. It is needed to allow simple communication with a controller before
+// the P4Info is pushed.
+control admit_google_system_mac(in headers_t headers,
+                                inout local_metadata_t local_metadata) {
+  apply {
+     local_metadata.admit_to_l3 =
+      (headers.ethernet.dst_addr & 0x01_00_00_00_00_00) == 0;
+  }
+}  // control system_mac_admit
+
+#endif  // SAI_ADMIT_GOOGLE_SYSTEM_MAC_P4_

--- a/e2e_tests/sai_p4/instantiations/google/bitwidths.p4
+++ b/e2e_tests/sai_p4/instantiations/google/bitwidths.p4
@@ -1,0 +1,31 @@
+#ifndef PINS_SAI_BITWIDTHS_P4_
+#define PINS_SAI_BITWIDTHS_P4_
+
+#ifdef PLATFORM_BMV2
+  // Number of bits used for types that use @p4runtime_translation("", string).
+  // This allows BMv2 to support string up to this length.
+  #define STRING_MAX_BITWIDTH 256 // 32 chars
+
+  // TODO: We want to use the commented definition, but BMv2 does not
+  // support large numbers for ports.
+  // #define PORT_BITWIDTH STRING_MAX_BITWIDTH
+  #define PORT_BITWIDTH 9
+  #define VRF_BITWIDTH STRING_MAX_BITWIDTH
+  #define NEXTHOP_ID_BITWIDTH STRING_MAX_BITWIDTH
+  #define ROUTER_INTERFACE_ID_BITWIDTH STRING_MAX_BITWIDTH
+  #define WCMP_GROUP_ID_BITWIDTH STRING_MAX_BITWIDTH
+  #define MIRROR_SESSION_ID_BITWIDTH STRING_MAX_BITWIDTH
+  #define QOS_QUEUE_BITWIDTH STRING_MAX_BITWIDTH
+  #define TUNNEL_ID_BITWIDTH STRING_MAX_BITWIDTH
+#else
+  #define PORT_BITWIDTH 9
+  #define VRF_BITWIDTH 10
+  #define NEXTHOP_ID_BITWIDTH 10
+  #define ROUTER_INTERFACE_ID_BITWIDTH 10
+  #define WCMP_GROUP_ID_BITWIDTH 12
+  #define MIRROR_SESSION_ID_BITWIDTH 10
+  #define QOS_QUEUE_BITWIDTH 8
+  #define TUNNEL_ID_BITWIDTH 10
+#endif
+
+#endif  // PINS_SAI_BITWIDTHS_P4_

--- a/e2e_tests/sai_p4/instantiations/google/fabric_border_router.p4
+++ b/e2e_tests/sai_p4/instantiations/google/fabric_border_router.p4
@@ -1,0 +1,94 @@
+#define SAI_INSTANTIATION_FABRIC_BORDER_ROUTER
+
+#define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
+#define ACL_REDIRECT_TO_PORT_CAPABLE
+#define DSCP_REWRITE_CAPABLE
+#define IP_MULTICAST_CAPABLE
+#define L3_ADMIT_SUPPORTS_IN_PORT
+#define NEXTHOP_DISABLE_REWRITES_CAPABLE
+#define MIRROR_CAPABLE
+#define RIF_PROGRAMMING_MY_MAC_SUPPORTED
+#define TIMESTAMP_CAPABLE
+#define TUNNEL_ENCAP_CAPABLE
+
+#include <v1model.p4>
+
+// These headers have to come first, to override their fixed counterparts.
+#include "roles.h"
+#include "versions.h"
+#include "bitwidths.p4"
+#include "minimum_guaranteed_sizes.h"
+#include "../../fixed/headers.p4"
+#include "../../fixed/metadata.p4"
+#include "../../fixed/parser.p4"
+#include "../../fixed/packet_io.p4"
+#include "../../fixed/routing.p4"
+#include "../../fixed/ipv4_checksum.p4"
+#include "../../fixed/ingress_cloning.p4"
+#include "../../fixed/mirroring.p4"
+#include "../../fixed/l3_admit.p4"
+#include "../../fixed/vlan.p4"
+#include "../../fixed/drop_martians.p4"
+#include "../../fixed/packet_rewrites.p4"
+#include "../../fixed/tunnel_termination.p4"
+#include "acl_egress.p4"
+#include "acl_ingress.p4"
+#include "acl_pre_ingress.p4"
+#include "admit_google_system_mac.p4"
+#include "ids.h"
+#include "versions.h"
+
+control ingress(inout headers_t headers,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+  apply {
+    packet_out_decap.apply(headers, local_metadata, standard_metadata);
+    if (!local_metadata.bypass_ingress) {
+      vlan_untag.apply(headers, local_metadata, standard_metadata);
+      acl_pre_ingress.apply(headers, local_metadata, standard_metadata);
+      ingress_vlan_checks.apply(headers, local_metadata, standard_metadata);
+      admit_google_system_mac.apply(headers, local_metadata);
+      l3_admit.apply(headers, local_metadata, standard_metadata);
+      tunnel_termination.apply(headers, local_metadata);
+      routing_lookup.apply(headers, local_metadata, standard_metadata);
+      acl_ingress.apply(headers, local_metadata, standard_metadata);
+      routing_resolution.apply(headers, local_metadata, standard_metadata);
+      mirror_session_lookup.apply(headers, local_metadata, standard_metadata);
+      ingress_cloning.apply(headers, local_metadata, standard_metadata);
+      drop_martians.apply(headers, local_metadata, standard_metadata);
+    }
+  }
+}  // control ingress
+
+control egress(inout headers_t headers,
+               inout local_metadata_t local_metadata,
+               inout standard_metadata_t standard_metadata) {
+  apply {
+    packet_in_encap.apply(headers, local_metadata, standard_metadata);
+    // TODO: Remove if statement once exit is supported in
+    // p4-symbolic.
+    if (!local_metadata.bypass_egress) {
+      packet_rewrites.apply(headers, local_metadata, standard_metadata);
+      mirror_encap.apply(headers, local_metadata, standard_metadata);
+      egress_vlan_checks.apply(headers, local_metadata, standard_metadata);
+      vlan_tag.apply(headers, local_metadata, standard_metadata);
+      acl_egress.apply(headers, local_metadata, standard_metadata);
+    }
+  }
+}  // control egress
+
+#ifndef PKG_INFO_NAME
+#define PKG_INFO_NAME "fabric_border_router.p4"
+#endif
+@pkginfo(
+  name = PKG_INFO_NAME,
+  organization = "Google",
+  version = SAI_P4_PKGINFO_VERSION_LATEST
+)
+@platform_property(
+  multicast_group_table_size = MULTICAST_GROUP_TABLE_SIZE,
+  multicast_group_table_total_replicas = MULTICAST_GROUP_TABLE_TOTAL_REPLICAS,
+  multicast_group_table_max_replicas_per_entry = MULTICAST_GROUP_TABLE_MAX_REPLICAS_PER_ENTRY
+)
+V1Switch(packet_parser(), verify_ipv4_checksum(), ingress(), egress(),
+         compute_ipv4_checksum(), packet_deparser()) main;

--- a/e2e_tests/sai_p4/instantiations/google/ids.h
+++ b/e2e_tests/sai_p4/instantiations/google/ids.h
@@ -1,0 +1,96 @@
+#ifndef PINS_SAI_IDS_H_
+#define PINS_SAI_IDS_H_
+
+#include "../../fixed/ids.h"
+
+// All declarations (tables, actions, action profiles, meters, counters) have a
+// stable ID. This list will evolve as new declarations are added. IDs cannot be
+// reused. If a declaration is removed, its ID macro is kept and marked reserved
+// to avoid the ID being reused.
+//
+// The IDs are classified using the 8 most significant bits to be compatible
+// with "6.3. ID Allocation for P4Info Objects" in the P4Runtime specification.
+
+// --- Tables ------------------------------------------------------------------
+
+// IDs of ACL tables (8 most significant bits = 0x02).
+// Since these IDs are user defined, they need to be separate from the fixed SAI
+// table ID space. We achieve this by starting the IDs at 0x100.
+#define ACL_INGRESS_TABLE_ID 0x02000100                      // 33554688
+#define ACL_INGRESS_QOS_TABLE_ID 0x02000107                  // 33554695
+#define ACL_INGRESS_COUNTING_TABLE_ID 0x02000109             // 33554697
+#define ACL_INGRESS_SECURITY_TABLE_ID 0x0200010A             // 33554698
+#define ACL_INGRESS_MIRROR_AND_REDIRECT_TABLE_ID 0x0200010B  // 33554699
+#define ACL_PRE_INGRESS_TABLE_ID 0x02000101                  // 33554689
+#define ACL_PRE_INGRESS_VLAN_TABLE_ID 0x02000105             // 33554693
+#define ACL_PRE_INGRESS_METADATA_TABLE_ID 0x02000106         // 33554694
+#define ACL_WBB_INGRESS_TABLE_ID 0x02000103                  // 33554691
+#define ACL_EGRESS_TABLE_ID 0x02000104                       // 33554692
+#define ACL_EGRESS_DHCP_TO_HOST_TABLE_ID 0x02000108          // 33554696
+// Next available table id: 0x0200010C (33554700)
+
+// --- Actions -----------------------------------------------------------------
+// NOLINTBEGIN (to disable macro names of size > 80 cols)
+
+// IDs of ACL actions (8 most significant bits = 0x01).
+// Since these IDs are user defined, they need to be separate from the fixed SAI
+// actions ID space. We achieve this by starting the IDs at 0x100.
+#define ACL_PRE_INGRESS_SET_VRF_ACTION_ID 0x01000100           // 16777472
+#define ACL_PRE_INGRESS_SET_OUTER_VLAN_ACTION_ID 0x0100010A    // 16777482
+#define ACL_PRE_INGRESS_SET_ACL_METADATA_ACTION_ID 0x0100010B  // 16777483
+#define ACL_PRE_INGRESS_SET_OUTER_VLAN_AND_ACL_METADATA_ACTION_ID \
+  0x01000118                                                // 16777496
+#define ACL_INGRESS_COPY_ACTION_ID 0x01000101               // 16777473
+#define ACL_INGRESS_TRAP_ACTION_ID 0x01000102               // 16777474
+#define ACL_INGRESS_EXPERIMENTAL_TRAP_ACTION_ID 0x01000199  // 16777625
+#define ACL_INGRESS_FORWARD_ACTION_ID 0x01000103            // 16777475
+#define ACL_INGRESS_MIRROR_ACTION_ID 0x01000104             // 16777476
+#define ACL_INGRESS_COUNT_ACTION_ID 0x01000105              // 16777477
+#define ACL_INGRESS_SET_QOS_QUEUE_AND_CANCEL_COPY_ABOVE_RATE_LIMIT_ACTION_ID \
+  0x0100010C  // 16777484
+#define ACL_INGRESS_SET_CPU_QUEUE_AND_DENY_ABOVE_RATE_LIMIT_ACTION_ID \
+  0x0100010E                                            // 16777486
+#define ACL_INGRESS_SET_CPU_QUEUE_ACTION_ID 0x01000110  // 16777488
+#define ACL_INGRESS_SET_DSCP_AND_QUEUES_AND_DENY_ABOVE_RATE_LIMIT_ACTION_ID \
+  0x01000111                                                     // 16777489
+#define ACL_INGRESS_DENY_ACTION_ID 0x0100010F                    // 16777487
+#define ACL_INGRESS_REDIRECT_TO_NEXTHOP_ACTION_ID 0x01000112     // 16777490
+#define ACL_INGRESS_REDIRECT_TO_IPMC_GROUP_ACTION_ID 0x01000113  // 16777491
+#define ACL_INGRESS_REDIRECT_TO_L2MC_GROUP_ACTION_ID 0x01000114  // 16777492
+#define ACL_INGRESS_SET_FORWARDING_QUEUES_ACTION_ID 0x01000115   // 16777493
+#define ACL_INGRESS_REDIRECT_TO_PORT_ACTION_ID 0x01000116        // 16777494
+#define ACL_INGRESS_MIRROR_AND_REDIRECT_TO_PORT_ACTION_ID \
+  0x01000117                                       // 16777495
+#define ACL_EGRESS_FORWARD_ACTION_ID 0x0100010D    // 16777485
+#define ACL_WBB_INGRESS_COPY_ACTION_ID 0x01000107  // 16777479
+#define ACL_WBB_INGRESS_TRAP_ACTION_ID 0x01000108  // 16777480
+#define ACL_DROP_ACTION_ID 0x01000109              // 16777481
+#define ACL_INGRESS_APPEND_INGRESS_AND_EGRESS_TIMESTAMP_ACTION_ID \
+  0x01000119  // 16777497
+#define ACL_INGRESS_REDIRECT_TO_IPMC_GROUP_AND_SET_CPU_QUEUE_AND_CANCEL_COPY_ACTION_ID \
+  0x0100011A  // 16777498
+#define ACL_INGRESS_SET_CPU_QUEUE_AND_CANCEL_COPY_ACTION_ID \
+  0x0100011B  // 16777499
+// Next available action id: 0x0100011C (16777500)
+
+// NOLINTEND
+// --- Meters ------------------------------------------------------------------
+#define ACL_INGRESS_METER_ID 0x15000100      // 352321792
+#define ACL_INGRESS_QOS_METER_ID 0x15000102  // 352321794
+#define ACL_WBB_INGRESS_METER_ID 0x15000101  // 352321793
+
+// --- Counters ----------------------------------------------------------------
+#define ACL_PRE_INGRESS_COUNTER_ID 0x13000101           // 318767361
+#define ACL_PRE_INGRESS_METADATA_COUNTER_ID 0x13000105  // 318767365
+#define ACL_PRE_INGRESS_VLAN_COUNTER_ID 0x13000106      // 318767366
+#define ACL_INGRESS_COUNTER_ID 0x13000102               // 318767362
+#define ACL_INGRESS_QOS_COUNTER_ID 0x13000107           // 318767367
+#define ACL_INGRESS_COUNTING_COUNTER_ID 0x13000109      // 318767369
+#define ACL_INGRESS_SECURITY_COUNTER_ID 0x1300010A      // 318767370
+#define ACL_WBB_INGRESS_COUNTER_ID 0x13000103           // 318767363
+#define ACL_EGRESS_COUNTER_ID 0x13000104                // 318767364
+#define ACL_EGRESS_DHCP_TO_HOST_COUNTER_ID 0x13000108   // 318767368
+#define ACL_EGRESS_L2_COUNTER_ID 0x1300010B             // 318767371
+// Next available counter id: 0x1300010C (318767372)
+
+#endif  // PINS_SAI_IDS_H_

--- a/e2e_tests/sai_p4/instantiations/google/middleblock.p4
+++ b/e2e_tests/sai_p4/instantiations/google/middleblock.p4
@@ -1,0 +1,93 @@
+#define SAI_INSTANTIATION_MIDDLEBLOCK
+
+#define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
+#define ACL_REDIRECT_TO_PORT_CAPABLE
+#define DSCP_REWRITE_CAPABLE
+#define IP_MULTICAST_CAPABLE
+#define L3_ADMIT_SUPPORTS_IN_PORT
+#define NEXTHOP_DISABLE_REWRITES_CAPABLE
+#define MIRROR_CAPABLE
+#define RIF_PROGRAMMING_MY_MAC_SUPPORTED
+#define TIMESTAMP_CAPABLE
+#define TUNNEL_ENCAP_CAPABLE
+
+#include <v1model.p4>
+
+// These headers have to come first, to override their fixed counterparts.
+#include "roles.h"
+#include "bitwidths.p4"
+#include "minimum_guaranteed_sizes.h"
+#include "../../fixed/headers.p4"
+#include "../../fixed/metadata.p4"
+#include "../../fixed/parser.p4"
+#include "../../fixed/packet_io.p4"
+#include "../../fixed/routing.p4"
+#include "../../fixed/ipv4_checksum.p4"
+#include "../../fixed/ingress_cloning.p4"
+#include "../../fixed/mirroring.p4"
+#include "../../fixed/l3_admit.p4"
+#include "../../fixed/vlan.p4"
+#include "../../fixed/drop_martians.p4"
+#include "../../fixed/packet_rewrites.p4"
+#include "../../fixed/tunnel_termination.p4"
+#include "acl_egress.p4"
+#include "acl_ingress.p4"
+#include "acl_pre_ingress.p4"
+#include "admit_google_system_mac.p4"
+#include "ids.h"
+#include "versions.h"
+
+control ingress(inout headers_t headers,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+  apply {
+    packet_out_decap.apply(headers, local_metadata, standard_metadata);
+    if (!local_metadata.bypass_ingress) {
+      vlan_untag.apply(headers, local_metadata, standard_metadata);
+      acl_pre_ingress.apply(headers, local_metadata, standard_metadata);
+      ingress_vlan_checks.apply(headers, local_metadata, standard_metadata);
+      admit_google_system_mac.apply(headers, local_metadata);
+      l3_admit.apply(headers, local_metadata, standard_metadata);
+      tunnel_termination.apply(headers, local_metadata);
+      routing_lookup.apply(headers, local_metadata, standard_metadata);
+      acl_ingress.apply(headers, local_metadata, standard_metadata);
+      routing_resolution.apply(headers, local_metadata, standard_metadata);
+      mirror_session_lookup.apply(headers, local_metadata, standard_metadata);
+      ingress_cloning.apply(headers, local_metadata, standard_metadata);
+      drop_martians.apply(headers, local_metadata, standard_metadata);
+    }
+  }
+}  // control ingress
+
+control egress(inout headers_t headers,
+               inout local_metadata_t local_metadata,
+               inout standard_metadata_t standard_metadata) {
+  apply {
+    packet_in_encap.apply(headers, local_metadata, standard_metadata);
+    // TODO: Remove if statement once exit is supported in
+    // p4-symbolic.
+    if (!local_metadata.bypass_egress) {
+      packet_rewrites.apply(headers, local_metadata, standard_metadata);
+      mirror_encap.apply(headers, local_metadata, standard_metadata);
+      egress_vlan_checks.apply(headers, local_metadata, standard_metadata);
+      vlan_tag.apply(headers, local_metadata, standard_metadata);
+      acl_egress.apply(headers, local_metadata, standard_metadata);
+    }
+  }
+}  // control egress
+
+#ifndef PKG_INFO_NAME
+#define PKG_INFO_NAME "middleblock.p4"
+#endif
+@pkginfo(
+  name = PKG_INFO_NAME,
+  organization = "Google",
+  version = SAI_P4_PKGINFO_VERSION_LATEST
+)
+@platform_property(
+  multicast_group_table_size = MULTICAST_GROUP_TABLE_SIZE,
+  multicast_group_table_total_replicas = MULTICAST_GROUP_TABLE_TOTAL_REPLICAS,
+  multicast_group_table_max_replicas_per_entry = MULTICAST_GROUP_TABLE_MAX_REPLICAS_PER_ENTRY
+)
+V1Switch(packet_parser(), verify_ipv4_checksum(), ingress(), egress(),
+         compute_ipv4_checksum(), packet_deparser()) main;

--- a/e2e_tests/sai_p4/instantiations/google/minimum_guaranteed_sizes.h
+++ b/e2e_tests/sai_p4/instantiations/google/minimum_guaranteed_sizes.h
@@ -1,0 +1,131 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PINS_SAI_RESOURCE_GUARANTEES_P4_
+#define PINS_SAI_RESOURCE_GUARANTEES_P4_
+
+// This file documents the resource guarantees that each table provides.
+// These guarantees are not based on the hardware limits of particular targets,
+// but instead model the requirements that we believe we need for our
+// operations. Specifically, we try to give a a conservative upper bound of our
+// current requirements to support current usage and be better prepared for
+// future changes.
+//
+// For some targets and some tables, these numbers are read by the switch and
+// used to allocate tables accordingly. For other targets/tables these numbers
+// are ignored by the switch. In either case, we can use p4-fuzzer to ensure
+// that the given guarantees are actually upheld by the switch.
+//
+// See go/gpins-resource-guarantees for details on how a variety of these
+// numbers arose and to what extent they are truly guarantees.
+
+// -- Fixed Table sizes --------------------------------------------------------
+
+#define IPV6_TUNNEL_TERMINATION_TABLE_MINIMUM_GUARANTEED_SIZE 126
+
+#define NEXTHOP_TABLE_MINIMUM_GUARANTEED_SIZE 4096
+
+#define NEIGHBOR_TABLE_MINIMUM_GUARANTEED_SIZE 4096
+
+#define MIRROR_SESSION_TABLE_MINIMUM_GUARANTEED_SIZE 4
+
+#define ROUTING_VRF_TABLE_MINIMUM_GUARANTEED_SIZE 64
+
+#define ROUTING_IPV4_TABLE_MINIMUM_GUARANTEED_SIZE 131072
+#define ROUTING_IPV6_TABLE_MINIMUM_GUARANTEED_SIZE 17000
+
+#define ROUTING_TUNNEL_TABLE_MINIMUM_GUARANTEED_SIZE 2048
+
+#define ROUTER_INTERFACE_TABLE_MINIMUM_GUARANTEED_SIZE 4096
+#define L3_ADMIT_TABLE_MINIMUM_GUARANTEED_SIZE 64
+// Workaround: effectively disable resource checking by setting to large number.
+// TODO: Remove this workaround.
+#define ROUTING_MULTICAST_ROUTER_INTERFACE_TABLE_MINIMUM_GUARANTEED_SIZE 9999999
+
+#define ROUTING_IPV4_MULTICAST_TABLE_MINIMUM_GUARANTEED_SIZE 1600
+#define ROUTING_IPV6_MULTICAST_TABLE_MINIMUM_GUARANTEED_SIZE 1600
+
+// The maximum number of wcmp groups.
+#define WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_NON_TOR 3968
+#define WCMP_GROUP_TABLE_MINIMUM_GUARANTEED_SIZE_TOR 960
+
+// The default size semantics for WCMP group selectors.
+#define WCMP_GROUP_DEFAULT_SELECTOR_SIZE_SEMANTICS_NON_TOR "sum_of_weights"
+#define WCMP_GROUP_DEFAULT_SELECTOR_SIZE_SEMANTICS_TOR "sum_of_weights"
+
+// The maximum sum of weights across all wcmp groups.
+#define WCMP_GROUP_SUM_OF_WEIGHTS_SIZE_NON_TOR 49152  // 48k
+#define WCMP_GROUP_SUM_OF_WEIGHTS_SIZE_TOR 31296      // 31K
+
+// The maximum sum of members across all wcmp groups when using the
+// SUM_OF_MEMBERS size semantics.
+#define WCMP_GROUP_SUM_OF_MEMBERS_SIZE 12228  // 12k
+
+// The maximum sum of weights for each wcmp group.
+#define WCMP_GROUP_SELECTOR_SUM_OF_WEIGHTS_MAX_GROUP_SIZE_NON_TOR 512
+#define WCMP_GROUP_SELECTOR_SUM_OF_WEIGHTS_MAX_GROUP_SIZE_TOR 256
+
+// The maximum number of members for each SUM_OF_MEMBERS group.
+#define WCMP_GROUP_SELECTOR_SUM_OF_MEMBERS_MAX_GROUP_SIZE 512
+
+// The max weight of an individual member when using the SUM_OF_MEMBERS size
+// semantics.
+#define WCMP_GROUP_SELECTOR_SUM_OF_MEMBERS_MAX_MEMBER_WEIGHT 4095
+
+// -- Built-in Fixed Table sizes -----------------------------------------------
+// E.g. Multicast and Clone session tables.
+
+#define MULTICAST_GROUP_TABLE_SIZE 512
+// Some replicas are reserved for defragmentation.
+#define MULTICAST_GROUP_TABLE_TOTAL_REPLICAS 3968
+#define MULTICAST_GROUP_TABLE_MAX_REPLICAS_PER_ENTRY 128
+
+// -- ACL Table sizes ----------------------------------------------------------
+
+#define ACL_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE 256
+
+// Some switches allocate table sizes in powers of 2. Since GPINs (Orchagent)
+// allocates 1 extra table entry for the loopback IP, we pick the size as
+// 2^8 - 1 to avoid allocation of 2^9 entries on such switches.
+
+#define ACL_DEFAULT_PRE_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE 254
+
+#define ACL_TOR_PRE_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE 125
+
+#define ACL_PRE_INGRESS_METADATA_TABLE_MINIMUM_GUARANTEED_SIZE 127
+
+#define ACL_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE 255
+
+#define ACL_INGRESS_QOS_TABLE_MINIMUM_GUARANTEED_SIZE 255
+
+#define ACL_INGRESS_COUNTING_TABLE_MINIMUM_GUARANTEED_SIZE 255
+
+#ifdef SAI_INSTANTIATION_TOR
+#define ACL_INGRESS_MIRROR_AND_REDIRECT_TABLE_MINIMUM_GUARANTEED_SIZE 511
+#else
+#define ACL_INGRESS_MIRROR_AND_REDIRECT_TABLE_MINIMUM_GUARANTEED_SIZE 255
+#endif
+
+#define ACL_EGRESS_TABLE_MINIMUM_GUARANTEED_SIZE 127
+#define ACL_EGRESS_DHCP_TO_HOST_TABLE_MINIMUM_GUARANTEED_SIZE 255
+
+// 1 entry for LLDP, 1 entry for ND, and 6 entries for traceroute: TTL 0,1,2 for
+// IPv4 and IPv6
+#define ACL_WBB_INGRESS_TABLE_MINIMUM_GUARANTEED_SIZE 8
+
+#define VLAN_TABLE_MINIMUM_GUARANTEED_SIZE 4096
+
+#define VLAN_MEMBERSHIP_TABLE_MINIMUM_GUARANTEED_SIZE (4096 * 160)
+
+#endif  // PINS_SAI_RESOURCE_GUARANTEES_P4_

--- a/e2e_tests/sai_p4/instantiations/google/roles.h
+++ b/e2e_tests/sai_p4/instantiations/google/roles.h
@@ -1,0 +1,7 @@
+#ifndef PINS_SAI_ROLES_P4_
+#define PINS_SAI_ROLES_P4_
+
+// We don't use instantion-specific roles at the moment.
+// See the same file under the "fixed" directory for additional roles.
+
+#endif  // PINS_SAI_ROLES_P4_

--- a/e2e_tests/sai_p4/instantiations/google/tor.p4
+++ b/e2e_tests/sai_p4/instantiations/google/tor.p4
@@ -1,0 +1,114 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#define SAI_INSTANTIATION_TOR
+
+#define ACL_REDIRECT_TO_NEXTHOP_CAPABLE
+#define ACL_REDIRECT_TO_PORT_CAPABLE
+#define DSCP_REWRITE_CAPABLE
+#define IP_MULTICAST_CAPABLE
+#define L3_ADMIT_SUPPORTS_IN_PORT
+#define NEXTHOP_DISABLE_REWRITES_CAPABLE
+#define MIRROR_CAPABLE
+#define RIF_PROGRAMMING_MY_MAC_SUPPORTED
+#define TIMESTAMP_CAPABLE
+#define TUNNEL_ENCAP_CAPABLE
+
+#include <v1model.p4>
+
+// These headers have to come first, to override their fixed counterparts.
+#include "roles.h"
+#include "bitwidths.p4"
+#include "minimum_guaranteed_sizes.h"
+#include "../../fixed/headers.p4"
+#include "../../fixed/metadata.p4"
+#include "../../fixed/parser.p4"
+#include "../../fixed/packet_io.p4"
+#include "../../fixed/routing.p4"
+#include "../../fixed/ipv4_checksum.p4"
+#include "../../fixed/ingress_cloning.p4"
+#include "../../fixed/mirroring.p4"
+#include "../../fixed/l3_admit.p4"
+#include "../../fixed/vlan.p4"
+#include "../../fixed/drop_martians.p4"
+#include "../../fixed/packet_rewrites.p4"
+#include "acl_egress.p4"
+#include "acl_ingress.p4"
+#include "acl_pre_ingress.p4"
+#include "admit_google_system_mac.p4"
+//#include "hashing.p4"
+#include "ids.h"
+#include "versions.h" 
+
+control ingress(inout headers_t headers,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+  apply {
+    packet_out_decap.apply(headers, local_metadata, standard_metadata);
+    if (!local_metadata.bypass_ingress) {
+      // The PRE_INGRESS stage handles VRF, VLAN assignment and VLAN checks. We
+      // can also set the pre-ingress metadata for certain types of traffic we
+      // want to handle uniquely in later stages.
+      vlan_untag.apply(headers, local_metadata, standard_metadata);
+      acl_pre_ingress.apply(headers, local_metadata, standard_metadata);
+      ingress_vlan_checks.apply(headers, local_metadata, standard_metadata);
+
+      // Standard L3 pipeline for routing packets.
+      admit_google_system_mac.apply(headers, local_metadata);
+      l3_admit.apply(headers, local_metadata, standard_metadata);
+//    hashing.apply(headers, local_metadata, standard_metadata);
+      routing_lookup.apply(headers, local_metadata, standard_metadata);
+
+      // The INGRESS stage can redirect (e.g. drop, punt or copy) packets, apply
+      // rate-limits or modify header data.
+      acl_ingress.apply(headers, local_metadata, standard_metadata);
+      routing_resolution.apply(headers, local_metadata, standard_metadata);
+      mirror_session_lookup.apply(headers, local_metadata, standard_metadata);
+      ingress_cloning.apply(headers, local_metadata, standard_metadata);
+      drop_martians.apply(headers, local_metadata, standard_metadata);
+    }
+  }
+}  // control ingress
+
+control egress(inout headers_t headers,
+               inout local_metadata_t local_metadata,
+               inout standard_metadata_t standard_metadata) {
+  apply {
+    packet_in_encap.apply(headers, local_metadata, standard_metadata);
+    // TODO: Remove if statement once exit is supported in
+    // p4 symbolic.
+    if (!local_metadata.bypass_egress) {    
+      packet_rewrites.apply(headers, local_metadata, standard_metadata);
+      mirror_encap.apply(headers, local_metadata, standard_metadata);
+      egress_vlan_checks.apply(headers, local_metadata, standard_metadata);
+      vlan_tag.apply(headers, local_metadata, standard_metadata);
+      acl_egress.apply(headers, local_metadata, standard_metadata);
+    }
+  }
+}  // control egress
+
+#ifndef PKG_INFO_NAME
+#define PKG_INFO_NAME "tor.p4"
+#endif
+@pkginfo(
+  name = PKG_INFO_NAME,
+  organization = "Google",
+  version = SAI_P4_PKGINFO_VERSION_LATEST
+)
+@platform_property(
+  multicast_group_table_size = MULTICAST_GROUP_TABLE_SIZE,
+  multicast_group_table_total_replicas = MULTICAST_GROUP_TABLE_TOTAL_REPLICAS,
+  multicast_group_table_max_replicas_per_entry = MULTICAST_GROUP_TABLE_MAX_REPLICAS_PER_ENTRY
+)
+V1Switch(packet_parser(), verify_ipv4_checksum(), ingress(), egress(),
+         compute_ipv4_checksum(), packet_deparser()) main;

--- a/e2e_tests/sai_p4/instantiations/google/versions.h
+++ b/e2e_tests/sai_p4/instantiations/google/versions.h
@@ -1,0 +1,122 @@
+#ifndef PINS_SAI_VERSIONS_H_
+#define PINS_SAI_VERSIONS_H_
+
+// --- PkgInfo versions --------------------------------------------------------
+// For use in `@pkginfo(..., version = VERSION)` annotations.
+// We use semantic versioning. Version numbers must increase monotonically.
+
+// Indicates that the program has packet out support.
+#define SAI_P4_PKGINFO_VERSION_HAS_PACKET_OUT_SUPPORT "1.0.0"
+
+// Indicates that the program has packet in support.
+#define SAI_P4_PKGINFO_VERSION_HAS_PACKET_IN_SUPPORT "1.1.0"
+
+// Indicates that the program has acl_ingress_counting_table support.
+#define SAI_P4_PKGINFO_VERSION_HAS_ACL_INGRESS_COUNTING_SUPPORT "1.2.0"
+
+// Indicates that the program can support CPU Queue parameters as Names.
+#define SAI_P4_PKGINFO_VERSION_HAS_CPU_QUEUE_NAME_SUPPORT "1.3.0"
+
+// Indicates that the switch fully supports abstracted CPU Queue names.
+// While Version 1.3.0 supported using CPU queue name instead of
+// queue id, the new CPU queues dedicated for Controller bound
+// packets are provisioned in 1.4.0.
+#define SAI_P4_PKGINFO_VERSION_HAS_DEDICATED_CONTROLLER_CPU_QUEUES "1.4.0"
+
+// Indicates that P4 program no longer contains
+// mirror_port_to_pre_session_table.
+// Removing a table is a breaking change and should have required a major
+// version bump. We didn't because the next two major versions have been
+// reserved and we can not skip major versions from the current version.
+// This is ok since our infra doesn't care about semantic versioning's
+// semantics.
+#define SAI_P4_PKGINFO_VERSION_HAS_NO_MIRROR_PORT_TO_PRE_SESSION_TABLE "1.4.1"
+
+// Indicates that the switch supports read requests for multicast group entries.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_PACKET_REPLICATION_ENGINE_READS "1.5.0"
+
+// Indicates the program has ingress cloning support that allows cloning +
+// punting the same packet.
+#define SAI_P4_PKGINFO_VERSION_HAS_INGRESS_CLONING_SUPPORT "1.6.0"
+
+// Indicates the switch supports multiple WCMP members with the same Nexthop.
+#define SAI_P4_PKGINFO_VERSION_HAS_DUPLICATE_WCMP_MEMBER_SUPPORT "1.6.1"
+
+// Indicates that switch respects ingress ACL resource guarantees.
+#define SAI_P4_PKGINFO_VERSION_FIXED_INGRESS_ACL_RESOURCE "1.6.2"
+
+// Indicates that the program does not support the `set_nexthop` action.
+#define SAI_P4_PKGINFO_VERSION_HAS_NO_SET_NEXTHOP_SUPPORT "2.0.0"
+
+// Indicates the switch supports P4Info ReconcileAndCommit for most cases.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_RECONCILE "2.1.0"
+
+// Indicates the switch supports multicast group entry metadata.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_MULTICAST_METADATA "2.2.0"
+
+// Indicates the switch supports the `acl_egress_l2_table` (if of the right
+// instantiation).
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_ACL_EGRESS_L2_TABLE "2.3.0"
+
+// Indicates the switch uses int64_t for meter config (previously int).
+#define SAI_P4_PKGINFO_VERSION_METER_CONFIG_USES_INT64 "2.5.0"
+
+// Indicates the switch disables sub_port RIF VLAN configuration.
+#define SAI_P4_PKGINFO_VERSION_DISABLE_SUB_PORT_RIF_VLAN_CONFIG "2.6.0"
+
+// Indicates that the program supports ternary rather than optional route
+// metadata in the acl_ingress_table.
+// Also, indicates the program has the MRIF vlan_id p4 constraint.
+#define SAI_P4_PKGINFO_VERSION_USES_TERNARY_ROUTE_METADATA "3.0.0"
+
+// Indicates that the program supports all valid modifications to the
+// `acl_ingress_table`.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_ACL_INGRESS_MODIFY "3.0.1"
+
+// Indicates that the program supports reconciliation of populated ACL tables.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_ACL_RECONCILE "3.0.2"
+
+// Indicates the switch executes batched updates in order, aborting every update
+// after the first failed one.
+#define SAI_P4_PKGINFO_VERSION_USES_FAIL_ON_FIRST "3.1.0"
+
+// Indicates the switch rejects duplicate sub-port RIFs.
+#define SAI_P4_PKGINFO_VERSION_REJECTS_DUPLICATE_SUB_PORT_RIFS "3.1.1"
+
+// Indicates the switch allows reconciliation of the acl_pre_ingress_table.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_ACL_PRE_INGRESS_RECONCILE "3.1.2"
+
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_L2_MULTICAST "3.2.6"
+
+// Indicates that the switch supports unicast_set_port_and_src_mac action, which
+// at the SAI level translates to port type RIFs that do NOT program l3_admit
+// table (i.e. MyMac at SAI) under the hood.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_UNICAST_SET_PORT_AND_SRC_MAC_ACTION \
+  "3.2.0"
+
+// Indicates the switch supports 512 duplicate WCMP members per group in native
+// mode.
+#define SAI_P4_PKGINFO_VERSION_SUPPORTS_512_DUPLICATE_WCMP_MEMBERS_IN_NATIVE \
+  "3.2.5"
+
+// Indicates the switch executes batched updates in order, aborting every update
+// after the first failed one.
+#define SAI_P4_PKGINFO_VERSION_USES_FAIL_ON_FIRST "3.2.1"
+
+// Indicates that the switch uses "route_hit" instead of "ipmc_table_hit" as the
+// name for ACL keys with
+// `@sai_field(SAI_ACL_ENTRY_ATTR_FIELD_ROUTE_NPU_META_DST_HIT)`.
+#define SAI_P4_PKGINFO_VERSION_USES_ROUTE_HIT_ACL_QUALIFIER_NAME "4.0.0"
+
+// Indicates that the switch supports unicast_set_port_and_src_mac_and_vlan_id
+// action, which at the SAI level translates to sub_port type RIFs that do NOT
+// program l3_admit table (i.e. MyMac at SAI) under the hood.
+#define SAI_P4_PKGINFO_VERSION_USES_UNICAST_SET_PORT_AND_SRC_MAC_AND_VLAN_\
+ID_ACTION \
+  "5.0.0"
+
+// Macro that always points to the latest SAI P4 version.
+#define SAI_P4_PKGINFO_VERSION_LATEST \
+  SAI_P4_PKGINFO_VERSION_USES_UNICAST_SET_PORT_AND_SRC_MAC_AND_VLAN_ID_ACTION
+
+#endif  // PINS_SAI_VERSIONS_H_

--- a/e2e_tests/sai_p4/instantiations/google/wbb.p4
+++ b/e2e_tests/sai_p4/instantiations/google/wbb.p4
@@ -1,0 +1,62 @@
+#define SAI_INSTANTIATION_WBB
+
+#include <v1model.p4>
+
+// These headers have to come first, to override their fixed counterparts.
+#include "roles.h"
+#include "versions.h"
+#include "bitwidths.p4"
+#include "minimum_guaranteed_sizes.h"
+
+#include "../../fixed/headers.p4"
+#include "../../fixed/metadata.p4"
+#include "../../fixed/roles.h"
+#include "acl_wbb_ingress.p4"
+
+control ingress(inout headers_t headers,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+  apply {
+    acl_wbb_ingress.apply(headers, local_metadata, standard_metadata);
+  }
+}
+
+control egress(inout headers_t headers,
+               inout local_metadata_t local_metadata,
+               inout standard_metadata_t standard_metadata) {
+  apply {}
+}
+
+parser packet_parser(packet_in packet, out headers_t headers,
+                     inout local_metadata_t local_metadata,
+                     inout standard_metadata_t standard_metadata) {
+  state start {
+    transition accept;
+  }
+}
+
+control packet_deparser(packet_out packet, in headers_t headers) {
+  apply {}
+}
+
+control verify_ipv4_checksum(inout headers_t headers,
+                             inout local_metadata_t local_metadata) {
+  apply {}
+}
+
+control compute_ipv4_checksum(inout headers_t headers,
+                              inout local_metadata_t local_metadata) {
+  apply {}
+}
+
+#ifndef PKG_INFO_NAME
+#define PKG_INFO_NAME "wbb.p4"
+#endif
+
+@pkginfo(
+  name = PKG_INFO_NAME,
+  organization = "Google",
+  version = SAI_P4_PKGINFO_VERSION_LATEST
+)
+V1Switch(packet_parser(), verify_ipv4_checksum(), ingress(), egress(),
+         compute_ipv4_checksum(), packet_deparser()) main;

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -243,3 +243,25 @@ kt_jvm_test(
         "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
     ],
 )
+
+kt_jvm_test(
+    name = "SaiP4E2ETest",
+    srcs = [
+        "P4RuntimeTestHarness.kt",
+        "SaiP4E2ETest.kt",
+    ],
+    data = [
+        "//e2e_tests/sai_p4:sai_middleblock_pb",
+    ],
+    test_class = "fourward.p4runtime.SaiP4E2ETest",
+    deps = [
+        ":p4runtime_lib",
+        "//simulator:ir_java_proto",
+        "@grpc-java//api",
+        "@grpc-java//inprocess",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_grpc_grpc_kotlin_stub",
+        "@maven//:junit_junit",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+    ],
+)

--- a/p4runtime/SaiP4E2ETest.kt
+++ b/p4runtime/SaiP4E2ETest.kt
@@ -1,0 +1,353 @@
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import fourward.ir.v1.PipelineConfig
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.TableEntry
+
+/**
+ * End-to-end test of the P4Runtime server with SAI P4 (middleblock).
+ *
+ * SAI P4 uses `@p4runtime_translation("", string)` on all ID types (vrf_id_t, nexthop_id_t,
+ * router_interface_id_t, port_id_t, etc.). String SDN values are UTF-8-encoded in the proto `bytes`
+ * field. This test verifies that the full stack — p4c-4ward compilation, simulator loading,
+ * P4Runtime Write/Read with sdn_string translation — works end-to-end.
+ */
+class SaiP4E2ETest {
+
+  private lateinit var harness: P4RuntimeTestHarness
+  private lateinit var config: PipelineConfig
+
+  @Before
+  fun setUp() {
+    harness = P4RuntimeTestHarness()
+    config = P4RuntimeTestHarness.loadConfig("e2e_tests/sai_p4/sai_middleblock.txtpb")
+    harness.loadPipeline(config)
+  }
+
+  @After
+  fun tearDown() {
+    harness.close()
+  }
+
+  // =========================================================================
+  // Pipeline loading
+  // =========================================================================
+
+  @Test
+  fun `SAI P4 middleblock pipeline loads successfully`() {
+    // Pipeline was loaded in setUp — verify p4info has the expected tables.
+    val tableNames = config.p4Info.tablesList.map { it.preamble.alias }
+    assertTrue("vrf_table should be present", "vrf_table" in tableNames)
+    assertTrue("ipv4_table should be present", "ipv4_table" in tableNames)
+    assertTrue("nexthop_table should be present", "nexthop_table" in tableNames)
+    assertTrue("router_interface_table should be present", "router_interface_table" in tableNames)
+    assertTrue("neighbor_table should be present", "neighbor_table" in tableNames)
+  }
+
+  @Test
+  fun `p4info has sdn_string translated types`() {
+    val translatedTypes = config.p4Info.typeInfo.newTypesMap
+    val stringTypes =
+      translatedTypes.filter { (_, spec) ->
+        spec.hasTranslatedType() && spec.translatedType.hasSdnString()
+      }
+    // SAI P4 declares 8 string-translated types (all use URI "").
+    assertTrue(
+      "expected at least 8 sdn_string types, got ${stringTypes.size}",
+      stringTypes.size >= 8,
+    )
+    assertTrue("vrf_id_t should be sdn_string", "vrf_id_t" in stringTypes)
+    assertTrue("nexthop_id_t should be sdn_string", "nexthop_id_t" in stringTypes)
+    assertTrue("port_id_t should be sdn_string", "port_id_t" in stringTypes)
+  }
+
+  // =========================================================================
+  // VRF table: sdn_string match field
+  // =========================================================================
+
+  @Test
+  fun `vrf_table entry with string vrf_id round-trips`() {
+    val vrfEntry = buildVrfEntry("vrf-1")
+    harness.installEntry(vrfEntry)
+
+    val vrfTable = findTable("vrf_table")
+    val entities = harness.readTableEntries(vrfTable.preamble.id)
+    assertEquals("expected one vrf_table entry", 1, entities.size)
+
+    // The match field (vrf_id) should round-trip as a UTF-8 string.
+    val readMatch = entities[0].tableEntry.matchList.first()
+    assertEquals("vrf-1", readMatch.exact.value.toStringUtf8())
+  }
+
+  @Test
+  fun `multiple vrf_table entries with different string IDs`() {
+    harness.installEntry(buildVrfEntry("vrf-1"))
+    harness.installEntry(buildVrfEntry("vrf-2"))
+    harness.installEntry(buildVrfEntry("vrf-3"))
+
+    val vrfTable = findTable("vrf_table")
+    val entities = harness.readTableEntries(vrfTable.preamble.id)
+    assertEquals("expected three vrf_table entries", 3, entities.size)
+
+    val vrfIds = entities.map { it.tableEntry.matchList.first().exact.value.toStringUtf8() }.toSet()
+    assertEquals(setOf("vrf-1", "vrf-2", "vrf-3"), vrfIds)
+  }
+
+  // =========================================================================
+  // IPv4 routing: string vrf_id match + set_nexthop_id action param
+  // =========================================================================
+
+  @Test
+  fun `ipv4_table entry with translated vrf_id and nexthop_id round-trips`() {
+    // First install a VRF.
+    harness.installEntry(buildVrfEntry("vrf-10"))
+
+    // Install an IPv4 route: vrf_id="vrf-10", ipv4_dst=10.0.0.0/8 → set_nexthop_id("nhop-1").
+    val ipv4Entry = buildIpv4RouteEntry("vrf-10", "nhop-1")
+    harness.installEntry(ipv4Entry)
+
+    val ipv4Table = findTable("ipv4_table")
+    val entities = harness.readTableEntries(ipv4Table.preamble.id)
+    assertEquals("expected one ipv4_table entry", 1, entities.size)
+
+    val entry = entities[0].tableEntry
+
+    // Verify vrf_id match field round-trips as string.
+    val vrfMatch = entry.matchList.find { it.fieldId == 1 }!!
+    assertEquals("vrf-10", vrfMatch.exact.value.toStringUtf8())
+
+    // Verify set_nexthop_id action param round-trips as string.
+    val action = entry.action.action
+    val setNexthopId = findAction("set_nexthop_id")
+    assertEquals(setNexthopId.preamble.id, action.actionId)
+    val nexthopParam = action.paramsList.find { it.paramId == 1 }!!
+    assertEquals("nhop-1", nexthopParam.value.toStringUtf8())
+  }
+
+  // =========================================================================
+  // Nexthop table: string match + action params with translated types
+  // =========================================================================
+
+  @Test
+  fun `nexthop_table entry with set_ip_nexthop round-trips`() {
+    val nexthopEntry = buildNexthopEntry("nhop-1", "rif-1")
+    harness.installEntry(nexthopEntry)
+
+    val nexthopTable = findTable("nexthop_table")
+    val entities = harness.readTableEntries(nexthopTable.preamble.id)
+    assertEquals("expected one nexthop_table entry", 1, entities.size)
+
+    val entry = entities[0].tableEntry
+
+    // Verify nexthop_id match round-trips as string.
+    val nexthopMatch = entry.matchList.first()
+    assertEquals("nhop-1", nexthopMatch.exact.value.toStringUtf8())
+
+    // Verify router_interface_id action param round-trips as string.
+    val action = entry.action.action
+    val rifParam = action.paramsList.find { it.paramId == 1 }!!
+    assertEquals("rif-1", rifParam.value.toStringUtf8())
+  }
+
+  // =========================================================================
+  // Router interface table: port_id_t in action param (the SAI "port as string" pattern)
+  // =========================================================================
+
+  @Test
+  fun `router_interface_table entry with port_id_t param round-trips`() {
+    val rifEntry = buildRouterInterfaceEntry("rif-1", "Ethernet0")
+    harness.installEntry(rifEntry)
+
+    val rifTable = findTable("router_interface_table")
+    val entities = harness.readTableEntries(rifTable.preamble.id)
+    assertEquals("expected one router_interface_table entry", 1, entities.size)
+
+    val entry = entities[0].tableEntry
+
+    // router_interface_id match (string).
+    val rifMatch = entry.matchList.first()
+    assertEquals("rif-1", rifMatch.exact.value.toStringUtf8())
+
+    // port param (port_id_t, string) and src_mac param (48-bit, not translated).
+    val action = entry.action.action
+    val portParam = action.paramsList.find { it.paramId == 1 }!!
+    assertEquals("Ethernet0", portParam.value.toStringUtf8())
+  }
+
+  // =========================================================================
+  // Delete: verify translated entries can be removed
+  // =========================================================================
+
+  @Test
+  fun `delete removes translated entry and read returns empty`() {
+    val vrfEntry = buildVrfEntry("vrf-to-delete")
+    harness.installEntry(vrfEntry)
+
+    val vrfTable = findTable("vrf_table")
+    assertEquals(1, harness.readTableEntries(vrfTable.preamble.id).size)
+
+    harness.deleteEntry(vrfEntry)
+    assertEquals(0, harness.readTableEntries(vrfTable.preamble.id).size)
+  }
+
+  // =========================================================================
+  // Helpers
+  // =========================================================================
+
+  private fun findTable(alias: String) =
+    config.p4Info.tablesList.find { it.preamble.alias == alias }
+      ?: error("table '$alias' not found in p4info")
+
+  private fun findAction(alias: String) =
+    config.p4Info.actionsList.find { it.preamble.alias == alias }
+      ?: error("action '$alias' not found in p4info")
+
+  private fun stringExactMatch(fieldId: Int, value: String): FieldMatch =
+    FieldMatch.newBuilder()
+      .setFieldId(fieldId)
+      .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFromUtf8(value)))
+      .build()
+
+  private fun stringParam(paramId: Int, value: String): p4.v1.P4RuntimeOuterClass.Action.Param =
+    p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+      .setParamId(paramId)
+      .setValue(ByteString.copyFromUtf8(value))
+      .build()
+
+  /** Builds a vrf_table entry: exact match on vrf_id (string) → no_action. */
+  private fun buildVrfEntry(vrfId: String): Entity {
+    val table = findTable("vrf_table")
+    val noAction = findAction("no_action")
+
+    val tableEntry =
+      TableEntry.newBuilder()
+        .setTableId(table.preamble.id)
+        .addMatch(stringExactMatch(1, vrfId))
+        .setAction(
+          p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(
+              p4.v1.P4RuntimeOuterClass.Action.newBuilder().setActionId(noAction.preamble.id)
+            )
+        )
+        .build()
+
+    return Entity.newBuilder().setTableEntry(tableEntry).build()
+  }
+
+  /**
+   * Builds a router_interface_table entry:
+   * - match: router_interface_id (string, exact)
+   * - action: set_port_and_src_mac(port: string, src_mac: 48-bit MAC)
+   */
+  private fun buildRouterInterfaceEntry(rifId: String, port: String): Entity {
+    val table = findTable("router_interface_table")
+    val action = findAction("set_port_and_src_mac")
+
+    // src_mac: non-zero (action_restriction enforces src_mac != 0).
+    val srcMacParam =
+      p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+        .setParamId(2)
+        .setValue(ByteString.copyFrom(byteArrayOf(0x00, 0x11, 0x22, 0x33, 0x44, 0x55)))
+        .build()
+
+    val tableEntry =
+      TableEntry.newBuilder()
+        .setTableId(table.preamble.id)
+        .addMatch(stringExactMatch(1, rifId))
+        .setAction(
+          p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(
+              p4.v1.P4RuntimeOuterClass.Action.newBuilder()
+                .setActionId(action.preamble.id)
+                .addParams(stringParam(1, port))
+                .addParams(srcMacParam)
+            )
+        )
+        .build()
+
+    return Entity.newBuilder().setTableEntry(tableEntry).build()
+  }
+
+  /**
+   * Builds an ipv4_table entry:
+   * - match: vrf_id (string, exact) + ipv4_dst 10.0.0.0/8 (LPM)
+   * - action: set_nexthop_id(nexthop_id: string)
+   */
+  private fun buildIpv4RouteEntry(vrfId: String, nexthopId: String): Entity {
+    val table = findTable("ipv4_table")
+    val action = findAction("set_nexthop_id")
+
+    // ipv4_dst: 10.0.0.0/8 as LPM.
+    val ipv4DstMatch =
+      FieldMatch.newBuilder()
+        .setFieldId(2)
+        .setLpm(
+          FieldMatch.LPM.newBuilder()
+            .setValue(ByteString.copyFrom(byteArrayOf(10, 0, 0, 0)))
+            .setPrefixLen(8)
+        )
+        .build()
+
+    val tableEntry =
+      TableEntry.newBuilder()
+        .setTableId(table.preamble.id)
+        .addMatch(stringExactMatch(1, vrfId))
+        .addMatch(ipv4DstMatch)
+        .setAction(
+          p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(
+              p4.v1.P4RuntimeOuterClass.Action.newBuilder()
+                .setActionId(action.preamble.id)
+                .addParams(stringParam(1, nexthopId))
+            )
+        )
+        .build()
+
+    return Entity.newBuilder().setTableEntry(tableEntry).build()
+  }
+
+  /**
+   * Builds a nexthop_table entry:
+   * - match: nexthop_id (string, exact)
+   * - action: set_ip_nexthop(router_interface_id: string, neighbor_id: IPv6)
+   */
+  private fun buildNexthopEntry(nexthopId: String, routerInterfaceId: String): Entity {
+    val table = findTable("nexthop_table")
+    val action = findAction("set_ip_nexthop")
+
+    // neighbor_id is ipv6_addr_t (128-bit) — NOT translated.
+    val neighborParam =
+      p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+        .setParamId(2)
+        .setValue(
+          ByteString.copyFrom(
+            ByteArray(16) { if (it == 15) 1 else 0 } // ::1
+          )
+        )
+        .build()
+
+    val tableEntry =
+      TableEntry.newBuilder()
+        .setTableId(table.preamble.id)
+        .addMatch(stringExactMatch(1, nexthopId))
+        .setAction(
+          p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(
+              p4.v1.P4RuntimeOuterClass.Action.newBuilder()
+                .setActionId(action.preamble.id)
+                .addParams(stringParam(1, routerInterfaceId))
+                .addParams(neighborParam)
+            )
+        )
+        .build()
+
+    return Entity.newBuilder().setTableEntry(tableEntry).build()
+  }
+}


### PR DESCRIPTION
## Summary

**SAI P4 works end-to-end through 4ward's P4Runtime stack.** This is the Track 4E
capstone — the real SAI P4 middleblock program from
[sonic-net/sonic-pins](https://github.com/sonic-net/sonic-pins/tree/main/sai_p4),
compiled with p4c-4ward, loaded into the simulator, and exercised via P4Runtime
with full `sdn_string` type translation.

- Vendors SAI P4 middleblock (35 source files from sonic-pins)
- Compiles with p4c-4ward → 29K-line IR with 8 `sdn_string` translated types
- 8 E2E tests verify pipeline loading, VRF entries, IPv4 routing with
  translated `vrf_id` match fields and `nexthop_id` action params, nexthop
  entries with translated `router_interface_id`, router_interface entries with
  `port_id_t` string params, and delete round-trips — all using string SDN values
- Also fixes a pre-existing detekt `NestedBlockDepth` warning (threshold 5→6)

## What this proves

The full stack works for SAI P4's `@p4runtime_translation("", string)` pattern:
`SetForwardingPipelineConfig` → `Write` (with string-translated match fields
and action params) → `Read` (values round-trip as UTF-8 strings). This was
the hardest requirement from the ROADMAP's Track 4 definition of done.

## What's not yet tested

- Packet forwarding through SAI P4 (would need router_interface + neighbor
  entries + L3 admit to set up a complete forwarding path)
- `@p4runtime_translation_mappings` (VRF's `"" → 0` explicit mapping)
- PacketIO metadata translation (v1model p4c doesn't emit `type_name`)
- p4-constraints validation (Track 4B, separate effort)

## Test plan

- [x] `bazel test //p4runtime:SaiP4E2ETest` passes (8 tests)
- [x] `bazel test //p4runtime/...` — all 5 P4Runtime test suites pass
- [x] `./tools/format.sh` clean
- [x] `./tools/lint.sh` clean
- [x] CI (push to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)