### PR TITLE
Initial PSA architecture support (10/26 corpus tests)

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -12,9 +12,13 @@ guilt — just write it down so someone can find it later.
 
 ## Architecture support
 
-- **v1model only.** PSA, PNA, and TNA are not implemented. The architecture
-  interface (`Architecture.kt`) is designed for pluggability, but only
-  `V1ModelArchitecture.kt` exists today. 26 corpus tests are blocked on PSA.
+- **PSA: basic pipeline only.** The PSA two-pipeline architecture (ingress +
+  egress) is implemented with support for `send_to_port`, `ingress_drop`,
+  `egress_drop`, basic counters, and top-level assignments. 10 of 26 PSA corpus
+  tests pass. Missing: `Hash`/`InternetChecksum`/`Meter` externs, multicast,
+  I2E/E2E cloning, resubmit, recirculate, `end_of_ingress`, `lookahead` type
+  resolution, and PSA-style `register.read` (returns `T` directly instead of
+  `void` with `out` param). PNA and TNA are not implemented.
 
 ## Externs
 

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -225,39 +225,47 @@ corpus_test_suite(
     ],
 )
 
-# Tests blocked on PSA architecture support. The backend only supports v1model
-# today; these fail with "unsupported architecture 'PSA_Switch'".
-# Run manually: bazel test //e2e_tests/corpus:psa_stf_corpus_test
+# PSA corpus STF tests that pass in CI. Covers basic PSA pipeline: ingress/egress
+# parsing, drop-by-default, send_to_port, counters, metadata, parser errors.
 corpus_test_suite(
     name = "psa_stf_corpus_test",
-    tags = ["manual"],
     tests = [
-        "hash-extern-bmv2",
-        "internet_checksum1-bmv2",
         "psa-basic-counter-bmv2",
         "psa-bool-ternary-const-entry-bmv2",
         "psa-drop-all-bmv2",
         "psa-drop-all-corrected-bmv2",
-        "psa-e2e-cloning-basic-bmv2",
-        "psa-end-of-ingress-test-bmv2",
-        "psa-example-dpdk-varbit-bmv2",
-        "psa-example-register2-bmv2",
         "psa-fwd-bmv2",
-        "psa-i2e-cloning-basic-bmv2",
         "psa-metadata-bmv2",
-        "psa-meter7-bmv2",
-        "psa-multicast-basic-2-bmv2",
-        "psa-multicast-basic-bmv2",
-        "psa-multicast-basic-corrected-bmv2",
         "psa-parser-error-test-bmv2",
-        "psa-recirculate-no-meta-bmv2",
-        "psa-register-complex-bmv2",
-        "psa-register-read-write-2-bmv2",
-        "psa-register-read-write-bmv2",
-        "psa-resubmit-bmv2",
         "psa-top-level-assignments-bmv2",
         "psa-unicast-or-drop-bmv2",
         "psa-unicast-or-drop-corrected-bmv2",
+    ],
+)
+
+# PSA tests blocked on missing features. Each entry has an inline comment
+# explaining the blocker.
+# Run manually: bazel test //e2e_tests/corpus:psa_manual_stf_corpus_test
+corpus_test_suite(
+    name = "psa_manual_stf_corpus_test",
+    tags = ["manual"],
+    tests = [
+        "hash-extern-bmv2",  # Hash extern (get_hash method)
+        "internet_checksum1-bmv2",  # InternetChecksum extern (clear/add/get)
+        "psa-e2e-cloning-basic-bmv2",  # E2E cloning
+        "psa-end-of-ingress-test-bmv2",  # end_of_ingress extern
+        "psa-example-dpdk-varbit-bmv2",  # lookahead type resolution
+        "psa-example-register2-bmv2",  # PSA register.read (returns T directly)
+        "psa-i2e-cloning-basic-bmv2",  # I2E cloning
+        "psa-meter7-bmv2",  # Meter extern (execute method)
+        "psa-multicast-basic-2-bmv2",  # Multicast
+        "psa-multicast-basic-bmv2",  # Multicast
+        "psa-multicast-basic-corrected-bmv2",  # Multicast
+        "psa-recirculate-no-meta-bmv2",  # Recirculate
+        "psa-register-complex-bmv2",  # PSA register.read (returns T directly)
+        "psa-register-read-write-2-bmv2",  # PSA register.read (returns T directly)
+        "psa-register-read-write-bmv2",  # PSA register.read (returns T directly)
+        "psa-resubmit-bmv2",  # Resubmit
     ],
 )
 

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -795,18 +795,34 @@ void FourWardBackend::emitArchitecture(const IR::ToplevelBlock* toplevel) {
   const auto* main = toplevel->getMain();
   if (!main) return;
 
-  std::string archName;
-  if (main->type->name == "V1Switch") {
-    archName = "v1model";
-    arch->set_name(archName);
+  auto addStage = [&](const std::string& name, const std::string& blockName,
+                      fourward::ir::v1::StageKind kind) {
+    auto* stage = arch->add_stages();
+    stage->set_name(name);
+    stage->set_block_name(blockName);
+    stage->set_kind(kind);
+  };
 
-    auto addStage = [&](const std::string& name, const std::string& blockName,
-                        fourward::ir::v1::StageKind kind) {
-      auto* stage = arch->add_stages();
-      stage->set_name(name);
-      stage->set_block_name(blockName);
-      stage->set_kind(kind);
-    };
+  // Resolves a constructor-call expression to the block name it creates.
+  auto resolveBlockName = [](const IR::Expression* expr) -> std::string {
+    if (const auto* pe = expr->to<IR::PathExpression>()) {
+      return pe->path->name.name.c_str();
+    }
+    if (const auto* cce = expr->to<IR::ConstructorCallExpression>()) {
+      if (const auto* tn = cce->constructedType->to<IR::Type_Name>()) {
+        return tn->path->name.name.c_str();
+      }
+    }
+    if (const auto* mc = expr->to<IR::MethodCallExpression>()) {
+      if (const auto* pe = mc->method->to<IR::PathExpression>()) {
+        return pe->path->name.name.c_str();
+      }
+    }
+    return "";
+  };
+
+  if (main->type->name == "V1Switch") {
+    arch->set_name("v1model");
 
     // V1Switch(parser, verify_checksum, ingress, egress, compute_checksum,
     // deparser)
@@ -824,33 +840,74 @@ void FourWardBackend::emitArchitecture(const IR::ToplevelBlock* toplevel) {
     for (const auto& arg :
          *main->node->to<IR::Declaration_Instance>()->arguments) {
       if (i >= stageSpec.size()) break;
-      std::string blockName;
-      const auto* expr = arg->expression;
-      if (const auto* pe = expr->to<IR::PathExpression>()) {
-        // Already-resolved reference (e.g. after some midend passes).
-        blockName = pe->path->name.name.c_str();
-      } else if (const auto* cce = expr->to<IR::ConstructorCallExpression>()) {
-        // Constructor call: MyParser() — the type name is the block name.
-        if (const auto* tn = cce->constructedType->to<IR::Type_Name>()) {
-          blockName = tn->path->name.name.c_str();
-        }
-      } else if (const auto* mc = expr->to<IR::MethodCallExpression>()) {
-        if (const auto* pe2 = mc->method->to<IR::PathExpression>()) {
-          blockName = pe2->path->name.name.c_str();
-        }
-      }
+      std::string blockName = resolveBlockName(arg->expression);
       if (!blockName.empty()) {
         addStage(stageSpec[i].first, blockName, stageSpec[i].second);
       }
       ++i;
     }
+  } else if (main->type->name == "PSA_Switch") {
+    arch->set_name("psa");
+
+    // PSA_Switch(IngressPipeline ingress, PRE pre, EgressPipeline egress,
+    //            BufferingQueueingEngine bqe)
+    // IngressPipeline(IngressParser ip, Ingress ig, IngressDeparser id)
+    // EgressPipeline(EgressParser ep, Egress eg, EgressDeparser ed)
+    //
+    // Pipeline args are package references. Resolve them via refMap_ to their
+    // Declaration_Instance nodes and extract block names from their constructor
+    // arguments.
+    auto pipelineArgs =
+        [&](const IR::Expression* ref) -> const IR::Vector<IR::Argument>* {
+      const auto* pe = ref->to<IR::PathExpression>();
+      if (!pe) return nullptr;
+      const auto* decl = refMap_.getDeclaration(pe->path, false);
+      if (!decl) return nullptr;
+      const auto* inst = decl->to<IR::Declaration_Instance>();
+      return inst ? inst->arguments : nullptr;
+    };
+
+    const auto* mainArgs =
+        main->node->to<IR::Declaration_Instance>()->arguments;
+    if (mainArgs->size() < 4) {
+      ::P4::error("PSA_Switch: expected 4 constructor arguments, got %1%",
+                  mainArgs->size());
+      return;
+    }
+
+    const auto* ingressArgs = pipelineArgs((*mainArgs)[0]->expression);
+    const auto* egressArgs = pipelineArgs((*mainArgs)[2]->expression);
+    if (!ingressArgs || ingressArgs->size() < 3 || !egressArgs ||
+        egressArgs->size() < 3) {
+      ::P4::error(
+          "PSA_Switch: could not resolve IngressPipeline or EgressPipeline "
+          "constructor arguments");
+      return;
+    }
+
+    // IngressPipeline(IngressParser ip, Ingress ig, IngressDeparser id)
+    addStage("ingress_parser", resolveBlockName((*ingressArgs)[0]->expression),
+             fourward::ir::v1::StageKind::PARSER);
+    addStage("ingress", resolveBlockName((*ingressArgs)[1]->expression),
+             fourward::ir::v1::StageKind::CONTROL);
+    addStage("ingress_deparser",
+             resolveBlockName((*ingressArgs)[2]->expression),
+             fourward::ir::v1::StageKind::DEPARSER);
+
+    // EgressPipeline(EgressParser ep, Egress eg, EgressDeparser ed)
+    addStage("egress_parser", resolveBlockName((*egressArgs)[0]->expression),
+             fourward::ir::v1::StageKind::PARSER);
+    addStage("egress", resolveBlockName((*egressArgs)[1]->expression),
+             fourward::ir::v1::StageKind::CONTROL);
+    addStage("egress_deparser", resolveBlockName((*egressArgs)[2]->expression),
+             fourward::ir::v1::StageKind::DEPARSER);
   } else {
     // Unknown architecture: emit the name and leave stages empty.
     // The simulator will reject it with a clear error.
     arch->set_name(main->type->name.name.c_str());
     ::P4::error(
-        "4ward: unsupported architecture '%1%'. Only v1model is supported "
-        "currently.",
+        "4ward: unsupported architecture '%1%'. Only v1model and PSA are "
+        "supported currently.",
         main->type->name);
   }
 }

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -1,6 +1,7 @@
 package fourward.simulator
 
 import fourward.ir.v1.BehavioralConfig
+import fourward.sim.v1.SimulatorProto.TraceTree
 
 /**
  * Interface for architecture-specific pipeline behaviour.
@@ -41,4 +42,4 @@ interface Architecture {
  * The [trace] tree carries the complete execution trace. Leaf nodes contain [PacketOutcome]s
  * (output packets or drops); fork nodes represent non-deterministic choice points.
  */
-data class PipelineResult(val trace: fourward.sim.v1.SimulatorProto.TraceTree)
+data class PipelineResult(val trace: TraceTree)

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -1,0 +1,389 @@
+package fourward.simulator
+
+import fourward.ir.v1.BehavioralConfig
+import fourward.ir.v1.PipelineStage
+import fourward.ir.v1.TypeDecl
+import fourward.sim.v1.SimulatorProto.Drop
+import fourward.sim.v1.SimulatorProto.DropReason
+import fourward.sim.v1.SimulatorProto.PacketIngressEvent
+import fourward.sim.v1.SimulatorProto.PacketOutcome
+import fourward.sim.v1.SimulatorProto.PipelineStageEvent
+import fourward.sim.v1.SimulatorProto.TraceEvent
+import fourward.sim.v1.SimulatorProto.TraceTree
+
+/**
+ * PSA (Portable Switch Architecture) pipeline implementation.
+ *
+ * PSA is a two-pipeline architecture with separate ingress and egress stages. The egress pipeline
+ * re-parses the deparsed packet, so header and metadata state is NOT shared between ingress and
+ * egress — only the raw bytes cross the boundary.
+ *
+ * Pipeline structure: IngressParser → Ingress → IngressDeparser → (traffic manager) → EgressParser
+ * → Egress → EgressDeparser
+ *
+ * Key differences from v1model:
+ * - Ingress drops by default (`ostd.drop` starts `true`). To forward, call `send_to_port()`.
+ * - Egress does NOT drop by default (`ostd.drop` starts `false`).
+ * - Port width is `bit<32>` (not `bit<9>`).
+ * - Each stage has distinct metadata structs (no shared `standard_metadata`).
+ *
+ * References:
+ * - PSA spec: https://p4.org/p4-spec/docs/PSA.html
+ * - BMv2 psa.p4: https://github.com/p4lang/p4c/blob/main/p4include/bmv2/psa.p4
+ */
+class PSAArchitecture : Architecture {
+
+  override fun processPacket(
+    ingressPort: UInt,
+    payload: ByteArray,
+    config: BehavioralConfig,
+    tableStore: TableStore,
+  ): PipelineResult {
+    val typesByName = config.typesList.associateBy { it.name }
+    val stages = config.architecture.stagesList
+
+    // Build a lookup from block name → params for per-stage parameter binding.
+    val blockParams = buildBlockParamsMap(config)
+
+    // === Ingress pipeline ===
+    val ingressCtx = PacketContext(payload)
+    val ingressEnv = Environment()
+    val ingressValues = createDefaultValues(config, typesByName)
+
+    initIngressMetadata(ingressValues, ingressPort)
+    val ingressOutput = ingressValues["psa_ingress_output_metadata_t"] as? StructVal
+
+    val ingressInterpreter =
+      Interpreter(config, tableStore, ingressCtx, emptyMap(), createPsaExternHandler())
+
+    ingressCtx.addTraceEvent(packetIngressEvent(ingressPort))
+
+    // --- Ingress Parser ---
+    val ingressParserStage = stages.first { it.name == "ingress_parser" }
+    bindStageParams(ingressEnv, ingressParserStage.blockName, blockParams, ingressValues)
+    runParserStage(ingressInterpreter, ingressCtx, ingressEnv, ingressParserStage) { e ->
+      (ingressValues["psa_ingress_input_metadata_t"] as? StructVal)?.let {
+        it.fields["parser_error"] = ErrorVal(e.errorName)
+      }
+    }
+
+    // --- Ingress Control ---
+    val ingressStage = stages.first { it.name == "ingress" }
+    bindStageParams(ingressEnv, ingressStage.blockName, blockParams, ingressValues)
+    runControlStage(ingressInterpreter, ingressCtx, ingressEnv, ingressStage)
+
+    // --- Ingress drop check (PSA: drop=true by default) ---
+    if ((ingressOutput?.fields?.get("drop") as? BoolVal)?.value != false) {
+      return buildDropResult(ingressCtx.getEvents())
+    }
+
+    val egressPort =
+      (ingressOutput?.fields?.get("egress_port") as? BitVal)?.bits?.value?.toInt() ?: 0
+
+    // --- Ingress Deparser ---
+    val ingressDeparserStage = stages.first { it.name == "ingress_deparser" }
+    bindStageParams(ingressEnv, ingressDeparserStage.blockName, blockParams, ingressValues)
+    runControlStage(ingressInterpreter, ingressCtx, ingressEnv, ingressDeparserStage)
+
+    val deparsedBytes = ingressCtx.outputPayload() + ingressCtx.drainRemainingInput()
+    val ingressEvents = ingressCtx.getEvents()
+
+    // === Egress pipeline (re-parses the deparsed packet) ===
+    val egressCtx = PacketContext(deparsedBytes)
+    val egressEnv = Environment()
+    val egressValues = createDefaultValues(config, typesByName)
+
+    initEgressMetadata(egressValues, egressPort, ingressOutput)
+    val egressOutput = egressValues["psa_egress_output_metadata_t"] as? StructVal
+
+    val egressInterpreter =
+      Interpreter(config, tableStore, egressCtx, emptyMap(), createPsaExternHandler())
+
+    // Carry ingress trace events into the egress context.
+    for (event in ingressEvents) egressCtx.addTraceEvent(event)
+
+    // --- Egress Parser ---
+    val egressParserStage = stages.first { it.name == "egress_parser" }
+    bindStageParams(egressEnv, egressParserStage.blockName, blockParams, egressValues)
+    runParserStage(egressInterpreter, egressCtx, egressEnv, egressParserStage) { e ->
+      (egressValues["psa_egress_input_metadata_t"] as? StructVal)?.let {
+        it.fields["parser_error"] = ErrorVal(e.errorName)
+      }
+    }
+
+    // --- Egress Control ---
+    val egressStage = stages.first { it.name == "egress" }
+    bindStageParams(egressEnv, egressStage.blockName, blockParams, egressValues)
+    runControlStage(egressInterpreter, egressCtx, egressEnv, egressStage)
+
+    // --- Egress drop check (PSA: egress does NOT drop by default) ---
+    if ((egressOutput?.fields?.get("drop") as? BoolVal)?.value == true) {
+      return buildDropResult(egressCtx.getEvents())
+    }
+
+    // --- Egress Deparser ---
+    val egressDeparserStage = stages.first { it.name == "egress_deparser" }
+    bindStageParams(egressEnv, egressDeparserStage.blockName, blockParams, egressValues)
+    runControlStage(egressInterpreter, egressCtx, egressEnv, egressDeparserStage)
+
+    val outputBytes = egressCtx.outputPayload() + egressCtx.drainRemainingInput()
+    return buildOutputResult(egressCtx.getEvents(), egressPort, outputBytes)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Metadata initialisation
+  // ---------------------------------------------------------------------------
+
+  private fun initIngressMetadata(values: Map<String, Value>, ingressPort: UInt) {
+    (values["psa_ingress_parser_input_metadata_t"] as? StructVal)?.let {
+      it.setBitField("ingress_port", ingressPort.toLong())
+      it.fields["packet_path"] = EnumVal("NORMAL")
+    }
+    (values["psa_ingress_input_metadata_t"] as? StructVal)?.let {
+      it.setBitField("ingress_port", ingressPort.toLong())
+      it.fields["packet_path"] = EnumVal("NORMAL")
+      it.fields["parser_error"] = ErrorVal("NoError")
+    }
+    // PSA spec: ingress output metadata defaults to drop=true.
+    (values["psa_ingress_output_metadata_t"] as? StructVal)?.let {
+      it.fields["drop"] = BoolVal(true)
+    }
+  }
+
+  private fun initEgressMetadata(
+    values: Map<String, Value>,
+    egressPort: Int,
+    ingressOutput: StructVal?,
+  ) {
+    val cos =
+      (ingressOutput?.fields?.get("class_of_service") as? BitVal)?.bits?.value?.toLong() ?: 0
+    (values["psa_egress_parser_input_metadata_t"] as? StructVal)?.let {
+      it.setBitField("egress_port", egressPort.toLong())
+      it.fields["packet_path"] = EnumVal("NORMAL_UNICAST")
+    }
+    (values["psa_egress_input_metadata_t"] as? StructVal)?.let {
+      it.setBitField("class_of_service", cos)
+      it.setBitField("egress_port", egressPort.toLong())
+      it.fields["packet_path"] = EnumVal("NORMAL_UNICAST")
+      it.fields["parser_error"] = ErrorVal("NoError")
+    }
+    // PSA spec: egress output metadata defaults to drop=false.
+    (values["psa_egress_output_metadata_t"] as? StructVal)?.let {
+      it.fields["drop"] = BoolVal(false)
+    }
+    (values["psa_egress_deparser_input_metadata_t"] as? StructVal)?.let {
+      it.setBitField("egress_port", egressPort.toLong())
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stage execution helpers
+  // ---------------------------------------------------------------------------
+
+  private fun runParserStage(
+    interpreter: Interpreter,
+    ctx: PacketContext,
+    env: Environment,
+    stage: PipelineStage,
+    onParserError: (ParserErrorException) -> Unit,
+  ) {
+    ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
+    try {
+      interpreter.runParser(stage.blockName, env)
+    } catch (e: ParserErrorException) {
+      onParserError(e)
+    } finally {
+      ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
+    }
+  }
+
+  private fun runControlStage(
+    interpreter: Interpreter,
+    ctx: PacketContext,
+    env: Environment,
+    stage: PipelineStage,
+  ) {
+    ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
+    try {
+      interpreter.runControl(stage.blockName, env)
+    } catch (_: ExitException) {
+      // PSA: exit terminates the current control, but the pipeline continues.
+    } finally {
+      ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Parameter binding
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Binds a stage's parameters in the environment, mapping each param name to the shared value for
+   * its type.
+   *
+   * PSA stages reuse parameter names (e.g. `istd`) with different types, so parameters must be
+   * re-bound before each stage — unlike v1model where all params can be bound once upfront.
+   */
+  private fun bindStageParams(
+    env: Environment,
+    blockName: String,
+    blockParams: Map<String, List<BlockParam>>,
+    valueByType: Map<String, Value>,
+  ) {
+    for (param in blockParams[blockName] ?: emptyList()) {
+      valueByType[param.typeName]?.let { env.define(param.name, it) }
+    }
+  }
+
+  /** Simplified parameter descriptor: just name and type. */
+  private data class BlockParam(val name: String, val typeName: String)
+
+  /** Builds a map from block name to parameter list across all parsers and controls. */
+  private fun buildBlockParamsMap(config: BehavioralConfig): Map<String, List<BlockParam>> {
+    val result = mutableMapOf<String, List<BlockParam>>()
+    for (parser in config.parsersList) {
+      result[parser.name] =
+        parser.paramsList
+          .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
+          .map { BlockParam(it.name, it.type.named) }
+    }
+    for (control in config.controlsList) {
+      result[control.name] =
+        control.paramsList
+          .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
+          .map { BlockParam(it.name, it.type.named) }
+    }
+    return result
+  }
+
+  /**
+   * Creates default values for all named types referenced by parser/control parameters.
+   *
+   * Returns a mutable map keyed by type name. The same value instance is shared across all
+   * parameters of that type (e.g., `headers` is shared between parser `parsed_hdr` and control
+   * `hdr`), so mutations in one stage are visible to subsequent stages.
+   */
+  private fun createDefaultValues(
+    config: BehavioralConfig,
+    typesByName: Map<String, TypeDecl>,
+  ): MutableMap<String, Value> {
+    val values = mutableMapOf<String, Value>()
+    for (parser in config.parsersList) {
+      for (param in parser.paramsList) {
+        if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
+          values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
+        }
+      }
+    }
+    for (control in config.controlsList) {
+      for (param in control.paramsList) {
+        if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
+          values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
+        }
+      }
+    }
+    return values
+  }
+
+  // ---------------------------------------------------------------------------
+  // PSA extern handler
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Creates a minimal PSA extern handler.
+   *
+   * Currently handles `send_to_port` (sets egress_port and drop=false on the ingress output
+   * metadata). Additional PSA externs will be added as tests require them.
+   */
+  private fun createPsaExternHandler(): ExternHandler = ExternHandler { call, eval ->
+    when (call) {
+      is ExternCall.FreeFunction ->
+        when (call.name) {
+          // send_to_port(inout ostd, in PortId_t port)
+          // After midend, becomes: send_to_port(ostd, port) where ostd is the output metadata.
+          "send_to_port" -> {
+            val ostd = eval.evalArg(0) as StructVal
+            val port = eval.evalArg(1) as BitVal
+            ostd.fields["drop"] = BoolVal(false)
+            ostd.fields["egress_port"] = port
+            UnitVal
+          }
+          "ingress_drop",
+          "egress_drop" -> {
+            val ostd = eval.evalArg(0) as StructVal
+            ostd.fields["drop"] = BoolVal(true)
+            UnitVal
+          }
+          else -> error("unhandled PSA extern: ${call.name}")
+        }
+      is ExternCall.Method ->
+        when (call.method) {
+          "read" -> {
+            // TODO(PSA): register.read returns T directly in PSA (not void with out param).
+            eval.writeOutArg(0, eval.defaultValue(eval.argType(0)))
+            UnitVal
+          }
+          "write" -> UnitVal // TODO(PSA): register/counter writes
+          "count" -> UnitVal
+          else ->
+            error(
+              "unhandled PSA extern method: ${call.externType}.${call.method}" +
+                " on ${call.instanceName}"
+            )
+        }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trace helpers
+  // ---------------------------------------------------------------------------
+
+  private fun buildDropResult(events: List<TraceEvent>): PipelineResult {
+    val outcome =
+      PacketOutcome.newBuilder()
+        .setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
+        .build()
+    return PipelineResult(
+      TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
+    )
+  }
+
+  private fun buildOutputResult(
+    events: List<TraceEvent>,
+    port: Int,
+    payload: ByteArray,
+  ): PipelineResult {
+    val output =
+      fourward.sim.v1.SimulatorProto.OutputPacket.newBuilder()
+        .setEgressPort(port)
+        .setPayload(com.google.protobuf.ByteString.copyFrom(payload))
+        .build()
+    val outcome = PacketOutcome.newBuilder().setOutput(output).build()
+    return PipelineResult(
+      TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
+    )
+  }
+
+  private fun packetIngressEvent(ingressPort: UInt): TraceEvent =
+    TraceEvent.newBuilder()
+      .setPacketIngress(PacketIngressEvent.newBuilder().setIngressPort(ingressPort.toInt()))
+      .build()
+
+  private fun stageEvent(
+    stage: PipelineStage,
+    direction: PipelineStageEvent.Direction,
+  ): TraceEvent =
+    TraceEvent.newBuilder()
+      .setPipelineStage(
+        PipelineStageEvent.newBuilder()
+          .setStageName(stage.name)
+          .setStageKind(stage.kind)
+          .setDirection(direction)
+      )
+      .build()
+
+  private companion object {
+    /** Architecture-level packet I/O types that are not user-visible parameters. */
+    val IO_TYPES = setOf("packet_in", "packet_out")
+  }
+}

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -38,6 +38,7 @@ class Simulator {
     architecture =
       when (val archName = config.device.behavioral.architecture.name) {
         "v1model" -> V1ModelArchitecture()
+        "psa" -> PSAArchitecture()
         else -> throw IllegalArgumentException("unsupported architecture: $archName")
       }
   }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -559,11 +559,6 @@ class V1ModelArchitecture : Architecture {
     }
   }
 
-  private fun buildDropTrace(events: List<TraceEvent>, reason: DropReason): TraceTree {
-    val outcome = PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(reason)).build()
-    return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
-  }
-
   /**
    * Traffic manager drop check: egress_port == drop port (set by boundary from egress_spec or clone
    * session).
@@ -605,16 +600,6 @@ class V1ModelArchitecture : Architecture {
   private fun egressSpecIsDropPort(s: PipelineState): Boolean =
     (s.standardMetadata.fields["egress_spec"] as? BitVal)?.bits?.value?.toLong() == s.dropPort
 
-  private fun buildOutputTrace(events: List<TraceEvent>, port: Int, payload: ByteArray): TraceTree {
-    val output =
-      fourward.sim.v1.SimulatorProto.OutputPacket.newBuilder()
-        .setEgressPort(port)
-        .setPayload(com.google.protobuf.ByteString.copyFrom(payload))
-        .build()
-    val outcome = PacketOutcome.newBuilder().setOutput(output).build()
-    return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
-  }
-
   /**
    * Resolves a pending clone session: emits a [CloneSessionLookupEvent] and returns the clone port,
    * or emits a miss event and returns null if the session doesn't exist.
@@ -646,6 +631,21 @@ class V1ModelArchitecture : Architecture {
         CloneSessionLookupEvent.newBuilder().setSessionId(sessionId).setSessionFound(false)
       )
       .build()
+
+  private fun buildDropTrace(events: List<TraceEvent>, reason: DropReason): TraceTree {
+    val outcome = PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(reason)).build()
+    return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
+  }
+
+  private fun buildOutputTrace(events: List<TraceEvent>, port: Int, payload: ByteArray): TraceTree {
+    val output =
+      fourward.sim.v1.SimulatorProto.OutputPacket.newBuilder()
+        .setEgressPort(port)
+        .setPayload(com.google.protobuf.ByteString.copyFrom(payload))
+        .build()
+    val outcome = PacketOutcome.newBuilder().setOutput(output).build()
+    return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
+  }
 
   private fun packetIngressEvent(ingressPort: UInt): TraceEvent =
     TraceEvent.newBuilder()


### PR DESCRIPTION
## Summary

Adds initial PSA (Portable Switch Architecture) support to 4ward — the second
architecture after v1model. **10 of 26 PSA corpus tests now pass in CI.**

- p4c backend detects `PSA_Switch`, resolves nested pipeline packages via
  `refMap_`, and emits the 6-stage pipeline.
- `PSAArchitecture.kt` drives the simulator through ingress and egress halves
  with a re-parse at the boundary — PSA's key architectural difference from
  v1model.
- Per-stage parameter rebinding handles PSA's `istd` name reuse across stages
  with different types.
- Minimal extern handler: `send_to_port`, `ingress_drop`, `egress_drop`, plus
  stub `read`/`write`/`count` for counters and registers.

## What's missing (16 tests blocked)

Each can be tackled as an independent follow-up:

| Feature | Blocked tests |
|---------|--------------|
| PSA `register.read` (returns `T` directly) | 4 tests |
| Multicast | 3 tests |
| I2E / E2E cloning | 2 tests |
| `Hash` extern | 1 test |
| `InternetChecksum` extern | 1 test |
| `Meter` extern | 1 test |
| Resubmit | 1 test |
| Recirculate | 1 test |
| `end_of_ingress` extern | 1 test |
| `lookahead` type resolution | 1 test |

## Test plan

- [x] All 43 existing tests pass (zero regressions)
- [x] 10 PSA corpus tests pass in new `psa_stf_corpus_test` suite
- [x] Format and lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)