### PR TITLE
ci: tag p4testgen test targets as heavy

### DIFF
--- a/e2e_tests/p4testgen.bzl
+++ b/e2e_tests/p4testgen.bzl
@@ -136,7 +136,7 @@ def p4_testgen_test(name, src_p4 = None, includes = [], max_tests = 0, seed = 0,
     kt_jvm_test(
         name = name + "_test",
         test_class = "fourward.e2e.p4testgen.P4TestgenSuiteTest",
-        tags = tags,
+        tags = tags + ["heavy"],
         data = data + ["//simulator"],
         deps = [
             "//e2e_tests/p4testgen:p4testgen_test_class",
@@ -168,7 +168,7 @@ def p4_testgen_suite(name, tests, includes = {}, max_tests = {}, tags = []):
     kt_jvm_test(
         name = name,
         test_class = "fourward.e2e.p4testgen.P4TestgenSuiteTest",
-        tags = tags,
+        tags = tags + ["heavy"],
         data = data,
         deps = [
             "//e2e_tests/p4testgen:p4testgen_test_class",


### PR DESCRIPTION
## Summary

Fixes the CI timeout that's been breaking main since #198.

PRs #201, #203, #204 added `--test_tag_filters=-heavy` to CI, but the
`p4testgen_suite_test` target was never actually tagged `heavy` — only
its build-phase rules (stfs generation, p4c compilation) were. The
`kt_jvm_test` targets in both `p4_testgen_test()` and
`p4_testgen_suite()` were missing the tag, so the filter had no effect.

Two-line fix in `p4testgen.bzl`: `tags = tags` → `tags = tags + ["heavy"]`
on both `kt_jvm_test` calls.

## Test plan

- [x] `bazel query` confirms `p4testgen_suite_test` now has `heavy` tag
- [x] `bazel query 'tests(//...) except attr(tags, heavy, //...)'` returns no p4testgen targets
- [x] CI (push to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)