### PR TITLE
fix: BMv2 driver priority inversion — ternary2-bmv2 passes

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -46,10 +46,6 @@ guilt — just write it down so someone can find it later.
 - **Multicast: basic replication only.** Multicast group replication works
   for the trace tree (forking per replica). PRE entries are installed via
   P4Runtime `PacketReplicationEngineEntry`.
-- **Per-table action specialization lost.** When a table has a single action
-  ID in p4info but different compile-time specializations, only one is kept.
-  Blocks 1 corpus test (`ternary2-bmv2`).
-
 ## BMv2 differential testing
 
 - **No action profile support in BMv2 driver.** The bmv2_driver binary does not
@@ -59,9 +55,8 @@ guilt — just write it down so someone can find it later.
   `libgmp` and `libpcap` rather than building them from source. The build uses
   genrules to copy headers into the build tree, but runtime linking requires the
   libraries to be installed (e.g. via Homebrew on macOS).
-- **183 of 186 corpus tests pass.** 3 tests are excluded: `ipv6-switch-ml-bmv2`
-  and `v1model-special-ops-bmv2` (multicast PRE limits in BMv2 driver), and
-  `ternary2-bmv2` (semantic mismatch under investigation).
+- **184 of 186 corpus tests pass.** 2 tests are excluded: `ipv6-switch-ml-bmv2`
+  and `v1model-special-ops-bmv2` (multicast PRE limits in BMv2 driver).
 
 ## p4c backend
 

--- a/e2e_tests/bmv2_diff/BUILD.bazel
+++ b/e2e_tests/bmv2_diff/BUILD.bazel
@@ -18,10 +18,6 @@ cc_binary(
 # ipv6-switch-ml-bmv2, v1model-special-ops-bmv2:
 #   MC_NODE_CREATE fails — the STF multicast setup exceeds BMv2's PRE limits
 #   or the driver's multicast handling needs extension.
-#
-# ternary2-bmv2:
-#   Semantic mismatch between 4ward and BMv2. Needs investigation to determine
-#   which simulator is correct.
 bmv2_diff_test_suite(
     name = "bmv2_diff_test",
     includes = [
@@ -205,6 +201,7 @@ bmv2_diff_test_suite(
         "table-entries-range-bmv2",
         "table-entries-ser-enum-bmv2",
         "table-entries-ternary-bmv2",
+        "ternary2-bmv2",
         "test-parserinvalidargument-error-bmv2",
         "union-bmv2",
         "union-valid-bmv2",

--- a/e2e_tests/bmv2_diff/bmv2_driver.cpp
+++ b/e2e_tests/bmv2_diff/bmv2_driver.cpp
@@ -292,8 +292,13 @@ int main(int argc, char* argv[]) {
 
       auto ad = parse_action_data(params);
       bm::entry_handle_t handle;
+      // BMv2 uses lower-value = higher-priority internally
+      // (lookup_structures.cpp picks the matching entry with the minimum
+      // priority field). The STF/P4Runtime convention is higher-value =
+      // higher-priority. Negate to bridge the gap.
+      int bmv2_priority = priority > 0 ? -priority : priority;
       auto rc = sw->mt_add_entry(0, table, match_keys, action, std::move(ad),
-                                 &handle, priority);
+                                 &handle, bmv2_priority);
       if (rc != MatchErrorCode::SUCCESS) {
         std::cout << "ERROR TABLE_ADD failed: " << static_cast<int>(rc)
                   << std::endl;


### PR DESCRIPTION
## Summary

Found and fixed the root cause of the `ternary2-bmv2` BMv2 differential test failure.

**The bug:** BMv2's internal ternary lookup uses lower-value = higher-priority (it picks the matching entry with the *minimum* priority field — see `lookup_structures.cpp:265-278`). Our BMv2 driver was passing STF priorities verbatim, but the STF/P4Runtime convention is higher-value = higher-priority. One-line fix: negate the priority before passing to `mt_add_entry`.

**The symptom:** For `ternary2-bmv2`, two entries matched on table `ex1`: `act1` at priority 100 (ternary `0x25**`) and `act2` at priority 110 (exact `0x2525`). BMv2 picked `act1` because 100 < 110, when it should have picked `act2`.

**184 of 186** BMv2 differential tests now pass (up from 183). The remaining 2 (`ipv6-switch-ml-bmv2`, `v1model-special-ops-bmv2`) are multicast PRE limits in the BMv2 driver.

## Test plan

- [x] `bazel test //e2e_tests/bmv2_diff:bmv2_diff_test` — 184/184 pass (including ternary2-bmv2)
- [x] `./tools/format.sh` + `./tools/lint.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)