### PR TITLE
feat: cookie support + pipeline reload clears state test

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ plane.
 
 | | BMv2 | 4ward goal | Status |
 |---|---|---|---|
-| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 [101/118 requirements](docs/P4RUNTIME_COMPLIANCE.md) |
+| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 [103/118 requirements](docs/P4RUNTIME_COMPLIANCE.md) |
 | Trace format | text | [**proto/JSON**](e2e_tests/trace_tree/clone_with_egress.golden.txtpb) | ✅ |
 | All possible traces | not natively | [**trace trees!**](docs/ROADMAP.md#track-3-trace-trees) | ✅ |
 | `@p4runtime_translation` | no | [**built-in translation engine**](#p4runtime_translation-done-right) | ✅ |

--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -19,8 +19,8 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 7.7 | VERIFY action validates without applying | N | |
 | 7.8 | VERIFY_AND_COMMIT applies atomically | Y | ConformanceTest #1 |
 | 7.9 | VERIFY_AND_SAVE / COMMIT / RECONCILE_AND_COMMIT | N/A | Two-phase commit not meaningful for a reference simulator |
-| 7.10 | Cookie stored and returned | N | |
-| 7.11 | Pipeline reload clears table entries | N | |
+| 7.10 | Cookie stored and returned | Y | ConformanceTest #59 |
+| 7.11 | Pipeline reload clears table entries | Y | ConformanceTest #58 |
 | 7.12 | Const table entries populated at load time | N | |
 
 ## General encoding (§8)
@@ -230,7 +230,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 
 | Category | Tested | Not tested | N/A |
 |----------|--------|------------|-----|
-| SetForwardingPipelineConfig | 5 | 4 | 1 |
+| SetForwardingPipelineConfig | 7 | 2 | 1 |
 | General encoding | 6 | 1 | 0 |
 | Write — tables | 28 | 1 | 0 |
 | Write — profiles | 8 | 0 | 0 |
@@ -248,4 +248,4 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Translation | 6 | 0 | 0 |
 | @refers_to | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **101** | **17** | **10** |
+| **Total** | **103** | **15** | **10** |

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -83,6 +83,43 @@ class P4RuntimeConformanceTest {
   }
 
   // =========================================================================
+  // SetForwardingPipelineConfig — state clearing & cookie (7.10, 7.11)
+  // =========================================================================
+
+  /** P4Runtime spec §7.11: reloading a pipeline clears all table entries. */
+  @Test
+  fun `58 - pipeline reload clears table entries`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    harness.installEntry(buildExactEntry(config, matchValue = 0x0800, port = 1))
+    assertEquals("entry should exist before reload", 1, harness.readEntries().size)
+
+    // Reload the same pipeline — entries should be gone.
+    harness.loadPipeline(config)
+    assertEquals("entries should be cleared after reload", 0, harness.readEntries().size)
+  }
+
+  /** P4Runtime spec §7.10: cookie set during pipeline load is returned on get. */
+  @Test
+  fun `59 - cookie round-trip through set and get`() {
+    val cookie = ForwardingPipelineConfig.Cookie.newBuilder().setCookie(0xDEADBEEF).build()
+    harness.loadPipeline(loadBasicTableConfig(), cookie)
+
+    // ALL response type should include the cookie.
+    val allResp = harness.getConfig()
+    assertEquals(0xDEADBEEF, allResp.config.cookie.cookie)
+
+    // COOKIE_ONLY should return just the cookie.
+    val cookieResp = harness.getConfig(GetForwardingPipelineConfigRequest.ResponseType.COOKIE_ONLY)
+    assertEquals(0xDEADBEEF, cookieResp.config.cookie.cookie)
+
+    // P4INFO_AND_COOKIE should include the cookie.
+    val p4InfoResp =
+      harness.getConfig(GetForwardingPipelineConfigRequest.ResponseType.P4INFO_AND_COOKIE)
+    assertEquals(0xDEADBEEF, p4InfoResp.config.cookie.cookie)
+  }
+
+  // =========================================================================
   // Write (scenarios 4-8)
   // =========================================================================
 

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -60,6 +60,7 @@ class P4RuntimeService(
   /** Bundled pipeline state — atomically swapped on pipeline load to avoid torn reads. */
   private data class PipelineState(
     val config: PipelineConfig,
+    val cookie: ForwardingPipelineConfig.Cookie,
     val typeTranslator: TypeTranslator?,
     val writeValidator: WriteValidator,
     val referenceValidator: ReferenceValidator?,
@@ -118,6 +119,7 @@ class P4RuntimeService(
       pipeline =
         PipelineState(
           config = pipelineConfig,
+          cookie = fwdConfig.cookie,
           typeTranslator = TypeTranslator.create(fwdConfig.p4Info, deviceConfig.translationsList),
           writeValidator = WriteValidator(pipelineConfig.p4Info),
           referenceValidator = ReferenceValidator.create(fwdConfig.p4Info),
@@ -359,23 +361,21 @@ class P4RuntimeService(
   override suspend fun getForwardingPipelineConfig(
     request: GetForwardingPipelineConfigRequest
   ): GetForwardingPipelineConfigResponse {
-    val config = requirePipeline().config
+    val state = requirePipeline()
 
-    val fwdConfig = ForwardingPipelineConfig.newBuilder()
+    val fwdConfig = ForwardingPipelineConfig.newBuilder().setCookie(state.cookie)
     when (request.responseType) {
       GetForwardingPipelineConfigRequest.ResponseType.ALL,
       GetForwardingPipelineConfigRequest.ResponseType.UNRECOGNIZED -> {
-        fwdConfig.setP4Info(config.p4Info)
-        fwdConfig.setP4DeviceConfig(config.device.toByteString())
+        fwdConfig.setP4Info(state.config.p4Info)
+        fwdConfig.setP4DeviceConfig(state.config.device.toByteString())
       }
-      GetForwardingPipelineConfigRequest.ResponseType.COOKIE_ONLY -> {
-        // No cookie support — return empty config.
-      }
+      GetForwardingPipelineConfigRequest.ResponseType.COOKIE_ONLY -> {}
       GetForwardingPipelineConfigRequest.ResponseType.P4INFO_AND_COOKIE -> {
-        fwdConfig.setP4Info(config.p4Info)
+        fwdConfig.setP4Info(state.config.p4Info)
       }
       GetForwardingPipelineConfigRequest.ResponseType.DEVICE_CONFIG_AND_COOKIE -> {
-        fwdConfig.setP4DeviceConfig(config.device.toByteString())
+        fwdConfig.setP4DeviceConfig(state.config.device.toByteString())
       }
     }
 

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -76,7 +76,10 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
   // Pipeline management
   // ---------------------------------------------------------------------------
 
-  fun loadPipeline(config: PipelineConfig): SetForwardingPipelineConfigResponse = runBlocking {
+  fun loadPipeline(
+    config: PipelineConfig,
+    cookie: ForwardingPipelineConfig.Cookie = ForwardingPipelineConfig.Cookie.getDefaultInstance(),
+  ): SetForwardingPipelineConfigResponse = runBlocking {
     stub.setForwardingPipelineConfig(
       SetForwardingPipelineConfigRequest.newBuilder()
         .setDeviceId(1)
@@ -85,6 +88,7 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
           ForwardingPipelineConfig.newBuilder()
             .setP4Info(config.p4Info)
             .setP4DeviceConfig(config.device.toByteString())
+            .setCookie(cookie)
         )
         .build()
     )


### PR DESCRIPTION
## Summary

Two P4Runtime compliance quick wins:

- **Cookie support** (7.10): Store the cookie from `SetForwardingPipelineConfig` and return it in all `GetForwardingPipelineConfig` response types. Three lines of implementation in `P4RuntimeService`.
- **Pipeline reload clears entries** (7.11): Behavior already worked — added a conformance test proving it.

Brings us to **103/118** P4Runtime requirements tested.

## Test plan

- [ ] `P4RuntimeConformanceTest` #58: load pipeline, install entry, reload, verify entries cleared
- [ ] `P4RuntimeConformanceTest` #59: cookie round-trip through ALL, COOKIE_ONLY, and P4INFO_AND_COOKIE response types
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)