### PR TITLE
refactor: pass P4Info directly to TableStore.loadMappings

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -38,7 +38,7 @@ style:
 complexity:
   # Test builder helpers legitimately need many parameters to fully specify a test
   # case without introducing opaque intermediate objects.
-  # loadMappings() takes one parameter per p4info entity type — no natural grouping.
+  # writeIndexedExtern() has 7 params (generic validation: type, name, id, index, info, storage, value).
   LongParameterList:
     functionThreshold: 8
     excludes: ['**/test/**', '**/*Test.kt']

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -65,23 +65,44 @@ Blocked on buf support for proto edition 2024.
 
 ---
 
-## Pass `P4Info` directly to `TableStore.loadMappings`
+## Deduplicate `collectOutputsFromTrace`
 
-**Files**: `simulator/TableStore.kt`, `simulator/Simulator.kt`,
-`simulator/TableStoreTest.kt`
+**Files**: `e2e_tests/stf/Runner.kt`, `simulator/V1ModelArchitectureTest.kt`
 
-**Problem**: `loadMappings` takes a growing list of parameters — one per
-entity type (`tableNameById`, `actionNameById`, `p4infoTables`,
-`p4infoRegisters`). Each new P4Runtime entity (counters, meters, digests)
-will add another parameter.
+**Problem**: `V1ModelArchitectureTest.collectOutputs` is a private copy of the
+public `collectOutputsFromTrace` in `Runner.kt`. Both recursively walk a
+`TraceTree` to collect output packets from leaves.
 
-**Fix**: Accept the `P4Info` proto directly (or a slim wrapper) and let
-`TableStore` extract what it needs internally. The two `Map<Int, String>`
-parameters are already derived from `P4Info` in `Simulator.kt` and could
-move inside `loadMappings`. This keeps the signature stable as entity
-coverage grows.
+**Fix**: Delete the private copy and import `collectOutputsFromTrace` from
+`fourward.e2e`.
 
-**Trigger**: when counters or meters are wired through P4Runtime.
+---
+
+## Deduplicate `allOnesMask` helpers
+
+**Files**: `e2e_tests/stf/Runner.kt`, `e2e_tests/bmv2_diff/Bmv2Runner.kt`
+
+**Problem**: `Runner.allOnesMask` and `Bmv2Runner.allOnesMaskHex` both compute
+an all-ones bitmask for a given bitwidth. They differ only in output format
+(`0x`-prefixed vs bare hex).
+
+**Fix**: Extract a shared utility, or have one call the other with a format
+flag.
+
+---
+
+## `data class` + `ByteArray` on `StfPacket`
+
+**Files**: `e2e_tests/stf/Runner.kt`
+
+**Problem**: `data class StfPacket` contains a `ByteArray` field. Kotlin data
+classes generate `equals`/`hashCode` using reference identity for arrays, so
+two `StfPacket` instances with identical content compare as not equal. Currently
+harmless (instances are only iterated, never compared), but a latent bug if
+anyone adds equality checks or uses them as map/set keys.
+
+**Fix**: Drop the `data` modifier (matching `StfExpectedOutput` and
+`ReceivedPacket`), or add `contentEquals`/`contentHashCode` overrides.
 
 ---
 

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -57,15 +57,7 @@ class Simulator {
         val alias = action.preamble.alias.ifEmpty { action.preamble.name }
         action.preamble.id to resolveName(alias, behavioralActions)
       }
-    tableStore.loadMappings(
-      tableNameById,
-      actionNameById,
-      config.p4Info.tablesList,
-      config.p4Info.registersList,
-      config.p4Info.actionProfilesList,
-      config.p4Info.countersList,
-      config.p4Info.metersList,
-    )
+    tableStore.loadMappings(tableNameById, actionNameById, config.p4Info)
 
     for (table in config.p4Info.tablesList) {
       // const_default_action_id: immutable default set in the P4 source with `const`.

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -111,28 +111,28 @@ class TableStore {
   /**
    * Initialises the ID→name maps for the loaded pipeline and clears all table entries.
    *
+   * [tableNameById] and [actionNameById] resolve p4info IDs to behavioral IR names (which may
+   * differ from p4info aliases for inlined controls). The remaining entity metadata is extracted
+   * from [p4info] internally.
+   *
    * Must be called before [write] or [lookup]. Calling it again (pipeline reload) resets all state.
    */
   fun loadMappings(
     tableNameById: Map<Int, String> = emptyMap(),
     actionNameById: Map<Int, String> = emptyMap(),
-    p4infoTables: List<P4InfoOuterClass.Table> = emptyList(),
-    p4infoRegisters: List<P4InfoOuterClass.Register> = emptyList(),
-    p4infoActionProfiles: List<P4InfoOuterClass.ActionProfile> = emptyList(),
-    p4infoCounters: List<P4InfoOuterClass.Counter> = emptyList(),
-    p4infoMeters: List<P4InfoOuterClass.Meter> = emptyList(),
+    p4info: P4InfoOuterClass.P4Info = P4InfoOuterClass.P4Info.getDefaultInstance(),
   ) {
     this.tableNameById = tableNameById
     this.actionNameById = actionNameById
     this.registerInfoById =
-      p4infoRegisters.associate { reg ->
+      p4info.registersList.associate { reg ->
         val bitwidth = reg.typeSpec.bitstring.bit.bitwidth
         reg.preamble.id to RegisterInfo(reg.preamble.name, bitwidth, reg.size)
       }
     this.counterInfoById =
-      p4infoCounters.associate { it.preamble.id to IndexedExternInfo(it.size.toInt()) }
+      p4info.countersList.associate { it.preamble.id to IndexedExternInfo(it.size.toInt()) }
     this.meterInfoById =
-      p4infoMeters.associate { it.preamble.id to IndexedExternInfo(it.size.toInt()) }
+      p4info.metersList.associate { it.preamble.id to IndexedExternInfo(it.size.toInt()) }
     tables.clear()
     forcedHits.clear()
     registers.clear()
@@ -144,9 +144,12 @@ class TableStore {
     cloneSessions.clear()
     multicastGroups.clear()
 
+    // Cache proto repeated-field accessors (each call creates a defensive copy).
+    val tables = p4info.tablesList
+
     // P4Runtime spec §9.27: enforce table size limits from p4info.
     tableSizeLimit =
-      p4infoTables
+      tables
         .filter { it.size > 0 }
         .mapNotNull { table ->
           val name = tableNameById[table.preamble.id] ?: return@mapNotNull null
@@ -156,12 +159,12 @@ class TableStore {
 
     // P4Runtime spec §9.2: enforce max_group_size from p4info action profiles.
     profileMaxGroupSize =
-      p4infoActionProfiles
+      p4info.actionProfilesList
         .filter { it.maxGroupSize > 0 }
         .associate { it.preamble.id to it.maxGroupSize }
 
     // Register which tables use action profiles (implementation_id != 0).
-    for (table in p4infoTables) {
+    for (table in tables) {
       if (table.implementationId != 0) {
         val tableName = tableNameById[table.preamble.id] ?: continue
         tableActionProfile[tableName] = table.implementationId

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -34,6 +34,22 @@ class TableStoreTest {
     )
   }
 
+  /** Builds a [P4InfoOuterClass.P4Info] from individual entity lists. */
+  private fun buildP4Info(
+    tables: List<P4InfoOuterClass.Table> = emptyList(),
+    registers: List<P4InfoOuterClass.Register> = emptyList(),
+    actionProfiles: List<P4InfoOuterClass.ActionProfile> = emptyList(),
+    counters: List<P4InfoOuterClass.Counter> = emptyList(),
+    meters: List<P4InfoOuterClass.Meter> = emptyList(),
+  ): P4InfoOuterClass.P4Info =
+    P4InfoOuterClass.P4Info.newBuilder()
+      .addAllTables(tables)
+      .addAllRegisters(registers)
+      .addAllActionProfiles(actionProfiles)
+      .addAllCounters(counters)
+      .addAllMeters(meters)
+      .build()
+
   // ---------------------------------------------------------------------------
   // Entry builders
   // ---------------------------------------------------------------------------
@@ -486,7 +502,7 @@ class TableStoreTest {
     store.loadMappings(
       tableNameById = mapOf(TABLE_ID to TABLE_NAME),
       actionNameById = ACTION_ID_TO_NAME,
-      p4infoTables = listOf(p4infoTable),
+      p4info = buildP4Info(tables = listOf(p4infoTable)),
     )
     return store
   }
@@ -506,7 +522,7 @@ class TableStoreTest {
     store.loadMappings(
       tableNameById = mapOf(PROFILE_TABLE_ID to PROFILE_TABLE_NAME),
       actionNameById = ACTION_ID_TO_NAME,
-      p4infoTables = listOf(p4infoTable),
+      p4info = buildP4Info(tables = listOf(p4infoTable)),
     )
     return store
   }
@@ -902,8 +918,8 @@ class TableStoreTest {
     store.loadMappings(
       tableNameById = mapOf(PROFILE_TABLE_ID to PROFILE_TABLE_NAME),
       actionNameById = ACTION_ID_TO_NAME,
-      p4infoTables = listOf(p4infoTable),
-      p4infoActionProfiles = listOf(p4infoActionProfile),
+      p4info =
+        buildP4Info(tables = listOf(p4infoTable), actionProfiles = listOf(p4infoActionProfile)),
     )
     return store
   }
@@ -1008,10 +1024,11 @@ class TableStoreTest {
   private fun storeWithRegister(): TableStore {
     val store = TableStore()
     store.loadMappings(
-      tableNameById = mapOf(TABLE_ID to TABLE_NAME),
-      actionNameById = ACTION_ID_TO_NAME,
-      p4infoRegisters =
-        listOf(buildRegisterProto(REGISTER_ID, REGISTER_NAME, REGISTER_BITWIDTH, REGISTER_SIZE)),
+      p4info =
+        buildP4Info(
+          registers =
+            listOf(buildRegisterProto(REGISTER_ID, REGISTER_NAME, REGISTER_BITWIDTH, REGISTER_SIZE))
+        )
     )
     return store
   }
@@ -1146,13 +1163,14 @@ class TableStoreTest {
   fun `readRegisterEntries wildcard returns all registers`() {
     val s = TableStore()
     s.loadMappings(
-      tableNameById = emptyMap(),
-      actionNameById = emptyMap(),
-      p4infoRegisters =
-        listOf(
-          buildRegisterProto(REGISTER_ID, REGISTER_NAME, REGISTER_BITWIDTH, 2),
-          buildRegisterProto(REGISTER_ID + 1, "otherRegister", 8, 1),
-        ),
+      p4info =
+        buildP4Info(
+          registers =
+            listOf(
+              buildRegisterProto(REGISTER_ID, REGISTER_NAME, REGISTER_BITWIDTH, 2),
+              buildRegisterProto(REGISTER_ID + 1, "otherRegister", 8, 1),
+            )
+        )
     )
     s.write(registerUpdate(Update.Type.MODIFY, registerId = REGISTER_ID, index = 0, value = 1))
     val filter = P4RuntimeOuterClass.RegisterEntry.getDefaultInstance()
@@ -1254,6 +1272,7 @@ class TableStoreTest {
       tableNameById = mapOf(TABLE_ID to TABLE_NAME, 3 to "otherTable"),
       actionNameById = ACTION_ID_TO_NAME,
     )
+
     val entry1 = exactEntry(fieldId = 1, value = byteArrayOf(1), actionId = 10)
     val entry2 =
       TableEntry.newBuilder()
@@ -1285,7 +1304,8 @@ class TableStoreTest {
   private fun storeWithCounter(): TableStore {
     val store = TableStore()
     store.loadMappings(
-      p4infoCounters = listOf(buildCounterProto(COUNTER_ID, "myCounter", COUNTER_SIZE))
+      p4info =
+        buildP4Info(counters = listOf(buildCounterProto(COUNTER_ID, "myCounter", COUNTER_SIZE)))
     )
     return store
   }
@@ -1418,13 +1438,14 @@ class TableStoreTest {
   fun `readCounterEntries wildcard returns all counters`() {
     val s = TableStore()
     s.loadMappings(
-      tableNameById = emptyMap(),
-      actionNameById = emptyMap(),
-      p4infoCounters =
-        listOf(
-          buildCounterProto(COUNTER_ID, "counter1", 2),
-          buildCounterProto(COUNTER_ID + 1, "counter2", 1),
-        ),
+      p4info =
+        buildP4Info(
+          counters =
+            listOf(
+              buildCounterProto(COUNTER_ID, "counter1", 2),
+              buildCounterProto(COUNTER_ID + 1, "counter2", 1),
+            )
+        )
     )
     val results = s.readCounterEntries()
     // 2 entries from first counter + 1 from second = 3
@@ -1444,7 +1465,9 @@ class TableStoreTest {
 
   private fun storeWithMeter(): TableStore {
     val store = TableStore()
-    store.loadMappings(p4infoMeters = listOf(buildMeterProto(METER_ID, "myMeter", METER_SIZE)))
+    store.loadMappings(
+      p4info = buildP4Info(meters = listOf(buildMeterProto(METER_ID, "myMeter", METER_SIZE)))
+    )
     return store
   }
 
@@ -1586,10 +1609,14 @@ class TableStoreTest {
   fun `readMeterEntries wildcard returns all meters`() {
     val s = TableStore()
     s.loadMappings(
-      tableNameById = emptyMap(),
-      actionNameById = emptyMap(),
-      p4infoMeters =
-        listOf(buildMeterProto(METER_ID, "meter1", 2), buildMeterProto(METER_ID + 1, "meter2", 1)),
+      p4info =
+        buildP4Info(
+          meters =
+            listOf(
+              buildMeterProto(METER_ID, "meter1", 2),
+              buildMeterProto(METER_ID + 1, "meter2", 1),
+            )
+        )
     )
     val results = s.readMeterEntries()
     // 2 entries from first meter + 1 from second = 3


### PR DESCRIPTION
## Summary

`TableStore.loadMappings` grew a new parameter for every P4Runtime entity type — 7 after adding counters and meters in #243. Now it takes `P4Info` directly and extracts what it needs internally, keeping the signature stable as entity coverage grows.

- **`loadMappings`**: 7 params → 3 (`tableNameById`, `actionNameById`, `p4info`)
- **`Simulator.loadPipeline`**: call site shrinks from 8 lines to 1
- **`detekt.yml`**: threshold comment updated (still 8, now justified by `writeIndexedExtern`)
- **REFACTORING.md**: resolved entry removed

## Test plan

- [x] All 38 non-heavy tests pass (`bazel test //... --test_tag_filters=-heavy`)
- [x] Formatter and linter clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)