### PR TITLE
feat: validate device_id on Write, Read, and GetConfig RPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ plane.
 
 | | BMv2 | 4ward goal | Status |
 |---|---|---|---|
-| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 [103/118 requirements](docs/P4RUNTIME_COMPLIANCE.md) |
+| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 [106/118 requirements](docs/P4RUNTIME_COMPLIANCE.md) |
 | Trace format | text | [**proto/JSON**](e2e_tests/trace_tree/clone_with_egress.golden.txtpb) | ✅ |
 | All possible traces | not natively | [**trace trees!**](docs/ROADMAP.md#track-3-trace-trees) | ✅ |
 | `@p4runtime_translation` | no | [**built-in translation engine**](#p4runtime_translation-done-right) | ✅ |

--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -133,7 +133,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 
 | # | Requirement | Status | Test |
 |---|-------------|--------|------|
-| 9.90 | device_id validated on Write | N | |
+| 9.90 | device_id validated on Write | Y | ConformanceTest #60 |
 | 9.91 | Write allowed without prior arbitration | Y | ConformanceTest (implicit) |
 
 ## Arbitration (§5)
@@ -163,7 +163,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 11.8 | Wildcard read for registers | Y | TableStoreTest |
 | 11.9 | Read unwritten register returns zero | Y | ConformanceTest #33 |
 | 11.10 | Default entry included in wildcard table reads | N | |
-| 11.11 | device_id validated on Read | N | |
+| 11.11 | device_id validated on Read | Y | ConformanceTest #61 |
 
 ## GetForwardingPipelineConfig (§7)
 
@@ -174,7 +174,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 12.3 | P4INFO_AND_COOKIE omits device config | Y | ConformanceTest #18 |
 | 12.4 | DEVICE_CONFIG_AND_COOKIE omits p4info | Y | ConformanceTest #22 |
 | 12.5 | COOKIE_ONLY returns empty config | Y | ConformanceTest #36 |
-| 12.6 | device_id validated | N | |
+| 12.6 | device_id validated | Y | ConformanceTest #62 |
 
 ## Capabilities (§17)
 
@@ -239,13 +239,13 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Write — PRE | 6 | 0 | 0 |
 | Write — other entities | 0 | 0 | 3 |
 | Write — atomicity | 0 | 3 | 1 |
-| Write — general | 1 | 1 | 0 |
+| Write — general | 2 | 0 | 0 |
 | Arbitration | 4 | 3 | 1 |
-| Read | 9 | 2 | 0 |
-| GetForwardingPipelineConfig | 5 | 1 | 0 |
+| Read | 10 | 1 | 0 |
+| GetForwardingPipelineConfig | 6 | 0 | 0 |
 | Capabilities | 1 | 0 | 0 |
 | StreamChannel | 3 | 1 | 4 |
 | Translation | 6 | 0 | 0 |
 | @refers_to | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **103** | **15** | **10** |
+| **Total** | **106** | **12** | **10** |

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -949,6 +949,61 @@ class P4RuntimeConformanceTest {
     assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.installEntry(directMeterEntity) }
   }
 
+  // =========================================================================
+  // device_id validation (scenarios 60-62)
+  // =========================================================================
+
+  /** P4Runtime spec §6.3: Write with wrong device_id → NOT_FOUND. */
+  @Test
+  fun `60 - write with wrong device_id returns NOT_FOUND`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    assertGrpcError(Status.Code.NOT_FOUND, "unknown device_id") {
+      runBlocking {
+        harness.stub.write(
+          p4.v1.P4RuntimeOuterClass.WriteRequest.newBuilder()
+            .setDeviceId(999)
+            .addUpdates(
+              p4.v1.P4RuntimeOuterClass.Update.newBuilder()
+                .setType(p4.v1.P4RuntimeOuterClass.Update.Type.INSERT)
+                .setEntity(buildExactEntry(config, matchValue = 0x0800, port = 1))
+            )
+            .build()
+        )
+      }
+    }
+  }
+
+  /** P4Runtime spec §6.3: Read with wrong device_id → NOT_FOUND. */
+  @Test
+  fun `61 - read with wrong device_id returns NOT_FOUND`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    assertGrpcError(Status.Code.NOT_FOUND, "unknown device_id") {
+      harness.readEntries(
+        ReadRequest.newBuilder()
+          .setDeviceId(999)
+          .addEntities(
+            Entity.newBuilder()
+              .setTableEntry(p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(0))
+          )
+          .build()
+      )
+    }
+  }
+
+  /** P4Runtime spec §6.3: GetForwardingPipelineConfig with wrong device_id → NOT_FOUND. */
+  @Test
+  fun `62 - getForwardingPipelineConfig with wrong device_id returns NOT_FOUND`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    assertGrpcError(Status.Code.NOT_FOUND, "unknown device_id") {
+      runBlocking {
+        harness.stub.getForwardingPipelineConfig(
+          GetForwardingPipelineConfigRequest.newBuilder().setDeviceId(999).build()
+        )
+      }
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Test helpers
   // ---------------------------------------------------------------------------

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -55,6 +55,7 @@ class P4RuntimeService(
   private val simulator: Simulator,
   private val constraintValidatorBinary: Path? = null,
   private val lock: Mutex = Mutex(),
+  private val deviceId: Long = DEFAULT_DEVICE_ID,
 ) : P4RuntimeGrpcKt.P4RuntimeCoroutineImplBase(), Closeable {
 
   /** Bundled pipeline state — atomically swapped on pipeline load to avoid torn reads. */
@@ -85,6 +86,7 @@ class P4RuntimeService(
     request: SetForwardingPipelineConfigRequest
   ): SetForwardingPipelineConfigResponse =
     lock.withLock {
+      requireDeviceId(request.deviceId)
       val fwdConfig = request.config
       if (!fwdConfig.hasP4Info() || fwdConfig.p4DeviceConfig.isEmpty) {
         throw Status.INVALID_ARGUMENT.withDescription(
@@ -136,6 +138,7 @@ class P4RuntimeService(
 
   override suspend fun write(request: WriteRequest): WriteResponse =
     lock.withLock {
+      requireDeviceId(request.deviceId)
       val state = requirePipeline()
       requirePrimaryOrNoArbitration(request.electionId)
       when (request.atomicity) {
@@ -247,6 +250,7 @@ class P4RuntimeService(
     // so the pipeline can't be swapped mid-read.
     val response =
       lock.withLock {
+        requireDeviceId(request.deviceId)
         val state = requirePipeline()
         val entities = simulator.readEntries(request.entitiesList)
         if (entities.isNotEmpty()) {
@@ -361,6 +365,7 @@ class P4RuntimeService(
   override suspend fun getForwardingPipelineConfig(
     request: GetForwardingPipelineConfigRequest
   ): GetForwardingPipelineConfigResponse {
+    requireDeviceId(request.deviceId)
     val state = requirePipeline()
 
     val fwdConfig = ForwardingPipelineConfig.newBuilder().setCookie(state.cookie)
@@ -406,6 +411,16 @@ class P4RuntimeService(
     }
   }
 
+  /** Rejects requests targeting a different device (P4Runtime spec §6.3). */
+  private fun requireDeviceId(requestDeviceId: Long) {
+    if (requestDeviceId != deviceId) {
+      throw Status.NOT_FOUND.withDescription(
+          "unknown device_id $requestDeviceId (this device is $deviceId)"
+        )
+        .asException()
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Unsupported feature guards
   // ---------------------------------------------------------------------------
@@ -445,6 +460,8 @@ class P4RuntimeService(
   }
 
   companion object {
+    private const val DEFAULT_DEVICE_ID = 1L
+
     // Well-known metadata IDs for v1model packet_in/packet_out headers.
     private const val INGRESS_PORT_METADATA_ID = 1
     private const val EGRESS_PORT_METADATA_ID = 2


### PR DESCRIPTION
## Summary

The P4Runtime server now validates `device_id` on all RPCs that carry it (Write, Read, GetForwardingPipelineConfig, SetForwardingPipelineConfig). Requests with a non-matching device_id get `NOT_FOUND`, per P4Runtime spec §6.3.

One `requireDeviceId` helper, four call sites, three conformance tests. **106/118** requirements tested.

## Test plan

- [ ] ConformanceTest #60: Write with wrong device_id → NOT_FOUND
- [ ] ConformanceTest #61: Read with wrong device_id → NOT_FOUND
- [ ] ConformanceTest #62: GetForwardingPipelineConfig with wrong device_id → NOT_FOUND
- [ ] All existing tests pass (they all use device_id=1, the default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)