### PR TITLE
web: interactive P4 playground

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,6 +86,7 @@ maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [
         "com.google.protobuf:protobuf-java:4.29.3",
+        "com.google.protobuf:protobuf-java-util:4.29.3",
         "com.google.protobuf:protobuf-kotlin:4.29.3",
         "junit:junit:4.13.2",
         "com.facebook:ktfmt:0.61",

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -93,34 +93,6 @@ events {
     direction: EXIT
   }
 }
-events {
-  pipeline_stage {
-    stage_name: "egress"
-    stage_kind: CONTROL
-    direction: ENTER
-  }
-}
-events {
-  pipeline_stage {
-    stage_name: "egress"
-    stage_kind: CONTROL
-    direction: EXIT
-  }
-}
-events {
-  pipeline_stage {
-    stage_name: "compute_checksum"
-    stage_kind: CONTROL
-    direction: ENTER
-  }
-}
-events {
-  pipeline_stage {
-    stage_name: "compute_checksum"
-    stage_kind: CONTROL
-    direction: EXIT
-  }
-}
 packet_outcome {
   drop {
     reason: MARK_TO_DROP

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -1,6 +1,5 @@
 events {
   packet_ingress {
-    ingress_port: 0
   }
 }
 events {
@@ -67,6 +66,13 @@ events {
     stage_name: "ingress"
     stage_kind: CONTROL
     direction: EXIT
+  }
+}
+events {
+  clone_session_lookup {
+    session_id: 100
+    session_found: true
+    egress_port: 3
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -1,6 +1,5 @@
 events {
   packet_ingress {
-    ingress_port: 0
   }
 }
 events {
@@ -69,18 +68,18 @@ events {
     direction: EXIT
   }
 }
+events {
+  clone_session_lookup {
+    session_id: 100
+    session_found: true
+    egress_port: 1
+  }
+}
 fork_outcome {
   reason: CLONE
   branches {
     label: "original"
     subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-        }
-      }
       events {
         pipeline_stage {
           stage_name: "egress"

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -1,6 +1,5 @@
 events {
   packet_ingress {
-    ingress_port: 0
   }
 }
 events {
@@ -80,18 +79,18 @@ events {
     direction: EXIT
   }
 }
+events {
+  clone_session_lookup {
+    session_id: 100
+    session_found: true
+    egress_port: 1
+  }
+}
 fork_outcome {
   reason: CLONE
   branches {
     label: "original"
     subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-        }
-      }
       events {
         pipeline_stage {
           stage_name: "egress"

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -1,6 +1,5 @@
 events {
   packet_ingress {
-    ingress_port: 0
   }
 }
 events {
@@ -114,18 +113,18 @@ fork_outcome {
           direction: EXIT
         }
       }
+      events {
+        clone_session_lookup {
+          session_id: 100
+          session_found: true
+          egress_port: 1
+        }
+      }
       fork_outcome {
         reason: CLONE
         branches {
           label: "original"
           subtree {
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-              }
-            }
             events {
               pipeline_stage {
                 stage_name: "egress"
@@ -250,18 +249,18 @@ fork_outcome {
           direction: EXIT
         }
       }
+      events {
+        clone_session_lookup {
+          session_id: 100
+          session_found: true
+          egress_port: 1
+        }
+      }
       fork_outcome {
         reason: CLONE
         branches {
           label: "original"
           subtree {
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-              }
-            }
             events {
               pipeline_stage {
                 stage_name: "egress"

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -1,6 +1,5 @@
 events {
   packet_ingress {
-    ingress_port: 0
   }
 }
 events {
@@ -69,18 +68,18 @@ events {
     direction: EXIT
   }
 }
+events {
+  clone_session_lookup {
+    session_id: 100
+    session_found: true
+    egress_port: 3
+  }
+}
 fork_outcome {
   reason: CLONE
   branches {
     label: "original"
     subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-        }
-      }
       events {
         table_lookup {
           table_name: "egress_classify"

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -179,24 +179,9 @@ fork_outcome {
           direction: EXIT
         }
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
-      }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
-      }
       packet_outcome {
-        output {
-          egress_port: 2
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
+        drop {
+          reason: MARK_TO_DROP
         }
       }
     }

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -78,8 +78,8 @@ fork_outcome {
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
           line: 41
-          column: 8
-          source_fragment: "IfStatement"
+          column: 12
+          source_fragment: "smeta.egress_port == 2"
         }
       }
       events {
@@ -143,8 +143,8 @@ fork_outcome {
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
           line: 41
-          column: 8
-          source_fragment: "IfStatement"
+          column: 12
+          source_fragment: "smeta.egress_port == 2"
         }
       }
       events {
@@ -219,8 +219,8 @@ fork_outcome {
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
           line: 41
-          column: 8
-          source_fragment: "IfStatement"
+          column: 12
+          source_fragment: "smeta.egress_port == 2"
         }
       }
       events {

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -441,7 +441,14 @@ fourward::ir::v1::Stmt FourWardBackend::emitStmt(const IR::StatOrDecl* node) {
   } else {
     LOG1("WARNING: unhandled statement " << node->node_type_name());
   }
-  *out.mutable_source_info() = emitSourceInfo(node);
+  // For if-statements, use the condition as the source fragment (e.g.
+  // "hdr.ipv4.isValid()") — the statement's own toString() is just
+  // "IfStatement" which isn't helpful in trace output.
+  if (const auto* ifst = node->to<IR::IfStatement>()) {
+    *out.mutable_source_info() = emitSourceInfo(ifst->condition);
+  } else {
+    *out.mutable_source_info() = emitSourceInfo(node);
+  }
   return out;
 }
 

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -13,11 +13,13 @@ load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm
 # Java proto messages — needed as a dep for grpc stub generation.
 java_proto_library(
     name = "p4runtime_java_proto",
+    visibility = ["//visibility:public"],
     deps = ["@p4runtime//proto/p4/v1:p4runtime_proto"],
 )
 
 java_proto_library(
     name = "p4info_java_proto",
+    visibility = ["//visibility:public"],
     deps = ["@p4runtime//proto/p4/config/v1:p4info_proto"],
 )
 

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -1238,11 +1238,15 @@ class ActionSelectorFork(
  * [parserEventCount] tracks how many trace events came from the parser (before ingress). The clone
  * branch skips ingress, so its prefix length is shorter.
  */
-class CloneFork(val sessionId: Int, val parserEventCount: Int, eventsBeforeFork: List<TraceEvent>) :
-  ForkException(eventsBeforeFork)
+class CloneFork(
+  val sessionId: Int,
+  val clonePort: Long,
+  val parserEventCount: Int,
+  eventsBeforeFork: List<TraceEvent>,
+) : ForkException(eventsBeforeFork)
 
 /** Fork after egress controls when an E2E clone was requested — "original" and "clone". */
-class EgressCloneFork(val sessionId: Int, eventsBeforeFork: List<TraceEvent>) :
+class EgressCloneFork(val sessionId: Int, val clonePort: Long, eventsBeforeFork: List<TraceEvent>) :
   ForkException(eventsBeforeFork)
 
 /** Fork at the ingress→egress boundary when mcast_grp is set — one branch per replica. */
@@ -1268,10 +1272,10 @@ sealed class BranchMode {
     BranchMode()
 
   /** I2E clone branch: skip ingress, set CLONE_I2E at boundary. */
-  data class I2EClone(val sessionId: Int) : BranchMode()
+  data class I2EClone(val sessionId: Int, val clonePort: Long) : BranchMode()
 
   /** E2E clone branch: re-run egress with CLONE_E2E after original egress completes. */
-  data class E2EClone(val sessionId: Int) : BranchMode()
+  data class E2EClone(val sessionId: Int, val clonePort: Long) : BranchMode()
 
   /** Multicast replica: set REPLICATION metadata at boundary. */
   data class Replica(val rid: Int, val port: Int) : BranchMode()

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -347,20 +347,25 @@ class V1ModelArchitecture : Architecture {
       runControlStages(s, s.ingressControls)
     }
 
-    // --- Ingress→egress boundary ---
+    // --- Ingress→egress boundary (traffic manager) ---
     ingressEgressBoundary(ctx, s, decisions, parserEventCount)
+    if (egressPortIsDropPort(s)) {
+      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+    }
 
     // --- Egress controls (egress, compute checksum) ---
     runControlStages(s, s.egressControls)
 
-    // --- Post-egress boundary ---
+    // --- Post-egress boundary (E2E clone / recirculate) ---
     postEgressBoundary(ctx, s, decisions)
 
-    val egressPort =
-      (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toLong() ?: 0L
+    // E2E clone branch: postEgressBoundary set up clone metadata — run egress again.
+    if (decisions.branchMode is BranchMode.E2EClone) {
+      runControlStages(s, s.egressControls)
+    }
 
-    // The drop port is all-ones for the port width (e.g. 511 for bit<9>).
-    if (egressPort == s.dropPort) {
+    // mark_to_drop() in egress sets egress_spec to the drop port.
+    if (egressSpecIsDropPort(s)) {
       return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
     }
 
@@ -383,7 +388,9 @@ class V1ModelArchitecture : Architecture {
       throw RecirculateFork(outputBytes, s.packetCtx.getEvents())
     }
 
-    return buildOutputTrace(s.packetCtx.getEvents(), egressPort.toInt(), outputBytes)
+    val egressPort =
+      (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
+    return buildOutputTrace(s.packetCtx.getEvents(), egressPort, outputBytes)
   }
 
   /** Runs a list of control stages, emitting enter/exit events for each. */
@@ -415,10 +422,9 @@ class V1ModelArchitecture : Architecture {
   ) {
     when (val mode = decisions.branchMode) {
       is BranchMode.I2EClone -> {
-        // I2E clone branch: set up clone metadata and continue to egress.
-        // BMv2 drops the clone if the session doesn't exist.
-        val session = ctx.tableStore.getCloneSession(mode.sessionId)
-        val clonePort = session?.replicasList?.firstOrNull()?.egressPort?.toLong() ?: s.dropPort
+        // I2E clone branch: session is guaranteed to exist (checked at fork creation).
+        val session = ctx.tableStore.getCloneSession(mode.sessionId)!!
+        val clonePort = session.replicasList.first().egressPort.toLong()
         s.standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
         s.standardMetadata.setBitField("egress_port", clonePort)
       }
@@ -431,8 +437,13 @@ class V1ModelArchitecture : Architecture {
       is BranchMode.E2EClone -> {
         // Normal path: check for pending I2E clone, resubmit, multicast, unicast.
         val suppressI2E = (mode as? BranchMode.Normal)?.suppressI2EClone == true
+        // BMv2 silently ignores clone() when the session doesn't exist.
         val pendingClone = s.packetCtx.pendingCloneSessionId
-        if (pendingClone != null && !suppressI2E) {
+        if (
+          pendingClone != null &&
+            !suppressI2E &&
+            ctx.tableStore.getCloneSession(pendingClone) != null
+        ) {
           throw CloneFork(pendingClone, parserEventCount, s.packetCtx.getEvents())
         }
         if (s.packetCtx.pendingResubmit) {
@@ -464,20 +475,22 @@ class V1ModelArchitecture : Architecture {
   private fun postEgressBoundary(ctx: PipelineContext, s: PipelineState, decisions: ForkDecisions) {
     when (val mode = decisions.branchMode) {
       is BranchMode.E2EClone -> {
-        // E2E clone branch: after the original egress ran (giving us modified headers),
-        // re-run egress with CLONE_E2E instance_type and the clone session's egress_port.
-        // BMv2 drops the clone if the session doesn't exist.
-        val session = ctx.tableStore.getCloneSession(mode.sessionId)
-        val clonePort = session?.replicasList?.firstOrNull()?.egressPort?.toLong() ?: s.dropPort
+        // E2E clone branch: session is guaranteed to exist (checked at fork creation).
+        val session = ctx.tableStore.getCloneSession(mode.sessionId)!!
+        val clonePort = session.replicasList.first().egressPort.toLong()
         s.standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
         s.standardMetadata.setBitField("egress_port", clonePort)
         s.packetCtx.pendingEgressCloneSessionId = null
-        runControlStages(s, s.egressControls)
       }
       else -> {
         val suppressE2E = (mode as? BranchMode.Normal)?.suppressE2EClone == true
+        // BMv2 silently ignores clone() when the session doesn't exist.
         val pendingE2EClone = s.packetCtx.pendingEgressCloneSessionId
-        if (pendingE2EClone != null && !suppressE2E) {
+        if (
+          pendingE2EClone != null &&
+            !suppressE2E &&
+            ctx.tableStore.getCloneSession(pendingE2EClone) != null
+        ) {
           throw EgressCloneFork(pendingE2EClone, s.packetCtx.getEvents())
         }
       }
@@ -488,6 +501,17 @@ class V1ModelArchitecture : Architecture {
     val outcome = PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(reason)).build()
     return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
   }
+
+  /**
+   * Traffic manager drop check: egress_port == drop port (set by boundary from egress_spec or clone
+   * session).
+   */
+  private fun egressPortIsDropPort(s: PipelineState): Boolean =
+    (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toLong() == s.dropPort
+
+  /** Post-egress drop check: mark_to_drop() in egress sets egress_spec to drop port. */
+  private fun egressSpecIsDropPort(s: PipelineState): Boolean =
+    (s.standardMetadata.fields["egress_spec"] as? BitVal)?.bits?.value?.toLong() == s.dropPort
 
   private fun buildOutputTrace(events: List<TraceEvent>, port: Int, payload: ByteArray): TraceTree {
     val output =

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -3,6 +3,7 @@ package fourward.simulator
 import fourward.ir.v1.BehavioralConfig
 import fourward.ir.v1.PipelineStage
 import fourward.ir.v1.StageKind
+import fourward.sim.v1.SimulatorProto.CloneSessionLookupEvent
 import fourward.sim.v1.SimulatorProto.Drop
 import fourward.sim.v1.SimulatorProto.DropReason
 import fourward.sim.v1.SimulatorProto.Fork
@@ -192,7 +193,7 @@ class V1ModelArchitecture : Architecture {
             BranchSpec(
               "clone",
               ctx,
-              decisions.copy(branchMode = BranchMode.I2EClone(fork.sessionId)),
+              decisions.copy(branchMode = BranchMode.I2EClone(fork.sessionId, fork.clonePort)),
               fork.parserEventCount,
             ),
           )
@@ -209,7 +210,7 @@ class V1ModelArchitecture : Architecture {
             BranchSpec(
               "clone",
               ctx,
-              decisions.copy(branchMode = BranchMode.E2EClone(fork.sessionId)),
+              decisions.copy(branchMode = BranchMode.E2EClone(fork.sessionId, fork.clonePort)),
               fork.eventsBeforeFork.size,
             ),
           )
@@ -422,11 +423,8 @@ class V1ModelArchitecture : Architecture {
   ) {
     when (val mode = decisions.branchMode) {
       is BranchMode.I2EClone -> {
-        // I2E clone branch: session is guaranteed to exist (checked at fork creation).
-        val session = ctx.tableStore.getCloneSession(mode.sessionId)!!
-        val clonePort = session.replicasList.first().egressPort.toLong()
         s.standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
-        s.standardMetadata.setBitField("egress_port", clonePort)
+        s.standardMetadata.setBitField("egress_port", mode.clonePort)
       }
       is BranchMode.Replica -> {
         s.standardMetadata.setBitField("instance_type", REPLICATION_INSTANCE_TYPE)
@@ -437,14 +435,16 @@ class V1ModelArchitecture : Architecture {
       is BranchMode.E2EClone -> {
         // Normal path: check for pending I2E clone, resubmit, multicast, unicast.
         val suppressI2E = (mode as? BranchMode.Normal)?.suppressI2EClone == true
-        // BMv2 silently ignores clone() when the session doesn't exist.
         val pendingClone = s.packetCtx.pendingCloneSessionId
-        if (
-          pendingClone != null &&
-            !suppressI2E &&
-            ctx.tableStore.getCloneSession(pendingClone) != null
-        ) {
-          throw CloneFork(pendingClone, parserEventCount, s.packetCtx.getEvents())
+        if (pendingClone != null && !suppressI2E) {
+          val session = ctx.tableStore.getCloneSession(pendingClone)
+          if (session != null) {
+            val clonePort = session.replicasList.first().egressPort.toLong()
+            s.packetCtx.addTraceEvent(cloneSessionLookupEvent(pendingClone, clonePort.toInt()))
+            throw CloneFork(pendingClone, clonePort, parserEventCount, s.packetCtx.getEvents())
+          } else {
+            s.packetCtx.addTraceEvent(cloneSessionMissEvent(pendingClone))
+          }
         }
         if (s.packetCtx.pendingResubmit) {
           throw ResubmitFork(s.packetCtx.getEvents())
@@ -475,23 +475,22 @@ class V1ModelArchitecture : Architecture {
   private fun postEgressBoundary(ctx: PipelineContext, s: PipelineState, decisions: ForkDecisions) {
     when (val mode = decisions.branchMode) {
       is BranchMode.E2EClone -> {
-        // E2E clone branch: session is guaranteed to exist (checked at fork creation).
-        val session = ctx.tableStore.getCloneSession(mode.sessionId)!!
-        val clonePort = session.replicasList.first().egressPort.toLong()
         s.standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
-        s.standardMetadata.setBitField("egress_port", clonePort)
+        s.standardMetadata.setBitField("egress_port", mode.clonePort)
         s.packetCtx.pendingEgressCloneSessionId = null
       }
       else -> {
         val suppressE2E = (mode as? BranchMode.Normal)?.suppressE2EClone == true
-        // BMv2 silently ignores clone() when the session doesn't exist.
         val pendingE2EClone = s.packetCtx.pendingEgressCloneSessionId
-        if (
-          pendingE2EClone != null &&
-            !suppressE2E &&
-            ctx.tableStore.getCloneSession(pendingE2EClone) != null
-        ) {
-          throw EgressCloneFork(pendingE2EClone, s.packetCtx.getEvents())
+        if (pendingE2EClone != null && !suppressE2E) {
+          val session = ctx.tableStore.getCloneSession(pendingE2EClone)
+          if (session != null) {
+            val clonePort = session.replicasList.first().egressPort.toLong()
+            s.packetCtx.addTraceEvent(cloneSessionLookupEvent(pendingE2EClone, clonePort.toInt()))
+            throw EgressCloneFork(pendingE2EClone, clonePort, s.packetCtx.getEvents())
+          } else {
+            s.packetCtx.addTraceEvent(cloneSessionMissEvent(pendingE2EClone))
+          }
         }
       }
     }
@@ -522,6 +521,23 @@ class V1ModelArchitecture : Architecture {
     val outcome = PacketOutcome.newBuilder().setOutput(output).build()
     return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
   }
+
+  private fun cloneSessionLookupEvent(sessionId: Int, egressPort: Int): TraceEvent =
+    TraceEvent.newBuilder()
+      .setCloneSessionLookup(
+        CloneSessionLookupEvent.newBuilder()
+          .setSessionId(sessionId)
+          .setSessionFound(true)
+          .setEgressPort(egressPort)
+      )
+      .build()
+
+  private fun cloneSessionMissEvent(sessionId: Int): TraceEvent =
+    TraceEvent.newBuilder()
+      .setCloneSessionLookup(
+        CloneSessionLookupEvent.newBuilder().setSessionId(sessionId).setSessionFound(false)
+      )
+      .build()
 
   private fun packetIngressEvent(ingressPort: UInt): TraceEvent =
     TraceEvent.newBuilder()

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -32,6 +32,7 @@ import fourward.sim.v1.SimulatorProto.PipelineStageEvent.Direction
 import fourward.sim.v1.SimulatorProto.TraceEvent
 import fourward.sim.v1.SimulatorProto.TraceTree
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import p4.v1.P4RuntimeOuterClass
@@ -470,8 +471,9 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `I2E clone with missing session drops clone branch`() {
-    // Clone session 99 is never installed — BMv2 drops the clone silently.
+  fun `I2E clone with missing session is silently ignored`() {
+    // Clone session 99 is never installed — BMv2 silently ignores the clone.
+    // No fork appears; the packet outputs normally.
     val config =
       v1modelConfig(
         externCall("clone", enumArg("I2E"), intArg(99, 32)),
@@ -480,16 +482,15 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    assertFalse(result.trace.hasForkOutcome())
     val outputs = collectOutputsFromTrace(result.trace)
-    // Only the original branch produces output; the clone branch is dropped.
     assertEquals(1, outputs.size)
     assertEquals(2, outputs[0].egressPort)
   }
 
   @Test
-  fun `E2E clone with missing session drops clone branch`() {
+  fun `E2E clone with missing session is silently ignored`() {
+    // Clone session 99 is never installed — BMv2 silently ignores the clone.
     val config =
       v1modelConfig(
         ingressStmts =
@@ -499,9 +500,8 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertFalse(result.trace.hasForkOutcome())
     val outputs = collectOutputsFromTrace(result.trace)
-    // Only the original branch produces output.
     assertEquals(1, outputs.size)
     assertEquals(3, outputs[0].egressPort)
   }

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -131,6 +131,7 @@ message TraceEvent {
     CloneEvent clone = 7;
     PacketIngressEvent packet_ingress = 8;
     PipelineStageEvent pipeline_stage = 9;
+    CloneSessionLookupEvent clone_session_lookup = 10;
   }
 
   fourward.ir.v1.SourceInfo source_info = 100;
@@ -177,9 +178,19 @@ message MarkToDropEvent {
   DropReason reason = 1;
 }
 
-// Fired when the P4 program requests a packet clone.
+// Fired when the P4 program calls clone().
 message CloneEvent {
   uint32 session_id = 1;
+}
+
+// Fired at the ingress→egress (or post-egress) boundary when the traffic
+// manager resolves a pending clone session.
+message CloneSessionLookupEvent {
+  uint32 session_id = 1;
+  bool session_found =
+      2;  // false = session not configured, clone silently dropped
+  uint32 egress_port =
+      3;  // clone destination; only meaningful when session_found
 }
 
 // Fired when a packet arrives at the pipeline — the very first event in any

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm_test")
+
+kt_jvm_library(
+    name = "web_lib",
+    srcs = glob(
+        ["*.kt"],
+        exclude = [
+            "*Test.kt",
+            "PlaygroundServer.kt",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//p4runtime:p4info_java_proto",
+        "//p4runtime:p4runtime_java_proto",
+        "//p4runtime:p4runtime_lib",
+        "//simulator:ir_java_proto",
+        "//simulator:simulator_java_proto",
+        "//simulator:simulator_lib",
+        "@grpc-java//api",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+    ],
+)
+
+kt_jvm_binary(
+    name = "playground",
+    srcs = ["PlaygroundServer.kt"],
+    data = [
+        "//p4c_backend:p4c-4ward",
+        "@p4c//:p4include",
+    ] + glob(["frontend/**"]),
+    main_class = "fourward.web.PlaygroundServerKt",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":web_lib",
+        "//p4runtime:p4runtime_lib",
+        "//simulator:simulator_lib",
+        "@grpc-java//netty",
+        "@maven//:io_grpc_grpc_netty_shaded",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+    ],
+)
+
+kt_jvm_test(
+    name = "WebServerTest",
+    srcs = ["WebServerTest.kt"],
+    test_class = "fourward.web.WebServerTest",
+    deps = [
+        ":web_lib",
+        "@maven//:junit_junit",
+    ],
+)

--- a/web/PlaygroundServer.kt
+++ b/web/PlaygroundServer.kt
@@ -1,0 +1,65 @@
+package fourward.web
+
+import fourward.p4runtime.DataplaneService
+import fourward.p4runtime.P4RuntimeService
+import fourward.simulator.Simulator
+import io.grpc.netty.NettyServerBuilder
+import java.nio.file.Path
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * 4ward Playground — combined gRPC + HTTP server.
+ *
+ * Runs two servers in the same process sharing a single [Simulator]:
+ * - **gRPC** (port 9559): standard P4Runtime + Dataplane services for CLI/controller use.
+ * - **HTTP** (port 8080): REST API + web UI for the interactive playground.
+ */
+fun main(args: Array<String>) {
+  val httpPort = flagValue(args, "--http-port")?.toIntOrNull() ?: WebServer.DEFAULT_HTTP_PORT
+  val grpcPort =
+    flagValue(args, "--grpc-port")?.toIntOrNull() ?: fourward.p4runtime.P4RuntimeServer.DEFAULT_PORT
+  val staticDir = flagValue(args, "--static-dir")?.let { Path.of(it) }
+
+  val simulator = Simulator()
+  val lock = Mutex()
+  val service = P4RuntimeService(simulator, lock = lock)
+  val dataplaneService = DataplaneService(simulator, lock)
+
+  // Start gRPC server.
+  val grpcServer =
+    NettyServerBuilder.forPort(grpcPort)
+      .addService(service)
+      .addService(dataplaneService)
+      .build()
+      .start()
+
+  // Start HTTP server.
+  val webServer =
+    WebServer(
+        simulator = simulator,
+        service = service,
+        lock = lock,
+        httpPort = httpPort,
+        staticDir = staticDir,
+      )
+      .start()
+
+  println("4ward Playground")
+  println("  Web UI:   http://localhost:$httpPort")
+  println("  gRPC:     localhost:${grpcServer.port}")
+  if (staticDir != null) println("  Static:   $staticDir")
+
+  Runtime.getRuntime()
+    .addShutdownHook(
+      Thread {
+        webServer.stop()
+        grpcServer.shutdown()
+        service.close()
+      }
+    )
+
+  grpcServer.awaitTermination()
+}
+
+private fun flagValue(args: Array<String>, flag: String): String? =
+  args.find { it.startsWith("$flag=") }?.substringAfter("=")

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -359,7 +359,10 @@ class WebServer(
             'r' -> sb.append('\r')
             't' -> sb.append('\t')
             '/' -> sb.append('/')
-            else -> { sb.append('\\'); sb.append(json[i]) }
+            else -> {
+              sb.append('\\')
+              sb.append(json[i])
+            }
           }
         } else {
           sb.append(c)

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -1,0 +1,370 @@
+package fourward.web
+
+import com.google.protobuf.ByteString
+import com.google.protobuf.TextFormat
+import com.google.protobuf.util.JsonFormat
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import fourward.ir.v1.PipelineConfig
+import fourward.simulator.Simulator
+import java.net.InetSocketAddress
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.Executors
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.ReadResponse
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.TableEntry
+import p4.v1.P4RuntimeOuterClass.WriteRequest
+
+/**
+ * HTTP server for the 4ward web playground.
+ *
+ * Provides a REST API that wraps P4 compilation and P4Runtime operations, plus serves the
+ * single-page frontend. Uses the JDK's built-in [HttpServer] to avoid adding external dependencies.
+ *
+ * All P4Runtime operations go through [P4RuntimeService][fourward.p4runtime.P4RuntimeService]:
+ * pipeline loading via SetForwardingPipelineConfig, table writes via Write, and reads via Read.
+ * Packet injection goes directly to the simulator (with the shared lock) to get trace trees.
+ */
+class WebServer(
+  private val simulator: Simulator,
+  private val service: fourward.p4runtime.P4RuntimeService,
+  private val lock: Mutex,
+  private val httpPort: Int = DEFAULT_HTTP_PORT,
+  private val staticDir: Path? = null,
+) {
+
+  private val server = HttpServer.create(InetSocketAddress(httpPort), 0)
+  private val jsonPrinter: JsonFormat.Printer =
+    JsonFormat.printer().preservingProtoFieldNames().alwaysPrintFieldsWithNoPresence()
+  private val jsonParser: JsonFormat.Parser = JsonFormat.parser().ignoringUnknownFields()
+
+  @Volatile private var loadedP4Info: p4.config.v1.P4InfoOuterClass.P4Info? = null
+
+  fun start(): WebServer {
+    server.createContext("/api/compile-and-load") { cors(it, ::handleCompileAndLoad) }
+    server.createContext("/api/pipeline") { cors(it, ::handleGetPipeline) }
+    server.createContext("/api/write") { cors(it, ::handleWrite) }
+    server.createContext("/api/read") { cors(it, ::handleRead) }
+    server.createContext("/api/packet") { cors(it, ::handlePacket) }
+    server.createContext("/") { handleStatic(it) }
+    server.executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE)
+    server.start()
+    return this
+  }
+
+  fun stop() {
+    server.stop(0)
+  }
+
+  // ---------------------------------------------------------------------------
+  // CORS wrapper
+  // ---------------------------------------------------------------------------
+
+  private fun cors(exchange: HttpExchange, handler: (HttpExchange) -> Unit) {
+    exchange.responseHeaders.add("Access-Control-Allow-Origin", "*")
+    exchange.responseHeaders.add("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+    exchange.responseHeaders.add("Access-Control-Allow-Headers", "Content-Type")
+
+    if (exchange.requestMethod == "OPTIONS") {
+      exchange.sendResponseHeaders(HTTP_NO_CONTENT, NO_BODY)
+      exchange.close()
+      return
+    }
+
+    try {
+      handler(exchange)
+    } catch (e: io.grpc.StatusException) {
+      sendJson(exchange, HTTP_BAD_REQUEST, errorJson(e.status.description ?: e.status.code.name))
+    } catch (e: Exception) {
+      sendJson(exchange, HTTP_INTERNAL_ERROR, errorJson(e.message ?: "Internal server error"))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /api/compile-and-load
+  // ---------------------------------------------------------------------------
+
+  private fun handleCompileAndLoad(exchange: HttpExchange) {
+    requirePost(exchange)
+    val body = exchange.requestBody.bufferedReader().readText()
+    val source = extractJsonString(body, "source") ?: throw badRequest("Missing 'source' field")
+
+    val tempP4 = Files.createTempFile("4ward-playground-", ".p4")
+    val tempOutput = Files.createTempFile("4ward-playground-", ".txtpb")
+    try {
+      Files.writeString(tempP4, source)
+      val result = compileP4(tempP4, tempOutput)
+      if (result.exitCode != 0) {
+        sendJson(exchange, HTTP_BAD_REQUEST, """{"error":${jsonEscape(result.output)}}""")
+        return
+      }
+
+      val configText = Files.readString(tempOutput)
+      val configBuilder = PipelineConfig.newBuilder()
+      TextFormat.merge(configText, configBuilder)
+      val config = configBuilder.build()
+
+      // Load via SetForwardingPipelineConfig — the standard P4Runtime path.
+      val request =
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+          .setConfig(
+            ForwardingPipelineConfig.newBuilder()
+              .setP4Info(config.p4Info)
+              .setP4DeviceConfig(config.device.toByteString())
+          )
+          .build()
+
+      runBlocking { service.setForwardingPipelineConfig(request) }
+      loadedP4Info = config.p4Info
+
+      sendJson(exchange, HTTP_OK, """{"success":true,"p4info":${jsonPrinter.print(config.p4Info)}}""")
+    } finally {
+      Files.deleteIfExists(tempP4)
+      Files.deleteIfExists(tempOutput)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /api/pipeline
+  // ---------------------------------------------------------------------------
+
+  private fun handleGetPipeline(exchange: HttpExchange) {
+    val p4info = loadedP4Info
+    if (p4info == null) {
+      sendJson(exchange, HTTP_OK, """{"loaded":false}""")
+    } else {
+      sendJson(exchange, HTTP_OK, """{"loaded":true,"p4info":${jsonPrinter.print(p4info)}}""")
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /api/write
+  // ---------------------------------------------------------------------------
+
+  private fun handleWrite(exchange: HttpExchange) {
+    requirePost(exchange)
+    val body = exchange.requestBody.bufferedReader().readText()
+    val builder = WriteRequest.newBuilder()
+    jsonParser.merge(body, builder)
+    if (builder.deviceId == 0L) builder.deviceId = 1
+    runBlocking { service.write(builder.build()) }
+    sendJson(exchange, HTTP_OK, """{"success":true}""")
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /api/read?table_id=0
+  // ---------------------------------------------------------------------------
+
+  private fun handleRead(exchange: HttpExchange) {
+    val tableId = queryParam(exchange, "table_id")?.toIntOrNull() ?: 0
+    val request =
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(tableId)))
+        .build()
+
+    val entities = mutableListOf<Entity>()
+    runBlocking { service.read(request).collect { entities.addAll(it.entitiesList) } }
+
+    val entitiesJson = entities.joinToString(",") { jsonPrinter.print(it) }
+    sendJson(exchange, HTTP_OK, """{"entities":[$entitiesJson]}""")
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /api/packet
+  // ---------------------------------------------------------------------------
+
+  private fun handlePacket(exchange: HttpExchange) {
+    requirePost(exchange)
+    val body = exchange.requestBody.bufferedReader().readText()
+    val ingressPort = extractJsonInt(body, "ingress_port") ?: 0
+    val payloadHex = extractJsonString(body, "payload_hex") ?: throw badRequest("Missing payload_hex")
+    val payload = hexToBytes(payloadHex)
+
+    val response = runBlocking { lock.withLock { simulator.processPacket(ingressPort, payload) } }
+
+    val outputsJson = response.outputPacketsList.joinToString(",") { jsonPrinter.print(it) }
+    val traceJson = jsonPrinter.print(response.trace)
+    sendJson(exchange, HTTP_OK, """{"output_packets":[$outputsJson],"trace":$traceJson}""")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Static file serving
+  // ---------------------------------------------------------------------------
+
+  private fun handleStatic(exchange: HttpExchange) {
+    val reqPath = exchange.requestURI.path.trimStart('/')
+    val filePath = if (reqPath.isEmpty()) "index.html" else reqPath
+
+    // Don't serve API paths as static files.
+    if (filePath.startsWith("api/")) {
+      exchange.sendResponseHeaders(HTTP_NOT_FOUND, NO_BODY)
+      exchange.close()
+      return
+    }
+
+    val content = readStaticFile(filePath)
+    if (content == null) {
+      exchange.sendResponseHeaders(HTTP_NOT_FOUND, NO_BODY)
+      exchange.close()
+      return
+    }
+
+    exchange.responseHeaders.add("Content-Type", contentType(filePath))
+    exchange.sendResponseHeaders(HTTP_OK, content.size.toLong())
+    exchange.responseBody.use { it.write(content) }
+  }
+
+  private fun readStaticFile(relativePath: String): ByteArray? {
+    // 1. Override directory (for development).
+    staticDir?.let { dir ->
+      val file = dir.resolve(relativePath).normalize()
+      if (file.startsWith(dir) && Files.isRegularFile(file)) {
+        return Files.readAllBytes(file)
+      }
+    }
+
+    // 2. Bazel runfiles.
+    val runfiles = System.getenv("JAVA_RUNFILES")
+    if (runfiles != null) {
+      val file = Path.of(runfiles, "_main/web/frontend", relativePath)
+      if (Files.isRegularFile(file)) return Files.readAllBytes(file)
+    }
+
+    // 3. Classpath.
+    return javaClass.getResourceAsStream("/frontend/$relativePath")?.readAllBytes()
+  }
+
+  // ---------------------------------------------------------------------------
+  // P4 compilation
+  // ---------------------------------------------------------------------------
+
+  private data class CompileResult(val exitCode: Int, val output: String)
+
+  private fun compileP4(source: Path, outputPath: Path): CompileResult {
+    val p4c = findP4c() ?: return CompileResult(1, "p4c-4ward not found")
+
+    val cmd = mutableListOf(p4c.toString())
+
+    // Add standard includes (core.p4, v1model.p4) from runfiles.
+    val runfiles = System.getenv("JAVA_RUNFILES")
+    if (runfiles != null) {
+      val p4include = Path.of(runfiles, "p4c+/p4include")
+      if (Files.isDirectory(p4include)) cmd += listOf("-I", p4include.toString())
+    }
+
+    cmd += listOf("-o", outputPath.toString())
+    cmd += source.toString()
+
+    val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+    val processOutput = process.inputStream.bufferedReader().readText()
+    val exitCode = process.waitFor()
+    return CompileResult(exitCode, processOutput)
+  }
+
+  private fun findP4c(): Path? {
+    val runfiles = System.getenv("JAVA_RUNFILES")
+    if (runfiles != null) {
+      val candidate = Path.of(runfiles, "_main/p4c_backend/p4c-4ward")
+      if (Files.isExecutable(candidate)) return candidate
+    }
+    val pathDirs = System.getenv("PATH")?.split(":") ?: emptyList()
+    for (dir in pathDirs) {
+      val candidate = Path.of(dir, "p4c-4ward")
+      if (Files.isExecutable(candidate)) return candidate
+    }
+    return null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private fun sendJson(exchange: HttpExchange, statusCode: Int, json: String) {
+    val bytes = json.toByteArray(Charsets.UTF_8)
+    exchange.responseHeaders.add("Content-Type", "application/json; charset=utf-8")
+    exchange.sendResponseHeaders(statusCode, bytes.size.toLong())
+    exchange.responseBody.use { it.write(bytes) }
+  }
+
+  private fun requirePost(exchange: HttpExchange) {
+    if (exchange.requestMethod != "POST") throw badRequest("POST required")
+  }
+
+  private fun badRequest(message: String) =
+    io.grpc.Status.INVALID_ARGUMENT.withDescription(message).asException()
+
+  private fun queryParam(exchange: HttpExchange, key: String): String? =
+    exchange.requestURI.query?.split("&")?.find { it.startsWith("$key=") }?.substringAfter("=")
+
+  companion object {
+    const val DEFAULT_HTTP_PORT = 8080
+
+    private const val THREAD_POOL_SIZE = 4
+    private const val HTTP_OK = 200
+    private const val HTTP_NO_CONTENT = 204
+    private const val HTTP_BAD_REQUEST = 400
+    private const val HTTP_NOT_FOUND = 404
+    private const val HTTP_INTERNAL_ERROR = 500
+    private const val NO_BODY = -1L
+
+    private fun contentType(path: String): String =
+      when {
+        path.endsWith(".html") -> "text/html; charset=utf-8"
+        path.endsWith(".css") -> "text/css; charset=utf-8"
+        path.endsWith(".js") -> "application/javascript; charset=utf-8"
+        path.endsWith(".json") -> "application/json; charset=utf-8"
+        path.endsWith(".svg") -> "image/svg+xml"
+        path.endsWith(".png") -> "image/png"
+        path.endsWith(".ico") -> "image/x-icon"
+        else -> "application/octet-stream"
+      }
+
+    /** Minimal JSON string extraction — avoids pulling in a JSON library. */
+    fun extractJsonString(json: String, key: String): String? {
+      val regex = """"$key"\s*:\s*"((?:[^"\\]|\\.)*)"""".toRegex()
+      val match = regex.find(json) ?: return null
+      return match.groupValues[1]
+        .replace("\\\"", "\"")
+        .replace("\\n", "\n")
+        .replace("\\r", "\r")
+        .replace("\\t", "\t")
+        .replace("\\\\", "\\")
+    }
+
+    fun extractJsonInt(json: String, key: String): Int? {
+      val regex = """"$key"\s*:\s*(-?\d+)""".toRegex()
+      return regex.find(json)?.groupValues?.get(1)?.toIntOrNull()
+    }
+
+    fun jsonEscape(s: String): String {
+      val escaped =
+        s.replace("\\", "\\\\")
+          .replace("\"", "\\\"")
+          .replace("\n", "\\n")
+          .replace("\r", "\\r")
+          .replace("\t", "\\t")
+      return "\"$escaped\""
+    }
+
+    fun errorJson(message: String): String = """{"error":${jsonEscape(message)}}"""
+
+    fun hexToBytes(hex: String): ByteArray {
+      val clean = hex.replace(Regex("[\\s:]+"), "").removePrefix("0x").removePrefix("0X")
+      require(clean.length % 2 == 0) { "Hex string must have even length" }
+      return ByteArray(clean.length / 2) { i ->
+        clean.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+      }
+    }
+  }
+}

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -334,14 +334,39 @@ class WebServer(
 
     /** Minimal JSON string extraction — avoids pulling in a JSON library. */
     fun extractJsonString(json: String, key: String): String? {
-      val regex = """"$key"\s*:\s*"((?:[^"\\]|\\.)*)"""".toRegex()
-      val match = regex.find(json) ?: return null
-      return match.groupValues[1]
-        .replace("\\\"", "\"")
-        .replace("\\n", "\n")
-        .replace("\\r", "\r")
-        .replace("\\t", "\t")
-        .replace("\\\\", "\\")
+      // Manual scan instead of regex: Java's NFA regex engine recurses per
+      // character in `(?:[^"\\]|\\.)*`, causing StackOverflowError on long
+      // P4 source strings.
+      val keyPattern = "\"$key\""
+      val keyIdx = json.indexOf(keyPattern)
+      if (keyIdx < 0) return null
+      var i = keyIdx + keyPattern.length
+      while (i < json.length && json[i].isWhitespace()) i++
+      if (i >= json.length || json[i] != ':') return null
+      i++
+      while (i < json.length && json[i].isWhitespace()) i++
+      if (i >= json.length || json[i] != '"') return null
+      i++ // skip opening quote
+      val sb = StringBuilder()
+      while (i < json.length) {
+        val c = json[i]
+        if (c == '"') return sb.toString()
+        if (c == '\\' && i + 1 < json.length) {
+          when (json[++i]) {
+            '"' -> sb.append('"')
+            '\\' -> sb.append('\\')
+            'n' -> sb.append('\n')
+            'r' -> sb.append('\r')
+            't' -> sb.append('\t')
+            '/' -> sb.append('/')
+            else -> { sb.append('\\'); sb.append(json[i]) }
+          }
+        } else {
+          sb.append(c)
+        }
+        i++
+      }
+      return null // unterminated string
     }
 
     fun extractJsonInt(json: String, key: String): Int? {

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -1,6 +1,5 @@
 package fourward.web
 
-import com.google.protobuf.ByteString
 import com.google.protobuf.TextFormat
 import com.google.protobuf.util.JsonFormat
 import com.sun.net.httpserver.HttpExchange
@@ -11,14 +10,12 @@ import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.Executors
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import p4.v1.P4RuntimeOuterClass.Entity
 import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
 import p4.v1.P4RuntimeOuterClass.ReadRequest
-import p4.v1.P4RuntimeOuterClass.ReadResponse
 import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
 import p4.v1.P4RuntimeOuterClass.TableEntry
 import p4.v1.P4RuntimeOuterClass.WriteRequest
@@ -127,7 +124,11 @@ class WebServer(
       runBlocking { service.setForwardingPipelineConfig(request) }
       loadedP4Info = config.p4Info
 
-      sendJson(exchange, HTTP_OK, """{"success":true,"p4info":${jsonPrinter.print(config.p4Info)}}""")
+      sendJson(
+        exchange,
+        HTTP_OK,
+        """{"success":true,"p4info":${jsonPrinter.print(config.p4Info)}}""",
+      )
     } finally {
       Files.deleteIfExists(tempP4)
       Files.deleteIfExists(tempOutput)
@@ -188,7 +189,8 @@ class WebServer(
     requirePost(exchange)
     val body = exchange.requestBody.bufferedReader().readText()
     val ingressPort = extractJsonInt(body, "ingress_port") ?: 0
-    val payloadHex = extractJsonString(body, "payload_hex") ?: throw badRequest("Missing payload_hex")
+    val payloadHex =
+      extractJsonString(body, "payload_hex") ?: throw badRequest("Missing payload_hex")
     val payload = hexToBytes(payloadHex)
 
     val response = runBlocking { lock.withLock { simulator.processPacket(ingressPort, payload) } }

--- a/web/WebServerTest.kt
+++ b/web/WebServerTest.kt
@@ -37,19 +37,16 @@ class WebServerTest {
 
   @Test
   fun `hexToBytes converts hex string to bytes`() {
-    assertArrayEquals(byteArrayOf(0xFF.toByte(), 0x00, 0xAB.toByte()), WebServer.hexToBytes("ff00ab"))
+    assertArrayEquals(
+      byteArrayOf(0xFF.toByte(), 0x00, 0xAB.toByte()),
+      WebServer.hexToBytes("ff00ab"),
+    )
   }
 
   @Test
   fun `hexToBytes handles spaces and colons`() {
-    assertArrayEquals(
-      byteArrayOf(0xDE.toByte(), 0xAD.toByte()),
-      WebServer.hexToBytes("de ad"),
-    )
-    assertArrayEquals(
-      byteArrayOf(0xBE.toByte(), 0xEF.toByte()),
-      WebServer.hexToBytes("be:ef"),
-    )
+    assertArrayEquals(byteArrayOf(0xDE.toByte(), 0xAD.toByte()), WebServer.hexToBytes("de ad"))
+    assertArrayEquals(byteArrayOf(0xBE.toByte(), 0xEF.toByte()), WebServer.hexToBytes("be:ef"))
   }
 
   @Test

--- a/web/WebServerTest.kt
+++ b/web/WebServerTest.kt
@@ -1,0 +1,72 @@
+package fourward.web
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WebServerTest {
+
+  @Test
+  fun `extractJsonString extracts simple values`() {
+    assertEquals("hello", WebServer.extractJsonString("""{"key":"hello"}""", "key"))
+    assertEquals("world", WebServer.extractJsonString("""{"a":"b","key":"world"}""", "key"))
+  }
+
+  @Test
+  fun `extractJsonString handles escaped characters`() {
+    assertEquals("line1\nline2", WebServer.extractJsonString("""{"s":"line1\nline2"}""", "s"))
+    assertEquals("a\"b", WebServer.extractJsonString("""{"s":"a\"b"}""", "s"))
+  }
+
+  @Test
+  fun `extractJsonString returns null for missing key`() {
+    assertNull(WebServer.extractJsonString("""{"other":"value"}""", "key"))
+  }
+
+  @Test
+  fun `extractJsonInt extracts integer values`() {
+    assertEquals(42, WebServer.extractJsonInt("""{"port":42}""", "port"))
+    assertEquals(0, WebServer.extractJsonInt("""{"port":0}""", "port"))
+  }
+
+  @Test
+  fun `extractJsonInt returns null for missing key`() {
+    assertNull(WebServer.extractJsonInt("""{"other":1}""", "port"))
+  }
+
+  @Test
+  fun `hexToBytes converts hex string to bytes`() {
+    assertArrayEquals(byteArrayOf(0xFF.toByte(), 0x00, 0xAB.toByte()), WebServer.hexToBytes("ff00ab"))
+  }
+
+  @Test
+  fun `hexToBytes handles spaces and colons`() {
+    assertArrayEquals(
+      byteArrayOf(0xDE.toByte(), 0xAD.toByte()),
+      WebServer.hexToBytes("de ad"),
+    )
+    assertArrayEquals(
+      byteArrayOf(0xBE.toByte(), 0xEF.toByte()),
+      WebServer.hexToBytes("be:ef"),
+    )
+  }
+
+  @Test
+  fun `hexToBytes handles 0x prefix`() {
+    assertArrayEquals(byteArrayOf(0xCA.toByte(), 0xFE.toByte()), WebServer.hexToBytes("0xCAFE"))
+  }
+
+  @Test
+  fun `jsonEscape escapes special characters`() {
+    assertEquals("\"hello\"", WebServer.jsonEscape("hello"))
+    assertEquals("\"a\\\"b\"", WebServer.jsonEscape("a\"b"))
+    assertEquals("\"line1\\nline2\"", WebServer.jsonEscape("line1\nline2"))
+  }
+
+  @Test
+  fun `errorJson produces valid JSON`() {
+    assertEquals("""{"error":"oops"}""", WebServer.errorJson("oops"))
+    assertEquals("""{"error":"a\"b"}""", WebServer.errorJson("a\"b"))
+  }
+}

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -872,11 +872,13 @@ function renderTraceEvent(event) {
 function formatSourceInfo(si) {
   if (!si) return '';
   const fragment = si.source_fragment || '';
-  const loc = si.line ? `:${si.line}` : '';
-  if (!fragment && !loc) return '';
-  const text = fragment ? escapeHtml(fragment) : `line ${si.line}`;
-  const lineAttr = si.line ? ` data-line="${si.line}"` : '';
-  return ` <span class="trace-source" onclick="jumpToLine(${si.line || 0})"${lineAttr}>${text}</span>`;
+  const line = si.line || 0;
+  if (!fragment && !line) return '';
+  const linePrefix = line ? `L${line}` : '';
+  const text = fragment
+    ? (linePrefix ? `${linePrefix}: ${escapeHtml(fragment)}` : escapeHtml(fragment))
+    : linePrefix;
+  return ` <span class="trace-source" onclick="jumpToLine(${line})" title="Jump to line ${line} in editor">${text}</span>`;
 }
 
 function jumpToLine(line) {

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -8,10 +8,12 @@
 // ---------------------------------------------------------------------------
 
 const state = {
-  p4info: null,       // loaded P4Info (JSON)
-  entries: [],        // installed table entries (for display)
-  lastTrace: null,    // last ProcessPacketWithTraceTree response
-  editor: null,       // Monaco editor instance
+  p4info: null,         // loaded P4Info (JSON)
+  entries: [],          // installed table entries (for display)
+  cloneSessions: [],    // installed clone sessions
+  lastTrace: null,      // last ProcessPacketWithTraceTree response
+  editor: null,         // Monaco editor instance
+  loadingExample: false, // guard for example loading
 };
 
 // ---------------------------------------------------------------------------
@@ -450,6 +452,8 @@ async function compileAndLoad() {
     const data = await api.compileAndLoad(source);
     state.p4info = data.p4info;
     state.entries = [];
+    state.cloneSessions = [];
+    renderCloneSessionsList();
     const nTables = (data.p4info.tables || []).length;
     const nActions = (data.p4info.actions || []).length;
     setStatus('loaded', `${nTables} table${nTables !== 1 ? 's' : ''}, ${nActions} action${nActions !== 1 ? 's' : ''}`);
@@ -652,6 +656,86 @@ async function deleteTableEntry(index) {
   } catch (e) {
     log(`Delete failed: ${e.message}`, 'error');
   }
+}
+
+// ---------------------------------------------------------------------------
+// Clone sessions
+// ---------------------------------------------------------------------------
+
+async function addCloneSession() {
+  const sessionId = parseInt(document.getElementById('clone-session-id').value, 10);
+  const egressPort = parseInt(document.getElementById('clone-egress-port').value, 10);
+
+  if (isNaN(sessionId) || isNaN(egressPort)) {
+    log('Enter valid session ID and egress port', 'error');
+    return;
+  }
+
+  try {
+    await api.write({
+      device_id: '1',
+      updates: [{
+        type: 'INSERT',
+        entity: {
+          packet_replication_engine_entry: {
+            clone_session_entry: {
+              session_id: sessionId,
+              replicas: [{ egress_port: egressPort }],
+            },
+          },
+        },
+      }],
+    });
+
+    state.cloneSessions.push({ sessionId, egressPort });
+    renderCloneSessionsList();
+    log(`Clone session ${sessionId} → port ${egressPort}`, 'success');
+  } catch (e) {
+    log(`Clone session failed: ${e.message}`, 'error');
+  }
+}
+
+async function deleteCloneSession(index) {
+  const session = state.cloneSessions[index];
+  if (!session) return;
+
+  try {
+    await api.write({
+      device_id: '1',
+      updates: [{
+        type: 'DELETE',
+        entity: {
+          packet_replication_engine_entry: {
+            clone_session_entry: {
+              session_id: session.sessionId,
+            },
+          },
+        },
+      }],
+    });
+
+    state.cloneSessions.splice(index, 1);
+    renderCloneSessionsList();
+    log(`Clone session ${session.sessionId} deleted`, 'success');
+  } catch (e) {
+    log(`Delete failed: ${e.message}`, 'error');
+  }
+}
+
+function renderCloneSessionsList() {
+  const list = document.getElementById('clone-sessions-list');
+  if (state.cloneSessions.length === 0) {
+    list.innerHTML = '';
+    return;
+  }
+
+  list.innerHTML = state.cloneSessions.map((s, i) =>
+    `<div class="entry-card">
+      <div class="entry-table">Session ${s.sessionId}</div>
+      <div class="entry-action">${'\u2192'} port ${s.egressPort}</div>
+      <button class="btn btn-danger btn-delete" onclick="deleteCloneSession(${i})">&#x2715;</button>
+    </div>`
+  ).join('');
 }
 
 async function sendPacket() {
@@ -1212,6 +1296,7 @@ function log(message, level = '') {
 function updateButtonStates() {
   const hasPipeline = !!state.p4info;
   document.getElementById('btn-add-entry').disabled = !hasPipeline;
+  document.getElementById('btn-add-clone').disabled = !hasPipeline;
   document.getElementById('btn-send-packet').disabled = !hasPipeline;
 }
 
@@ -1310,6 +1395,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Buttons
   document.getElementById('btn-compile').addEventListener('click', compileAndLoad);
   document.getElementById('btn-add-entry').addEventListener('click', addTableEntry);
+  document.getElementById('btn-add-clone').addEventListener('click', addCloneSession);
   document.getElementById('btn-send-packet').addEventListener('click', sendPacket);
 
   // Example selector

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -246,10 +246,9 @@ control MyIngress(inout headers_t hdr, inout metadata_t meta,
 
     apply {
         if (hdr.ipv4.isValid()) {
-            if (ipv4_lpm.apply().hit) {
-                // Mirror forwarded traffic (clone to session 100).
-                clone(CloneType.I2E, 32w100);
-            }
+            ipv4_lpm.apply();
+            // Mirror all forwarded traffic (clone to session 100).
+            clone(CloneType.I2E, 32w100);
         }
     }
 }

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -1088,6 +1088,13 @@ function renderTraceEvent(event) {
   if (event.clone) {
     return `<div class="trace-event clone">clone session ${event.clone.session_id}${src}</div>`;
   }
+  if (event.clone_session_lookup) {
+    const csl = event.clone_session_lookup;
+    if (csl.session_found) {
+      return `<div class="trace-event clone-session-hit">clone session ${csl.session_id} → port ${csl.egress_port}</div>`;
+    }
+    return `<div class="trace-event clone-session-miss">clone session ${csl.session_id}: not configured (clone dropped)</div>`;
+  }
   return '';
 }
 

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -1074,7 +1074,12 @@ function renderTraceEvent(event) {
   if (event.branch) {
     const b = event.branch;
     const dir = b.taken ? 'then' : 'else';
-    return `<div class="trace-event branch">branch ${b.control_name}: ${dir}${src}</div>`;
+    // Show the condition from source_fragment (e.g. "hdr.ipv4.isValid()")
+    // instead of the generic statement type that the pill would show.
+    const frag = event.source_info?.source_fragment || '';
+    const cond = frag.replace(/^if\s*\(/, '').replace(/\)\s*$/, '') || '';
+    const condStr = cond ? `: <code>${escapeHtml(cond)}</code>` : '';
+    return `<div class="trace-event branch">branch ${dir}${condStr}${src}</div>`;
   }
   if (event.extern_call) {
     const ec = event.extern_call;

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -1209,7 +1209,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const isMac = navigator.platform.includes('Mac');
   const mod = isMac ? '⌘' : 'Ctrl';
   initEditor().then(() => {
-    log(`Editor ready — ${mod}+Enter to compile, ${mod}+Enter in payload to send packet`, 'info');
+    log(`Editor ready — ${mod}+Enter to compile & load`, 'info');
   });
 
   // Check if pipeline is already loaded (e.g. page refresh)

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -246,9 +246,10 @@ control MyIngress(inout headers_t hdr, inout metadata_t meta,
 
     apply {
         if (hdr.ipv4.isValid()) {
-            ipv4_lpm.apply();
-            // Mirror all forwarded traffic (clone to session 100).
-            clone(CloneType.I2E, 32w100);
+            if (ipv4_lpm.apply().hit) {
+                // Mirror forwarded traffic (clone to session 100).
+                clone(CloneType.I2E, 32w100);
+            }
         }
     }
 }

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -1,0 +1,1212 @@
+// 4ward Playground — main application
+// Vanilla JS, no build step. Monaco editor loaded from CDN.
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const state = {
+  p4info: null,       // loaded P4Info (JSON)
+  entries: [],        // installed table entries (for display)
+  lastTrace: null,    // last ProcessPacketWithTraceTree response
+  editor: null,       // Monaco editor instance
+};
+
+// ---------------------------------------------------------------------------
+// API client
+// ---------------------------------------------------------------------------
+
+const api = {
+  async compileAndLoad(source) {
+    return post('/api/compile-and-load', { source });
+  },
+
+  async write(writeRequest) {
+    return post('/api/write', writeRequest);
+  },
+
+  async read(tableId = 0) {
+    const resp = await fetch(`/api/read?table_id=${tableId}`);
+    return resp.json();
+  },
+
+  async sendPacket(ingressPort, payloadHex) {
+    return post('/api/packet', { ingress_port: ingressPort, payload_hex: payloadHex });
+  },
+
+  async getPipeline() {
+    const resp = await fetch('/api/pipeline');
+    return resp.json();
+  },
+};
+
+async function post(url, body) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await resp.json();
+  if (!resp.ok || data.error) {
+    throw new Error(data.error || `HTTP ${resp.status}`);
+  }
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Example P4 programs
+// ---------------------------------------------------------------------------
+
+const EXAMPLES = {
+  basic_table: `// basic_table.p4 — simplest table-based v1model program.
+//
+// Looks up the Ethernet type in an exact-match table.
+// If it matches, forward to the specified port; otherwise, drop.
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t standard_metadata) {
+
+    action drop() { mark_to_drop(standard_metadata); }
+    action forward(bit<9> port) { standard_metadata.egress_spec = port; }
+
+    table port_table {
+        key = { hdr.ethernet.etherType : exact; }
+        actions = { forward; drop; NoAction; }
+        default_action = drop();
+    }
+
+    apply { port_table.apply(); }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;
+`,
+
+  passthrough: `// passthrough.p4 — forward every packet to port 1.
+//
+// No tables, no parsing — the simplest possible v1model program.
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply { smeta.egress_spec = 1; }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;
+`,
+};
+
+// ---------------------------------------------------------------------------
+// P4 language definition for Monaco
+// ---------------------------------------------------------------------------
+
+function registerP4Language(monaco) {
+  monaco.languages.register({ id: 'p4' });
+
+  monaco.languages.setMonarchTokensProvider('p4', {
+    keywords: [
+      'action', 'apply', 'bit', 'bool', 'const', 'control', 'default',
+      'else', 'enum', 'error', 'extern', 'false', 'header', 'header_union',
+      'if', 'in', 'inout', 'int', 'match_kind', 'out', 'package', 'parser',
+      'return', 'select', 'state', 'struct', 'switch', 'table', 'transition',
+      'true', 'tuple', 'type', 'typedef', 'varbit', 'void',
+    ],
+    builtins: [
+      'exact', 'ternary', 'lpm', 'range', 'optional',
+      'packet_in', 'packet_out', 'mark_to_drop', 'NoAction',
+      'standard_metadata_t', 'V1Switch',
+    ],
+    operators: [
+      '=', '>', '<', '!', '~', '?', ':',
+      '==', '<=', '>=', '!=', '&&', '||',
+      '+', '-', '*', '/', '&', '|', '^', '%',
+      '<<', '>>', '++', '--',
+    ],
+    symbols: /[=><!~?:&|+\-*/^%]+/,
+
+    tokenizer: {
+      root: [
+        [/#include\b/, 'keyword.directive'],
+        [/#\w+/, 'keyword.directive'],
+        [/[a-zA-Z_]\w*/, {
+          cases: {
+            '@keywords': 'keyword',
+            '@builtins': 'type.identifier',
+            '@default': 'identifier',
+          },
+        }],
+        { include: '@whitespace' },
+        [/[{}()[\]]/, '@brackets'],
+        [/@symbols/, {
+          cases: {
+            '@operators': 'operator',
+            '@default': '',
+          },
+        }],
+        [/\d+[wWsS]\d+/, 'number'],  // sized literals: 8w0, 16s5
+        [/0[xX][0-9a-fA-F]+/, 'number.hex'],
+        [/\d+/, 'number'],
+        [/"([^"\\]|\\.)*$/, 'string.invalid'],
+        [/"/, 'string', '@string'],
+      ],
+      whitespace: [
+        [/[ \t\r\n]+/, 'white'],
+        [/\/\*/, 'comment', '@comment'],
+        [/\/\/.*$/, 'comment'],
+      ],
+      comment: [
+        [/[^/*]+/, 'comment'],
+        [/\*\//, 'comment', '@pop'],
+        [/[/*]/, 'comment'],
+      ],
+      string: [
+        [/[^\\"]+/, 'string'],
+        [/\\./, 'string.escape'],
+        [/"/, 'string', '@pop'],
+      ],
+    },
+  });
+
+  // Dark theme tuned for P4
+  monaco.editor.defineTheme('4ward-dark', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [
+      { token: 'keyword', foreground: 'c586c0' },
+      { token: 'keyword.directive', foreground: '569cd6' },
+      { token: 'type.identifier', foreground: '4ec9b0' },
+      { token: 'comment', foreground: '6a9955' },
+      { token: 'number', foreground: 'b5cea8' },
+      { token: 'number.hex', foreground: 'b5cea8' },
+      { token: 'string', foreground: 'ce9178' },
+      { token: 'operator', foreground: 'd4d4d4' },
+    ],
+    colors: {
+      'editor.background': '#0d1117',
+      'editor.foreground': '#e6edf3',
+      'editor.lineHighlightBackground': '#161b2240',
+      'editorLineNumber.foreground': '#6e7681',
+      'editorLineNumber.activeForeground': '#e6edf3',
+      'editor.selectionBackground': '#264f7840',
+      'editorCursor.foreground': '#58a6ff',
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Monaco editor initialization
+// ---------------------------------------------------------------------------
+
+function initEditor() {
+  return new Promise((resolve) => {
+    require.config({
+      paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs' },
+    });
+    require(['vs/editor/editor.main'], function (monaco) {
+      window.monaco = monaco;
+      registerP4Language(monaco);
+
+      const editor = monaco.editor.create(document.getElementById('editor-container'), {
+        value: EXAMPLES.basic_table,
+        language: 'p4',
+        theme: '4ward-dark',
+        minimap: { enabled: false },
+        fontSize: 13,
+        fontFamily: "var(--font-mono), 'Cascadia Code', 'JetBrains Mono', Consolas, monospace",
+        lineNumbers: 'on',
+        scrollBeyondLastLine: false,
+        automaticLayout: true,
+        tabSize: 4,
+        renderLineHighlight: 'line',
+        padding: { top: 8, bottom: 8 },
+      });
+
+      // Ctrl/Cmd+Enter = Compile & Load
+      editor.addAction({
+        id: 'compile-and-load',
+        label: 'Compile & Load',
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+        run: () => compileAndLoad(),
+      });
+
+      state.editor = editor;
+      resolve(editor);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+async function compileAndLoad() {
+  const source = state.editor.getValue();
+  setStatus('loading', 'Compiling…');
+  log('Compiling P4 program…', 'info');
+  const btn = document.getElementById('btn-compile');
+  btn.disabled = true;
+  btn.textContent = 'Compiling…';
+  clearEditorDecorations();
+
+  try {
+    const data = await api.compileAndLoad(source);
+    state.p4info = data.p4info;
+    state.entries = [];
+    const nTables = (data.p4info.tables || []).length;
+    const nActions = (data.p4info.actions || []).length;
+    setStatus('loaded', `${nTables} table${nTables !== 1 ? 's' : ''}, ${nActions} action${nActions !== 1 ? 's' : ''}`);
+    log('Pipeline loaded successfully', 'success');
+    renderTablesPanel();
+    renderEntriesList();
+    updateButtonStates();
+    updateTabBadges();
+
+    // Auto-read entries (pipeline may have static entries from const entries).
+    try {
+      const readData = await api.read();
+      if (readData.entities && readData.entities.length > 0) {
+        for (const entity of readData.entities) {
+          const te = entity.table_entry;
+          if (!te) continue;
+          const table = data.p4info.tables.find(t => t.preamble.id === te.table_id);
+          const action = te.action?.action;
+          const actionInfo = action ? data.p4info.actions.find(a => a.preamble.id === action.action_id) : null;
+          state.entries.push({
+            tableName: table?.preamble.name || `table_${te.table_id}`,
+            actionName: actionInfo?.preamble.name || 'unknown',
+            matchFields: (te.match || []).map(m => {
+              const mfInfo = table?.match_fields?.find(f => f.id === m.field_id);
+              const val = m.exact?.value || m.lpm?.value || m.ternary?.value || m.optional?.value || '';
+              return { name: mfInfo?.name || `field_${m.field_id}`, value: val ? base64ToHex(val) : '' };
+            }),
+            params: (action?.params || []).map(p => {
+              const pInfo = actionInfo?.params?.find(pp => pp.id === p.param_id);
+              return { name: pInfo?.name || `param_${p.param_id}`, value: p.value ? decodeParamValue(p.value) : '' };
+            }),
+            raw: te,
+            isStatic: true,
+          });
+        }
+        if (state.entries.length > 0) {
+          renderEntriesList();
+          updateTabBadges();
+          log(`Pipeline loaded with ${state.entries.length} static entr${state.entries.length !== 1 ? 'ies' : 'y'}`, 'success');
+        }
+      }
+    } catch (_) { /* static entry read is best-effort */ }
+  } catch (e) {
+    setStatus('error', 'Compilation failed');
+    log(e.message, 'error');
+    highlightCompileErrors(e.message);
+  } finally {
+    btn.disabled = false;
+    btn.innerHTML = 'Compile &amp; Load';
+  }
+}
+
+async function addTableEntry() {
+  const p4info = state.p4info;
+  if (!p4info) return;
+
+  const tableSelect = document.getElementById('entry-table');
+  const actionSelect = document.getElementById('entry-action');
+  const table = p4info.tables[tableSelect.selectedIndex];
+  const actionRef = table.action_refs[actionSelect.selectedIndex];
+  const action = p4info.actions.find(a => a.preamble.id === actionRef.id);
+
+  try {
+    // Build match fields
+    const matchFields = [];
+    for (const mf of table.match_fields || []) {
+      const input = document.getElementById(`match-${mf.id}`);
+      if (!input || !input.value.trim()) continue;
+      const fieldMatch = { field_id: mf.id };
+      const value = encodeValue(input.value.trim(), mf.bitwidth);
+
+      switch (mf.match_type) {
+        case 'EXACT':
+          fieldMatch.exact = { value };
+          break;
+        case 'LPM': {
+          const parts = input.value.trim().split('/');
+          fieldMatch.lpm = {
+            value: encodeValue(parts[0], mf.bitwidth),
+            prefix_len: parseInt(parts[1] || mf.bitwidth, 10),
+          };
+          break;
+        }
+        case 'TERNARY': {
+          const parts = input.value.trim().split('&&&');
+          fieldMatch.ternary = {
+            value: encodeValue(parts[0].trim(), mf.bitwidth),
+            mask: parts[1] ? encodeValue(parts[1].trim(), mf.bitwidth) : allOnes(mf.bitwidth),
+          };
+          break;
+        }
+        case 'OPTIONAL':
+          fieldMatch.optional = { value };
+          break;
+        default:
+          fieldMatch.exact = { value };
+      }
+      matchFields.push(fieldMatch);
+    }
+
+    // Build action params
+    const params = [];
+    for (const param of action.params || []) {
+      const input = document.getElementById(`param-${param.id}`);
+      if (!input) continue;
+      params.push({
+        param_id: param.id,
+        value: encodeValue(input.value.trim(), param.bitwidth),
+      });
+    }
+
+    // Priority for ternary/range tables
+    const priorityInput = document.getElementById('entry-priority');
+    const needsPriority = (table.match_fields || []).some(
+      mf => mf.match_type === 'TERNARY' || mf.match_type === 'RANGE'
+    );
+
+    const tableEntry = {
+      table_id: table.preamble.id,
+      match: matchFields,
+      action: {
+        action: {
+          action_id: action.preamble.id,
+          params,
+        },
+      },
+    };
+
+    if (needsPriority) {
+      tableEntry.priority = parseInt(priorityInput.value, 10) || 1;
+    }
+
+    const writeRequest = {
+      device_id: '1',
+      updates: [{
+        type: 'INSERT',
+        entity: { table_entry: tableEntry },
+      }],
+    };
+
+    await api.write(writeRequest);
+
+    // Track the entry for display
+    state.entries.push({
+      tableName: table.preamble.name,
+      actionName: action.preamble.name,
+      matchFields: matchFields.map((mf, i) => ({
+        name: table.match_fields[i]?.name || `field_${mf.field_id}`,
+        value: document.getElementById(`match-${table.match_fields[i]?.id}`)?.value || '',
+      })),
+      params: params.map((p, i) => ({
+        name: action.params?.[i]?.name || `param_${p.param_id}`,
+        value: document.getElementById(`param-${action.params?.[i]?.id}`)?.value || '',
+      })),
+      raw: tableEntry,
+    });
+
+    renderEntriesList();
+    updateTabBadges();
+    log(`Entry added to ${table.preamble.name}`, 'success');
+
+    // Clear input fields for next entry
+    for (const mf of table.match_fields || []) {
+      const input = document.getElementById(`match-${mf.id}`);
+      if (input) input.value = '';
+    }
+    for (const param of action.params || []) {
+      const input = document.getElementById(`param-${param.id}`);
+      if (input) input.value = '';
+    }
+  } catch (e) {
+    log(`Write failed: ${e.message}`, 'error');
+  }
+}
+
+async function deleteTableEntry(index) {
+  const entry = state.entries[index];
+  if (!entry) return;
+
+  try {
+    // Build a minimal delete key: table_id + match fields
+    const deleteEntry = {
+      table_id: entry.raw.table_id,
+      match: entry.raw.match,
+    };
+    if (entry.raw.priority) deleteEntry.priority = entry.raw.priority;
+
+    await api.write({
+      device_id: '1',
+      updates: [{
+        type: 'DELETE',
+        entity: { table_entry: deleteEntry },
+      }],
+    });
+
+    state.entries.splice(index, 1);
+    renderEntriesList();
+    updateTabBadges();
+    log(`Entry deleted from ${entry.tableName}`, 'success');
+  } catch (e) {
+    log(`Delete failed: ${e.message}`, 'error');
+  }
+}
+
+async function sendPacket() {
+  const port = parseInt(document.getElementById('pkt-port').value, 10) || 0;
+  const payloadHex = document.getElementById('pkt-payload').value.trim();
+
+  if (!payloadHex) {
+    log('Enter a packet payload in hex', 'error');
+    return;
+  }
+
+  log('Sending packet…', 'info');
+
+  try {
+    const data = await api.sendPacket(port, payloadHex);
+    state.lastTrace = data;
+
+    renderPacketResults(data.output_packets);
+    renderTraceTree(data.trace);
+
+    const nOut = data.output_packets.length;
+    log(`Packet processed: ${nOut} output${nOut !== 1 ? 's' : ''}`, 'success');
+    updateTabBadges();
+
+    // Auto-switch to trace tab
+    switchTab('trace');
+  } catch (e) {
+    log(`Packet send failed: ${e.message}`, 'error');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: Tables panel
+// ---------------------------------------------------------------------------
+
+function renderTablesPanel() {
+  const p4info = state.p4info;
+  document.getElementById('tables-empty').classList.toggle('hidden', !!p4info);
+  document.getElementById('tables-loaded').classList.toggle('hidden', !p4info);
+
+  if (!p4info) return;
+
+  const tables = p4info.tables || [];
+  const tableSelect = document.getElementById('entry-table');
+  tableSelect.innerHTML = tables.map(t =>
+    `<option value="${t.preamble.id}">${t.preamble.name}</option>`
+  ).join('');
+
+  tableSelect.onchange = () => renderTableFields();
+  renderTableFields();
+}
+
+function renderTableFields() {
+  const p4info = state.p4info;
+  if (!p4info) return;
+
+  const tableSelect = document.getElementById('entry-table');
+  const table = p4info.tables[tableSelect.selectedIndex];
+  if (!table) return;
+
+  // Match fields
+  const matchDiv = document.getElementById('match-fields');
+  matchDiv.innerHTML = (table.match_fields || []).map(mf => {
+    const label = `${mf.name} (${mf.match_type.toLowerCase()}, ${mf.bitwidth}b)`;
+    const placeholder = matchPlaceholder(mf);
+    return `
+      <div class="form-row">
+        <label for="match-${mf.id}">${label}</label>
+        <input id="match-${mf.id}" class="input-full mono" placeholder="${placeholder}">
+      </div>`;
+  }).join('');
+
+  // Action select
+  const actionSelect = document.getElementById('entry-action');
+  const actionRefs = table.action_refs || [];
+  actionSelect.innerHTML = actionRefs.map(ref => {
+    const action = p4info.actions.find(a => a.preamble.id === ref.id);
+    return `<option value="${ref.id}">${action?.preamble.name || ref.id}</option>`;
+  }).join('');
+
+  actionSelect.onchange = () => renderActionParams();
+  renderActionParams();
+
+  // Show/hide priority
+  const needsPriority = (table.match_fields || []).some(
+    mf => mf.match_type === 'TERNARY' || mf.match_type === 'RANGE'
+  );
+  document.getElementById('priority-row').style.display = needsPriority ? '' : 'none';
+}
+
+function renderActionParams() {
+  const p4info = state.p4info;
+  if (!p4info) return;
+
+  const actionSelect = document.getElementById('entry-action');
+  const actionId = parseInt(actionSelect.value, 10);
+  const action = p4info.actions.find(a => a.preamble.id === actionId);
+
+  const paramsDiv = document.getElementById('action-params');
+  if (!action || !action.params || action.params.length === 0) {
+    paramsDiv.innerHTML = '';
+    return;
+  }
+
+  paramsDiv.innerHTML = action.params.map(p =>
+    `<div class="form-row">
+      <label for="param-${p.id}">${p.name} (${p.bitwidth}b)</label>
+      <input id="param-${p.id}" class="input-full mono" placeholder="0">
+    </div>`
+  ).join('');
+}
+
+function matchPlaceholder(mf) {
+  switch (mf.match_type) {
+    case 'EXACT': return `e.g. ${mf.bitwidth <= 16 ? '0x0800' : '10.0.0.1'}`;
+    case 'LPM': return `e.g. 10.0.0.0/24`;
+    case 'TERNARY': return `value &&& mask`;
+    case 'OPTIONAL': return `exact value or leave empty`;
+    case 'RANGE': return `low..high`;
+    default: return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: Entries list
+// ---------------------------------------------------------------------------
+
+function renderEntriesList() {
+  const list = document.getElementById('entries-list');
+  if (state.entries.length === 0) {
+    list.innerHTML = '<p class="empty-hint">No entries installed.</p>';
+    return;
+  }
+
+  list.innerHTML = state.entries.map((entry, i) => {
+    const staticCls = entry.isStatic ? ' static' : '';
+    const staticBadge = entry.isStatic ? '<span class="entry-static-badge">const</span>' : '';
+    const deleteBtn = entry.isStatic ? '' : `<button class="btn btn-danger btn-delete" onclick="deleteTableEntry(${i})">&#x2715;</button>`;
+    return `<div class="entry-card${staticCls}">
+      ${staticBadge}
+      <div class="entry-table">${entry.tableName}</div>
+      <div class="entry-match">${entry.matchFields.map(m => `${m.name}=${m.value}`).join(', ')}</div>
+      <div class="entry-action">${'\u2192'} ${entry.actionName}(${entry.params.map(p => `${p.name}=${p.value}`).join(', ')})</div>
+      ${deleteBtn}
+    </div>`;
+  }).join('');
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: Packet results
+// ---------------------------------------------------------------------------
+
+function renderPacketResults(outputPackets) {
+  const container = document.getElementById('packet-results');
+  const div = document.getElementById('output-packets');
+
+  if (!outputPackets || outputPackets.length === 0) {
+    container.classList.remove('hidden');
+    div.innerHTML = '<div class="output-drop">Packet dropped (no output)</div>';
+    return;
+  }
+
+  container.classList.remove('hidden');
+  div.innerHTML = outputPackets.map(pkt => {
+    const bytes = pkt.payload ? base64ToUint8Array(pkt.payload) : new Uint8Array(0);
+    const hex = formatHexDump(bytes);
+    return `<div class="output-packet">
+      <span class="output-port">Port ${pkt.egress_port}</span>
+      <span class="output-bytes">(${bytes.length} bytes)</span>
+      <div class="output-hex">${hex}</div>
+    </div>`;
+  }).join('');
+}
+
+/** Format bytes as a hex dump with offset markers every 16 bytes. */
+function formatHexDump(bytes) {
+  if (bytes.length <= 16) {
+    return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
+  }
+  const lines = [];
+  for (let off = 0; off < bytes.length; off += 16) {
+    const chunk = bytes.slice(off, off + 16);
+    const hex = Array.from(chunk).map(b => b.toString(16).padStart(2, '0')).join(' ');
+    const offset = off.toString(16).padStart(4, '0');
+    lines.push(`<span class="hex-offset">${offset}</span>  ${hex}`);
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: Trace tree
+// ---------------------------------------------------------------------------
+
+function renderTraceTree(trace) {
+  const emptyEl = document.getElementById('trace-empty');
+  const treeEl = document.getElementById('trace-tree');
+
+  if (!trace) {
+    emptyEl.classList.remove('hidden');
+    treeEl.classList.add('hidden');
+    return;
+  }
+
+  emptyEl.classList.add('hidden');
+  treeEl.classList.remove('hidden');
+  treeEl.innerHTML = renderTraceNode(trace, true);
+}
+
+let traceCollapseId = 0;
+
+function renderTraceNode(node, isRoot) {
+  const cls = isRoot ? 'trace-node root' : 'trace-node';
+  let html = `<div class="${cls}">`;
+
+  // Group events by pipeline stage for collapsible sections.
+  const events = node.events || [];
+  let i = 0;
+  while (i < events.length) {
+    const event = events[i];
+    if (event.pipeline_stage && event.pipeline_stage.direction === 'ENTER') {
+      // Collect events until the matching EXIT.
+      const stageName = event.pipeline_stage.stage_name;
+      const stageEvents = [];
+      i++;
+      while (i < events.length) {
+        if (events[i].pipeline_stage && events[i].pipeline_stage.direction === 'EXIT'
+            && events[i].pipeline_stage.stage_name === stageName) {
+          i++;
+          break;
+        }
+        stageEvents.push(events[i]);
+        i++;
+      }
+      html += renderStageGroup(stageName, event.pipeline_stage.stage_kind, stageEvents);
+    } else {
+      html += renderTraceEvent(event);
+      i++;
+    }
+  }
+
+  // Outcome
+  if (node.packet_outcome) {
+    html += renderPacketOutcome(node.packet_outcome);
+  } else if (node.fork_outcome) {
+    html += renderFork(node.fork_outcome);
+  }
+
+  html += '</div>';
+  return html;
+}
+
+function renderStageGroup(name, kind, events) {
+  const id = `stage-${traceCollapseId++}`;
+  const kindLabel = formatStageKind(kind);
+  const summary = summarizeStageEvents(events);
+  const summarySpan = summary ? `<span class="stage-summary">${summary}</span>` : '';
+
+  if (events.length === 0) {
+    return `<div class="trace-stage empty">
+      <span class="stage-icon">${stageIcon(kind)}</span>
+      <span class="stage-name">${name}</span> ${summarySpan}
+    </div>`;
+  }
+
+  return `<div class="trace-stage">
+    <div class="trace-collapse" onclick="this.classList.toggle('collapsed')" id="${id}">
+      <span class="stage-icon">${stageIcon(kind)}</span>
+      <span class="stage-name">${name}</span> ${summarySpan}
+    </div>
+    <div class="trace-stage-body">
+      ${events.map(e => renderTraceEvent(e)).join('')}
+    </div>
+  </div>`;
+}
+
+function stageIcon(kind) {
+  switch (kind) {
+    case 'STAGE_KIND_PARSER': return '⟨⟩';
+    case 'STAGE_KIND_CONTROL': return '◇';
+    case 'STAGE_KIND_DEPARSER': return '⟩⟨';
+    default: return '·';
+  }
+}
+
+function formatStageKind(kind) {
+  if (!kind) return '';
+  return kind.replace('STAGE_KIND_', '').toLowerCase();
+}
+
+function summarizeStageEvents(events) {
+  const parts = [];
+  for (const e of events) {
+    if (e.table_lookup) {
+      const tl = e.table_lookup;
+      parts.push(`${tl.table_name}: ${tl.hit ? 'hit' : 'miss'}`);
+    } else if (e.parser_transition && e.parser_transition.to_state === 'accept') {
+      parts.push('accept');
+    } else if (e.parser_transition && e.parser_transition.to_state === 'reject') {
+      parts.push('reject');
+    } else if (e.mark_to_drop) {
+      parts.push('drop');
+    }
+  }
+  return parts.join(', ');
+}
+
+function renderTraceEvent(event) {
+  const src = formatSourceInfo(event.source_info);
+  if (event.packet_ingress) {
+    return `<div class="trace-event ingress">▸ Packet ingress port ${event.packet_ingress.ingress_port}</div>`;
+  }
+  if (event.pipeline_stage) {
+    const s = event.pipeline_stage;
+    const dir = s.direction === 'ENTER' ? '→' : '←';
+    const cls = s.direction === 'ENTER' ? 'stage-enter' : 'stage-exit';
+    return `<div class="trace-event ${cls}">${dir} ${s.stage_name}</div>`;
+  }
+  if (event.parser_transition) {
+    const pt = event.parser_transition;
+    return `<div class="trace-event parser">parse: ${pt.from_state} → ${pt.to_state}${src}</div>`;
+  }
+  if (event.table_lookup) {
+    const tl = event.table_lookup;
+    const cls = tl.hit ? 'table-hit' : 'table-miss';
+    const result = tl.hit ? 'hit' : 'miss';
+    return `<div class="trace-event ${cls}">table ${tl.table_name}: ${result} → ${tl.action_name}${src}</div>`;
+  }
+  if (event.action_execution) {
+    const ae = event.action_execution;
+    const params = Object.entries(ae.params || {}).map(([k, v]) =>
+      `${k}=${decodeParamValue(v)}`
+    ).join(', ');
+    const paramsStr = params ? `(${params})` : '';
+    return `<div class="trace-event action">action ${ae.action_name}${paramsStr}${src}</div>`;
+  }
+  if (event.branch) {
+    const b = event.branch;
+    const dir = b.taken ? 'then' : 'else';
+    return `<div class="trace-event branch">branch ${b.control_name}: ${dir}${src}</div>`;
+  }
+  if (event.extern_call) {
+    const ec = event.extern_call;
+    return `<div class="trace-event extern">extern ${ec.extern_instance_name}.${ec.method}()${src}</div>`;
+  }
+  if (event.mark_to_drop) {
+    return `<div class="trace-event mark-to-drop">mark_to_drop()${src}</div>`;
+  }
+  if (event.clone) {
+    return `<div class="trace-event clone">clone session ${event.clone.session_id}${src}</div>`;
+  }
+  return '';
+}
+
+function formatSourceInfo(si) {
+  if (!si) return '';
+  const fragment = si.source_fragment || '';
+  const loc = si.line ? `:${si.line}` : '';
+  if (!fragment && !loc) return '';
+  const text = fragment ? escapeHtml(fragment) : `line ${si.line}`;
+  const lineAttr = si.line ? ` data-line="${si.line}"` : '';
+  return ` <span class="trace-source" onclick="jumpToLine(${si.line || 0})"${lineAttr}>${text}</span>`;
+}
+
+function jumpToLine(line) {
+  if (!state.editor || !line) return;
+  state.editor.revealLineInCenter(line);
+  state.editor.setPosition({ lineNumber: line, column: 1 });
+  state.editor.focus();
+}
+
+function escapeHtml(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function renderPacketOutcome(outcome) {
+  if (outcome.output) {
+    const o = outcome.output;
+    const bytes = o.payload ? base64ToUint8Array(o.payload) : new Uint8Array(0);
+    return `<div class="trace-outcome output">→ output port ${o.egress_port} (${bytes.length} bytes)</div>`;
+  }
+  if (outcome.drop) {
+    const reason = formatDropReason(outcome.drop.reason);
+    return `<div class="trace-outcome drop">✕ drop (${reason})</div>`;
+  }
+  return '';
+}
+
+function renderFork(fork) {
+  const reason = fork.reason?.toLowerCase().replace(/_/g, ' ') || 'fork';
+  let html = `<div class="trace-fork-label">⑂ fork (${reason})</div>`;
+  for (const branch of fork.branches || []) {
+    html += `<div class="trace-branch-label">branch: ${branch.label}</div>`;
+    html += renderTraceNode(branch.subtree, false);
+  }
+  return html;
+}
+
+function formatDropReason(reason) {
+  switch (reason) {
+    case 'MARK_TO_DROP': return 'mark_to_drop';
+    case 'PARSER_REJECT': return 'parser reject';
+    case 'PIPELINE_EXECUTION_LIMIT_REACHED': return 'execution limit';
+    default: return reason || 'unknown';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Compilation error highlighting
+// ---------------------------------------------------------------------------
+
+/** Parse p4c error messages and highlight lines in the editor. */
+function highlightCompileErrors(errorText) {
+  if (!state.editor) return;
+  const monaco = window.monaco;
+  if (!monaco) return;
+
+  // p4c error formats:
+  //   "file.p4(line):message"            — most common
+  //   "file.p4(line): error: message"    — explicit severity
+  //   "file.p4:line:col: error: message" — GCC-style
+  const markers = [];
+  const lines = errorText.split('\n');
+  for (const line of lines) {
+    let lineNum, message, severity;
+
+    // Format: file.p4(LINE):message or file.p4(LINE): error: message
+    let m = line.match(/\.p4\((\d+)\):\s*(?:(error|warning):\s*)?(.*)/);
+    if (!m) {
+      // Format: file.p4:LINE:COL: error: message
+      m = line.match(/\.p4:(\d+):\d+:\s*(?:(error|warning):\s*)?(.*)/);
+    }
+    if (m) {
+      lineNum = parseInt(m[1], 10);
+      severity = m[2] === 'warning'
+        ? monaco.MarkerSeverity.Warning : monaco.MarkerSeverity.Error;
+      message = m[3] || line;
+      markers.push({
+        severity,
+        startLineNumber: lineNum,
+        startColumn: 1,
+        endLineNumber: lineNum,
+        endColumn: 1000,
+        message,
+      });
+    }
+  }
+
+  if (markers.length > 0) {
+    monaco.editor.setModelMarkers(state.editor.getModel(), 'p4c', markers);
+    state.editor.revealLineInCenter(markers[0].startLineNumber);
+  }
+}
+
+function clearEditorDecorations() {
+  if (!state.editor || !window.monaco) return;
+  window.monaco.editor.setModelMarkers(state.editor.getModel(), 'p4c', []);
+}
+
+// ---------------------------------------------------------------------------
+// Value encoding helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode a user-supplied value into a base64 string (protobuf bytes wire format in JSON).
+ * Supports decimal, hex (0x...), and dotted notation (10.0.0.1, AA:BB:CC:DD:EE:FF).
+ */
+function encodeValue(input, bitwidth) {
+  const byteLen = Math.ceil(bitwidth / 8);
+  let bytes;
+
+  if (input.includes('.')) {
+    // Dotted decimal (IPv4-style)
+    const parts = input.split('.').map(Number);
+    bytes = new Uint8Array(parts);
+  } else if (input.includes(':')) {
+    // Colon-separated hex (MAC-style)
+    const parts = input.split(':').map(s => parseInt(s, 16));
+    bytes = new Uint8Array(parts);
+  } else {
+    // Numeric: decimal or hex
+    let n = input.startsWith('0x') || input.startsWith('0X')
+      ? BigInt(input) : BigInt(input);
+    bytes = new Uint8Array(byteLen);
+    for (let i = byteLen - 1; i >= 0; i--) {
+      bytes[i] = Number(n & 0xFFn);
+      n >>= 8n;
+    }
+  }
+
+  // Pad to expected byte length
+  if (bytes.length < byteLen) {
+    const padded = new Uint8Array(byteLen);
+    padded.set(bytes, byteLen - bytes.length);
+    bytes = padded;
+  }
+
+  return uint8ArrayToBase64(bytes);
+}
+
+function allOnes(bitwidth) {
+  const byteLen = Math.ceil(bitwidth / 8);
+  const bytes = new Uint8Array(byteLen).fill(0xFF);
+  // Mask off excess bits in the most significant byte
+  const excessBits = byteLen * 8 - bitwidth;
+  if (excessBits > 0) {
+    bytes[0] = (0xFF >> excessBits);
+  }
+  return uint8ArrayToBase64(bytes);
+}
+
+function uint8ArrayToBase64(bytes) {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+function base64ToUint8Array(b64) {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function base64ToHex(b64) {
+  if (!b64) return '';
+  const bytes = base64ToUint8Array(b64);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
+}
+
+function decodeParamValue(b64) {
+  if (!b64) return '0';
+  const bytes = base64ToUint8Array(b64);
+  let n = 0n;
+  for (const b of bytes) n = (n << 8n) | BigInt(b);
+  return n.toString();
+}
+
+// ---------------------------------------------------------------------------
+// UI helpers
+// ---------------------------------------------------------------------------
+
+function setStatus(statusClass, text) {
+  const dot = document.getElementById('status-indicator');
+  const textEl = document.getElementById('status-text');
+  dot.className = 'status-dot ' + statusClass;
+  textEl.textContent = text;
+}
+
+function log(message, level = '') {
+  const bar = document.getElementById('log-bar');
+  const text = document.getElementById('log-text');
+  bar.className = level;
+  text.textContent = message;
+}
+
+function updateButtonStates() {
+  const hasPipeline = !!state.p4info;
+  document.getElementById('btn-add-entry').disabled = !hasPipeline;
+  document.getElementById('btn-send-packet').disabled = !hasPipeline;
+}
+
+function switchTab(name) {
+  document.querySelectorAll('.tab').forEach(t =>
+    t.classList.toggle('active', t.dataset.tab === name)
+  );
+  document.querySelectorAll('.tab-content').forEach(c =>
+    c.classList.toggle('active', c.id === `tab-${name}`)
+  );
+}
+
+function updateTabBadges() {
+  const tablesTab = document.querySelector('.tab[data-tab="tables"]');
+  const packetsTab = document.querySelector('.tab[data-tab="packets"]');
+  const n = state.entries.length;
+  tablesTab.textContent = n > 0 ? `Tables (${n})` : 'Tables';
+  const lastOutputs = state.lastTrace?.output_packets?.length || 0;
+  packetsTab.textContent = lastOutputs > 0 ? `Packets (${lastOutputs})` : 'Packets';
+}
+
+// ---------------------------------------------------------------------------
+// Resize handle
+// ---------------------------------------------------------------------------
+
+function initResize() {
+  const handle = document.getElementById('resize-handle');
+  const editorPane = document.getElementById('editor-pane');
+  const rightPane = document.getElementById('right-pane');
+  let startX, startWidth;
+
+  handle.addEventListener('mousedown', (e) => {
+    startX = e.clientX;
+    startWidth = editorPane.getBoundingClientRect().width;
+    handle.classList.add('active');
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMouseMove = (e) => {
+      const delta = e.clientX - startX;
+      const newWidth = Math.max(200, Math.min(startWidth + delta, window.innerWidth - 200));
+      editorPane.style.flex = `0 0 ${newWidth}px`;
+      rightPane.style.flex = '1';
+    };
+
+    const onMouseUp = () => {
+      handle.classList.remove('active');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Packet presets
+// ---------------------------------------------------------------------------
+
+const PACKET_PRESETS = {
+  // Ethernet: dst=broadcast src=00:00:00:00:00:01
+  ipv4: 'ff ff ff ff ff ff 00 00 00 00 00 01 08 00' +
+        ' 45 00 00 1c 00 01 00 00 40 00 00 00 0a 00 00 01 0a 00 00 02' +
+        ' de ad be ef',
+  ipv6: 'ff ff ff ff ff ff 00 00 00 00 00 01 86 dd' +
+        ' 60 00 00 00 00 04 3b 40' +
+        ' 20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 01' +
+        ' 20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 02' +
+        ' de ad be ef',
+  arp:  'ff ff ff ff ff ff 00 00 00 00 00 01 08 06' +
+        ' 00 01 08 00 06 04 00 01 00 00 00 00 00 01 0a 00 00 01' +
+        ' 00 00 00 00 00 00 0a 00 00 02',
+  raw:  'ff ff ff ff ff ff 00 00 00 00 00 01 00 00 de ad be ef',
+};
+
+function applyPreset(name) {
+  const preset = PACKET_PRESETS[name];
+  if (preset) {
+    document.getElementById('pkt-payload').value = preset;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event bindings & init
+// ---------------------------------------------------------------------------
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Tabs
+  document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => switchTab(tab.dataset.tab));
+  });
+
+  // Buttons
+  document.getElementById('btn-compile').addEventListener('click', compileAndLoad);
+  document.getElementById('btn-add-entry').addEventListener('click', addTableEntry);
+  document.getElementById('btn-send-packet').addEventListener('click', sendPacket);
+
+  // Example selector
+  document.getElementById('example-select').addEventListener('change', (e) => {
+    const example = EXAMPLES[e.target.value];
+    if (example && state.editor) {
+      state.editor.setValue(example);
+      e.target.value = '';
+    }
+  });
+
+  // Resize
+  initResize();
+
+  // Ctrl/Cmd+Enter on payload sends packet
+  document.getElementById('pkt-payload').addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      sendPacket();
+    }
+  });
+
+  // Initialize Monaco editor
+  const isMac = navigator.platform.includes('Mac');
+  const mod = isMac ? '⌘' : 'Ctrl';
+  initEditor().then(() => {
+    log(`Editor ready — ${mod}+Enter to compile, ${mod}+Enter in payload to send packet`, 'info');
+  });
+
+  // Check if pipeline is already loaded (e.g. page refresh)
+  api.getPipeline().then(data => {
+    if (data.loaded) {
+      state.p4info = data.p4info;
+      setStatus('loaded', 'Pipeline loaded');
+      renderTablesPanel();
+    }
+  }).catch(() => {});
+});

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -1074,11 +1074,8 @@ function renderTraceEvent(event) {
   if (event.branch) {
     const b = event.branch;
     const dir = b.taken ? 'then' : 'else';
-    // Show the condition from source_fragment (e.g. "hdr.ipv4.isValid()")
-    // instead of the generic statement type that the pill would show.
     const frag = event.source_info?.source_fragment || '';
-    const cond = frag.replace(/^if\s*\(/, '').replace(/\)\s*$/, '') || '';
-    const condStr = cond ? `: <code>${escapeHtml(cond)}</code>` : '';
+    const condStr = frag ? `: <code>${escapeHtml(frag)}</code>` : '';
     return `<div class="trace-event branch">branch ${dir}${condStr}${src}</div>`;
   }
   if (event.extern_call) {

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -283,6 +283,14 @@ function initEditor() {
         padding: { top: 8, bottom: 8 },
       });
 
+      // Show initial example in dropdown; reset when user edits.
+      document.getElementById('example-select').value = 'basic_table';
+      editor.onDidChangeModelContent(() => {
+        if (!state.loadingExample) {
+          document.getElementById('example-select').value = '';
+        }
+      });
+
       // Ctrl/Cmd+Enter = Compile & Load
       editor.addAction({
         id: 'compile-and-load',
@@ -1180,8 +1188,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('example-select').addEventListener('change', (e) => {
     const example = EXAMPLES[e.target.value];
     if (example && state.editor) {
+      state.loadingExample = true;
       state.editor.setValue(example);
-      e.target.value = '';
+      state.loadingExample = false;
     }
   });
 

--- a/web/frontend/app.js
+++ b/web/frontend/app.js
@@ -156,6 +156,134 @@ control MyDeparser(packet_out pkt, in headers_t hdr) {
 V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
          MyEgress(), MyComputeChecksum(), MyDeparser()) main;
 `,
+
+  mirror: `// mirror.p4 — IPv4 router with port mirroring.
+//
+// Parses Ethernet + IPv4, routes via LPM on the destination IP,
+// and clones every forwarded packet to a mirror port for monitoring.
+// The trace tree forks at the clone point, showing both paths.
+//
+// To try it:
+//   1. Compile & Load
+//   2. Add a route: ipv4_lpm with dstAddr=10.0.0.0/8, action=forward, port=1
+//   3. Send an IPv4 packet (use the IPv4 preset)
+//   4. Check the Trace tab — the clone fork shows both paths!
+//
+// The clone branch drops until a clone session is configured (via the
+// P4Runtime PRE API). The original packet routes normally. Cloned
+// copies get their source MAC rewritten to identify them as mirrors.
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct metadata_t {}
+
+// --- Parser: Ethernet → IPv4 ---
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+// --- Ingress: LPM routing + clone for mirroring ---
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    action drop() { mark_to_drop(smeta); }
+
+    action forward(bit<9> port) {
+        smeta.egress_spec = port;
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+    }
+
+    table ipv4_lpm {
+        key = { hdr.ipv4.dstAddr : lpm; }
+        actions = { forward; drop; }
+        default_action = drop();
+    }
+
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_lpm.apply();
+            // Mirror all forwarded traffic (clone to session 100).
+            clone(CloneType.I2E, 32w100);
+        }
+    }
+}
+
+// --- Egress: tag mirrored copies ---
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) {
+
+    action tag_mirror() {
+        // Mark mirrored copies with a distinctive source MAC.
+        hdr.ethernet.srcAddr = 48w0xDEAD00000000;
+    }
+
+    // instance_type: 0 = original, 1 = ingress clone
+    table classify {
+        key = { smeta.instance_type : exact; }
+        actions = { NoAction; tag_mirror; }
+        const entries = {
+            0 : NoAction();   // original — pass through
+            1 : tag_mirror(); // clone — tag it
+        }
+    }
+
+    apply { classify.apply(); }
+}
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;
+`,
 };
 
 // ---------------------------------------------------------------------------

--- a/web/frontend/index.html
+++ b/web/frontend/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>4ward Playground</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Header -->
+  <header id="header">
+    <div class="header-left">
+      <h1>4ward<span class="header-subtle"> Playground</span></h1>
+    </div>
+    <div class="header-right">
+      <span id="status-indicator" class="status-dot"></span>
+      <span id="status-text" class="status-text">No pipeline loaded</span>
+      <button id="btn-compile" class="btn btn-primary" title="Compile P4 source and load into simulator">
+        Compile &amp; Load
+      </button>
+    </div>
+  </header>
+
+  <!-- Main layout: editor + right panel -->
+  <div id="main">
+
+    <!-- Left: P4 editor -->
+    <div id="editor-pane">
+      <div class="pane-header">
+        <span class="pane-title">P4 Source</span>
+        <select id="example-select" class="select-small" title="Load example program">
+          <option value="">Examples…</option>
+          <option value="basic_table">basic_table.p4</option>
+          <option value="passthrough">passthrough.p4</option>
+        </select>
+      </div>
+      <div id="editor-container"></div>
+    </div>
+
+    <!-- Resize handle -->
+    <div id="resize-handle" class="resize-handle"></div>
+
+    <!-- Right: tabbed panels -->
+    <div id="right-pane">
+      <div class="tab-bar">
+        <button class="tab active" data-tab="tables">Tables</button>
+        <button class="tab" data-tab="packets">Packets</button>
+        <button class="tab" data-tab="trace">Trace</button>
+      </div>
+
+      <!-- Tables tab -->
+      <div id="tab-tables" class="tab-content active">
+        <div id="tables-empty" class="empty-state">
+          <p>No pipeline loaded.</p>
+          <p class="empty-hint">Write P4 code and click <strong>Compile &amp; Load</strong> to get started.</p>
+        </div>
+        <div id="tables-loaded" class="hidden">
+          <div class="form-section">
+            <h3>Add Table Entry</h3>
+            <div class="form-row">
+              <label for="entry-table">Table</label>
+              <select id="entry-table" class="select-full"></select>
+            </div>
+            <div id="match-fields"></div>
+            <div class="form-row">
+              <label for="entry-action">Action</label>
+              <select id="entry-action" class="select-full"></select>
+            </div>
+            <div id="action-params"></div>
+            <div class="form-row" id="priority-row" style="display:none">
+              <label for="entry-priority">Priority</label>
+              <input id="entry-priority" type="number" value="1" min="1" class="input-full">
+            </div>
+            <button id="btn-add-entry" class="btn btn-secondary">Insert Entry</button>
+          </div>
+          <div class="form-section">
+            <h3>Installed Entries</h3>
+            <div id="entries-list" class="entries-list">
+              <p class="empty-hint">No entries installed.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Packets tab -->
+      <div id="tab-packets" class="tab-content">
+        <div class="form-section">
+          <h3>Send Packet</h3>
+          <div class="form-row">
+            <label>Presets</label>
+            <div class="preset-buttons">
+              <button class="btn btn-small" onclick="applyPreset('ipv4')" title="Ethernet + IPv4 (etherType=0x0800)">IPv4</button>
+              <button class="btn btn-small" onclick="applyPreset('ipv6')" title="Ethernet + IPv6 (etherType=0x86DD)">IPv6</button>
+              <button class="btn btn-small" onclick="applyPreset('arp')" title="Ethernet + ARP (etherType=0x0806)">ARP</button>
+              <button class="btn btn-small" onclick="applyPreset('raw')" title="Minimal Ethernet frame">Raw</button>
+            </div>
+          </div>
+          <div class="form-row">
+            <label for="pkt-port">Ingress Port</label>
+            <input id="pkt-port" type="number" value="0" min="0" class="input-full">
+          </div>
+          <div class="form-row">
+            <label for="pkt-payload">Payload (hex)</label>
+            <textarea id="pkt-payload" class="input-full mono" rows="3"
+              placeholder="ff ff ff ff ff ff 00 00 00 00 00 01 08 00 de ad be ef"></textarea>
+          </div>
+          <div class="form-row">
+            <button id="btn-send-packet" class="btn btn-secondary" disabled>Send Packet</button>
+          </div>
+        </div>
+        <div id="packet-results" class="hidden">
+          <div class="form-section">
+            <h3>Output Packets</h3>
+            <div id="output-packets" class="output-area mono"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Trace tab -->
+      <div id="tab-trace" class="tab-content">
+        <div id="trace-empty" class="empty-state">
+          <p>No trace yet.</p>
+          <p class="empty-hint">Send a packet to see the execution trace.</p>
+        </div>
+        <div id="trace-tree" class="hidden"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Log bar -->
+  <div id="log-bar">
+    <span id="log-text"></span>
+  </div>
+
+  <!-- Monaco Editor from CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/loader.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/frontend/index.html
+++ b/web/frontend/index.html
@@ -33,6 +33,7 @@
           <option value="">Examples…</option>
           <option value="basic_table">basic_table.p4</option>
           <option value="passthrough">passthrough.p4</option>
+          <option value="mirror">mirror.p4</option>
         </select>
       </div>
       <div id="editor-container"></div>

--- a/web/frontend/index.html
+++ b/web/frontend/index.html
@@ -76,6 +76,21 @@
             <button id="btn-add-entry" class="btn btn-secondary">Insert Entry</button>
           </div>
           <div class="form-section">
+            <h3>Clone Sessions</h3>
+            <div class="form-row-inline">
+              <div class="form-field">
+                <label for="clone-session-id">Session ID</label>
+                <input id="clone-session-id" type="number" value="100" min="0" class="input-full mono">
+              </div>
+              <div class="form-field">
+                <label for="clone-egress-port">Egress Port</label>
+                <input id="clone-egress-port" type="number" value="5" min="0" class="input-full mono">
+              </div>
+              <button id="btn-add-clone" class="btn btn-secondary btn-inline">Add</button>
+            </div>
+            <div id="clone-sessions-list" class="entries-list"></div>
+          </div>
+          <div class="form-section">
             <h3>Installed Entries</h3>
             <div id="entries-list" class="entries-list">
               <p class="empty-hint">No entries installed.</p>

--- a/web/frontend/style.css
+++ b/web/frontend/style.css
@@ -509,6 +509,7 @@ input:focus, select:focus, textarea:focus {
 .trace-event.table-miss { color: var(--warning); }
 .trace-event.action { color: var(--accent); }
 .trace-event.branch { color: #bc8cff; }
+.trace-event.branch code { color: #e2c5ff; font-size: 11px; }
 .trace-event.extern { color: #f0883e; }
 .trace-event.mark-to-drop { color: var(--error); }
 .trace-event.clone { color: #f778ba; }

--- a/web/frontend/style.css
+++ b/web/frontend/style.css
@@ -513,6 +513,8 @@ input:focus, select:focus, textarea:focus {
 .trace-event.extern { color: #f0883e; }
 .trace-event.mark-to-drop { color: var(--error); }
 .trace-event.clone { color: #f778ba; }
+.trace-event.clone-session-hit { color: #f778ba; }
+.trace-event.clone-session-miss { color: var(--error); }
 .trace-event.stage-enter { color: var(--text-muted); font-weight: 600; }
 .trace-event.stage-exit { color: var(--text-muted); }
 .trace-event.ingress { color: var(--text-primary); font-weight: 600; }

--- a/web/frontend/style.css
+++ b/web/frontend/style.css
@@ -1,0 +1,696 @@
+/* 4ward Playground — Dark theme inspired by GitHub Dark */
+
+:root {
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #1c2128;
+  --bg-hover: #1f2937;
+  --border: #30363d;
+  --border-light: #21262d;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #6e7681;
+  --accent: #58a6ff;
+  --accent-hover: #79c0ff;
+  --accent-bg: rgba(56, 139, 253, 0.15);
+  --success: #3fb950;
+  --success-bg: rgba(63, 185, 80, 0.15);
+  --error: #f85149;
+  --error-bg: rgba(248, 81, 73, 0.15);
+  --warning: #d29922;
+  --warning-bg: rgba(210, 153, 34, 0.15);
+  --radius: 6px;
+  --radius-sm: 4px;
+  --font-mono: 'Cascadia Code', 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --header-height: 48px;
+  --log-height: 28px;
+  --transition: 150ms ease;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* =========================================================================
+   Header
+   ========================================================================= */
+
+#header {
+  height: var(--header-height);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  flex-shrink: 0;
+}
+
+.header-left h1 {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.header-subtle {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: background var(--transition);
+}
+
+.status-dot.loaded { background: var(--success); }
+.status-dot.loading { background: var(--warning); animation: pulse 1s infinite; }
+.status-dot.error { background: var(--error); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.status-text {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* =========================================================================
+   Buttons & inputs
+   ========================================================================= */
+
+.btn {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+
+.btn-danger {
+  background: var(--error-bg);
+  color: var(--error);
+  border-color: var(--error);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: var(--error);
+  color: #fff;
+}
+
+input, select, textarea {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 5px 8px;
+  outline: none;
+  transition: border-color var(--transition);
+}
+
+input:focus, select:focus, textarea:focus {
+  border-color: var(--accent);
+}
+
+.input-full { width: 100%; }
+.select-full { width: 100%; }
+
+.select-small {
+  font-size: 11px;
+  padding: 2px 6px;
+  background: var(--bg-tertiary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+/* =========================================================================
+   Main layout
+   ========================================================================= */
+
+#main {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+#editor-pane {
+  flex: 1 1 55%;
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+}
+
+.pane-header {
+  height: 32px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  flex-shrink: 0;
+}
+
+.pane-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+#editor-container {
+  flex: 1;
+  overflow: hidden;
+}
+
+.resize-handle {
+  width: 4px;
+  cursor: col-resize;
+  background: transparent;
+  transition: background var(--transition);
+  flex-shrink: 0;
+}
+
+.resize-handle:hover,
+.resize-handle.active {
+  background: var(--accent);
+}
+
+#right-pane {
+  flex: 1 1 45%;
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* =========================================================================
+   Tabs
+   ========================================================================= */
+
+.tab-bar {
+  height: 32px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: stretch;
+  flex-shrink: 0;
+}
+
+.tab {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0 16px;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.tab-content {
+  display: none;
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+/* =========================================================================
+   Empty states
+   ========================================================================= */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.empty-state p { margin: 4px 0; }
+.empty-hint { font-size: 11px; color: var(--text-muted); }
+
+.hidden { display: none !important; }
+
+/* =========================================================================
+   Form sections
+   ========================================================================= */
+
+.form-section {
+  margin-bottom: 16px;
+}
+
+.form-section h3 {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-bottom: 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.form-row {
+  margin-bottom: 8px;
+}
+
+.form-row label {
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 3px;
+}
+
+/* =========================================================================
+   Table entries list
+   ========================================================================= */
+
+.entries-list {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.entry-card {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  margin-bottom: 6px;
+  font-size: 11px;
+  position: relative;
+}
+
+.entry-card:hover {
+  border-color: var(--border);
+}
+
+.entry-card .entry-table {
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 2px;
+}
+
+.entry-card .entry-match,
+.entry-card .entry-action {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.entry-card .entry-action {
+  color: var(--success);
+}
+
+.entry-card .btn-delete {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  font-size: 10px;
+  padding: 2px 6px;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.entry-card:hover .btn-delete {
+  opacity: 1;
+}
+
+/* =========================================================================
+   Packet output
+   ========================================================================= */
+
+.output-area {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  max-height: 200px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.output-packet {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.output-packet:last-child { border-bottom: none; }
+
+.output-port {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.output-bytes {
+  color: var(--text-muted);
+  font-size: 10px;
+  margin-left: 6px;
+}
+
+.output-hex {
+  color: var(--text-secondary);
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  white-space: pre;
+  line-height: 1.4;
+}
+
+.hex-offset {
+  color: var(--text-muted);
+  user-select: none;
+}
+
+.output-drop {
+  color: var(--error);
+  font-style: italic;
+}
+
+/* =========================================================================
+   Trace tree
+   ========================================================================= */
+
+#trace-tree {
+  padding: 8px;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.trace-node {
+  margin-left: 16px;
+  border-left: 1px solid var(--border-light);
+  padding-left: 12px;
+}
+
+.trace-node.root {
+  margin-left: 0;
+  border-left: none;
+  padding-left: 0;
+}
+
+.trace-event {
+  padding: 1px 0;
+  color: var(--text-secondary);
+}
+
+.trace-event.parser { color: #c9d1d9; }
+.trace-event.table-hit { color: var(--success); }
+.trace-event.table-miss { color: var(--warning); }
+.trace-event.action { color: var(--accent); }
+.trace-event.branch { color: #bc8cff; }
+.trace-event.extern { color: #f0883e; }
+.trace-event.mark-to-drop { color: var(--error); }
+.trace-event.clone { color: #f778ba; }
+.trace-event.stage-enter { color: var(--text-muted); font-weight: 600; }
+.trace-event.stage-exit { color: var(--text-muted); }
+.trace-event.ingress { color: var(--text-primary); font-weight: 600; }
+
+.trace-source {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-style: italic;
+  cursor: pointer;
+  margin-left: 4px;
+  opacity: 0.7;
+  transition: opacity var(--transition);
+}
+
+.trace-source:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.trace-outcome {
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  display: inline-block;
+  margin: 2px 0;
+  font-weight: 600;
+}
+
+.trace-outcome.output {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+.trace-outcome.drop {
+  background: var(--error-bg);
+  color: var(--error);
+}
+
+.trace-fork-label {
+  color: #f778ba;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+
+.trace-fork-label:hover {
+  text-decoration: underline;
+}
+
+.trace-branch-label {
+  color: var(--text-muted);
+  font-style: italic;
+  margin: 2px 0;
+}
+
+.trace-stage {
+  margin: 2px 0;
+}
+
+.trace-stage.empty {
+  color: var(--text-muted);
+  padding: 1px 0;
+}
+
+.trace-stage .trace-collapse {
+  cursor: pointer;
+  user-select: none;
+  padding: 2px 4px;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition);
+}
+
+.trace-stage .trace-collapse:hover {
+  background: var(--bg-hover);
+}
+
+.trace-collapse::before {
+  content: '▾ ';
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.trace-collapse.collapsed::before {
+  content: '▸ ';
+}
+
+.trace-collapse.collapsed + .trace-stage-body {
+  display: none;
+}
+
+.stage-icon {
+  color: var(--text-muted);
+  margin-right: 2px;
+}
+
+.stage-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.stage-summary {
+  color: var(--text-secondary);
+  font-weight: 400;
+  margin-left: 8px;
+  font-size: 11px;
+}
+
+.trace-stage-body {
+  margin-left: 16px;
+  padding-left: 12px;
+  border-left: 1px solid var(--border-light);
+}
+
+.preset-buttons {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.btn-small {
+  font-size: 11px;
+  padding: 3px 8px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.btn-small:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.entry-card.static {
+  border-left: 3px solid var(--text-muted);
+}
+
+.entry-static-badge {
+  font-size: 9px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  letter-spacing: 0.5px;
+  float: right;
+}
+
+/* =========================================================================
+   Log bar
+   ========================================================================= */
+
+#log-bar {
+  height: var(--log-height);
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+}
+
+#log-bar.success { color: var(--success); }
+#log-bar.error { color: var(--error); }
+#log-bar.info { color: var(--accent); }
+
+/* =========================================================================
+   Scrollbar styling
+   ========================================================================= */
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* =========================================================================
+   Responsive adjustments
+   ========================================================================= */
+
+@media (max-width: 768px) {
+  #main {
+    flex-direction: column;
+  }
+  #editor-pane {
+    flex: 0 0 50%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+  .resize-handle { display: none; }
+  #right-pane { flex: 1; }
+}

--- a/web/frontend/style.css
+++ b/web/frontend/style.css
@@ -493,17 +493,21 @@ input:focus, select:focus, textarea:focus {
 .trace-event.ingress { color: var(--text-primary); font-weight: 600; }
 
 .trace-source {
-  color: var(--text-muted);
+  display: inline-block;
   font-size: 10px;
-  font-style: italic;
+  font-style: normal;
+  color: var(--accent);
+  background: var(--accent-bg);
+  padding: 0 5px;
+  border-radius: 3px;
   cursor: pointer;
-  margin-left: 4px;
-  opacity: 0.7;
-  transition: opacity var(--transition);
+  margin-left: 6px;
+  vertical-align: middle;
+  transition: all var(--transition);
 }
 
 .trace-source:hover {
-  opacity: 1;
+  background: rgba(56, 139, 253, 0.3);
   text-decoration: underline;
 }
 

--- a/web/frontend/style.css
+++ b/web/frontend/style.css
@@ -344,6 +344,30 @@ input:focus, select:focus, textarea:focus {
   margin-bottom: 3px;
 }
 
+.form-row-inline {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  margin-bottom: 8px;
+}
+
+.form-row-inline .form-field {
+  flex: 1;
+}
+
+.form-row-inline .form-field label {
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 3px;
+}
+
+.btn-inline {
+  flex-shrink: 0;
+  margin-bottom: 1px;
+}
+
 /* =========================================================================
    Table entries list
    ========================================================================= */


### PR DESCRIPTION
## Summary

Browser-based playground for writing P4 programs, configuring tables, sending packets, and visualizing execution traces — all against the 4ward simulator.

**Backend** (`web/`): JDK `HttpServer` wrapping the existing `P4RuntimeService` and simulator. Compiles P4 on-the-fly via `p4c-4ward`, loads pipelines via `SetForwardingPipelineConfig`, manages table entries and clone sessions via `Write`/`Read`, and injects packets directly into the simulator for trace trees.

**Frontend** (`web/frontend/`): Single-page app with Monaco editor (custom P4 syntax highlighting + dark theme), three-tab right panel (Tables, Packets, Trace), and resizable split layout.

### Features

- **Compile & Load** with inline error markers (red squiggles on the offending lines, jumps to first error)
- **Table entry management** with dynamic forms generated from P4Info (match fields, actions, params, priority)
- **Clone session configuration** for P4Runtime PRE (CloneSessionEntry)
- **Packet injection** with hex presets (IPv4, IPv6, ARP, Raw) and hex dump output
- **Trace tree visualization** with collapsible nodes, color-coded events, fork branches, and clickable source-info pills that jump to the corresponding editor line
- **Three built-in examples**: `basic_table.p4` (simple forwarding), `passthrough.p4` (no tables), `mirror.p4` (IPv4 routing with I2E clone fork)
- **Keyboard shortcut**: Cmd/Ctrl+Enter to compile & load

## Test plan

- [x] `bazel test //web:WebServerTest` passes
- [ ] Manual: compile each example, add entries, send packets, verify trace
- [ ] Manual: mirror.p4 → add clone session 100 → port 5 → send IPv4 packet → verify fork in trace
- [ ] Manual: introduce syntax error → verify red squiggles + error in log bar
- [ ] Manual: click source-info pill in trace → editor jumps to line

🤖 Generated with [Claude Code](https://claude.com/claude-code)