### PR TITLE
Fix build failure on Debian (#275)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,21 +2,30 @@
 common --enable_bzlmod
 common --noenable_workspace
 
+# Auto-select build:linux / build:macos / build:windows based on the host OS,
+# so platform-specific flags don't need manual --config= activation.
+common --enable_platform_specific_config
+
 # Use a hermetic remote JDK rather than whatever happens to be installed locally.
 build --java_runtime_version=remotejdk_21
 build --tool_java_runtime_version=remotejdk_21
 
 # Force the use of Clang for all builds, matching p4c upstream.
+# action_env sets CC/CXX for sandboxed build actions.
 build --action_env=CC=clang
 build --action_env=CXX=clang++
 
-# macOS: use Command Line Tools clang (avoids requiring a full Xcode install)
-# and raise the deployment target to 10.15, which is the minimum for
-# std::filesystem support in libc++.
+# Toolchain auto-configuration (cc_configure) needs repo_env, which is
+# platform-specific because macOS needs the absolute CLT path to avoid
+# picking up a Homebrew clang with an incompatible libc++.
+build:macos --repo_env=CC=/usr/bin/clang
+build:linux --repo_env=CC=clang
+
+# macOS: use Command Line Tools clang (avoids requiring a full Xcode install).
+# Deployment target 10.15 is the minimum for std::filesystem in libc++.
 # host_macos_minimum_os covers tool builds (e.g. p4c's ir-generator).
-build --repo_env=CC=/usr/bin/clang
-build --macos_minimum_os=10.15
-build --host_macos_minimum_os=10.15
+build:macos --macos_minimum_os=10.15
+build:macos --host_macos_minimum_os=10.15
 
 # C++20 for the p4c backend.
 build --cxxopt=-std=c++20


### PR DESCRIPTION
## Summary

- The unconditional `--repo_env=CC=/usr/bin/clang` hardcoded a macOS-specific
  path that doesn't exist on Debian, causing `execvp` failures in the sandbox
- Enables `--enable_platform_specific_config` so `build:macos` / `build:linux`
  flags are auto-activated by host OS — no manual `--config=` needed
- macOS keeps the absolute CLT path (critical: bare `clang` can pick up
  Homebrew LLVM with an incompatible libc++, causing linker errors)
- Linux uses bare `clang` resolved via PATH, working with any distro's
  clang installation

Closes #275.

## Test plan

- [x] macOS: `bazel clean --expunge && bazel build //...` — all 1405 targets build
- [x] macOS: `bazel test //... --test_tag_filters=-heavy` — 41/41 pass
- [ ] CI: Ubuntu 24.04 build + test
- [ ] CI: macOS build + test
- [ ] Manual: Debian build with `clang-18` (no unversioned symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)