### PR TITLE
docs: American spelling throughout, add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{kt,kts}]
+indent_style = space
+indent_size = 2
+
+[*.{cpp,h,cc}]
+indent_style = space
+indent_size = 2
+
+[*.proto]
+indent_style = space
+indent_size = 2
+
+[*.{py,bzl}]
+indent_style = space
+indent_size = 4
+
+[BUILD.bazel]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ this isn't the intended design — and knows exactly how to clean it up later.
 for language semantics is the
 [P4₁₆ Language Specification](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html).
 **When in doubt, consult the spec.** If the spec is ambiguous, follow p4c's
-behaviour and document the ambiguity with a comment citing the relevant spec
+behavior and document the ambiguity with a comment citing the relevant spec
 section. For v1model architecture semantics (clone/resubmit/recirculate
 ordering, last-writer-wins, metadata preservation, ingress→egress boundary),
 the de facto spec is the

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ branch — delivered as a structured trace tree you can actually read.
 4ward is a **spec-compliant reference implementation** of the
 [P4₁₆ language](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html)
 and [P4Runtime](https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.html),
-optimised for **correctness, observability, and extensibility** rather than
+optimized for **correctness, observability, and extensibility** rather than
 performance. Think of it as a debugger that speaks P4, not a production data
 plane.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,12 +11,12 @@ want to hack on it, keep reading.
 4ward's primary goal is to be a faithful implementation of the
 [P4₁₆ language specification](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html).
 Every language feature should behave exactly as the spec describes. When the
-spec is ambiguous, we follow p4c's reference compiler behaviour and document
+spec is ambiguous, we follow p4c's reference compiler behavior and document
 the ambiguity. When the spec is clear, we follow it — even if BMv2 or other
 implementations do something different.
 
 This means correctness always wins over convenience, performance, or
-compatibility with non-standard behaviour. The simulator is meant to be the
+compatibility with non-standard behavior. The simulator is meant to be the
 implementation you trust when you need to know what a P4 program *should* do.
 
 The north star is to replace BMv2 as the reference simulator in
@@ -90,7 +90,7 @@ Interpreter.kt           The big one: IR tree-walker for parsers, controls, acti
 Environment.kt           Variable bindings, packet state (headers + metadata)
 Values.kt                Runtime value types (BitVector, BoolVal, HeaderVal, ...)
 BitVector.kt             Bit-precise integer arithmetic (backed by BigInteger)
-Architecture.kt          Interface for architecture-specific behaviour
+Architecture.kt          Interface for architecture-specific behavior
 V1ModelArchitecture.kt   v1model specifics: recirculate, clone, resubmit, drop
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Run `./tools/dev.sh help` for a summary of available developer commands.
 ## Making changes
 
 1. Fork the repo and create a branch.
-2. Make your change. New behaviour needs a test (usually an STF test does the
+2. Make your change. New behavior needs a test (usually an STF test does the
    trick).
 3. Run `bazel test //...` — everything should be green.
 4. Run `./tools/format.sh` to auto-format everything.
@@ -75,7 +75,7 @@ Add new fields instead.
 4ward is a spec-compliant reference implementation: it should behave exactly as
 the [P4₁₆ spec](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html)
 describes. When you're unsure about a language detail, check the spec. If the
-spec is ambiguous, follow p4c's behaviour and document the ambiguity in a
+spec is ambiguous, follow p4c's behavior and document the ambiguity in a
 comment citing the relevant section.
 
 4ward is proudly not fast. It's correct, it's observable, and it's readable.


### PR DESCRIPTION
## Summary

- **American spelling** — `optimised` → `optimized`, `behaviour` → `behavior` across README, AGENTS, ARCHITECTURE, and CONTRIBUTING
- **`.editorconfig`** — editors auto-detect indent style (2-space for Kotlin/C++/proto, 4-space for Python/Bazel), charset, and trailing whitespace rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)