### PR TITLE
fix: enforce INSERT/MODIFY/DELETE semantics for PRE entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ plane.
 
 | | BMv2 | 4ward goal | Status |
 |---|---|---|---|
-| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 [97/118 requirements](docs/P4RUNTIME_COMPLIANCE.md) |
+| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 [101/118 requirements](docs/P4RUNTIME_COMPLIANCE.md) |
 | Trace format | text | [**proto/JSON**](e2e_tests/trace_tree/clone_with_egress.golden.txtpb) | ✅ |
 | All possible traces | not natively | [**trace trees!**](docs/ROADMAP.md#track-3-trace-trees) | ✅ |
 | `@p4runtime_translation` | no | [**built-in translation engine**](#p4runtime_translation-done-right) | ✅ |

--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -107,10 +107,10 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 |---|-------------|--------|------|
 | 9.60 | Multicast group CRUD | Y | ConformanceTest (via PRE entries) |
 | 9.61 | Clone session CRUD | Y | ConformanceTest (via PRE entries) |
-| 9.62 | PRE INSERT existing → ALREADY_EXISTS | N | |
-| 9.63 | PRE MODIFY non-existent → NOT_FOUND | N | |
-| 9.64 | PRE DELETE non-existent → NOT_FOUND | N | |
-| 9.65 | PRE entries readable via Read RPC | N | |
+| 9.62 | PRE INSERT existing → ALREADY_EXISTS | Y | TableStoreTest |
+| 9.63 | PRE MODIFY non-existent → NOT_FOUND | Y | TableStoreTest |
+| 9.64 | PRE DELETE non-existent → NOT_FOUND | Y | TableStoreTest |
+| 9.65 | PRE entries readable via Read RPC | Y | TableStoreTest |
 
 ## Write RPC — other entity types (§9.6, §9.8, §9.9)
 
@@ -236,7 +236,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Write — profiles | 8 | 0 | 0 |
 | Write — registers | 5 | 0 | 0 |
 | Write — counters/meters | 4 | 0 | 0 |
-| Write — PRE | 2 | 4 | 0 |
+| Write — PRE | 6 | 0 | 0 |
 | Write — other entities | 0 | 0 | 3 |
 | Write — atomicity | 0 | 3 | 1 |
 | Write — general | 1 | 1 | 0 |
@@ -248,4 +248,4 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Translation | 6 | 0 | 0 |
 | @refers_to | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **97** | **21** | **10** |
+| **Total** | **101** | **17** | **10** |

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -119,6 +119,8 @@ class Simulator {
         entity.hasDirectCounterEntry() ->
           tableStore.readDirectCounterEntries(entity.directCounterEntry)
         entity.hasDirectMeterEntry() -> tableStore.readDirectMeterEntries(entity.directMeterEntry)
+        entity.hasPacketReplicationEngineEntry() ->
+          tableStore.readPreEntries(entity.packetReplicationEngineEntry)
         else -> emptyList()
       }
     }

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -602,10 +602,8 @@ class TableStore {
       entity.hasDirectCounterEntry() ->
         writeDirectCounterEntry(update.type, entity.directCounterEntry)
       entity.hasDirectMeterEntry() -> writeDirectMeterEntry(update.type, entity.directMeterEntry)
-      entity.hasPacketReplicationEngineEntry() -> {
-        writePreEntry(entity.packetReplicationEngineEntry)
-        WriteResult.Success
-      }
+      entity.hasPacketReplicationEngineEntry() ->
+        writePreEntry(update.type, entity.packetReplicationEngineEntry)
       entity.hasTableEntry() -> writeTableEntry(update)
       else ->
         WriteResult.InvalidArgument(
@@ -734,20 +732,82 @@ class TableStore {
     )
   }
 
-  private fun writePreEntry(pre: P4RuntimeOuterClass.PacketReplicationEngineEntry) {
+  private fun writePreEntry(
+    type: Update.Type,
+    pre: P4RuntimeOuterClass.PacketReplicationEngineEntry,
+  ): WriteResult =
     when {
-      pre.hasCloneSessionEntry() ->
-        cloneSessions[pre.cloneSessionEntry.sessionId] = pre.cloneSessionEntry
-      pre.hasMulticastGroupEntry() ->
-        multicastGroups[pre.multicastGroupEntry.multicastGroupId] = pre.multicastGroupEntry
+      pre.hasCloneSessionEntry() -> {
+        val entry = pre.cloneSessionEntry
+        writeProfileEntity(
+          type,
+          cloneSessions,
+          entry.sessionId,
+          entry,
+          "clone session ${entry.sessionId}",
+        )
+      }
+      pre.hasMulticastGroupEntry() -> {
+        val entry = pre.multicastGroupEntry
+        writeProfileEntity(
+          type,
+          multicastGroups,
+          entry.multicastGroupId,
+          entry,
+          "multicast group ${entry.multicastGroupId}",
+        )
+      }
+      else -> WriteResult.InvalidArgument("PRE entry must have a clone session or multicast group")
     }
-  }
 
   fun getCloneSession(sessionId: Int): P4RuntimeOuterClass.CloneSessionEntry? =
     cloneSessions[sessionId]
 
   fun getMulticastGroup(groupId: Int): P4RuntimeOuterClass.MulticastGroupEntry? =
     multicastGroups[groupId]
+
+  /**
+   * Reads PRE entries matching the filter.
+   *
+   * No oneof set → wildcard (return all clone sessions and multicast groups). One oneof set →
+   * return entries of that type; ID 0 means all of that type, non-zero means that specific entry.
+   */
+  fun readPreEntries(
+    filter: P4RuntimeOuterClass.PacketReplicationEngineEntry =
+      P4RuntimeOuterClass.PacketReplicationEngineEntry.getDefaultInstance()
+  ): List<P4RuntimeOuterClass.Entity> {
+    val includeClone = filter.hasCloneSessionEntry() || !filter.hasMulticastGroupEntry()
+    val includeMulticast = filter.hasMulticastGroupEntry() || !filter.hasCloneSessionEntry()
+    return buildList {
+      if (includeClone) {
+        val id = if (filter.hasCloneSessionEntry()) filter.cloneSessionEntry.sessionId else 0
+        for (entry in readFromMap(cloneSessions, id)) {
+          add(entry.toPreEntity { setCloneSessionEntry(entry) })
+        }
+      }
+      if (includeMulticast) {
+        val id =
+          if (filter.hasMulticastGroupEntry()) filter.multicastGroupEntry.multicastGroupId else 0
+        for (entry in readFromMap(multicastGroups, id)) {
+          add(entry.toPreEntity { setMulticastGroupEntry(entry) })
+        }
+      }
+    }
+  }
+
+  /** Returns all values if [id] is 0 (wildcard), or the single entry matching [id]. */
+  private fun <T> readFromMap(map: MutableMap<Int, T>, id: Int): Collection<T> =
+    if (id != 0) listOfNotNull(map[id]) else map.values
+
+  /** Wraps a PRE sub-entry into an `Entity` proto. */
+  private fun <T> T.toPreEntity(
+    setter: P4RuntimeOuterClass.PacketReplicationEngineEntry.Builder.(T) -> Unit
+  ): P4RuntimeOuterClass.Entity =
+    P4RuntimeOuterClass.Entity.newBuilder()
+      .setPacketReplicationEngineEntry(
+        P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder().also { it.setter(this) }
+      )
+      .build()
 
   // -------------------------------------------------------------------------
   // Snapshot / Restore (for ROLLBACK_ON_ERROR / DATAPLANE_ATOMIC)

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -797,10 +797,15 @@ class TableStoreTest {
   // PRE: clone sessions and multicast groups
   // ---------------------------------------------------------------------------
 
-  private fun writeCloneSession(target: TableStore = store, sessionId: Int, egressPort: Int) {
+  private fun writeCloneSession(
+    target: TableStore = store,
+    sessionId: Int,
+    egressPort: Int,
+    type: Update.Type = Update.Type.INSERT,
+  ): WriteResult =
     target.write(
       Update.newBuilder()
-        .setType(Update.Type.INSERT)
+        .setType(type)
         .setEntity(
           Entity.newBuilder()
             .setPacketReplicationEngineEntry(
@@ -814,16 +819,16 @@ class TableStoreTest {
         )
         .build()
     )
-  }
 
   private fun writeMulticastGroup(
     target: TableStore = store,
     groupId: Int,
     replicas: List<Pair<Int, Int>>,
-  ) {
+    type: Update.Type = Update.Type.INSERT,
+  ): WriteResult =
     target.write(
       Update.newBuilder()
-        .setType(Update.Type.INSERT)
+        .setType(type)
         .setEntity(
           Entity.newBuilder()
             .setPacketReplicationEngineEntry(
@@ -844,7 +849,6 @@ class TableStoreTest {
         )
         .build()
     )
-  }
 
   @Test
   fun `clone session round-trip`() {
@@ -875,6 +879,138 @@ class TableStoreTest {
   @Test
   fun `multicast group miss returns null`() {
     assertNull(store.getMulticastGroup(999))
+  }
+
+  @Test
+  fun `clone session INSERT duplicate fails`() {
+    assertEquals(WriteResult.Success, writeCloneSession(sessionId = 1, egressPort = 5))
+    assertTrue(writeCloneSession(sessionId = 1, egressPort = 6) is WriteResult.AlreadyExists)
+  }
+
+  @Test
+  fun `clone session MODIFY existing succeeds`() {
+    writeCloneSession(sessionId = 1, egressPort = 5)
+    assertEquals(
+      WriteResult.Success,
+      writeCloneSession(sessionId = 1, egressPort = 9, type = Update.Type.MODIFY),
+    )
+    assertEquals(9, store.getCloneSession(1)!!.replicasList[0].egressPort)
+  }
+
+  @Test
+  fun `clone session MODIFY non-existent fails`() {
+    assertTrue(
+      writeCloneSession(sessionId = 1, egressPort = 5, type = Update.Type.MODIFY)
+        is WriteResult.NotFound
+    )
+  }
+
+  @Test
+  fun `clone session DELETE existing succeeds`() {
+    writeCloneSession(sessionId = 1, egressPort = 5)
+    assertEquals(
+      WriteResult.Success,
+      writeCloneSession(sessionId = 1, egressPort = 0, type = Update.Type.DELETE),
+    )
+    assertNull(store.getCloneSession(1))
+  }
+
+  @Test
+  fun `clone session DELETE non-existent fails`() {
+    assertTrue(
+      writeCloneSession(sessionId = 1, egressPort = 0, type = Update.Type.DELETE)
+        is WriteResult.NotFound
+    )
+  }
+
+  @Test
+  fun `multicast group INSERT duplicate fails`() {
+    assertEquals(WriteResult.Success, writeMulticastGroup(groupId = 1, replicas = listOf(0 to 1)))
+    assertTrue(
+      writeMulticastGroup(groupId = 1, replicas = listOf(0 to 2)) is WriteResult.AlreadyExists
+    )
+  }
+
+  @Test
+  fun `multicast group MODIFY existing succeeds`() {
+    writeMulticastGroup(groupId = 1, replicas = listOf(0 to 1))
+    assertEquals(
+      WriteResult.Success,
+      writeMulticastGroup(groupId = 1, replicas = listOf(0 to 5, 0 to 6), type = Update.Type.MODIFY),
+    )
+    assertEquals(2, store.getMulticastGroup(1)!!.replicasCount)
+  }
+
+  @Test
+  fun `multicast group MODIFY non-existent fails`() {
+    assertTrue(
+      writeMulticastGroup(groupId = 1, replicas = listOf(0 to 1), type = Update.Type.MODIFY)
+        is WriteResult.NotFound
+    )
+  }
+
+  @Test
+  fun `multicast group DELETE existing succeeds`() {
+    writeMulticastGroup(groupId = 1, replicas = listOf(0 to 1))
+    assertEquals(
+      WriteResult.Success,
+      writeMulticastGroup(groupId = 1, replicas = emptyList(), type = Update.Type.DELETE),
+    )
+    assertNull(store.getMulticastGroup(1))
+  }
+
+  @Test
+  fun `multicast group DELETE non-existent fails`() {
+    assertTrue(
+      writeMulticastGroup(groupId = 1, replicas = emptyList(), type = Update.Type.DELETE)
+        is WriteResult.NotFound
+    )
+  }
+
+  @Test
+  fun `PRE wildcard read returns all entries`() {
+    writeCloneSession(sessionId = 1, egressPort = 5)
+    writeCloneSession(sessionId = 2, egressPort = 6)
+    writeMulticastGroup(groupId = 10, replicas = listOf(0 to 1))
+    val results = store.readPreEntries()
+    assertEquals(3, results.size)
+  }
+
+  @Test
+  fun `PRE read by clone session ID`() {
+    writeCloneSession(sessionId = 1, egressPort = 5)
+    writeCloneSession(sessionId = 2, egressPort = 6)
+    val filter =
+      P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+        .setCloneSessionEntry(P4RuntimeOuterClass.CloneSessionEntry.newBuilder().setSessionId(1))
+        .build()
+    val results = store.readPreEntries(filter)
+    assertEquals(1, results.size)
+    assertEquals(1, results[0].packetReplicationEngineEntry.cloneSessionEntry.sessionId)
+  }
+
+  @Test
+  fun `PRE read by multicast group ID`() {
+    writeMulticastGroup(groupId = 1, replicas = listOf(0 to 1))
+    writeMulticastGroup(groupId = 2, replicas = listOf(0 to 2))
+    val filter =
+      P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+        .setMulticastGroupEntry(
+          P4RuntimeOuterClass.MulticastGroupEntry.newBuilder().setMulticastGroupId(2)
+        )
+        .build()
+    val results = store.readPreEntries(filter)
+    assertEquals(1, results.size)
+    assertEquals(2, results[0].packetReplicationEngineEntry.multicastGroupEntry.multicastGroupId)
+  }
+
+  @Test
+  fun `PRE read non-existent returns empty`() {
+    val filter =
+      P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+        .setCloneSessionEntry(P4RuntimeOuterClass.CloneSessionEntry.newBuilder().setSessionId(999))
+        .build()
+    assertEquals(0, store.readPreEntries(filter).size)
   }
 
   @Test


### PR DESCRIPTION
## Summary

PRE writes (clone sessions, multicast groups) were silently upsert-ing regardless of `Update.Type`, violating the P4Runtime spec. Now they use the same `writeProfileEntity` helper as action profiles — INSERT of an existing entry → `ALREADY_EXISTS`, MODIFY/DELETE of a non-existent → `NOT_FOUND`.

Also adds `readPreEntries()` with wildcard and filtered-by-ID support, wired into the Read RPC dispatch.

- 14 new unit tests covering all INSERT/MODIFY/DELETE error cases + read variants
- Closes compliance gaps 9.62–9.65, bringing us to **101/118** requirements

## Test plan

- [ ] All existing tests pass (`bazel test //...`)
- [ ] New `TableStoreTest` PRE tests cover INSERT duplicate, MODIFY existing/non-existent, DELETE existing/non-existent, wildcard read, filtered read, read non-existent — for both clone sessions and multicast groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)