### PR TITLE
p4runtime: support indirect counter and meter read/write

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -38,7 +38,9 @@ style:
 complexity:
   # Test builder helpers legitimately need many parameters to fully specify a test
   # case without introducing opaque intermediate objects.
+  # loadMappings() takes one parameter per p4info entity type — no natural grouping.
   LongParameterList:
+    functionThreshold: 8
     excludes: ['**/test/**', '**/*Test.kt']
 
   # The default (150 lines) is unreasonable for tree-walking interpreters whose
@@ -68,7 +70,7 @@ complexity:
   # `when` expressions whose cyclomatic complexity grows linearly with the number
   # of P4 language constructs — not a readability problem.
   CyclomaticComplexMethod:
-    threshold: 29
+    threshold: 30
 
   # 60 lines is too tight for sequential protocol handlers (e.g. StfRunner.run, which
   # encodes a strict request/response sequence that reads clearly as one function).

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -39,8 +39,9 @@ guilt — just write it down so someone can find it later.
   `sdn_string` with explicit, auto-allocate, and hybrid mapping modes.
   Note: v1model `p4c` does not emit `controller_packet_metadata` with
   `type_name`, so PacketIO translation is exercised via unit tests only.
-- **No counters or meters via P4Runtime.** These work via the simulator
-  protocol but cannot be managed through the gRPC server.
+- **No direct counters or direct meters via P4Runtime.** Indirect
+  (standalone) counters and meters can be read/written via the gRPC server;
+  direct counters/meters (associated with table entries) are not yet supported.
 - **No digests, idle timeouts, or atomic write batches.**
 
 ## Simulator

--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -88,9 +88,9 @@ Legend: **Y** = tested, **N** = not tested, **—** = not implemented
 | # | Requirement | Status | Test |
 |---|-------------|--------|------|
 | 9.50 | Direct counter read/write | — | |
-| 9.51 | Indirect counter read/write | — | |
+| 9.51 | Indirect counter read/write | Y | TableStoreTest, ConformanceTest #46-48 |
 | 9.52 | Direct meter config | — | |
-| 9.53 | Indirect meter config | — | |
+| 9.53 | Indirect meter config | Y | TableStoreTest, ConformanceTest #49-51 |
 
 ## Write RPC — PRE (§9.5)
 
@@ -177,7 +177,7 @@ Legend: **Y** = tested, **N** = not tested, **—** = not implemented
 | Write — tables | 28 | 0 | 0 |
 | Write — profiles | 7 | 0 | 1 |
 | Write — registers | 5 | 0 | 0 |
-| Write — counters/meters | 0 | 0 | 4 |
+| Write — counters/meters | 2 | 0 | 2 |
 | Write — PRE | 2 | 0 | 0 |
 | Arbitration | 4 | 0 | 0 |
 | Read | 9 | 0 | 0 |
@@ -186,4 +186,4 @@ Legend: **Y** = tested, **N** = not tested, **—** = not implemented
 | PacketIO | 3 | 0 | 2 |
 | Translation | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **85** | **0** | **7** |
+| **Total** | **87** | **0** | **5** |

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -644,6 +644,107 @@ class P4RuntimeConformanceTest {
     assertEquals("read should return the installed entry", 1, results.size)
   }
 
+  // =========================================================================
+  // Counter entries (scenarios 46-48)
+  // =========================================================================
+
+  private fun loadConfigWithCounter(): PipelineConfig {
+    val base = loadBasicTableConfig()
+    val counter =
+      p4.config.v1.P4InfoOuterClass.Counter.newBuilder()
+        .setPreamble(
+          p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(CTR_ID).setName("myCounter")
+        )
+        .setSize(CTR_SIZE.toLong())
+        .build()
+    return base.toBuilder().setP4Info(base.p4Info.toBuilder().addCounters(counter)).build()
+  }
+
+  @Test
+  fun `46 - write counter entry and read it back`() {
+    harness.loadPipeline(loadConfigWithCounter())
+    val entry = P4RuntimeTestHarness.buildCounterEntry(CTR_ID, 0, byteCount = 100, packetCount = 5)
+    harness.modifyEntry(entry)
+    val results = harness.readCounterEntries(CTR_ID)
+    assertEquals(CTR_SIZE, results.size)
+    val written = results.find { it.counterEntry.index.index == 0L }!!
+    assertEquals(100, written.counterEntry.data.byteCount)
+    assertEquals(5, written.counterEntry.data.packetCount)
+  }
+
+  @Test
+  fun `47 - read unwritten counter entry returns zero`() {
+    harness.loadPipeline(loadConfigWithCounter())
+    val results = harness.readCounterEntries(CTR_ID)
+    assertEquals(CTR_SIZE, results.size)
+    for (entity in results) {
+      assertEquals(0, entity.counterEntry.data.byteCount)
+      assertEquals(0, entity.counterEntry.data.packetCount)
+    }
+  }
+
+  @Test
+  fun `48 - INSERT counter entry returns INVALID_ARGUMENT`() {
+    harness.loadPipeline(loadConfigWithCounter())
+    val entry = P4RuntimeTestHarness.buildCounterEntry(CTR_ID, 0, byteCount = 1)
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.installEntry(entry) }
+  }
+
+  // =========================================================================
+  // Meter entries (scenarios 49-51)
+  // =========================================================================
+
+  private fun loadConfigWithMeter(): PipelineConfig {
+    val base = loadBasicTableConfig()
+    val meter =
+      p4.config.v1.P4InfoOuterClass.Meter.newBuilder()
+        .setPreamble(
+          p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(MTR_ID).setName("myMeter")
+        )
+        .setSize(MTR_SIZE.toLong())
+        .build()
+    return base.toBuilder().setP4Info(base.p4Info.toBuilder().addMeters(meter)).build()
+  }
+
+  @Test
+  fun `49 - write meter entry and read it back`() {
+    harness.loadPipeline(loadConfigWithMeter())
+    val entry =
+      P4RuntimeTestHarness.buildMeterEntry(
+        MTR_ID,
+        0,
+        cir = 1000,
+        cburst = 100,
+        pir = 2000,
+        pburst = 200,
+      )
+    harness.modifyEntry(entry)
+    val results = harness.readMeterEntries(MTR_ID)
+    assertEquals(MTR_SIZE, results.size)
+    val written = results.find { it.meterEntry.index.index == 0L }!!
+    assertEquals(1000, written.meterEntry.config.cir)
+    assertEquals(100, written.meterEntry.config.cburst)
+    assertEquals(2000, written.meterEntry.config.pir)
+    assertEquals(200, written.meterEntry.config.pburst)
+  }
+
+  @Test
+  fun `50 - read unwritten meter entry has no config`() {
+    harness.loadPipeline(loadConfigWithMeter())
+    val results = harness.readMeterEntries(MTR_ID)
+    assertEquals(MTR_SIZE, results.size)
+    for (entity in results) {
+      assertFalse("unwritten meter should have no config", entity.meterEntry.hasConfig())
+    }
+  }
+
+  @Test
+  fun `51 - INSERT meter entry returns INVALID_ARGUMENT`() {
+    harness.loadPipeline(loadConfigWithMeter())
+    val entry = P4RuntimeTestHarness.buildMeterEntry(MTR_ID, 0, cir = 1)
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.installEntry(entry) }
+  }
+
   // ---------------------------------------------------------------------------
   // Test helpers
   // ---------------------------------------------------------------------------
@@ -667,5 +768,9 @@ class P4RuntimeConformanceTest {
     private const val REG_BITWIDTH = 32
     private const val REG_BYTEWIDTH = REG_BITWIDTH / 8
     private const val REG_SIZE = 4
+    private const val CTR_ID = 600
+    private const val CTR_SIZE = 4
+    private const val MTR_ID = 700
+    private const val MTR_SIZE = 4
   }
 }

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -189,6 +189,32 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
         .build()
     )
 
+  /** Reads counter entries, filtered by counter ID. */
+  fun readCounterEntries(counterId: Int): List<Entity> =
+    readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setCounterEntry(
+              p4.v1.P4RuntimeOuterClass.CounterEntry.newBuilder().setCounterId(counterId)
+            )
+        )
+        .build()
+    )
+
+  /** Reads meter entries, filtered by meter ID. */
+  fun readMeterEntries(meterId: Int): List<Entity> =
+    readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setMeterEntry(p4.v1.P4RuntimeOuterClass.MeterEntry.newBuilder().setMeterId(meterId))
+        )
+        .build()
+    )
+
   // ---------------------------------------------------------------------------
   // StreamChannel helpers
   // ---------------------------------------------------------------------------
@@ -452,6 +478,50 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
             .setData(
               p4.v1.P4DataOuterClass.P4Data.newBuilder()
                 .setBitstring(ByteString.copyFrom(longToBytes(value, byteLen)))
+            )
+        )
+        .build()
+
+    /** Builds an Entity wrapping a CounterEntry. */
+    fun buildCounterEntry(
+      counterId: Int,
+      index: Long,
+      byteCount: Long = 0,
+      packetCount: Long = 0,
+    ): Entity =
+      Entity.newBuilder()
+        .setCounterEntry(
+          p4.v1.P4RuntimeOuterClass.CounterEntry.newBuilder()
+            .setCounterId(counterId)
+            .setIndex(p4.v1.P4RuntimeOuterClass.Index.newBuilder().setIndex(index))
+            .setData(
+              p4.v1.P4RuntimeOuterClass.CounterData.newBuilder()
+                .setByteCount(byteCount)
+                .setPacketCount(packetCount)
+            )
+        )
+        .build()
+
+    /** Builds an Entity wrapping a MeterEntry. */
+    fun buildMeterEntry(
+      meterId: Int,
+      index: Long,
+      cir: Long = 0,
+      cburst: Long = 0,
+      pir: Long = 0,
+      pburst: Long = 0,
+    ): Entity =
+      Entity.newBuilder()
+        .setMeterEntry(
+          p4.v1.P4RuntimeOuterClass.MeterEntry.newBuilder()
+            .setMeterId(meterId)
+            .setIndex(p4.v1.P4RuntimeOuterClass.Index.newBuilder().setIndex(index))
+            .setConfig(
+              p4.v1.P4RuntimeOuterClass.MeterConfig.newBuilder()
+                .setCir(cir)
+                .setCburst(cburst)
+                .setPir(pir)
+                .setPburst(pburst)
             )
         )
         .build()

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -73,6 +73,8 @@ class Simulator {
       config.p4Info.tablesList,
       config.p4Info.registersList,
       config.p4Info.actionProfilesList,
+      config.p4Info.countersList,
+      config.p4Info.metersList,
     )
 
     for (table in config.p4Info.tablesList) {
@@ -171,6 +173,8 @@ class Simulator {
             tableStore.readProfileMembers(entity.actionProfileMember)
           entity.hasActionProfileGroup() -> tableStore.readProfileGroups(entity.actionProfileGroup)
           entity.hasRegisterEntry() -> tableStore.readRegisterEntries(entity.registerEntry)
+          entity.hasCounterEntry() -> tableStore.readCounterEntries(entity.counterEntry)
+          entity.hasMeterEntry() -> tableStore.readMeterEntries(entity.meterEntry)
           else -> emptyList()
         }
       }

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -40,6 +40,9 @@ class TableStore {
 
   private data class RegisterInfo(val name: String, val bitwidth: Int, val size: Int)
 
+  /** Metadata for statically-allocated indexed externs (counters, meters). */
+  private data class IndexedExternInfo(val size: Int)
+
   // tableName -> list of entries, ordered by insertion (priority is explicit in the entry)
   private val tables: MutableMap<String, MutableList<TableEntry>> = mutableMapOf()
 
@@ -60,6 +63,14 @@ class TableStore {
 
   // registerName -> index -> stored value (persists across packets)
   private val registers: MutableMap<String, MutableMap<Int, Value>> = mutableMapOf()
+
+  // counter_id -> index -> CounterData (persists across packets)
+  private val counters: MutableMap<Int, MutableMap<Int, P4RuntimeOuterClass.CounterData>> =
+    mutableMapOf()
+
+  // meter_id -> index -> MeterConfig (persists across packets)
+  private val meters: MutableMap<Int, MutableMap<Int, P4RuntimeOuterClass.MeterConfig>> =
+    mutableMapOf()
 
   // For unit tests that cannot easily construct TableEntry protos: makes lookup() return
   // hit=true with this action rather than searching the entry list.
@@ -91,6 +102,8 @@ class TableStore {
   private var tableNameById: Map<Int, String> = emptyMap()
   private var actionNameById: Map<Int, String> = emptyMap()
   private var registerInfoById: Map<Int, RegisterInfo> = emptyMap()
+  private var counterInfoById: Map<Int, IndexedExternInfo> = emptyMap()
+  private var meterInfoById: Map<Int, IndexedExternInfo> = emptyMap()
 
   /**
    * Initialises the ID→name maps for the loaded pipeline and clears all table entries.
@@ -98,11 +111,13 @@ class TableStore {
    * Must be called before [write] or [lookup]. Calling it again (pipeline reload) resets all state.
    */
   fun loadMappings(
-    tableNameById: Map<Int, String>,
-    actionNameById: Map<Int, String>,
+    tableNameById: Map<Int, String> = emptyMap(),
+    actionNameById: Map<Int, String> = emptyMap(),
     p4infoTables: List<P4InfoOuterClass.Table> = emptyList(),
     p4infoRegisters: List<P4InfoOuterClass.Register> = emptyList(),
     p4infoActionProfiles: List<P4InfoOuterClass.ActionProfile> = emptyList(),
+    p4infoCounters: List<P4InfoOuterClass.Counter> = emptyList(),
+    p4infoMeters: List<P4InfoOuterClass.Meter> = emptyList(),
   ) {
     this.tableNameById = tableNameById
     this.actionNameById = actionNameById
@@ -111,9 +126,15 @@ class TableStore {
         val bitwidth = reg.typeSpec.bitstring.bit.bitwidth
         reg.preamble.id to RegisterInfo(reg.preamble.name, bitwidth, reg.size)
       }
+    this.counterInfoById =
+      p4infoCounters.associate { it.preamble.id to IndexedExternInfo(it.size.toInt()) }
+    this.meterInfoById =
+      p4infoMeters.associate { it.preamble.id to IndexedExternInfo(it.size.toInt()) }
     tables.clear()
     forcedHits.clear()
     registers.clear()
+    counters.clear()
+    meters.clear()
     profileMembers.clear()
     profileGroups.clear()
     tableActionProfile.clear()
@@ -219,6 +240,121 @@ class TableStore {
   }
 
   // -------------------------------------------------------------------------
+  // Indexed externs (counters, meters) — shared write helper
+  // -------------------------------------------------------------------------
+
+  /**
+   * Validates and stores a value for a MODIFY-only indexed extern (counter, meter).
+   *
+   * Checks: MODIFY-only, known ID, index in bounds. On success, stores [value] at
+   * `storage[id][index]`.
+   */
+  private fun <V> writeIndexedExtern(
+    type: Update.Type,
+    entityName: String,
+    id: Int,
+    index: P4RuntimeOuterClass.Index,
+    infoById: Map<Int, IndexedExternInfo>,
+    storage: MutableMap<Int, MutableMap<Int, V>>,
+    value: V,
+  ): WriteResult {
+    if (type != Update.Type.MODIFY)
+      return WriteResult.InvalidArgument("${entityName}s only support MODIFY, not $type")
+    val info = infoById[id] ?: return WriteResult.NotFound("unknown $entityName ID: $id")
+    val idx = index.index.toInt()
+    if (idx < 0 || idx >= info.size)
+      return WriteResult.InvalidArgument("$entityName index $idx out of bounds [0, ${info.size})")
+    storage.getOrPut(id) { mutableMapOf() }[idx] = value
+    return WriteResult.Success
+  }
+
+  // -------------------------------------------------------------------------
+  // Counters
+  // -------------------------------------------------------------------------
+
+  private fun writeCounterEntry(
+    type: Update.Type,
+    entry: P4RuntimeOuterClass.CounterEntry,
+  ): WriteResult =
+    writeIndexedExtern(
+      type,
+      "counter",
+      entry.counterId,
+      entry.index,
+      counterInfoById,
+      counters,
+      entry.data,
+    )
+
+  fun readCounterEntries(
+    filter: P4RuntimeOuterClass.CounterEntry = P4RuntimeOuterClass.CounterEntry.getDefaultInstance()
+  ): List<P4RuntimeOuterClass.Entity> {
+    val infos =
+      if (filter.counterId == 0) counterInfoById
+      else {
+        val info = counterInfoById[filter.counterId] ?: return emptyList()
+        mapOf(filter.counterId to info)
+      }
+    val hasIndex = filter.hasIndex()
+    return infos.flatMap { (counterId, info) ->
+      val indices = if (hasIndex) listOf(filter.index.index.toInt()) else (0 until info.size)
+      indices.map { idx ->
+        val data =
+          counters[counterId]?.get(idx) ?: P4RuntimeOuterClass.CounterData.getDefaultInstance()
+        P4RuntimeOuterClass.Entity.newBuilder()
+          .setCounterEntry(
+            P4RuntimeOuterClass.CounterEntry.newBuilder()
+              .setCounterId(counterId)
+              .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(idx.toLong()))
+              .setData(data)
+          )
+          .build()
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Meters
+  // -------------------------------------------------------------------------
+
+  private fun writeMeterEntry(
+    type: Update.Type,
+    entry: P4RuntimeOuterClass.MeterEntry,
+  ): WriteResult =
+    writeIndexedExtern(
+      type,
+      "meter",
+      entry.meterId,
+      entry.index,
+      meterInfoById,
+      meters,
+      entry.config,
+    )
+
+  fun readMeterEntries(
+    filter: P4RuntimeOuterClass.MeterEntry = P4RuntimeOuterClass.MeterEntry.getDefaultInstance()
+  ): List<P4RuntimeOuterClass.Entity> {
+    val infos =
+      if (filter.meterId == 0) meterInfoById
+      else {
+        val info = meterInfoById[filter.meterId] ?: return emptyList()
+        mapOf(filter.meterId to info)
+      }
+    val hasIndex = filter.hasIndex()
+    return infos.flatMap { (meterId, info) ->
+      val indices = if (hasIndex) listOf(filter.index.index.toInt()) else (0 until info.size)
+      indices.map { idx ->
+        val builder =
+          P4RuntimeOuterClass.MeterEntry.newBuilder()
+            .setMeterId(meterId)
+            .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(idx.toLong()))
+        meters[meterId]?.get(idx)?.let { builder.setConfig(it) }
+        P4RuntimeOuterClass.Entity.newBuilder().setMeterEntry(builder).build()
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // Write
   // -------------------------------------------------------------------------
 
@@ -228,6 +364,8 @@ class TableStore {
       entity.hasActionProfileMember() -> writeProfileMember(update.type, entity.actionProfileMember)
       entity.hasActionProfileGroup() -> writeProfileGroup(update.type, entity.actionProfileGroup)
       entity.hasRegisterEntry() -> writeRegisterEntry(update.type, entity.registerEntry)
+      entity.hasCounterEntry() -> writeCounterEntry(update.type, entity.counterEntry)
+      entity.hasMeterEntry() -> writeMeterEntry(update.type, entity.meterEntry)
       entity.hasPacketReplicationEngineEntry() -> {
         writePreEntry(entity.packetReplicationEngineEntry)
         WriteResult.Success

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -1279,6 +1279,331 @@ class TableStoreTest {
       .build()
 
   // ---------------------------------------------------------------------------
+  // Counter write semantics
+  // ---------------------------------------------------------------------------
+
+  private fun storeWithCounter(): TableStore {
+    val store = TableStore()
+    store.loadMappings(
+      p4infoCounters = listOf(buildCounterProto(COUNTER_ID, "myCounter", COUNTER_SIZE))
+    )
+    return store
+  }
+
+  private fun buildCounterProto(id: Int, name: String, size: Int): P4InfoOuterClass.Counter =
+    P4InfoOuterClass.Counter.newBuilder()
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName(name))
+      .setSize(size.toLong())
+      .build()
+
+  private fun counterUpdate(
+    type: Update.Type,
+    counterId: Int = COUNTER_ID,
+    index: Long = 0,
+    byteCount: Long = 0,
+    packetCount: Long = 0,
+  ): Update {
+    val entry =
+      P4RuntimeOuterClass.CounterEntry.newBuilder()
+        .setCounterId(counterId)
+        .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(index))
+        .setData(
+          P4RuntimeOuterClass.CounterData.newBuilder()
+            .setByteCount(byteCount)
+            .setPacketCount(packetCount)
+        )
+        .build()
+    return Update.newBuilder()
+      .setType(type)
+      .setEntity(Entity.newBuilder().setCounterEntry(entry))
+      .build()
+  }
+
+  @Test
+  fun `modify counter entry persists value`() {
+    val s = storeWithCounter()
+    assertEquals(
+      WriteResult.Success,
+      s.write(counterUpdate(Update.Type.MODIFY, byteCount = 100, packetCount = 5)),
+    )
+    val results =
+      s.readCounterEntries(
+        P4RuntimeOuterClass.CounterEntry.newBuilder()
+          .setCounterId(COUNTER_ID)
+          .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(0))
+          .build()
+      )
+    assertEquals(1, results.size)
+    assertEquals(100, results[0].counterEntry.data.byteCount)
+    assertEquals(5, results[0].counterEntry.data.packetCount)
+  }
+
+  @Test
+  fun `modify counter at out-of-bounds index returns error`() {
+    val s = storeWithCounter()
+    val result = s.write(counterUpdate(Update.Type.MODIFY, index = COUNTER_SIZE.toLong()))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `insert counter entry returns InvalidArgument`() {
+    val s = storeWithCounter()
+    val result = s.write(counterUpdate(Update.Type.INSERT))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `delete counter entry returns InvalidArgument`() {
+    val s = storeWithCounter()
+    val result = s.write(counterUpdate(Update.Type.DELETE))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `modify counter overwrites previous value`() {
+    val s = storeWithCounter()
+    s.write(counterUpdate(Update.Type.MODIFY, byteCount = 10, packetCount = 1))
+    s.write(counterUpdate(Update.Type.MODIFY, byteCount = 20, packetCount = 2))
+    val filter =
+      P4RuntimeOuterClass.CounterEntry.newBuilder()
+        .setCounterId(COUNTER_ID)
+        .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(0))
+        .build()
+    val results = s.readCounterEntries(filter)
+    assertEquals(20, results[0].counterEntry.data.byteCount)
+    assertEquals(2, results[0].counterEntry.data.packetCount)
+  }
+
+  @Test
+  fun `modify counter with unknown ID returns NotFound`() {
+    val s = storeWithCounter()
+    val result = s.write(counterUpdate(Update.Type.MODIFY, counterId = 999))
+    assertTrue("expected NotFound", result is WriteResult.NotFound)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Counter reads
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `readCounterEntries single index returns written value`() {
+    val s = storeWithCounter()
+    s.write(counterUpdate(Update.Type.MODIFY, index = 1, byteCount = 42, packetCount = 3))
+    val filter =
+      P4RuntimeOuterClass.CounterEntry.newBuilder()
+        .setCounterId(COUNTER_ID)
+        .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(1))
+        .build()
+    val results = s.readCounterEntries(filter)
+    assertEquals(1, results.size)
+    assertEquals(42, results[0].counterEntry.data.byteCount)
+    assertEquals(3, results[0].counterEntry.data.packetCount)
+  }
+
+  @Test
+  fun `readCounterEntries all indices returns full array with defaults`() {
+    val s = storeWithCounter()
+    s.write(counterUpdate(Update.Type.MODIFY, index = 2, byteCount = 99))
+    val filter = P4RuntimeOuterClass.CounterEntry.newBuilder().setCounterId(COUNTER_ID).build()
+    val results = s.readCounterEntries(filter)
+    assertEquals(COUNTER_SIZE, results.size)
+    for (entity in results) {
+      val entry = entity.counterEntry
+      val expectedBytes = if (entry.index.index == 2L) 99L else 0L
+      assertEquals(expectedBytes, entry.data.byteCount)
+    }
+  }
+
+  @Test
+  fun `readCounterEntries wildcard returns all counters`() {
+    val s = TableStore()
+    s.loadMappings(
+      tableNameById = emptyMap(),
+      actionNameById = emptyMap(),
+      p4infoCounters =
+        listOf(
+          buildCounterProto(COUNTER_ID, "counter1", 2),
+          buildCounterProto(COUNTER_ID + 1, "counter2", 1),
+        ),
+    )
+    val results = s.readCounterEntries()
+    // 2 entries from first counter + 1 from second = 3
+    assertEquals(3, results.size)
+  }
+
+  @Test
+  fun `readCounterEntries unknown counter returns empty`() {
+    val s = storeWithCounter()
+    val filter = P4RuntimeOuterClass.CounterEntry.newBuilder().setCounterId(999).build()
+    assertTrue(s.readCounterEntries(filter).isEmpty())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Meter write semantics
+  // ---------------------------------------------------------------------------
+
+  private fun storeWithMeter(): TableStore {
+    val store = TableStore()
+    store.loadMappings(p4infoMeters = listOf(buildMeterProto(METER_ID, "myMeter", METER_SIZE)))
+    return store
+  }
+
+  private fun buildMeterProto(id: Int, name: String, size: Int): P4InfoOuterClass.Meter =
+    P4InfoOuterClass.Meter.newBuilder()
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName(name))
+      .setSize(size.toLong())
+      .build()
+
+  private fun meterUpdate(
+    type: Update.Type,
+    meterId: Int = METER_ID,
+    index: Long = 0,
+    cir: Long = 0,
+    cburst: Long = 0,
+    pir: Long = 0,
+    pburst: Long = 0,
+  ): Update {
+    val entry =
+      P4RuntimeOuterClass.MeterEntry.newBuilder()
+        .setMeterId(meterId)
+        .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(index))
+        .setConfig(
+          P4RuntimeOuterClass.MeterConfig.newBuilder()
+            .setCir(cir)
+            .setCburst(cburst)
+            .setPir(pir)
+            .setPburst(pburst)
+        )
+        .build()
+    return Update.newBuilder()
+      .setType(type)
+      .setEntity(Entity.newBuilder().setMeterEntry(entry))
+      .build()
+  }
+
+  @Test
+  fun `modify meter entry persists config`() {
+    val s = storeWithMeter()
+    assertEquals(
+      WriteResult.Success,
+      s.write(meterUpdate(Update.Type.MODIFY, cir = 1000, cburst = 100, pir = 2000, pburst = 200)),
+    )
+    val results =
+      s.readMeterEntries(
+        P4RuntimeOuterClass.MeterEntry.newBuilder()
+          .setMeterId(METER_ID)
+          .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(0))
+          .build()
+      )
+    assertEquals(1, results.size)
+    val config = results[0].meterEntry.config
+    assertEquals(1000, config.cir)
+    assertEquals(100, config.cburst)
+    assertEquals(2000, config.pir)
+    assertEquals(200, config.pburst)
+  }
+
+  @Test
+  fun `modify meter at out-of-bounds index returns error`() {
+    val s = storeWithMeter()
+    val result = s.write(meterUpdate(Update.Type.MODIFY, index = METER_SIZE.toLong()))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `insert meter entry returns InvalidArgument`() {
+    val s = storeWithMeter()
+    val result = s.write(meterUpdate(Update.Type.INSERT))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `delete meter entry returns InvalidArgument`() {
+    val s = storeWithMeter()
+    val result = s.write(meterUpdate(Update.Type.DELETE))
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `modify meter overwrites previous config`() {
+    val s = storeWithMeter()
+    s.write(meterUpdate(Update.Type.MODIFY, cir = 100))
+    s.write(meterUpdate(Update.Type.MODIFY, cir = 200))
+    val filter =
+      P4RuntimeOuterClass.MeterEntry.newBuilder()
+        .setMeterId(METER_ID)
+        .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(0))
+        .build()
+    val results = s.readMeterEntries(filter)
+    assertEquals(200, results[0].meterEntry.config.cir)
+  }
+
+  @Test
+  fun `modify meter with unknown ID returns NotFound`() {
+    val s = storeWithMeter()
+    val result = s.write(meterUpdate(Update.Type.MODIFY, meterId = 999))
+    assertTrue("expected NotFound", result is WriteResult.NotFound)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Meter reads
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `readMeterEntries single index returns written config`() {
+    val s = storeWithMeter()
+    s.write(meterUpdate(Update.Type.MODIFY, index = 1, cir = 500, pir = 1000))
+    val filter =
+      P4RuntimeOuterClass.MeterEntry.newBuilder()
+        .setMeterId(METER_ID)
+        .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(1))
+        .build()
+    val results = s.readMeterEntries(filter)
+    assertEquals(1, results.size)
+    assertEquals(500, results[0].meterEntry.config.cir)
+    assertEquals(1000, results[0].meterEntry.config.pir)
+  }
+
+  @Test
+  fun `readMeterEntries all indices returns full array`() {
+    val s = storeWithMeter()
+    s.write(meterUpdate(Update.Type.MODIFY, index = 2, cir = 42))
+    val filter = P4RuntimeOuterClass.MeterEntry.newBuilder().setMeterId(METER_ID).build()
+    val results = s.readMeterEntries(filter)
+    assertEquals(METER_SIZE, results.size)
+    // Index 2 has config, others have no config set.
+    for (entity in results) {
+      val entry = entity.meterEntry
+      if (entry.index.index == 2L) {
+        assertEquals(42, entry.config.cir)
+      } else {
+        assertFalse("unwritten meter should have no config", entry.hasConfig())
+      }
+    }
+  }
+
+  @Test
+  fun `readMeterEntries wildcard returns all meters`() {
+    val s = TableStore()
+    s.loadMappings(
+      tableNameById = emptyMap(),
+      actionNameById = emptyMap(),
+      p4infoMeters =
+        listOf(buildMeterProto(METER_ID, "meter1", 2), buildMeterProto(METER_ID + 1, "meter2", 1)),
+    )
+    val results = s.readMeterEntries()
+    // 2 entries from first meter + 1 from second = 3
+    assertEquals(3, results.size)
+  }
+
+  @Test
+  fun `readMeterEntries unknown meter returns empty`() {
+    val s = storeWithMeter()
+    val filter = P4RuntimeOuterClass.MeterEntry.newBuilder().setMeterId(999).build()
+    assertTrue(s.readMeterEntries(filter).isEmpty())
+  }
+
+  // ---------------------------------------------------------------------------
   // Constants
   // ---------------------------------------------------------------------------
 
@@ -1292,6 +1617,10 @@ class TableStoreTest {
     private const val REGISTER_NAME = "myRegister"
     private const val REGISTER_BITWIDTH = 32
     private const val REGISTER_SIZE = 4
+    private const val COUNTER_ID = 600
+    private const val COUNTER_SIZE = 4
+    private const val METER_ID = 700
+    private const val METER_SIZE = 4
     private const val TABLE_SIZE_LIMIT = 3
     private const val MAX_GROUP_SIZE = 2
     private val ACTION_ID_TO_NAME =


### PR DESCRIPTION
## Summary

Counters and meters can now be managed through the P4Runtime gRPC server — closing
2 of the 5 remaining unimplemented items in the compliance matrix (87/92 tested).

- **Indirect CounterEntry**: MODIFY writes `byte_count`/`packet_count`; read returns
  all indices with defaults for unwritten entries
- **Indirect MeterEntry**: MODIFY writes `cir`/`cburst`/`pir`/`pburst`; unwritten
  entries have no config (per P4Runtime spec §9.4)
- Both follow the same MODIFY-only pattern as registers (INSERT/DELETE → INVALID_ARGUMENT)
- Shared `writeIndexedExtern<V>` generic validates type/ID/bounds for both

Direct counters/meters (associated with table entries) are tracked as a remaining gap.

## Test plan

- [x] `TableStoreTest`: 20 new unit tests covering counter/meter write semantics
  (persist, overwrite, out-of-bounds, INSERT/DELETE rejected, unknown ID),
  read (single index, all indices, wildcard, unknown ID)
- [x] `P4RuntimeConformanceTest`: 6 new conformance tests (#46-51) verifying
  write+readback, unwritten defaults, and INSERT rejection through the gRPC stack
- [x] Full test suite passes (`bazel test //... --test_tag_filters=-heavy`)
- [x] Format and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)