### PR TITLE
BMv2 diff: all 186 corpus tests pass

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -55,8 +55,7 @@ guilt — just write it down so someone can find it later.
   `libgmp` and `libpcap` rather than building them from source. The build uses
   genrules to copy headers into the build tree, but runtime linking requires the
   libraries to be installed (e.g. via Homebrew on macOS).
-- **183 of 185 corpus tests pass.** 2 tests are excluded: `ipv6-switch-ml-bmv2`
-  and `v1model-special-ops-bmv2` (multicast PRE limits in BMv2 driver).
+- **All 186 corpus tests pass.**
 
 ## p4c backend
 

--- a/e2e_tests/bmv2_diff/BUILD.bazel
+++ b/e2e_tests/bmv2_diff/BUILD.bazel
@@ -13,11 +13,6 @@ cc_binary(
     deps = ["@behavioral_model//:simple_switch_lib"],
 )
 
-# Tests excluded from the diff suite:
-#
-# ipv6-switch-ml-bmv2, v1model-special-ops-bmv2:
-#   MC_NODE_CREATE fails — the STF multicast setup exceeds BMv2's PRE limits
-#   or the driver's multicast handling needs extension.
 bmv2_diff_test_suite(
     name = "bmv2_diff_test",
     includes = [
@@ -131,6 +126,7 @@ bmv2_diff_test_suite(
         "header-bool-bmv2",
         "header-stack-ops-bmv2",
         "invalid-hdr-warnings3-bmv2",
+        "ipv6-switch-ml-bmv2",
         "issue-2123-2-bmv2",
         "issue-2123-3-bmv2",
         "issue1000-bmv2",
@@ -209,5 +205,6 @@ bmv2_diff_test_suite(
         "union2-bmv2",
         "union3-bmv2",
         "v1model-const-entries-bmv2",
+        "v1model-special-ops-bmv2",
     ],
 )

--- a/e2e_tests/bmv2_diff/Bmv2Runner.kt
+++ b/e2e_tests/bmv2_diff/Bmv2Runner.kt
@@ -172,11 +172,12 @@ class Bmv2Runner(driverBinary: Path, jsonPath: Path, private val p4Info: P4InfoO
         "$valueHex&&&$maskHex"
       }
       MatchKind.EXACT -> {
-        // If the table declares ternary but the STF value is exact, promote to ternary.
-        if (mf.matchType == P4InfoOuterClass.MatchField.MatchType.TERNARY) {
-          "$valueHex&&&${allOnesMaskHex(mf.bitwidth)}"
-        } else {
-          valueHex
+        when (mf.matchType) {
+          // If the table declares ternary/lpm but the STF value is exact, promote.
+          P4InfoOuterClass.MatchField.MatchType.TERNARY ->
+            "$valueHex&&&${allOnesMaskHex(mf.bitwidth)}"
+          P4InfoOuterClass.MatchField.MatchType.LPM -> "$valueHex/${mf.bitwidth}"
+          else -> valueHex
         }
       }
     }

--- a/e2e_tests/bmv2_diff/bmv2_driver.cpp
+++ b/e2e_tests/bmv2_diff/bmv2_driver.cpp
@@ -19,6 +19,7 @@
 
 #include <bm/bm_sim/options_parse.h>
 #include <bm/bm_sim/simple_pre.h>
+#include <bm/bm_sim/simple_pre_lag.h>
 #include <bm/bm_sim/switch.h>
 #include <simple_switch.h>
 
@@ -242,6 +243,8 @@ int main(int argc, char* argv[]) {
 
   sw->start_and_return();
 
+  auto pre = sw->get_component<bm::McSimplePreLAG>();
+
   // Signal readiness.
   std::cout << "READY" << std::endl;
 
@@ -347,7 +350,6 @@ int main(int argc, char* argv[]) {
         std::cout << "ERROR bad MC_MGRP_CREATE" << std::endl;
         continue;
       }
-      auto pre = sw->get_component<bm::McSimplePre>();
       bm::McSimplePre::mgrp_hdl_t mgrp_hdl;
       auto rc = pre->mc_mgrp_create(std::stoi(tokens[1]), &mgrp_hdl);
       if (rc != bm::McSimplePre::McReturnCode::SUCCESS) {
@@ -362,7 +364,6 @@ int main(int argc, char* argv[]) {
         std::cout << "ERROR bad MC_NODE_CREATE" << std::endl;
         continue;
       }
-      auto pre = sw->get_component<bm::McSimplePre>();
       int rid = std::stoi(tokens[1]);
       bm::McSimplePre::PortMap port_map;
       for (size_t i = 2; i < tokens.size(); i++) {
@@ -370,7 +371,9 @@ int main(int argc, char* argv[]) {
         if (p >= 0 && static_cast<size_t>(p) < port_map.size()) port_map[p] = 1;
       }
       bm::McSimplePre::l1_hdl_t l1_hdl;
-      auto rc = pre->mc_node_create(rid, port_map, &l1_hdl);
+      // McSimplePreLAG::mc_node_create requires a LagMap; pass empty (no LAG).
+      bm::McSimplePreLAG::LagMap lag_map;
+      auto rc = pre->mc_node_create(rid, port_map, lag_map, &l1_hdl);
       if (rc != bm::McSimplePre::McReturnCode::SUCCESS) {
         std::cout << "ERROR MC_NODE_CREATE failed" << std::endl;
       } else {
@@ -383,7 +386,6 @@ int main(int argc, char* argv[]) {
         std::cout << "ERROR bad MC_NODE_ASSOCIATE" << std::endl;
         continue;
       }
-      auto pre = sw->get_component<bm::McSimplePre>();
       auto mgrp_hdl =
           static_cast<bm::McSimplePre::mgrp_hdl_t>(std::stoi(tokens[1]));
       auto l1_hdl =

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -695,6 +695,12 @@ private fun resolveStfMatchField(
       fmBuilder.setOptional(
         P4RuntimeOuterClass.FieldMatch.Optional.newBuilder().setValue(encodedValue)
       )
+    m.kind == MatchKind.EXACT && p4infoType == P4InfoOuterClass.MatchField.MatchType.LPM ->
+      fmBuilder.setLpm(
+        P4RuntimeOuterClass.FieldMatch.LPM.newBuilder()
+          .setValue(encodedValue)
+          .setPrefixLen(mf.bitwidth)
+      )
     else ->
       fmBuilder.setExact(P4RuntimeOuterClass.FieldMatch.Exact.newBuilder().setValue(encodedValue))
   }


### PR DESCRIPTION
## Summary

All 186 v1model STF corpus tests now pass bit-for-bit against BMv2 — up from 184. The last two holdouts (`ipv6-switch-ml-bmv2`, `v1model-special-ops-bmv2`) were blocked by two independent driver bugs:

- **Multicast PRE type mismatch**: BMv2's `simple_switch` registers `McSimplePreLAG` (not `McSimplePre`), so `get_component<McSimplePre>()` returned nullptr. Switched to `McSimplePreLAG` with an empty LAG map.

- **Missing exact→LPM promotion**: When an STF entry uses exact-match syntax for an LPM table field, the Kotlin runner now promotes it to LPM with full prefix length — matching the existing exact→ternary promotion path. Fixed in both `Bmv2Runner` (BMv2 driver) and `Runner` (P4Runtime STF runner).

## Test plan

- [x] `bazel test //e2e_tests/bmv2_diff:bmv2_diff_test` passes all 186 tests
- [x] `bazel test //... --test_tag_filters=-heavy` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)