### PR TITLE
cli: rich terminal output with ANSI colors

### DIFF
--- a/cli/Main.kt
+++ b/cli/Main.kt
@@ -10,6 +10,13 @@ enum class OutputFormat {
   TEXTPROTO,
 }
 
+/** Controls ANSI color output. */
+enum class ColorMode {
+  AUTO,
+  ALWAYS,
+  NEVER,
+}
+
 /** Thrown on invalid CLI arguments. Caught by [main] and reported as a usage error. */
 private class UsageError(message: String) : RuntimeException(message)
 
@@ -23,16 +30,18 @@ Commands:
 
 Options:
   --format=human|textproto   Trace output format (default: human).
+  --color=auto|always|never  Color output (default: auto, enabled on TTY).
   --help                     Show this help message."""
 
 private const val SIM_USAGE =
-  """Usage: 4ward sim [--format=human|textproto] <pipeline.txtpb> <test.stf>
+  """Usage: 4ward sim [--format=human|textproto] [--color=auto|always|never] <pipeline.txtpb> <test.stf>
 
 Loads a compiled pipeline config and runs an STF test against it.
 Prints the trace tree for each packet and reports PASS/FAIL.
 
 Options:
-  --format=human|textproto   Trace output format (default: human)."""
+  --format=human|textproto   Trace output format (default: human).
+  --color=auto|always|never  Color output (default: auto)."""
 
 private const val COMPILE_USAGE =
   """Usage: 4ward compile [options] <program.p4>
@@ -44,12 +53,13 @@ Options:
   -I <dir>             Add include directory for P4 headers."""
 
 private const val RUN_USAGE =
-  """Usage: 4ward run [--format=human|textproto] <program.p4> <test.stf>
+  """Usage: 4ward run [--format=human|textproto] [--color=auto|always|never] <program.p4> <test.stf>
 
 Compiles a P4 program and runs an STF test against it in one step.
 
 Options:
-  --format=human|textproto   Trace output format (default: human)."""
+  --format=human|textproto   Trace output format (default: human).
+  --color=auto|always|never  Color output (default: auto)."""
 
 fun main(args: Array<String>) {
   if (args.isEmpty() || args[0] == "--help" || args[0] == "-h") {
@@ -79,11 +89,13 @@ private fun handleSim(args: List<String>): Int {
   }
 
   var format = OutputFormat.HUMAN
+  var colorMode = ColorMode.AUTO
   val positional = mutableListOf<String>()
 
   for (arg in args) {
     when {
       arg.startsWith("--format=") -> format = parseFormat(arg)
+      arg.startsWith("--color=") -> colorMode = parseColorMode(arg)
       arg.startsWith("-") && arg != "-" -> throw UsageError("unknown option '$arg'")
       else -> positional += arg
     }
@@ -93,7 +105,12 @@ private fun handleSim(args: List<String>): Int {
     throw UsageError("'sim' requires exactly 2 arguments: <pipeline.txtpb> <test.stf>\n$SIM_USAGE")
   }
 
-  return simulate(resolveUserPath(positional[0]), stfPath(positional[1]), format)
+  return simulate(
+    resolveUserPath(positional[0]),
+    stfPath(positional[1]),
+    format,
+    resolveColor(colorMode),
+  )
 }
 
 private fun handleCompile(args: List<String>): Int {
@@ -143,6 +160,7 @@ private fun handleRun(args: List<String>): Int {
   }
 
   var format = OutputFormat.HUMAN
+  var colorMode = ColorMode.AUTO
   val includeDirs = mutableListOf<String>()
   val positional = mutableListOf<String>()
 
@@ -150,6 +168,7 @@ private fun handleRun(args: List<String>): Int {
   while (i < args.size) {
     when {
       args[i].startsWith("--format=") -> format = parseFormat(args[i])
+      args[i].startsWith("--color=") -> colorMode = parseColorMode(args[i])
       args[i] == "-I" -> {
         i++
         if (i >= args.size) throw UsageError("-I requires an argument")
@@ -170,6 +189,7 @@ private fun handleRun(args: List<String>): Int {
     stfPath(positional[1]),
     format,
     includeDirs.map { resolveUserPath(it) },
+    resolveColor(colorMode),
   )
 }
 
@@ -178,6 +198,22 @@ private fun parseFormat(arg: String): OutputFormat =
     "human" -> OutputFormat.HUMAN
     "textproto" -> OutputFormat.TEXTPROTO
     else -> throw UsageError("unknown format '$f'")
+  }
+
+private fun parseColorMode(arg: String): ColorMode =
+  when (val c = arg.removePrefix("--color=")) {
+    "auto" -> ColorMode.AUTO
+    "always" -> ColorMode.ALWAYS
+    "never" -> ColorMode.NEVER
+    else -> throw UsageError("unknown color mode '$c'")
+  }
+
+/** Resolves [ColorMode.AUTO] to a concrete boolean by checking if stdout is a terminal. */
+private fun resolveColor(mode: ColorMode): Boolean =
+  when (mode) {
+    ColorMode.ALWAYS -> true
+    ColorMode.NEVER -> false
+    ColorMode.AUTO -> System.console() != null
   }
 
 /** Resolves an STF argument: `-` reads stdin into a temp file, anything else is a file path. */

--- a/cli/Run.kt
+++ b/cli/Run.kt
@@ -8,8 +8,14 @@ import java.nio.file.Path
  * Compiles the P4 source to a temporary pipeline config, then runs the STF test against it. This is
  * the "hello world" entry point for newcomers. Returns an exit code (does not call `exitProcess`).
  */
-fun run(p4Source: Path, stfPath: Path, format: OutputFormat, includeDirs: List<Path>): Int {
+fun run(
+  p4Source: Path,
+  stfPath: Path,
+  format: OutputFormat,
+  includeDirs: List<Path>,
+  color: Boolean,
+): Int {
   val (pipelinePath, compileCode) = compileToTemp(p4Source, includeDirs)
   if (pipelinePath == null) return compileCode
-  return simulate(pipelinePath, stfPath, format)
+  return simulate(pipelinePath, stfPath, format, color)
 }

--- a/cli/Simulate.kt
+++ b/cli/Simulate.kt
@@ -18,7 +18,7 @@ import java.nio.file.Path
  * Loads the pipeline, installs table entries, sends packets, verifies expectations, and prints the
  * trace tree for each packet. Returns an exit code (does not call `exitProcess`).
  */
-fun simulate(pipelinePath: Path, stfPath: Path, format: OutputFormat): Int {
+fun simulate(pipelinePath: Path, stfPath: Path, format: OutputFormat, color: Boolean): Int {
   val config =
     try {
       loadPipelineConfig(pipelinePath)
@@ -63,8 +63,9 @@ fun simulate(pipelinePath: Path, stfPath: Path, format: OutputFormat): Int {
     val trace = resp.trace
     when (format) {
       OutputFormat.HUMAN -> {
-        println("packet received: port ${packet.ingressPort}, ${packet.payload.size} bytes")
-        println(TraceFormatter.format(trace).trim().prependIndent("  "))
+        val header = "packet received: port ${packet.ingressPort}, ${packet.payload.size} bytes"
+        println(if (color) "\u001b[1m$header\u001b[0m" else header)
+        println(TraceFormatter.format(trace, color).trim().prependIndent("  "))
       }
       OutputFormat.TEXTPROTO -> print(textProtoPrinter.printToString(trace))
     }
@@ -80,6 +81,6 @@ fun simulate(pipelinePath: Path, stfPath: Path, format: OutputFormat): Int {
     for (f in failures) System.err.println("  $f")
     return ExitCode.TEST_FAILURE
   }
-  println("PASS")
+  println(if (color) "\u001b[1;32mPASS\u001b[0m" else "PASS")
   return ExitCode.SUCCESS
 }

--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -4,22 +4,32 @@ import fourward.sim.v1.SimulatorProto.DropReason
 import fourward.sim.v1.SimulatorProto.TraceEvent
 import fourward.sim.v1.SimulatorProto.TraceTree
 
-/** Renders a [TraceTree] as a human-readable indented string. */
+/** Renders a [TraceTree] as a human-readable indented string, optionally with ANSI colors. */
 object TraceFormatter {
 
-  fun format(tree: TraceTree): String = buildString { appendTree(tree, indent = 0) }
+  fun format(tree: TraceTree, color: Boolean = false): String = buildString {
+    appendTree(tree, prefix = "", color)
+  }
 
-  private fun StringBuilder.appendTree(tree: TraceTree, indent: Int) {
+  private fun StringBuilder.appendTree(tree: TraceTree, prefix: String, color: Boolean) {
     for (event in tree.eventsList) {
-      appendEvent(event, indent)
+      appendEvent(event, prefix, color)
     }
     when {
       tree.hasForkOutcome() -> {
         val fork = tree.forkOutcome
-        appendLine("${pad(indent)}fork (${fork.reason.humanName()})")
-        for (branch in fork.branchesList) {
-          appendLine("${pad(indent + 1)}branch: ${branch.label}")
-          appendTree(branch.subtree, indent + 2)
+        appendLine("$prefix${style("fork (${fork.reason.humanName()})", MAGENTA, color)}")
+        for ((i, branch) in fork.branchesList.withIndex()) {
+          val isLast = i == fork.branchesList.lastIndex
+          if (color) {
+            val connector = if (isLast) "└─ " else "├─ "
+            val childPrefix = prefix + if (isLast) "   " else "│  "
+            appendLine("$prefix${style(connector + branch.label, MAGENTA, color)}")
+            appendTree(branch.subtree, childPrefix, color)
+          } else {
+            appendLine("$prefix  branch: ${branch.label}")
+            appendTree(branch.subtree, "$prefix    ", color)
+          }
         }
       }
       tree.hasPacketOutcome() -> {
@@ -27,36 +37,41 @@ object TraceFormatter {
         when {
           outcome.hasOutput() -> {
             val out = outcome.output
-            appendLine("${pad(indent)}output port ${out.egressPort}, ${out.payload.size()} bytes")
+            val text = "output port ${out.egressPort}, ${out.payload.size()} bytes"
+            appendLine("$prefix${style(text, BOLD_GREEN, color)}")
           }
           outcome.hasDrop() -> {
-            appendLine("${pad(indent)}drop (reason: ${outcome.drop.reason.humanName()})")
+            val text = "drop (reason: ${outcome.drop.reason.humanName()})"
+            appendLine("$prefix${style(text, BOLD_RED, color)}")
           }
         }
       }
     }
   }
 
-  private fun StringBuilder.appendEvent(event: TraceEvent, indent: Int) {
-    val prefix = pad(indent)
+  private fun StringBuilder.appendEvent(event: TraceEvent, prefix: String, color: Boolean) {
+    val arrow = if (color) "→" else "->"
     when {
       event.hasParserTransition() -> {
         val pt = event.parserTransition
-        appendLine("${prefix}parse: ${pt.fromState} -> ${pt.toState}")
+        appendLine("$prefix${style("parse: ${pt.fromState} $arrow ${pt.toState}", CYAN, color)}")
       }
       event.hasTableLookup() -> {
         val tl = event.tableLookup
         val result = if (tl.hit) "hit" else "miss"
-        appendLine("${prefix}table ${tl.tableName}: $result -> ${tl.actionName}")
+        val text = "table ${tl.tableName}: $result $arrow ${tl.actionName}"
+        appendLine("$prefix${style(text, if (tl.hit) GREEN else RED, color)}")
       }
       event.hasActionExecution() -> {
         val ae = event.actionExecution
-        if (ae.paramsMap.isEmpty()) {
-          appendLine("${prefix}action ${ae.actionName}")
-        } else {
-          val params = ae.paramsMap.entries.joinToString(", ") { (k, v) -> "$k=${v.decimal()}" }
-          appendLine("${prefix}action ${ae.actionName}($params)")
-        }
+        val text =
+          if (ae.paramsMap.isEmpty()) {
+            "action ${ae.actionName}"
+          } else {
+            val params = ae.paramsMap.entries.joinToString(", ") { (k, v) -> "$k=${v.decimal()}" }
+            "action ${ae.actionName}($params)"
+          }
+        appendLine("$prefix${style(text, YELLOW, color)}")
       }
       event.hasBranch() -> {
         val b = event.branch
@@ -67,12 +82,27 @@ object TraceFormatter {
         val ec = event.externCall
         appendLine("${prefix}extern ${ec.externInstanceName}.${ec.method}()")
       }
-      event.hasMarkToDrop() -> appendLine("${prefix}mark_to_drop()")
-      event.hasClone() -> appendLine("${prefix}clone session ${event.clone.sessionId}")
+      event.hasMarkToDrop() -> appendLine("$prefix${style("mark_to_drop()", RED, color)}")
+      event.hasClone() ->
+        appendLine("$prefix${style("clone session ${event.clone.sessionId}", MAGENTA, color)}")
     }
   }
 
-  private fun pad(level: Int): String = "  ".repeat(level)
+  // -- ANSI helpers --
+
+  private const val RESET = "\u001b[0m"
+  private const val CYAN = "\u001b[36m"
+  private const val GREEN = "\u001b[32m"
+  private const val RED = "\u001b[31m"
+  private const val YELLOW = "\u001b[33m"
+  private const val MAGENTA = "\u001b[35m"
+  private const val BOLD_GREEN = "\u001b[1;32m"
+  private const val BOLD_RED = "\u001b[1;31m"
+
+  private fun style(text: String, code: String, color: Boolean): String =
+    if (color) "$code$text$RESET" else text
+
+  // -- Formatting helpers --
 
   private fun com.google.protobuf.ByteString.decimal(): String =
     java.math.BigInteger(1, toByteArray()).toString()

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -19,6 +19,8 @@ import org.junit.Test
 
 class TraceFormatterTest {
 
+  // -- Plain text (color=false, the default) --
+
   @Test
   fun simplePassthrough() {
     val tree =
@@ -174,6 +176,130 @@ class TraceFormatterTest {
       |    output port 2, 0 bytes
       |"""
         .trimMargin(),
+      output,
+    )
+  }
+
+  // -- Colored output (color=true) --
+
+  @Test
+  fun coloredPassthrough() {
+    val tree =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setParserTransition(
+              ParserTransitionEvent.newBuilder().setFromState("start").setToState("accept")
+            )
+        )
+        .setPacketOutcome(
+          PacketOutcome.newBuilder()
+            .setOutput(OutputPacket.newBuilder().setEgressPort(1).setPayload(ByteString.EMPTY))
+        )
+        .build()
+
+    val output = TraceFormatter.format(tree, color = true)
+    assertEquals(
+      "\u001b[36mparse: start → accept\u001b[0m\n" +
+        "\u001b[1;32moutput port 1, 0 bytes\u001b[0m\n",
+      output,
+    )
+  }
+
+  @Test
+  fun coloredTableHitAndMiss() {
+    val hit =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setTableLookup(
+              TableLookupEvent.newBuilder().setTableName("t").setHit(true).setActionName("fwd")
+            )
+        )
+        .build()
+    val miss =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setTableLookup(
+              TableLookupEvent.newBuilder().setTableName("t").setHit(false).setActionName("drop")
+            )
+        )
+        .build()
+
+    assertEquals(
+      "\u001b[32mtable t: hit → fwd\u001b[0m\n",
+      TraceFormatter.format(hit, color = true),
+    )
+    assertEquals(
+      "\u001b[31mtable t: miss → drop\u001b[0m\n",
+      TraceFormatter.format(miss, color = true),
+    )
+  }
+
+  @Test
+  fun coloredDrop() {
+    val tree =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
+        )
+        .setPacketOutcome(
+          PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
+        )
+        .build()
+
+    val output = TraceFormatter.format(tree, color = true)
+    assertEquals(
+      "\u001b[31mmark_to_drop()\u001b[0m\n" + "\u001b[1;31mdrop (reason: mark_to_drop)\u001b[0m\n",
+      output,
+    )
+  }
+
+  @Test
+  fun coloredForkUsesTreeChars() {
+    val tree =
+      TraceTree.newBuilder()
+        .setForkOutcome(
+          Fork.newBuilder()
+            .setReason(ForkReason.CLONE)
+            .addBranches(
+              ForkBranch.newBuilder()
+                .setLabel("original")
+                .setSubtree(
+                  TraceTree.newBuilder()
+                    .setPacketOutcome(
+                      PacketOutcome.newBuilder()
+                        .setOutput(
+                          OutputPacket.newBuilder().setEgressPort(1).setPayload(ByteString.EMPTY)
+                        )
+                    )
+                )
+            )
+            .addBranches(
+              ForkBranch.newBuilder()
+                .setLabel("clone")
+                .setSubtree(
+                  TraceTree.newBuilder()
+                    .setPacketOutcome(
+                      PacketOutcome.newBuilder()
+                        .setOutput(
+                          OutputPacket.newBuilder().setEgressPort(2).setPayload(ByteString.EMPTY)
+                        )
+                    )
+                )
+            )
+        )
+        .build()
+
+    val output = TraceFormatter.format(tree, color = true)
+    assertEquals(
+      "\u001b[35mfork (clone)\u001b[0m\n" +
+        "\u001b[35m├─ original\u001b[0m\n" +
+        "│  \u001b[1;32moutput port 1, 0 bytes\u001b[0m\n" +
+        "\u001b[35m└─ clone\u001b[0m\n" +
+        "   \u001b[1;32moutput port 2, 0 bytes\u001b[0m\n",
       output,
     )
   }

--- a/examples/tutorial.t
+++ b/examples/tutorial.t
@@ -233,7 +233,7 @@ Every subcommand has --help:
   Usage: 4ward compile [options] <program.p4>
 
   $ 4ward sim --help | head -1
-  Usage: 4ward sim [--format=human|textproto] <pipeline.txtpb> <test.stf>
+  Usage: 4ward sim [--format=human|textproto] [--color=auto|always|never] <pipeline.txtpb> <test.stf>
 
   $ 4ward run --help | head -1
-  Usage: 4ward run [--format=human|textproto] <program.p4> <test.stf>
+  Usage: 4ward run [--format=human|textproto] [--color=auto|always|never] <program.p4> <test.stf>


### PR DESCRIPTION
## Summary

Trace output comes alive on a terminal. Semantic colors make it easy to
scan a trace at a glance — parser transitions in cyan, table hits in green,
misses in red, actions in yellow, drops in bold red, forks in magenta.
Fork branches use unicode tree-drawing characters instead of flat indentation.

`--color=auto` (default) enables colors when stdout is a TTY, so piped
output and the cram tutorial stay plain text. `--color=always|never` to
override.

Before:
```
parse: start -> accept
table port_table: hit -> forward
action forward(port=1)
output port 1, 18 bytes
```

After (on a terminal — colors can't be shown here, but trust the unit tests):
```
parse: start → accept          ← cyan, unicode arrow
table port_table: hit → forward ← green
action forward(port=1)          ← yellow
output port 1, 18 bytes         ← bold green
```

## Test plan

- [x] `bazel test //cli:TraceFormatterTest` — plain + colored output tests
- [x] `bazel test //examples:tutorial_test` — cram test (piped, no colors)
- [ ] CI green (Ubuntu + macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)