### PR TITLE
p4runtime: pipeline config validation tests, extract handleSafely

### DIFF
--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -13,6 +13,8 @@ Legend: **Y** = tested, **N** = not tested, **—** = not implemented
 | 7.1 | Load valid pipeline succeeds | Y | ConformanceTest #1 |
 | 7.2 | Pipeline reload replaces previous | Y | ConformanceTest #2 |
 | 7.3 | Empty/invalid config → INVALID_ARGUMENT | Y | ConformanceTest #3 |
+| 7.4 | Invalid p4_device_config bytes → INVALID_ARGUMENT | Y | ConformanceTest #37 |
+| 7.5 | Missing p4_device_config → INVALID_ARGUMENT | Y | ConformanceTest #38 |
 
 ## Match field encoding (§8.3)
 
@@ -128,6 +130,7 @@ Legend: **Y** = tested, **N** = not tested, **—** = not implemented
 | 12.2 | Without pipeline → FAILED_PRECONDITION | Y | ConformanceTest #17 |
 | 12.3 | P4INFO_AND_COOKIE omits device config | Y | ConformanceTest #18 |
 | 12.4 | DEVICE_CONFIG_AND_COOKIE omits p4info | Y | ConformanceTest #22 |
+| 12.5 | COOKIE_ONLY returns empty config | Y | ConformanceTest #36 |
 
 ## Capabilities
 
@@ -169,7 +172,7 @@ Legend: **Y** = tested, **N** = not tested, **—** = not implemented
 
 | Category | Tested | Not tested | Not implemented |
 |----------|--------|------------|-----------------|
-| SetForwardingPipelineConfig | 3 | 0 | 0 |
+| SetForwardingPipelineConfig | 5 | 0 | 0 |
 | Match encoding | 6 | 0 | 0 |
 | Write — tables | 26 | 2 | 0 |
 | Write — profiles | 6 | 1 | 1 |
@@ -178,9 +181,9 @@ Legend: **Y** = tested, **N** = not tested, **—** = not implemented
 | Write — PRE | 2 | 0 | 0 |
 | Arbitration | 1 | 3 | 0 |
 | Read | 9 | 0 | 0 |
-| GetForwardingPipelineConfig | 4 | 0 | 0 |
+| GetForwardingPipelineConfig | 5 | 0 | 0 |
 | Capabilities | 1 | 0 | 0 |
 | PacketIO | 3 | 0 | 2 |
 | Translation | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **76** | **6** | **7** |
+| **Total** | **79** | **6** | **7** |

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -8,6 +8,7 @@ import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildGroupEntity
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildMemberEntity
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
 import io.grpc.Status
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -16,8 +17,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
 import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigRequest
 import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
 
 /**
  * P4Runtime conformance tests.
@@ -248,6 +251,31 @@ class P4RuntimeConformanceTest {
   }
 
   // =========================================================================
+  // SetForwardingPipelineConfig validation (scenarios 37-38)
+  // =========================================================================
+
+  @Test
+  fun `37 - setForwardingPipelineConfig with invalid device config returns INVALID_ARGUMENT`() {
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "not a valid DeviceConfig") {
+      loadRawPipeline(
+        ForwardingPipelineConfig.newBuilder()
+          .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
+          .setP4DeviceConfig(com.google.protobuf.ByteString.copyFromUtf8("not-a-proto"))
+      )
+    }
+  }
+
+  @Test
+  fun `38 - setForwardingPipelineConfig without device config returns INVALID_ARGUMENT`() {
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "must include p4info and p4_device_config") {
+      loadRawPipeline(
+        ForwardingPipelineConfig.newBuilder()
+          .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
+      )
+    }
+  }
+
+  // =========================================================================
   // Read filtering (scenarios 20-21)
   // =========================================================================
 
@@ -274,7 +302,7 @@ class P4RuntimeConformanceTest {
   }
 
   // =========================================================================
-  // GetForwardingPipelineConfig response types (scenario 22)
+  // GetForwardingPipelineConfig response types (scenarios 22, 36)
   // =========================================================================
 
   @Test
@@ -284,6 +312,14 @@ class P4RuntimeConformanceTest {
       harness.getConfig(GetForwardingPipelineConfigRequest.ResponseType.DEVICE_CONFIG_AND_COOKIE)
     assertFalse("p4info should be absent", resp.config.hasP4Info())
     assertFalse("device config should be present", resp.config.p4DeviceConfig.isEmpty)
+  }
+
+  @Test
+  fun `36 - getForwardingPipelineConfig COOKIE_ONLY returns empty config`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val resp = harness.getConfig(GetForwardingPipelineConfigRequest.ResponseType.COOKIE_ONLY)
+    assertFalse("p4info should be absent", resp.config.hasP4Info())
+    assertTrue("device config should be empty", resp.config.p4DeviceConfig.isEmpty)
   }
 
   // =========================================================================
@@ -486,6 +522,17 @@ class P4RuntimeConformanceTest {
 
   private fun buildReadFilter(config: PipelineConfig, matchValue: Long): Entity =
     P4RuntimeTestHarness.buildMatchFilter(config, matchValue)
+
+  /** Sends a raw SetForwardingPipelineConfig — bypasses the harness to test validation paths. */
+  private fun loadRawPipeline(config: ForwardingPipelineConfig.Builder) = runBlocking {
+    harness.stub.setForwardingPipelineConfig(
+      SetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+        .setConfig(config)
+        .build()
+    )
+  }
 
   companion object {
     private const val REG_ID = 500

--- a/simulator/Main.kt
+++ b/simulator/Main.kt
@@ -1,5 +1,7 @@
 package fourward.simulator
 
+import fourward.sim.v1.ErrorCode
+import fourward.sim.v1.ErrorResponse
 import fourward.sim.v1.SimRequest
 import fourward.sim.v1.SimResponse
 import java.io.DataInputStream
@@ -27,29 +29,32 @@ fun main() {
 
   while (true) {
     val request = readRequest(input) ?: break
-    // Catch-all at the subprocess boundary: any uncaught exception becomes an
-    // ErrorResponse so the controller can report it gracefully rather than
-    // receiving a truncated or missing response.
-    @Suppress("TooGenericExceptionCaught")
-    val response =
-      try {
-        simulator.handle(request)
-      } catch (e: Exception) {
-        System.err.println("error handling request: ${e.message}")
-        e.printStackTrace(System.err)
-        SimResponse.newBuilder()
-          .setError(
-            fourward.sim.v1.ErrorResponse.newBuilder()
-              .setCode(fourward.sim.v1.ErrorCode.INTERNAL_ERROR)
-              .setMessage(e.message ?: "unknown error")
-          )
-          .build()
-      }
+    val response = handleSafely(simulator, request)
     writeResponse(output, response)
   }
 
   System.err.println("4ward simulator exiting")
 }
+
+/**
+ * Catch-all at the subprocess boundary: any uncaught exception becomes an ErrorResponse so the
+ * controller can report it gracefully rather than receiving a truncated or missing response.
+ */
+@Suppress("TooGenericExceptionCaught")
+fun handleSafely(simulator: Simulator, request: SimRequest): SimResponse =
+  try {
+    simulator.handle(request)
+  } catch (e: Exception) {
+    System.err.println("error handling request: ${e.message}")
+    e.printStackTrace(System.err)
+    SimResponse.newBuilder()
+      .setError(
+        ErrorResponse.newBuilder()
+          .setCode(ErrorCode.INTERNAL_ERROR)
+          .setMessage(e.message ?: "unknown error")
+      )
+      .build()
+  }
 
 /**
  * Reads one [SimRequest] from [input].

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -158,6 +158,15 @@ class SimulatorTest {
   }
 
   @Test
+  fun `handleSafely catches exception and returns INTERNAL_ERROR`() {
+    val sim = Simulator()
+    // An empty SimRequest has no request kind set, causing Simulator.handle() to throw.
+    val resp = handleSafely(sim, SimRequest.getDefaultInstance())
+    assertTrue("should return error", resp.hasError())
+    assertEquals(ErrorCode.INTERNAL_ERROR, resp.error.code)
+  }
+
+  @Test
   fun `write entry with no pipeline loaded returns NO_PIPELINE_LOADED error`() {
     val sim = Simulator()
     val req =


### PR DESCRIPTION
## Summary

Closes 3 test coverage gaps in the P4Runtime server and simulator:

- **Pipeline config validation**: 3 new conformance tests (#36-38) covering COOKIE_ONLY response type, invalid `p4_device_config` proto bytes, and missing device config — all previously untested `P4RuntimeService` code paths
- **Simulator error handling**: extract `handleSafely` from `Main.kt` into a testable function with a unit test covering the catch-all exception→ErrorResponse path
- **Compliance matrix**: 76 → 79 tested

## Test plan

- [x] `bazel test //...` passes (34/34)
- [x] `./tools/format.sh` clean
- [x] `./tools/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)