### PR TITLE
docs: add Track 7 — standalone CLI — to roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -241,6 +241,41 @@ corpus tests as acceptance criteria. Each architecture is a significant lift
 
 **Done when:** PSA corpus tests pass.
 
+### Track 7: standalone CLI
+
+**Priority: not now | Depends on: tracks 1, 3**
+
+Today 4ward is only usable through Bazel test targets or the P4Runtime gRPC
+API. There's no `4ward run my_program.p4` — a newcomer who finds the repo
+can build and test, but can't easily try it with their own program.
+
+A standalone CLI would make 4ward accessible to anyone with a P4 program and
+an STF test file:
+
+```sh
+# Compile and simulate in one step.
+4ward run program.p4 test.stf
+
+# Or step by step.
+4ward compile program.p4 -o pipeline.txtpb
+4ward sim pipeline.txtpb test.stf
+```
+
+STF is the natural interface — it already handles table entries, packets, and
+expectations in one file, and it's the P4 ecosystem's established test format.
+
+Scope:
+
+1. **`4ward compile`** — thin wrapper around `p4c-4ward` with sensible
+   defaults (auto-detect include paths, architecture).
+2. **`4ward sim`** — load a pipeline, run an STF file, print trace trees to
+   stdout in text proto or JSON.
+3. **`4ward run`** — compile + simulate in one shot. The "hello world"
+   experience.
+
+**Done when:** a newcomer can `4ward run examples/passthrough.p4` and see a
+trace tree without touching Bazel.
+
 ## Sequencing
 
 ```
@@ -257,6 +292,9 @@ corpus tests as acceptance criteria. Each architecture is a significant lift
   Track 5     │ arch customization  │    │              │    │          │
               │                     │    │              │    │          │
   Track 6     │                     │    │              │    │   PSA    │
+              │                     │    │              │    │          │
+  Track 7     │                     │    │ standalone   │    │          │
+              │                     │    │ CLI          │    │          │
               └─────────────────────┘    └──────────────┘    └──────────┘
 ```
 
@@ -266,3 +304,5 @@ corpus tests as acceptance criteria. Each architecture is a significant lift
 - Track 2 is picked up opportunistically.
 - Track 6 (PSA) depends on v1model being done (shared interpreter, proven
   patterns).
+- Track 7 (CLI) depends on the simulator being feature-complete enough to be
+  useful standalone (tracks 1, 3).


### PR DESCRIPTION
## Summary

Adds a new roadmap track for a standalone CLI that makes 4ward accessible
without Bazel. A newcomer with a P4 program and an STF file should be able
to `4ward run program.p4 test.stf` and see a trace tree.

- Uses STF as the interface — no new formats to invent
- Three subcommands: `compile`, `sim`, `run`
- Slotted as "next" priority, depends on tracks 1 and 3

Motivated by reviewing the repo from a newcomer's perspective: the README
has no "try it with your own program" path today.

## Test plan

- [ ] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)