### PR TITLE
docs: fix stale test counts (186→185)

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -55,7 +55,7 @@ guilt — just write it down so someone can find it later.
   `libgmp` and `libpcap` rather than building them from source. The build uses
   genrules to copy headers into the build tree, but runtime linking requires the
   libraries to be installed (e.g. via Homebrew on macOS).
-- **184 of 186 corpus tests pass.** 2 tests are excluded: `ipv6-switch-ml-bmv2`
+- **183 of 185 corpus tests pass.** 2 tests are excluded: `ipv6-switch-ml-bmv2`
   and `v1model-special-ops-bmv2` (multicast PRE limits in BMv2 driver).
 
 ## p4c backend

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -99,8 +99,8 @@ Three subtracks, each a different testing methodology:
 unpinned across the full corpus (1B), and BMv2 diff testing surfaces no
 mismatches (1C).
 
-**Current status:** 1A complete (186/186). 1B: 155 programs, all unpinned.
-1C: 183 programs diff-tested. See [STATUS.md](STATUS.md).
+**Current status:** 1A complete (185/185). 1B: 155 programs, all unpinned.
+1C: 183 programs diff-tested (2 excluded). See [STATUS.md](STATUS.md).
 
 ### Track 2: infrastructure
 


### PR DESCRIPTION
## Summary

Docs said 186 v1model corpus tests / 184 diff-tested — actual BUILD.bazel counts are **185** corpus / **183** diff-tested (2 excluded for PRE limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)