### PR TITLE
docs: remove simulator process reuse from refactoring backlog

### DIFF
--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -59,23 +59,6 @@ The module extension has read access to the p4c source tree (via
 
 ---
 
-## Reuse simulator process across p4testgen sub-tests
-
-**Files**: `e2e_tests/stf/Runner.kt`, `e2e_tests/p4testgen/P4TestgenTest.kt`
-
-**Problem**: Each sub-test in a p4testgen target spawns a fresh simulator
-subprocess and re-loads the same pipeline config. With `max_tests = 100`,
-subprocess overhead (~330ms each) dominates — 100 sub-tests take ~33s
-when the actual packet processing is negligible.
-
-**Fix**: All sub-tests within a target share the same `.txtpb`. Launch the
-simulator once, load the pipeline once, then for each STF: install table
-entries, send packets, check outputs. `StfRunner` currently assumes
-one-shot execution (launch → run → destroy); refactor it to support a
-persistent session that resets table state between STFs.
-
----
-
 ## Re-enable buf lint
 
 Blocked on buf support for proto edition 2024.


### PR DESCRIPTION
## Summary

Removes the "reuse simulator process across p4testgen sub-tests" entry from REFACTORING.md. The CI-only time savings (~2-5 min) doesn't justify the complexity: adding a `ResetEntries` proto message, refactoring Runner into a persistent session, and losing the clean test isolation of one-process-per-STF.

## Test plan

- Docs-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)