### PR TITLE
refactor: extract shared p4c_compile() macro

### DIFF
--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -59,34 +59,11 @@ The module extension has read access to the p4c source tree (via
 
 ---
 
-## Extract shared `p4_compile` genrule macro
+## ~~Extract shared `p4_compile` genrule macro~~ — DONE
 
-**Files**: new `e2e_tests/p4_compile.bzl`, all callers
-
-**Problem**: The p4c-4ward compilation genrule is copy-pasted across 8
-locations (`corpus.bzl`, `p4testgen.bzl`, and 6 hand-written `BUILD.bazel`
-files). Each copy has the same `cmd`, `tools`, and `outs` pattern.
-
-**Fix**: Extract a shared Starlark function in `e2e_tests/p4_compile.bzl`:
-
-```python
-def p4_compile(name, p4_src, tags = []):
-    native.genrule(
-        name = name + "_pb",
-        srcs = [p4_src],
-        outs = [name + ".txtpb"],
-        cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-        tools = [
-            "//p4c_backend:p4c-4ward",
-            "@p4c//:core_p4",
-            "@p4c//:p4include",
-        ],
-        tags = tags,
-    )
-```
-
-Then `corpus.bzl`, `p4testgen.bzl`, and the standalone `BUILD.bazel` files
-all call `p4_compile(name, p4_src)` instead of inlining the genrule.
+Extracted `p4c_compile()` into `e2e_tests/p4c.bzl`. All 11 call sites
+(`corpus.bzl`, `p4testgen.bzl`, `bmv2_diff.bzl`, and 8 `BUILD.bazel` files)
+now use the shared helper.
 
 ---
 

--- a/e2e_tests/basic_table/BUILD.bazel
+++ b/e2e_tests/basic_table/BUILD.bazel
@@ -1,15 +1,9 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-genrule(
-    name = "basic_table_pb",
-    srcs = ["basic_table.p4"],
-    outs = ["basic_table.txtpb"],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-    tools = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
-    ],
+p4c_compile(
+    name = "basic_table",
+    src_p4 = "basic_table.p4",
     visibility = ["//p4runtime:__pkg__"],
 )
 

--- a/e2e_tests/bmv2_diff.bzl
+++ b/e2e_tests/bmv2_diff.bzl
@@ -18,6 +18,7 @@ For each test this creates:
 """
 
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
 def bmv2_diff_test_suite(name, tests, tags = [], includes = []):
     """Compiles corpus P4 files for both backends and runs differential tests.
@@ -33,10 +34,10 @@ def bmv2_diff_test_suite(name, tests, tags = [], includes = []):
         "//simulator",
     ]
 
-    if includes:
-        include_flag = " -I $$(dirname $(execpath " + includes[0] + "))"
-    else:
-        include_flag = ""
+    include_flags = "".join([
+        " -I $$(dirname $(execpath " + inc + "))"
+        for inc in includes
+    ])
 
     for test in tests:
         p4_src = "@p4c//testdata/p4_16_samples:" + test + ".p4"
@@ -46,7 +47,7 @@ def bmv2_diff_test_suite(name, tests, tags = [], includes = []):
             name = test + "_json",
             srcs = [p4_src] + includes,
             outs = [test + ".json"],
-            cmd = "$(execpath @p4c//:p4c_bmv2) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flag + " -o $@ $(execpath " + p4_src + ")",
+            cmd = "$(execpath @p4c//:p4c_bmv2) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flags + " -o $@ $(execpath " + p4_src + ")",
             tags = tags,
             tools = [
                 "@p4c//:p4c_bmv2",
@@ -56,18 +57,7 @@ def bmv2_diff_test_suite(name, tests, tags = [], includes = []):
         )
 
         # Compile to 4ward PipelineConfig (needed for P4Info).
-        native.genrule(
-            name = test + "_pb",
-            srcs = [p4_src] + includes,
-            outs = [test + ".txtpb"],
-            cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flag + " -o $@ $(execpath " + p4_src + ")",
-            tags = tags,
-            tools = [
-                "//p4c_backend:p4c-4ward",
-                "@p4c//:core_p4",
-                "@p4c//:p4include",
-            ],
-        )
+        p4c_compile(test, p4_src, includes, tags)
 
         native.genrule(
             name = test + "_stf",

--- a/e2e_tests/corpus.bzl
+++ b/e2e_tests/corpus.bzl
@@ -16,6 +16,7 @@ This creates:
 """
 
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
 def corpus_test_suite(name, tests, tags = [], includes = [], stf_overrides = {}):
     """Compiles p4c corpus P4 files and runs all STF tests in a single JVM.
@@ -33,28 +34,10 @@ def corpus_test_suite(name, tests, tags = [], includes = [], stf_overrides = {})
     """
     data = ["//simulator"]
 
-    # Build -I flags for any extra includes.
-    if includes:
-        # All includes are assumed to be in the same directory; one -I suffices.
-        include_flag = " -I $$(dirname $(execpath " + includes[0] + "))"
-    else:
-        include_flag = ""
-
     for test in tests:
         p4_src = "@p4c//testdata/p4_16_samples:" + test + ".p4"
 
-        native.genrule(
-            name = test + "_pb",
-            srcs = [p4_src] + includes,
-            outs = [test + ".txtpb"],
-            cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flag + " -o $@ $(execpath " + p4_src + ")",
-            tags = tags,
-            tools = [
-                "//p4c_backend:p4c-4ward",
-                "@p4c//:core_p4",
-                "@p4c//:p4include",
-            ],
-        )
+        p4c_compile(test, p4_src, includes, tags)
 
         if test in stf_overrides:
             # Local override: use the file directly, no genrule needed.

--- a/e2e_tests/lpm_routing/BUILD.bazel
+++ b/e2e_tests/lpm_routing/BUILD.bazel
@@ -1,15 +1,9 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-genrule(
-    name = "lpm_routing_pb",
-    srcs = ["lpm_routing.p4"],
-    outs = ["lpm_routing.txtpb"],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-    tools = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
-    ],
+p4c_compile(
+    name = "lpm_routing",
+    src_p4 = "lpm_routing.p4",
 )
 
 kt_jvm_test(

--- a/e2e_tests/multi_table/BUILD.bazel
+++ b/e2e_tests/multi_table/BUILD.bazel
@@ -1,15 +1,9 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-genrule(
-    name = "multi_table_pb",
-    srcs = ["multi_table.p4"],
-    outs = ["multi_table.txtpb"],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-    tools = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
-    ],
+p4c_compile(
+    name = "multi_table",
+    src_p4 = "multi_table.p4",
 )
 
 kt_jvm_test(

--- a/e2e_tests/p4c.bzl
+++ b/e2e_tests/p4c.bzl
@@ -1,0 +1,32 @@
+"""Shared p4c-4ward compilation helper for e2e test macros."""
+
+def p4c_compile(name, src_p4, includes = [], tags = [], visibility = None):
+    """Compiles a P4 source file to a PipelineConfig txtpb using p4c-4ward.
+
+    Creates a genrule named `<name>_pb` that produces `<name>.txtpb`.
+
+    Args:
+        name:       base name (e.g. "opassign1-bmv2").
+        src_p4:     P4 source file label.
+        includes:   extra P4 file labels whose directories are added to the
+                    include path via `-I`.
+        tags:       Bazel tags forwarded to the genrule.
+        visibility: Bazel visibility for the genrule output.
+    """
+    include_flags = "".join([
+        " -I $$(dirname $(execpath " + inc + "))"
+        for inc in includes
+    ])
+    native.genrule(
+        name = name + "_pb",
+        srcs = [src_p4] + includes,
+        outs = [name + ".txtpb"],
+        cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flags + " -o $@ $(execpath " + src_p4 + ")",
+        tools = [
+            "//p4c_backend:p4c-4ward",
+            "@p4c//:core_p4",
+            "@p4c//:p4include",
+        ],
+        tags = tags,
+        visibility = visibility,
+    )

--- a/e2e_tests/p4testgen.bzl
+++ b/e2e_tests/p4testgen.bzl
@@ -22,6 +22,7 @@ This creates:
 
 load("@rules_cc//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_TYPE", "find_cc_toolchain", "use_cc_toolchain")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
 def _p4testgen_stfs_impl(ctx):
     cc_toolchain = find_cc_toolchain(ctx)
@@ -96,7 +97,6 @@ def _p4_testgen_rules(name, src_p4, includes, max_tests, seed, tags):
     """
     tags = tags + ["heavy"]
     stfs_name = name + "_stfs"
-    pb_name = name + "_pb"
 
     _p4testgen_stfs(
         name = stfs_name,
@@ -107,23 +107,9 @@ def _p4_testgen_rules(name, src_p4, includes, max_tests, seed, tags):
         tags = tags,
     )
 
-    include_flags = "".join([" -I $$(dirname $(execpath " + inc + "))" for inc in includes])
+    p4c_compile(name, src_p4, includes, tags)
 
-    # Compile P4 → PipelineConfig txtpb (same as corpus.bzl).
-    native.genrule(
-        name = pb_name,
-        srcs = [src_p4] + includes,
-        outs = [name + ".txtpb"],
-        cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flags + " -o $@ $(execpath " + src_p4 + ")",
-        tools = [
-            "//p4c_backend:p4c-4ward",
-            "@p4c//:core_p4",
-            "@p4c//:p4include",
-        ],
-        tags = tags,
-    )
-
-    return [":" + stfs_name, ":" + pb_name]
+    return [":" + stfs_name, ":" + name + "_pb"]
 
 def p4_testgen_test(name, src_p4 = None, includes = [], max_tests = 0, seed = 0, tags = []):
     """Generates p4testgen STF tests and runs them against the 4ward simulator.

--- a/e2e_tests/passthrough/BUILD.bazel
+++ b/e2e_tests/passthrough/BUILD.bazel
@@ -1,19 +1,9 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-# Compiles passthrough.p4 to a PipelineConfig text proto.
-# The -I flag points p4c at the p4include directory so it can find core.p4 and
-# v1model.p4. We derive the path from core_p4's execpath rather than
-# hard-coding it because the exact external-repo directory varies by platform.
-genrule(
-    name = "passthrough_pb",
-    srcs = ["passthrough.p4"],
-    outs = ["passthrough.txtpb"],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-    tools = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
-    ],
+p4c_compile(
+    name = "passthrough",
+    src_p4 = "passthrough.p4",
     visibility = ["//p4runtime:__pkg__"],
 )
 

--- a/e2e_tests/switch_action_run/BUILD.bazel
+++ b/e2e_tests/switch_action_run/BUILD.bazel
@@ -1,15 +1,9 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-genrule(
-    name = "switch_action_run_pb",
-    srcs = ["switch_action_run.p4"],
-    outs = ["switch_action_run.txtpb"],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-    tools = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
-    ],
+p4c_compile(
+    name = "switch_action_run",
+    src_p4 = "switch_action_run.p4",
 )
 
 kt_jvm_test(

--- a/e2e_tests/ternary_acl/BUILD.bazel
+++ b/e2e_tests/ternary_acl/BUILD.bazel
@@ -1,15 +1,9 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-genrule(
-    name = "ternary_acl_pb",
-    srcs = ["ternary_acl.p4"],
-    outs = ["ternary_acl.txtpb"],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-    tools = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
-    ],
+p4c_compile(
+    name = "ternary_acl",
+    src_p4 = "ternary_acl.p4",
 )
 
 kt_jvm_test(

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
 
 # =============================================================================
 # Trace tree golden tests (Track 3)
@@ -28,16 +29,9 @@ _PASSING = _P4_PROGRAMS
 
 _MANUAL = []
 
-[genrule(
-    name = "%s_pb" % name,
-    srcs = ["%s.p4" % name],
-    outs = ["%s.txtpb" % name],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-    tools = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
-    ],
+[p4c_compile(
+    name,
+    "%s.p4" % name,
 ) for name in _P4_PROGRAMS]
 
 _TEST_DEPS = [

--- a/e2e_tests/translated_type/BUILD.bazel
+++ b/e2e_tests/translated_type/BUILD.bazel
@@ -1,12 +1,7 @@
-genrule(
-    name = "translated_type_pb",
-    srcs = ["translated_type.p4"],
-    outs = ["translated_type.txtpb"],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
-    tools = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
-    ],
+load("//e2e_tests:p4c.bzl", "p4c_compile")
+
+p4c_compile(
+    name = "translated_type",
+    src_p4 = "translated_type.p4",
     visibility = ["//p4runtime:__pkg__"],
 )


### PR DESCRIPTION
## Summary

The p4c-4ward compilation genrule was copy-pasted across 11 locations — one
change to the compilation command meant updating 11 files. Now there's one
`p4c_compile()` helper in `e2e_tests/p4c.bzl` that all callers use.

- **3 `.bzl` macros** (`corpus.bzl`, `p4testgen.bzl`, `bmv2_diff.bzl`) and
  **8 hand-written `BUILD.bazel` files** replaced with `p4c_compile()` calls
- The helper also upgrades corpus/bmv2_diff from single-directory include
  handling to per-include `-I` flags (a strict superset, no behavior change
  for current callers)
- Net -83 lines

Resolves the "Extract shared `p4_compile` genrule macro" item in REFACTORING.md.

## Test plan

- [x] `bazel test //...` — 30/30 pass
- [x] `./tools/format.sh` — clean
- [x] `./tools/lint.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)