### PR TITLE
refactor: resolve three REFACTORING.md items

### DIFF
--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -65,47 +65,6 @@ Blocked on buf support for proto edition 2024.
 
 ---
 
-## Deduplicate `collectOutputsFromTrace`
-
-**Files**: `e2e_tests/stf/Runner.kt`, `simulator/V1ModelArchitectureTest.kt`
-
-**Problem**: `V1ModelArchitectureTest.collectOutputs` is a private copy of the
-public `collectOutputsFromTrace` in `Runner.kt`. Both recursively walk a
-`TraceTree` to collect output packets from leaves.
-
-**Fix**: Delete the private copy and import `collectOutputsFromTrace` from
-`fourward.e2e`.
-
----
-
-## Deduplicate `allOnesMask` helpers
-
-**Files**: `e2e_tests/stf/Runner.kt`, `e2e_tests/bmv2_diff/Bmv2Runner.kt`
-
-**Problem**: `Runner.allOnesMask` and `Bmv2Runner.allOnesMaskHex` both compute
-an all-ones bitmask for a given bitwidth. They differ only in output format
-(`0x`-prefixed vs bare hex).
-
-**Fix**: Extract a shared utility, or have one call the other with a format
-flag.
-
----
-
-## `data class` + `ByteArray` on `StfPacket`
-
-**Files**: `e2e_tests/stf/Runner.kt`
-
-**Problem**: `data class StfPacket` contains a `ByteArray` field. Kotlin data
-classes generate `equals`/`hashCode` using reference identity for arrays, so
-two `StfPacket` instances with identical content compare as not equal. Currently
-harmless (instances are only iterated, never compared), but a latent bug if
-anyone adds equality checks or uses them as map/set keys.
-
-**Fix**: Drop the `data` modifier (matching `StfExpectedOutput` and
-`ReceivedPacket`), or add `contentEquals`/`contentHashCode` overrides.
-
----
-
 ## Separate simulator return type from gRPC wire type
 
 **Files**: `simulator/Simulator.kt`, `p4runtime/DataplaneService.kt`,

--- a/e2e_tests/bmv2_diff/Bmv2Runner.kt
+++ b/e2e_tests/bmv2_diff/Bmv2Runner.kt
@@ -6,6 +6,7 @@ import fourward.e2e.StfFile
 import fourward.e2e.StfMatchField
 import fourward.e2e.StfSetDefault
 import fourward.e2e.StfTableDirective
+import fourward.e2e.allOnesMask
 import fourward.e2e.decodeHex
 import fourward.e2e.encodeValue
 import fourward.e2e.extractParamName
@@ -168,14 +169,13 @@ class Bmv2Runner(driverBinary: Path, jsonPath: Path, private val p4Info: P4InfoO
         val mask = stf.mask
         val maskHex =
           if (mask != null) encodeValue(mask, mf.bitwidth).toByteArray().hex()
-          else allOnesMaskHex(mf.bitwidth)
+          else allOnesMask(mf.bitwidth)
         "$valueHex&&&$maskHex"
       }
       MatchKind.EXACT -> {
         when (mf.matchType) {
           // If the table declares ternary/lpm but the STF value is exact, promote.
-          P4InfoOuterClass.MatchField.MatchType.TERNARY ->
-            "$valueHex&&&${allOnesMaskHex(mf.bitwidth)}"
+          P4InfoOuterClass.MatchField.MatchType.TERNARY -> "$valueHex&&&${allOnesMask(mf.bitwidth)}"
           P4InfoOuterClass.MatchField.MatchType.LPM -> "$valueHex/${mf.bitwidth}"
           else -> valueHex
         }
@@ -192,13 +192,4 @@ class Bmv2Runner(driverBinary: Path, jsonPath: Path, private val p4Info: P4InfoO
   companion object {
     private val ARRAY_INDEX_REGEX = Regex("\\$(\\d+)")
   }
-}
-
-@Suppress("MagicNumber")
-private fun allOnesMaskHex(bitwidth: Int): String {
-  val byteLen = (bitwidth + 7) / 8
-  val bytes = ByteArray(byteLen) { 0xFF.toByte() }
-  val unusedBits = byteLen * 8 - bitwidth
-  if (unusedBits > 0) bytes[0] = (bytes[0].toInt() and (0xFF shr unusedBits)).toByte()
-  return bytes.hex()
 }

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -628,11 +628,11 @@ private fun update(
 ): P4RuntimeOuterClass.Update =
   P4RuntimeOuterClass.Update.newBuilder().setType(type).setEntity(entity).build()
 
-/** Returns a bit-precise hex mask for the given bitwidth (e.g. 9 → "0x01FF", 16 → "0xFFFF"). */
-private fun allOnesMask(bitwidth: Int): String {
+/** Returns a bare-hex all-ones mask for the given bitwidth (e.g. 9 → "01ff", 16 → "ffff"). */
+fun allOnesMask(bitwidth: Int): String {
   val byteLen = (bitwidth + 7) / 8
   val value = BigInteger.ONE.shiftLeft(bitwidth).subtract(BigInteger.ONE)
-  return "0x" + value.toString(16).padStart(byteLen * 2, '0')
+  return value.toString(16).padStart(byteLen * 2, '0')
 }
 
 fun findTable(name: String, p4info: P4InfoOuterClass.P4Info): P4InfoOuterClass.Table =
@@ -686,7 +686,7 @@ private fun resolveStfMatchField(
     m.kind == MatchKind.TERNARY ||
       (m.kind == MatchKind.EXACT &&
         p4infoType == P4InfoOuterClass.MatchField.MatchType.TERNARY) -> {
-      val mask = m.mask ?: allOnesMask(mf.bitwidth)
+      val mask = m.mask ?: "0x${allOnesMask(mf.bitwidth)}"
       fmBuilder.setTernary(
         P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
           .setValue(encodedValue)


### PR DESCRIPTION
## Summary

Closes three REFACTORING.md entries in one shot (-50 lines):

- **`allOnesMask`**: Runner and BmvRunner had independent implementations. Made Runner's version public (bare hex output), deleted BmvRunner's copy.
- **`collectOutputsFromTrace`**: Already resolved by #252 (moved to `Simulator.kt`, same package as `V1ModelArchitectureTest`).
- **`StfPacket`**: Already resolved by #252 (dropped `data` modifier).

## Test plan

- [x] All 38 non-heavy tests pass
- [x] Formatter and linter clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)