### PR TITLE
docs: update stale LIMITATIONS.md and REFACTORING.md entries

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -59,9 +59,9 @@ guilt — just write it down so someone can find it later.
   `libgmp` and `libpcap` rather than building them from source. The build uses
   genrules to copy headers into the build tree, but runtime linking requires the
   libraries to be installed (e.g. via Homebrew on macOS).
-- **Small starter test set.** Only 5 corpus tests are diff-tested. Expanding to
-  the full corpus requires verifying each test compiles under p4c-bm2-ss and
-  produces matching output.
+- **183 of 186 corpus tests pass.** 3 tests are excluded: `ipv6-switch-ml-bmv2`
+  and `v1model-special-ops-bmv2` (multicast PRE limits in BMv2 driver), and
+  `ternary2-bmv2` (semantic mismatch under investigation).
 
 ## p4c backend
 

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -59,31 +59,6 @@ The module extension has read access to the p4c source tree (via
 
 ---
 
-## ~~Extract shared `p4_compile` genrule macro~~ — DONE
-
-Extracted `p4c_compile()` into `e2e_tests/p4c.bzl`. All 11 call sites
-(`corpus.bzl`, `p4testgen.bzl`, `bmv2_diff.bzl`, and 8 `BUILD.bazel` files)
-now use the shared helper.
-
----
-
-## Reuse simulator process across p4testgen sub-tests
-
-**Files**: `e2e_tests/stf/Runner.kt`, `e2e_tests/p4testgen/P4TestgenTest.kt`
-
-**Problem**: Each sub-test in a p4testgen target spawns a fresh simulator
-subprocess and re-loads the same pipeline config. With `max_tests = 100`,
-subprocess overhead (~330ms each) dominates — 100 sub-tests take ~33s
-when the actual packet processing is negligible.
-
-**Fix**: All sub-tests within a target share the same `.txtpb`. Launch the
-simulator once, load the pipeline once, then for each STF: install table
-entries, send packets, check outputs. `StfRunner` currently assumes
-one-shot execution (launch → run → destroy); refactor it to support a
-persistent session that resets table state between STFs.
-
----
-
 ## Make `matchesMasked` internal for test reuse
 
 **Files**: `e2e_tests/stf/Runner.kt`, `e2e_tests/stf/StfParserTest.kt`


### PR DESCRIPTION
## Summary

- **LIMITATIONS.md**: BMv2 diff testing entry said "only 5 corpus tests" — now 183/186, with the 3 exclusions documented
- **REFACTORING.md**: marked "reuse simulator process across p4testgen sub-tests" as done (PR #198 batched into one JVM)

## Test plan

- Docs-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)