### PR TITLE
ci: fix p4testgen suite timeout on main

### DIFF
--- a/e2e_tests/p4testgen.bzl
+++ b/e2e_tests/p4testgen.bzl
@@ -168,6 +168,7 @@ def p4_testgen_suite(name, tests, includes = {}, max_tests = {}, tags = []):
     kt_jvm_test(
         name = name,
         test_class = "fourward.e2e.p4testgen.P4TestgenSuiteTest",
+        size = "large",  # 155 tests with Z3 constraint solving; needs 900s
         tags = tags + ["heavy"],
         data = data,
         deps = [


### PR DESCRIPTION
## Summary

The p4testgen suite (155 tests with Z3 constraint solving) times out at
Bazel's default 300s on CI, breaking every main push since #198. Sets
`size = "large"` (900s timeout) on the batched `kt_jvm_test`.

This only affects the `Run heavy tests` step which runs on main pushes.
PR CI correctly skips heavy tests via `--test_tag_filters=-heavy` (#206).

## Test plan

- [x] One-line change, CI verifies it builds
- [ ] Next main push should pass the heavy test step

🤖 Generated with [Claude Code](https://claude.com/claude-code)