### PR TITLE
refactor: move pipeline init into TableStore.loadMappings

### DIFF
--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -33,61 +33,7 @@ class Simulator {
   fun loadPipeline(config: PipelineConfig) {
     pipeline = config
 
-    // The behavioral IR uses its own table/action names (TableBehavior.name,
-    // ActionDecl.name/current_name), which may differ from p4info aliases
-    // (e.g. inlined controls: behavioral "c_t" vs p4info alias "t").
-    // Resolve p4info IDs to behavioral names so the TableStore uses the same
-    // keys as the interpreter.
-    val behavioralTables = config.device.behavioral.tablesList.map { it.name }
-    val behavioralActions =
-      (config.device.behavioral.actionsList +
-          config.device.behavioral.controlsList.flatMap { it.localActionsList })
-        .flatMap { action -> listOfNotNull(action.name, action.currentName.ifEmpty { null }) }
-
-    fun resolveName(alias: String, candidates: List<String>): String =
-      candidates.find { it == alias } ?: candidates.find { it.endsWith("_$alias") } ?: alias
-
-    val tableNameById =
-      config.p4Info.tablesList.associate { table ->
-        val alias = table.preamble.alias.ifEmpty { table.preamble.name }
-        table.preamble.id to resolveName(alias, behavioralTables)
-      }
-    val actionNameById =
-      config.p4Info.actionsList.associate { action ->
-        val alias = action.preamble.alias.ifEmpty { action.preamble.name }
-        action.preamble.id to resolveName(alias, behavioralActions)
-      }
-    tableStore.loadMappings(tableNameById, actionNameById, config.p4Info)
-
-    for (table in config.p4Info.tablesList) {
-      // const_default_action_id: immutable default set in the P4 source with `const`.
-      // initial_default_action: mutable default set in the P4 source without `const`.
-      val defaultActionId =
-        if (table.constDefaultActionId != 0) table.constDefaultActionId
-        else if (table.hasInitialDefaultAction()) table.initialDefaultAction.actionId else 0
-      if (defaultActionId != 0) {
-        val tableName = tableNameById[table.preamble.id] ?: continue
-        val actionName = actionNameById[defaultActionId] ?: "NoAction"
-        // Convert p4info TableActionCall.Argument to P4Runtime Action.Param.
-        val params =
-          if (table.hasInitialDefaultAction())
-            table.initialDefaultAction.argumentsList.map { arg ->
-              p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
-                .setParamId(arg.paramId)
-                .setValue(arg.value)
-                .build()
-            }
-          else emptyList()
-        tableStore.setDefaultAction(tableName, actionName, params)
-      }
-    }
-
-    // Install static table entries declared with `const entries` in the P4
-    // source. These are serialized by p4c's P4Runtime serializer and embedded
-    // in the PipelineConfig at compile time.
-    for (update in config.device.staticEntries.updatesList) {
-      tableStore.write(update)
-    }
+    tableStore.loadMappings(config.p4Info, config.device)
 
     architecture =
       when (val archName = config.device.behavioral.architecture.name) {

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -1,6 +1,7 @@
 package fourward.simulator
 
 import com.google.protobuf.ByteString
+import fourward.ir.v1.DeviceConfig
 import java.math.BigInteger
 import p4.config.v1.P4InfoOuterClass
 import p4.v1.P4RuntimeOuterClass
@@ -109,21 +110,44 @@ class TableStore {
   private var meterInfoById: Map<Int, IndexedExternInfo> = emptyMap()
 
   /**
-   * Initialises the ID→name maps for the loaded pipeline and clears all table entries.
+   * Initialises the store for a loaded pipeline and clears all mutable state.
    *
-   * [tableNameById] and [actionNameById] resolve p4info IDs to behavioral IR names (which may
-   * differ from p4info aliases for inlined controls). The remaining entity metadata is extracted
-   * from [p4info] internally.
+   * Resolves p4info IDs to behavioral IR names (which may differ from p4info aliases for inlined
+   * controls — e.g. behavioral "c_t" vs p4info alias "t"). When [device] has no behavioral config,
+   * p4info aliases are used directly (convenient for tests).
+   *
+   * Also installs default actions and static table entries from [p4info] and [device].
    *
    * Must be called before [write] or [lookup]. Calling it again (pipeline reload) resets all state.
    */
   fun loadMappings(
-    tableNameById: Map<Int, String> = emptyMap(),
-    actionNameById: Map<Int, String> = emptyMap(),
     p4info: P4InfoOuterClass.P4Info = P4InfoOuterClass.P4Info.getDefaultInstance(),
+    device: DeviceConfig = DeviceConfig.getDefaultInstance(),
   ) {
-    this.tableNameById = tableNameById
-    this.actionNameById = actionNameById
+    // Extract behavioral names from the IR. The behavioral IR uses its own table/action
+    // names (e.g. inlined "c_t" vs p4info alias "t"). When the device config is empty
+    // (e.g. unit tests), resolveName falls through to the p4info alias itself.
+    val behavioral = device.behavioral
+    val behavioralTableNames = behavioral.tablesList.map { it.name }
+    val behavioralActionNames =
+      (behavioral.actionsList + behavioral.controlsList.flatMap { it.localActionsList }).flatMap {
+        action ->
+        listOfNotNull(action.name, action.currentName.ifEmpty { null })
+      }
+
+    fun resolveName(alias: String, candidates: List<String>): String =
+      candidates.find { it == alias } ?: candidates.find { it.endsWith("_$alias") } ?: alias
+
+    this.tableNameById =
+      p4info.tablesList.associate { table ->
+        val alias = table.preamble.alias.ifEmpty { table.preamble.name }
+        table.preamble.id to resolveName(alias, behavioralTableNames)
+      }
+    this.actionNameById =
+      p4info.actionsList.associate { action ->
+        val alias = action.preamble.alias.ifEmpty { action.preamble.name }
+        action.preamble.id to resolveName(alias, behavioralActionNames)
+      }
     this.registerInfoById =
       p4info.registersList.associate { reg ->
         val bitwidth = reg.typeSpec.bitstring.bit.bitwidth
@@ -134,6 +158,7 @@ class TableStore {
     this.meterInfoById =
       p4info.metersList.associate { it.preamble.id to IndexedExternInfo(it.size.toInt()) }
     tables.clear()
+    defaultActions.clear()
     forcedHits.clear()
     registers.clear()
     counters.clear()
@@ -144,12 +169,12 @@ class TableStore {
     cloneSessions.clear()
     multicastGroups.clear()
 
-    // Cache proto repeated-field accessors (each call creates a defensive copy).
-    val tables = p4info.tablesList
+    // Cache proto repeated-field accessor (each call creates a defensive copy).
+    val p4infoTables = p4info.tablesList
 
     // P4Runtime spec §9.27: enforce table size limits from p4info.
     tableSizeLimit =
-      tables
+      p4infoTables
         .filter { it.size > 0 }
         .mapNotNull { table ->
           val name = tableNameById[table.preamble.id] ?: return@mapNotNull null
@@ -164,11 +189,40 @@ class TableStore {
         .associate { it.preamble.id to it.maxGroupSize }
 
     // Register which tables use action profiles (implementation_id != 0).
-    for (table in tables) {
+    for (table in p4infoTables) {
       if (table.implementationId != 0) {
         val tableName = tableNameById[table.preamble.id] ?: continue
         tableActionProfile[tableName] = table.implementationId
       }
+    }
+
+    // Install default actions from p4info.
+    for (table in p4infoTables) {
+      // const_default_action_id: immutable default set in the P4 source with `const`.
+      // initial_default_action: mutable default set in the P4 source without `const`.
+      val defaultActionId =
+        if (table.constDefaultActionId != 0) table.constDefaultActionId
+        else if (table.hasInitialDefaultAction()) table.initialDefaultAction.actionId else 0
+      if (defaultActionId != 0) {
+        val tableName = tableNameById[table.preamble.id] ?: continue
+        val actionName = actionNameById[defaultActionId] ?: "NoAction"
+        // Convert p4info TableActionCall.Argument to P4Runtime Action.Param.
+        val params =
+          if (table.hasInitialDefaultAction())
+            table.initialDefaultAction.argumentsList.map { arg ->
+              p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+                .setParamId(arg.paramId)
+                .setValue(arg.value)
+                .build()
+            }
+          else emptyList()
+        setDefaultAction(tableName, actionName, params)
+      }
+    }
+
+    // Install static table entries declared with `const entries` in the P4 source.
+    for (update in device.staticEntries.updatesList) {
+      write(update)
     }
   }
 

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -28,15 +28,13 @@ class TableStoreTest {
   @Before
   fun setUp() {
     store = TableStore()
-    store.loadMappings(
-      tableNameById = mapOf(TABLE_ID to TABLE_NAME),
-      actionNameById = ACTION_ID_TO_NAME,
-    )
+    store.loadMappings(p4info = BASE_P4INFO)
   }
 
   /** Builds a [P4InfoOuterClass.P4Info] from individual entity lists. */
   private fun buildP4Info(
     tables: List<P4InfoOuterClass.Table> = emptyList(),
+    actions: List<P4InfoOuterClass.Action> = emptyList(),
     registers: List<P4InfoOuterClass.Register> = emptyList(),
     actionProfiles: List<P4InfoOuterClass.ActionProfile> = emptyList(),
     counters: List<P4InfoOuterClass.Counter> = emptyList(),
@@ -44,10 +42,24 @@ class TableStoreTest {
   ): P4InfoOuterClass.P4Info =
     P4InfoOuterClass.P4Info.newBuilder()
       .addAllTables(tables)
+      .addAllActions(actions)
       .addAllRegisters(registers)
       .addAllActionProfiles(actionProfiles)
       .addAllCounters(counters)
       .addAllMeters(meters)
+      .build()
+
+  /** Builds a minimal p4info [P4InfoOuterClass.Table] with the given ID and name. */
+  private fun p4infoTable(
+    id: Int,
+    name: String,
+    size: Long = 0,
+    implementationId: Int = 0,
+  ): P4InfoOuterClass.Table =
+    P4InfoOuterClass.Table.newBuilder()
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setAlias(name))
+      .setSize(size)
+      .setImplementationId(implementationId)
       .build()
 
   // ---------------------------------------------------------------------------
@@ -494,15 +506,12 @@ class TableStoreTest {
   /** Creates a TableStore with a table that has a size limit. */
   private fun storeWithTableSize(size: Int): TableStore {
     val store = TableStore()
-    val p4infoTable =
-      P4InfoOuterClass.Table.newBuilder()
-        .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(TABLE_ID))
-        .setSize(size.toLong())
-        .build()
     store.loadMappings(
-      tableNameById = mapOf(TABLE_ID to TABLE_NAME),
-      actionNameById = ACTION_ID_TO_NAME,
-      p4info = buildP4Info(tables = listOf(p4infoTable)),
+      p4info =
+        buildP4Info(
+          tables = listOf(p4infoTable(TABLE_ID, TABLE_NAME, size = size.toLong())),
+          actions = ACTION_LIST,
+        )
     )
     return store
   }
@@ -514,15 +523,15 @@ class TableStoreTest {
   /** Creates a TableStore with an action-profile-backed table for profile tests. */
   private fun storeWithProfile(): TableStore {
     val store = TableStore()
-    val p4infoTable =
-      P4InfoOuterClass.Table.newBuilder()
-        .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_TABLE_ID))
-        .setImplementationId(PROFILE_ID)
-        .build()
     store.loadMappings(
-      tableNameById = mapOf(PROFILE_TABLE_ID to PROFILE_TABLE_NAME),
-      actionNameById = ACTION_ID_TO_NAME,
-      p4info = buildP4Info(tables = listOf(p4infoTable)),
+      p4info =
+        buildP4Info(
+          tables =
+            listOf(
+              p4infoTable(PROFILE_TABLE_ID, PROFILE_TABLE_NAME, implementationId = PROFILE_ID)
+            ),
+          actions = ACTION_LIST,
+        )
     )
     return store
   }
@@ -772,13 +781,21 @@ class TableStoreTest {
     writeCloneSession(sessionId = 1, egressPort = 5)
     writeMulticastGroup(groupId = 1, replicas = listOf(0 to 1))
 
-    store.loadMappings(
-      tableNameById = mapOf(TABLE_ID to TABLE_NAME),
-      actionNameById = ACTION_ID_TO_NAME,
-    )
+    store.loadMappings(p4info = BASE_P4INFO)
 
     assertNull(store.getCloneSession(1))
     assertNull(store.getMulticastGroup(1))
+  }
+
+  @Test
+  fun `loadMappings clears default actions`() {
+    store.setDefaultAction(TABLE_NAME, "customAction")
+    assertEquals("customAction", store.lookup(TABLE_NAME, emptyList()).actionName)
+
+    // Reload without any default action configured — should revert to NoAction.
+    store.loadMappings(p4info = BASE_P4INFO)
+
+    assertEquals("NoAction", store.lookup(TABLE_NAME, emptyList()).actionName)
   }
 
   // ---------------------------------------------------------------------------
@@ -905,21 +922,22 @@ class TableStoreTest {
   /** Creates a TableStore with an action profile that has a max_group_size limit. */
   private fun storeWithProfileMaxGroupSize(maxGroupSize: Int): TableStore {
     val store = TableStore()
-    val p4infoTable =
-      P4InfoOuterClass.Table.newBuilder()
-        .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_TABLE_ID))
-        .setImplementationId(PROFILE_ID)
-        .build()
-    val p4infoActionProfile =
-      P4InfoOuterClass.ActionProfile.newBuilder()
-        .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_ID))
-        .setMaxGroupSize(maxGroupSize)
-        .build()
     store.loadMappings(
-      tableNameById = mapOf(PROFILE_TABLE_ID to PROFILE_TABLE_NAME),
-      actionNameById = ACTION_ID_TO_NAME,
       p4info =
-        buildP4Info(tables = listOf(p4infoTable), actionProfiles = listOf(p4infoActionProfile)),
+        buildP4Info(
+          tables =
+            listOf(
+              p4infoTable(PROFILE_TABLE_ID, PROFILE_TABLE_NAME, implementationId = PROFILE_ID)
+            ),
+          actions = ACTION_LIST,
+          actionProfiles =
+            listOf(
+              P4InfoOuterClass.ActionProfile.newBuilder()
+                .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_ID))
+                .setMaxGroupSize(maxGroupSize)
+                .build()
+            ),
+        )
     )
     return store
   }
@@ -1269,8 +1287,11 @@ class TableStoreTest {
   @Test
   fun `readEntities wildcard returns all entries across tables`() {
     store.loadMappings(
-      tableNameById = mapOf(TABLE_ID to TABLE_NAME, 3 to "otherTable"),
-      actionNameById = ACTION_ID_TO_NAME,
+      p4info =
+        buildP4Info(
+          tables = listOf(p4infoTable(TABLE_ID, TABLE_NAME), p4infoTable(3, "otherTable")),
+          actions = ACTION_LIST,
+        )
     )
 
     val entry1 = exactEntry(fieldId = 1, value = byteArrayOf(1), actionId = 10)
@@ -1650,7 +1671,24 @@ class TableStoreTest {
     private const val METER_SIZE = 4
     private const val TABLE_SIZE_LIMIT = 3
     private const val MAX_GROUP_SIZE = 2
-    private val ACTION_ID_TO_NAME =
-      listOf(10, 20, 42, 50, 77, 99, 100, 200).associateWith { "action$it" }
+    private val ACTION_IDS = listOf(10, 20, 42, 50, 77, 99, 100, 200)
+    private val ACTION_LIST: List<P4InfoOuterClass.Action> =
+      ACTION_IDS.map { id ->
+        P4InfoOuterClass.Action.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setAlias("action$id"))
+          .build()
+      }
+
+    /** Default p4info used by most tests: one table + the standard set of action IDs. */
+    private val BASE_P4INFO: P4InfoOuterClass.P4Info =
+      P4InfoOuterClass.P4Info.newBuilder()
+        .addTables(
+          P4InfoOuterClass.Table.newBuilder()
+            .setPreamble(
+              P4InfoOuterClass.Preamble.newBuilder().setId(TABLE_ID).setAlias(TABLE_NAME)
+            )
+        )
+        .addAllActions(ACTION_LIST)
+        .build()
   }
 }


### PR DESCRIPTION
## Summary

TableStore now owns all pipeline-load-time state initialization — name resolution, default actions, static entries — in a single `loadMappings(p4info, device)` call. `Simulator.loadPipeline()` passes two protos and nothing else.

**Before:** Simulator extracted behavioral names, resolved aliases, built ID→name maps, iterated p4info tables for default actions, installed static entries — then passed pre-computed maps to TableStore. Pipeline knowledge was split across two files.

**After:** Simulator passes raw protos (P4Info + DeviceConfig). TableStore extracts behavioral names, resolves aliases, and handles all initialization internally. The API is maximally stable — two protos in, no parameters to add when new entity types appear.

Also fixes a pre-existing bug where `defaultActions` was not cleared on pipeline reload, causing stale defaults from the old pipeline to persist.

## Test plan

- [x] `bazel test //... --test_tag_filters=-heavy` — all tests pass
- [x] New test: `loadMappings clears default actions`
- [x] `./tools/format.sh` clean
- [x] `./tools/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)