### PR TITLE
refactor: clean up three REFACTORING backlog items

### DIFF
--- a/cli/Simulate.kt
+++ b/cli/Simulate.kt
@@ -3,11 +3,11 @@ package fourward.cli
 import com.google.protobuf.TextFormat
 import fourward.e2e.ReceivedPacket
 import fourward.e2e.StfFile
-import fourward.e2e.collectOutputsFromTrace
 import fourward.e2e.installStfEntries
 import fourward.e2e.loadPipelineConfig
 import fourward.e2e.matchOutputAgainstExpects
 import fourward.simulator.Simulator
+import fourward.simulator.collectOutputsFromTrace
 import java.io.FileNotFoundException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -85,47 +85,6 @@ coverage grows.
 
 ---
 
-## Deduplicate `collectOutputsFromTrace`
-
-**Files**: `e2e_tests/stf/Runner.kt`, `simulator/V1ModelArchitectureTest.kt`
-
-**Problem**: `V1ModelArchitectureTest.collectOutputs` is a private copy of the
-public `collectOutputsFromTrace` in `Runner.kt`. Both recursively walk a
-`TraceTree` to collect output packets from leaves.
-
-**Fix**: Delete the private copy and import `collectOutputsFromTrace` from
-`fourward.e2e`.
-
----
-
-## Deduplicate `allOnesMask` helpers
-
-**Files**: `e2e_tests/stf/Runner.kt`, `e2e_tests/bmv2_diff/Bmv2Runner.kt`
-
-**Problem**: `Runner.allOnesMask` and `Bmv2Runner.allOnesMaskHex` both compute
-an all-ones bitmask for a given bitwidth. They differ only in output format
-(`0x`-prefixed vs bare hex).
-
-**Fix**: Extract a shared utility, or have one call the other with a format
-flag.
-
----
-
-## `data class` + `ByteArray` on `StfPacket`
-
-**Files**: `e2e_tests/stf/Runner.kt`
-
-**Problem**: `data class StfPacket` contains a `ByteArray` field. Kotlin data
-classes generate `equals`/`hashCode` using reference identity for arrays, so
-two `StfPacket` instances with identical content compare as not equal. Currently
-harmless (instances are only iterated, never compared), but a latent bug if
-anyone adds equality checks or uses them as map/set keys.
-
-**Fix**: Drop the `data` modifier (matching `StfExpectedOutput` and
-`ReceivedPacket`), or add `contentEquals`/`contentHashCode` overrides.
-
----
-
 ## Separate simulator return type from gRPC wire type
 
 **Files**: `simulator/Simulator.kt`, `p4runtime/DataplaneService.kt`,

--- a/e2e_tests/bmv2_diff/Bmv2DiffTest.kt
+++ b/e2e_tests/bmv2_diff/Bmv2DiffTest.kt
@@ -1,11 +1,11 @@
 package fourward.e2e.bmv2
 
 import fourward.e2e.StfFile
-import fourward.e2e.collectOutputsFromTrace
 import fourward.e2e.hex
 import fourward.e2e.installStfEntries
 import fourward.e2e.loadPipelineConfig
 import fourward.simulator.Simulator
+import fourward.simulator.collectOutputsFromTrace
 import java.io.File
 import java.nio.file.Paths
 import org.junit.Assert

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -3,23 +3,14 @@ package fourward.e2e
 import com.google.protobuf.ByteString
 import com.google.protobuf.TextFormat
 import fourward.ir.v1.PipelineConfig
-import fourward.sim.v1.SimulatorProto.TraceTree
 import fourward.simulator.Simulator
 import fourward.simulator.WriteResult
+import fourward.simulator.collectOutputsFromTrace
 import java.math.BigInteger
 import java.nio.file.Path
 import java.nio.file.Paths
 import p4.config.v1.P4InfoOuterClass
 import p4.v1.P4RuntimeOuterClass
-
-/** Recursively collects output packets from trace tree leaves (for forking programs). */
-fun collectOutputsFromTrace(tree: TraceTree): List<fourward.sim.v1.SimulatorProto.OutputPacket> =
-  when {
-    tree.hasForkOutcome() ->
-      tree.forkOutcome.branchesList.flatMap { collectOutputsFromTrace(it.subtree) }
-    tree.hasPacketOutcome() && tree.packetOutcome.hasOutput() -> listOf(tree.packetOutcome.output)
-    else -> emptyList()
-  }
 
 /** BMv2 STF files use `$N` for array indices; normalize to `[N]`. */
 private val ARRAY_INDEX_REGEX = Regex("\\$(\\d+)")
@@ -758,7 +749,7 @@ fun encodeValue(raw: String, bitwidth: Int): ByteString {
 // Data types
 // ---------------------------------------------------------------------------
 
-data class StfPacket(val ingressPort: Int, val payload: ByteArray)
+class StfPacket(val ingressPort: Int, val payload: ByteArray)
 
 /** An output packet received from the simulator, before matching against expects. */
 class ReceivedPacket(val egressPort: Int, val payload: ByteArray)

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -1,7 +1,9 @@
 package fourward.simulator
 
 import fourward.ir.v1.PipelineConfig
+import fourward.sim.v1.SimulatorProto.OutputPacket
 import fourward.sim.v1.SimulatorProto.ProcessPacketResponse
+import fourward.sim.v1.SimulatorProto.TraceTree
 
 /**
  * The top-level simulator state machine.
@@ -160,3 +162,12 @@ class Simulator {
       }
     }
 }
+
+/** Recursively collects output packets from trace tree leaves (for forking programs). */
+fun collectOutputsFromTrace(tree: TraceTree): List<OutputPacket> =
+  when {
+    tree.hasForkOutcome() ->
+      tree.forkOutcome.branchesList.flatMap { collectOutputsFromTrace(it.subtree) }
+    tree.hasPacketOutcome() && tree.packetOutcome.hasOutput() -> listOf(tree.packetOutcome.output)
+    else -> emptyList()
+  }

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -28,7 +28,6 @@ import fourward.ir.v1.TypeDecl
 import fourward.ir.v1.VarDecl
 import fourward.sim.v1.SimulatorProto.DropReason
 import fourward.sim.v1.SimulatorProto.ForkReason
-import fourward.sim.v1.SimulatorProto.OutputPacket
 import fourward.sim.v1.SimulatorProto.PipelineStageEvent.Direction
 import fourward.sim.v1.SimulatorProto.TraceEvent
 import fourward.sim.v1.SimulatorProto.TraceTree
@@ -287,16 +286,6 @@ class V1ModelArchitectureTest {
     )
   }
 
-  /** Collects all [OutputPacket] leaf outcomes from a trace tree (depth-first). */
-  private fun collectOutputs(tree: TraceTree): List<OutputPacket> =
-    if (tree.hasForkOutcome()) {
-      tree.forkOutcome.branchesList.flatMap { collectOutputs(it.subtree) }
-    } else if (tree.hasPacketOutcome() && tree.packetOutcome.hasOutput()) {
-      listOf(tree.packetOutcome.output)
-    } else {
-      emptyList()
-    }
-
   // ---------------------------------------------------------------------------
   // Tests
   // ---------------------------------------------------------------------------
@@ -309,7 +298,7 @@ class V1ModelArchitectureTest {
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val result = V1ModelArchitecture().processPacket(0u, payload, config, tableStore)
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
 
     assertEquals(2, outputs.size)
     assertEquals(2, outputs[0].egressPort)
@@ -325,7 +314,7 @@ class V1ModelArchitectureTest {
       v1modelConfig(assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS))
     val payload = byteArrayOf(0x01, 0x02, 0x03)
     val result = V1ModelArchitecture().processPacket(0u, payload, config, TableStore())
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
 
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].egressPort)
@@ -364,7 +353,7 @@ class V1ModelArchitectureTest {
           ),
       )
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
 
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].egressPort)
@@ -404,7 +393,7 @@ class V1ModelArchitectureTest {
     assertEquals("original", branches[0].label)
     assertEquals("clone", branches[1].label)
 
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
     assertEquals(2, outputs.size)
     // Original branch uses egress_spec set by ingress.
     assertEquals(2, outputs[0].egressPort)
@@ -433,7 +422,7 @@ class V1ModelArchitectureTest {
     assertEquals("original", branches[0].label)
     assertEquals("clone", branches[1].label)
 
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
     assertEquals(2, outputs.size)
     assertEquals(3, outputs[0].egressPort)
     assertEquals(8, outputs[1].egressPort)
@@ -493,7 +482,7 @@ class V1ModelArchitectureTest {
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
     // Only the original branch produces output; the clone branch is dropped.
     assertEquals(1, outputs.size)
     assertEquals(2, outputs[0].egressPort)
@@ -511,7 +500,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
     // Only the original branch produces output.
     assertEquals(1, outputs.size)
     assertEquals(3, outputs[0].egressPort)
@@ -529,7 +518,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
     // No fork — falls through to unicast path.
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].egressPort)
   }
@@ -646,7 +635,7 @@ class V1ModelArchitectureTest {
     val largePort = 1000L // beyond bit<9> range
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", largePort, portBits))
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
 
     assertEquals(1, outputs.size)
     assertEquals(largePort.toInt(), outputs[0].egressPort)
@@ -669,7 +658,7 @@ class V1ModelArchitectureTest {
     val portBits = 16
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", 511, portBits))
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
 
     assertEquals(1, outputs.size)
     assertEquals(511, outputs[0].egressPort)
@@ -699,7 +688,7 @@ class V1ModelArchitectureTest {
     val largePort = 100_000L
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", largePort, portBits))
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectOutputs(result.trace)
+    val outputs = collectOutputsFromTrace(result.trace)
 
     assertEquals(1, outputs.size)
     assertEquals(largePort.toInt(), outputs[0].egressPort)


### PR DESCRIPTION
## Summary

Knocks out three tech debt items from REFACTORING.md:

- **`collectOutputsFromTrace` dedup**: moved the canonical definition from `Runner.kt` to `Simulator.kt` (where `TraceTree` lives), eliminated the private copy in `V1ModelArchitectureTest`, and updated all 4 consumers (Runner, Bmv2DiffTest, Simulate CLI, V1ModelArchitectureTest)
- **`StfPacket` data class bug**: dropped `data` modifier — `ByteArray` fields break `equals`/`hashCode` in data classes. Matches the convention already used by `ReceivedPacket` and `StfExpectedOutput`
- **`allOnesMask` dedup**: removed from backlog — the two helpers serve different consumers with different output formats, unifying would add coupling for no gain

## Test plan

- [x] `bazel test //... --test_tag_filters=-heavy` — all 38 tests pass
- [x] `./tools/format.sh` clean
- [x] `./tools/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)