### PR TITLE
ci: run heavy tests on main pushes only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,38 @@ jobs:
           key: bazel-${{ matrix.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}-${{ github.run_id }}
 
 
+  heavy-tests:
+    name: Heavy tests
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure remote cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
+            echo "build --config=ci" >> ~/.bazelrc
+            echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
+          fi
+
+      - name: Restore Bazel cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/bazel
+          key: bazel-ubuntu-24.04-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}
+          restore-keys: bazel-ubuntu-24.04-
+
+      # p4testgen links against system libgmp via p4c.
+      - name: Install system dependencies
+        run: sudo apt-get install -y libgmp-dev
+
+      - name: Run heavy tests
+        run: bazel test //... --test_tag_filters=heavy
+
+
   coverage:
     name: Coverage
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Proper fix for the p4testgen timeout (#201 was a quick workaround).

- **PRs**: skip heavy tests (`--test_tag_filters=-heavy`) — fast feedback
- **Main pushes**: dedicated "Heavy tests" job with 15-minute timeout catches regressions
- Coverage continues to exclude heavy tests (they don't instrument simulator code anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)