### PR TITLE
docs: redesign README comparison table with honest status column

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ plane.
 
 | | BMv2 | 4ward goal | Status |
 |---|---|---|---|
-| P4Runtime support | has gaps | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 Write, Read, PacketIO working |
+| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 Write, Read, PacketIO working |
 | Trace format | text | [**proto/JSON**](e2e_tests/trace_tree/clone_with_egress.golden.txtpb) | ✅ |
 | All possible traces | not natively | [**trace trees!**](docs/ROADMAP.md#track-3-trace-trees) | ✅ |
 | `@p4runtime_translation` | no | [**built-in translation engine**](#p4runtime_translation-done-right) | ✅ |


### PR DESCRIPTION
## Summary

Redesigns the README comparison table to separate aspiration from reality:

- **New "Status" column** with ✅/🚧 indicators — readers can instantly tell what works today vs. what's in progress
- **Dropped "Real hardware" column** — not a relevant comparison for simulators
- **Dropped "Simple, readable codebase" row** — subjective; let the code speak
- **Dropped "Spec compliance" row** — BMv2 *is* the de facto v1model reference, claiming it "has gaps" is misleading
- **Renamed "4ward" column to "4ward goal"** — makes explicit that bold claims are aspirations

## Test plan

- [x] Docs-only change, no code affected
- [x] All links verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)