### PR TITLE
Close 4 P4Runtime compliance gaps (115/128)

### DIFF
--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -15,13 +15,13 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 7.3 | Empty/invalid config → INVALID_ARGUMENT | Y | ConformanceTest #3 |
 | 7.4 | Invalid p4_device_config bytes → INVALID_ARGUMENT | Y | ConformanceTest #37 |
 | 7.5 | Missing p4_device_config → INVALID_ARGUMENT | Y | ConformanceTest #38 |
-| 7.6 | Requires primary controller when arbitration is active | N | |
+| 7.6 | Requires primary controller when arbitration is active | Y | ConformanceTest #66 |
 | 7.7 | VERIFY action validates without applying | N | |
 | 7.8 | VERIFY_AND_COMMIT applies atomically | Y | ConformanceTest #1 |
 | 7.9 | VERIFY_AND_SAVE / COMMIT / RECONCILE_AND_COMMIT | N/A | Two-phase commit not meaningful for a reference simulator |
 | 7.10 | Cookie stored and returned | Y | ConformanceTest #59 |
 | 7.11 | Pipeline reload clears table entries | Y | ConformanceTest #58 |
-| 7.12 | Const table entries populated at load time | N | |
+| 7.12 | Const table entries populated at load time | Y | ConformanceTest #65 |
 
 ## General encoding (§8)
 
@@ -67,7 +67,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 9.26 | Default entry: MODIFY semantics | Y | WriteValidatorTest |
 | 9.27 | RESOURCE_EXHAUSTED when table is full | Y | TableStoreTest, ConformanceTest |
 | 9.28 | Write batch: updates applied in order | Y | ConformanceTest #39 |
-| 9.29 | Direct counter/meter data in table entry reads | N | |
+| 9.29 | Direct counter/meter data in table entry reads | Y | ConformanceTest #68-69 |
 
 ## Write RPC — action profiles (§9.2)
 
@@ -189,7 +189,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 14.1 | PacketOut processed, PacketIn returned | Y | ConformanceTest #13 |
 | 14.2 | PacketOut with table entries forwards correctly | Y | ConformanceTest #14 |
 | 14.3 | Multiple packets preserve ordering | Y | ConformanceTest #15 |
-| 14.4 | StreamError on invalid stream message | N | |
+| 14.4 | StreamError on invalid stream message | Y | ConformanceTest #67 |
 | 14.5 | Digest delivery | N/A | Out of scope — no real packet rates to trigger digests |
 | 14.6 | DigestListAck handling | N/A | Digests out of scope |
 | 14.7 | Idle timeout notifications | N/A | Out of scope — no wall-clock time in a reference simulator |
@@ -230,9 +230,9 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 
 | Category | Tested | Not tested | N/A |
 |----------|--------|------------|-----|
-| SetForwardingPipelineConfig | 7 | 2 | 1 |
+| SetForwardingPipelineConfig | 9 | 0 | 1 |
 | General encoding | 7 | 0 | 0 |
-| Write — tables | 28 | 1 | 0 |
+| Write — tables | 29 | 0 | 0 |
 | Write — profiles | 8 | 0 | 0 |
 | Write — registers | 5 | 0 | 0 |
 | Write — counters/meters | 4 | 0 | 0 |
@@ -244,8 +244,8 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Read | 11 | 0 | 0 |
 | GetForwardingPipelineConfig | 6 | 0 | 0 |
 | Capabilities | 1 | 0 | 0 |
-| StreamChannel | 3 | 1 | 4 |
+| StreamChannel | 4 | 0 | 4 |
 | Translation | 6 | 0 | 0 |
 | @refers_to | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **111** | **7** | **10** |
+| **Total** | **115** | **3** | **10** |

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -41,7 +41,14 @@ _MANUAL = []
 [p4c_compile(
     name,
     "%s.p4" % name,
-) for name in _P4_PROGRAMS]
+) for name in _P4_PROGRAMS if name != "clone_with_egress"]
+
+# Compiled separately so p4runtime conformance tests can use it as a data dep.
+p4c_compile(
+    name = "clone_with_egress",
+    src_p4 = "clone_with_egress.p4",
+    visibility = ["//p4runtime:__pkg__"],
+)
 
 _TEST_DEPS = [
     "//e2e_tests/stf:stf_runner",

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -94,6 +94,7 @@ kt_jvm_test(
     data = [
         "//e2e_tests/basic_table:basic_table_pb",
         "//e2e_tests/passthrough:passthrough_pb",
+        "//e2e_tests/trace_tree:clone_with_egress_pb",
     ],
     test_class = "fourward.p4runtime.P4RuntimeConformanceTest",
     deps = [

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -17,11 +17,14 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import p4.v1.P4RuntimeOuterClass
 import p4.v1.P4RuntimeOuterClass.Entity
 import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
 import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigRequest
 import p4.v1.P4RuntimeOuterClass.ReadRequest
 import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.StreamMessageRequest
+import p4.v1.P4RuntimeOuterClass.Uint128
 
 /**
  * P4Runtime conformance tests.
@@ -55,6 +58,9 @@ class P4RuntimeConformanceTest {
 
   private fun loadPassthroughConfig() =
     P4RuntimeTestHarness.loadConfig("e2e_tests/passthrough/passthrough.txtpb")
+
+  private fun loadConstEntriesConfig() =
+    P4RuntimeTestHarness.loadConfig("e2e_tests/trace_tree/clone_with_egress.txtpb")
 
   // =========================================================================
   // SetForwardingPipelineConfig (scenarios 1-3)
@@ -1075,6 +1081,172 @@ class P4RuntimeConformanceTest {
       "default action should be drop",
       dropAction.preamble.id,
       defaultEntry.action.action.actionId,
+    )
+  }
+
+  // =========================================================================
+  // Const table entries populated at load time (scenario 65)
+  // =========================================================================
+
+  /** P4Runtime spec §7: const entries in P4 source appear after pipeline load. */
+  @Test
+  fun `65 - const entries populated at load time`() {
+    val config = loadConstEntriesConfig()
+    harness.loadPipeline(config)
+
+    // The clone_with_egress program has a table `egress_classify` with 2 const entries.
+    val egressTable =
+      config.p4Info.tablesList.first { it.preamble.name.contains("egress_classify") }
+    val entries = harness.readRegularTableEntries(egressTable.preamble.id)
+    assertEquals("expected 2 const entries", 2, entries.size)
+
+    // P4Runtime spec §9.1: const tables are immutable.
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.modifyEntry(entries[0]) }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.deleteEntry(entries[0]) }
+  }
+
+  // =========================================================================
+  // SetPipeline requires primary controller (scenario 66)
+  // =========================================================================
+
+  /** P4Runtime spec §7: SetForwardingPipelineConfig requires primary when arbitration active. */
+  @Test
+  fun `66 - SetPipeline from non-primary returns PERMISSION_DENIED`() {
+    // Establish primary with election_id=5.
+    harness.openStream().use { stream -> stream.arbitrate(electionId = 5) }
+
+    // Attempt SetPipeline with election_id=3 (non-primary).
+    val config = loadBasicTableConfig()
+    assertGrpcError(Status.Code.PERMISSION_DENIED) {
+      runBlocking {
+        harness.stub.setForwardingPipelineConfig(
+          SetForwardingPipelineConfigRequest.newBuilder()
+            .setDeviceId(1)
+            .setElectionId(Uint128.newBuilder().setHigh(0).setLow(3))
+            .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+            .setConfig(harness.buildForwardingPipelineConfig(config))
+            .build()
+        )
+      }
+    }
+  }
+
+  // =========================================================================
+  // StreamError on invalid stream message (scenario 67)
+  // =========================================================================
+
+  /** P4Runtime spec §16: unrecognized stream messages get a StreamError response. */
+  @Test
+  fun `67 - unrecognized stream message returns StreamError`() {
+    harness.openStream().use { stream ->
+      stream.arbitrate()
+      // Send an empty StreamMessageRequest (no oneof field set).
+      val response = stream.sendRaw(StreamMessageRequest.getDefaultInstance())
+      assertNotNull("expected a StreamError response", response)
+      assertTrue("should be a StreamError", response!!.hasError())
+      assertEquals(com.google.rpc.Code.INVALID_ARGUMENT_VALUE, response.error.canonicalCode)
+    }
+  }
+
+  // =========================================================================
+  // Direct counter/meter data in table entry reads (scenario 68)
+  // =========================================================================
+
+  /** P4Runtime spec §9.1: table entry reads include inline direct counter data. */
+  @Test
+  fun `68 - table entry read includes direct counter data`() {
+    val config = loadConfigWithDirectCounter()
+    harness.loadPipeline(config)
+    val tableEntry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(tableEntry)
+
+    // Write direct counter data.
+    val directCounterEntity =
+      Entity.newBuilder()
+        .setDirectCounterEntry(
+          P4RuntimeOuterClass.DirectCounterEntry.newBuilder()
+            .setTableEntry(tableEntry.tableEntry)
+            .setData(
+              P4RuntimeOuterClass.CounterData.newBuilder().setPacketCount(42).setByteCount(1000)
+            )
+        )
+        .build()
+    harness.modifyEntry(directCounterEntity)
+
+    // Read table entries — counter_data should be inlined.
+    val results = harness.readRegularEntries()
+    assertEquals(1, results.size)
+    assertTrue("should have counter_data", results[0].tableEntry.hasCounterData())
+    assertEquals(42, results[0].tableEntry.counterData.packetCount)
+    assertEquals(1000, results[0].tableEntry.counterData.byteCount)
+  }
+
+  /** P4Runtime spec §9.1: table entry reads include inline direct meter config. */
+  @Test
+  fun `69 - table entry read includes direct meter config`() {
+    val config = loadConfigWithDirectMeter()
+    harness.loadPipeline(config)
+    val tableEntry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(tableEntry)
+
+    // Write direct meter config.
+    val directMeterEntity =
+      Entity.newBuilder()
+        .setDirectMeterEntry(
+          P4RuntimeOuterClass.DirectMeterEntry.newBuilder()
+            .setTableEntry(tableEntry.tableEntry)
+            .setConfig(
+              P4RuntimeOuterClass.MeterConfig.newBuilder()
+                .setCir(1000)
+                .setCburst(500)
+                .setPir(2000)
+                .setPburst(1000)
+            )
+        )
+        .build()
+    harness.modifyEntry(directMeterEntity)
+
+    // Read table entries — meter_config should be inlined.
+    val results = harness.readRegularEntries()
+    assertEquals(1, results.size)
+    assertTrue("should have meter_config", results[0].tableEntry.hasMeterConfig())
+    assertEquals(1000, results[0].tableEntry.meterConfig.cir)
+    assertEquals(2000, results[0].tableEntry.meterConfig.pir)
+  }
+
+  /** P4Runtime spec §9.1: unwritten direct counter defaults to zero in table reads. */
+  @Test
+  fun `70 - table entry read includes zero counter data for unwritten direct counter`() {
+    val config = loadConfigWithDirectCounter()
+    harness.loadPipeline(config)
+    val tableEntry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(tableEntry)
+
+    // Do NOT write any counter data — the read should still include counter_data with zeros.
+    val results = harness.readRegularEntries()
+    assertEquals(1, results.size)
+    assertTrue(
+      "should have counter_data even without explicit write",
+      results[0].tableEntry.hasCounterData(),
+    )
+    assertEquals(0, results[0].tableEntry.counterData.packetCount)
+    assertEquals(0, results[0].tableEntry.counterData.byteCount)
+  }
+
+  /** P4Runtime spec §9.1: unwritten direct meter is omitted from table reads (unlike counters). */
+  @Test
+  fun `71 - table entry read omits meter config for unwritten direct meter`() {
+    val config = loadConfigWithDirectMeter()
+    harness.loadPipeline(config)
+    val tableEntry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(tableEntry)
+
+    // Do NOT write any meter config — the read should NOT include meter_config.
+    val results = harness.readRegularEntries()
+    assertEquals(1, results.size)
+    assertFalse(
+      "should not have meter_config without explicit write",
+      results[0].tableEntry.hasMeterConfig(),
     )
   }
 

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -87,6 +87,7 @@ class P4RuntimeService(
   ): SetForwardingPipelineConfigResponse =
     lock.withLock {
       requireDeviceId(request.deviceId)
+      requirePrimaryOrNoArbitration(request.electionId)
       val fwdConfig = request.config
       if (!fwdConfig.hasP4Info() || fwdConfig.p4DeviceConfig.isEmpty) {
         throw Status.INVALID_ARGUMENT.withDescription(
@@ -302,6 +303,18 @@ class P4RuntimeService(
           }
           msg.hasDigestAck() ->
             throw Status.UNIMPLEMENTED.withDescription(DIGEST_NOT_SUPPORTED).asException()
+          // P4Runtime spec §16: unrecognized stream messages get an error response.
+          else ->
+            emit(
+              StreamMessageResponse.newBuilder()
+                .setError(
+                  P4RuntimeOuterClass.StreamError.newBuilder()
+                    .setCanonicalCode(com.google.rpc.Code.INVALID_ARGUMENT_VALUE)
+                    .setMessage("unrecognized stream message")
+                    .setOther(P4RuntimeOuterClass.StreamOtherError.getDefaultInstance())
+                )
+                .build()
+            )
         }
       }
     }

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -76,6 +76,17 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
   // Pipeline management
   // ---------------------------------------------------------------------------
 
+  /** Converts a [PipelineConfig] to the gRPC [ForwardingPipelineConfig] wire format. */
+  fun buildForwardingPipelineConfig(
+    config: PipelineConfig,
+    cookie: ForwardingPipelineConfig.Cookie = ForwardingPipelineConfig.Cookie.getDefaultInstance(),
+  ): ForwardingPipelineConfig =
+    ForwardingPipelineConfig.newBuilder()
+      .setP4Info(config.p4Info)
+      .setP4DeviceConfig(config.device.toByteString())
+      .setCookie(cookie)
+      .build()
+
   fun loadPipeline(
     config: PipelineConfig,
     cookie: ForwardingPipelineConfig.Cookie = ForwardingPipelineConfig.Cookie.getDefaultInstance(),
@@ -84,12 +95,7 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
       SetForwardingPipelineConfigRequest.newBuilder()
         .setDeviceId(1)
         .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
-        .setConfig(
-          ForwardingPipelineConfig.newBuilder()
-            .setP4Info(config.p4Info)
-            .setP4DeviceConfig(config.device.toByteString())
-            .setCookie(cookie)
-        )
+        .setConfig(buildForwardingPipelineConfig(config, cookie))
         .build()
     )
   }
@@ -377,6 +383,12 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
           )
           .build()
       )
+      withTimeoutOrNull(STREAM_TIMEOUT_MS) { responseChannel.receive() }
+    }
+
+    /** Sends an arbitrary stream message and waits for a response. */
+    fun sendRaw(msg: StreamMessageRequest): StreamMessageResponse? = runBlocking {
+      requestChannel.send(msg)
       withTimeoutOrNull(STREAM_TIMEOUT_MS) { responseChannel.receive() }
     }
 

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -552,18 +552,10 @@ class TableStore {
       P4RuntimeOuterClass.DirectCounterEntry.getDefaultInstance()
   ): List<P4RuntimeOuterClass.Entity> {
     val tableEntry = filter.tableEntry
-    val tablesToRead =
-      if (tableEntry.tableId == 0) directCounterTables
-      else {
-        val tableName = tableNameById[tableEntry.tableId] ?: return emptyList()
-        if (tableName !in directCounterTables) return emptyList()
-        setOf(tableName)
-      }
-    val hasMatchFilter = tableEntry.matchCount > 0
-    return tablesToRead.flatMap { tableName ->
-      val entries = tables[tableName] ?: return@flatMap emptyList()
-      val filtered = if (hasMatchFilter) entries.filter { it.sameKey(tableEntry) } else entries
-      filtered.map { entry ->
+    val tableNames = resolveTableNames(tableEntry.tableId, directCounterTables)
+    val matchFilter = if (tableEntry.matchCount > 0) tableEntry else null
+    return tableNames.flatMap { tableName ->
+      filteredEntries(tableName, matchFilter).map { entry ->
         val data = directCounterData[entry] ?: P4RuntimeOuterClass.CounterData.getDefaultInstance()
         P4RuntimeOuterClass.Entity.newBuilder()
           .setDirectCounterEntry(
@@ -591,18 +583,10 @@ class TableStore {
       P4RuntimeOuterClass.DirectMeterEntry.getDefaultInstance()
   ): List<P4RuntimeOuterClass.Entity> {
     val tableEntry = filter.tableEntry
-    val tablesToRead =
-      if (tableEntry.tableId == 0) directMeterTables
-      else {
-        val tableName = tableNameById[tableEntry.tableId] ?: return emptyList()
-        if (tableName !in directMeterTables) return emptyList()
-        setOf(tableName)
-      }
-    val hasMatchFilter = tableEntry.matchCount > 0
-    return tablesToRead.flatMap { tableName ->
-      val entries = tables[tableName] ?: return@flatMap emptyList()
-      val filtered = if (hasMatchFilter) entries.filter { it.sameKey(tableEntry) } else entries
-      filtered.map { entry ->
+    val tableNames = resolveTableNames(tableEntry.tableId, directMeterTables)
+    val matchFilter = if (tableEntry.matchCount > 0) tableEntry else null
+    return tableNames.flatMap { tableName ->
+      filteredEntries(tableName, matchFilter).map { entry ->
         val builder = P4RuntimeOuterClass.DirectMeterEntry.newBuilder().setTableEntry(entry)
         directMeterData[entry]?.let { builder.setConfig(it) }
         P4RuntimeOuterClass.Entity.newBuilder().setDirectMeterEntry(builder).build()
@@ -848,6 +832,25 @@ class TableStore {
   // Read
   // -------------------------------------------------------------------------
 
+  /** Resolves table names for a read, optionally restricted to [scope]. */
+  private fun resolveTableNames(tableId: Int, scope: Set<String>? = null): Collection<String> {
+    if (tableId == 0) return scope ?: tableNameById.values
+    val name = tableNameById[tableId] ?: return emptyList()
+    if (scope != null && name !in scope) return emptyList()
+    return listOf(name)
+  }
+
+  /** Returns entries from [tableName], filtered by match key if [matchFilter] is non-null. */
+  private fun filteredEntries(
+    tableName: String,
+    matchFilter: P4RuntimeOuterClass.TableEntry?,
+  ): List<P4RuntimeOuterClass.TableEntry> {
+    val entries = tables[tableName] ?: return emptyList()
+    if (matchFilter == null) return entries
+    // P4Runtime spec §9.1: match key + priority uniquely identify an entry.
+    return listOfNotNull(entries.find { it.sameKey(matchFilter) })
+  }
+
   /**
    * Returns table entries as P4Runtime Entity protos, filtered by [filter].
    * - `table_id=0`, no match fields → wildcard: returns all entries from all tables.
@@ -858,24 +861,30 @@ class TableStore {
   fun readEntities(
     filter: P4RuntimeOuterClass.TableEntry = P4RuntimeOuterClass.TableEntry.getDefaultInstance()
   ): List<P4RuntimeOuterClass.Entity> {
+    val tableNames = resolveTableNames(filter.tableId)
     val hasMatchFilter = filter.matchCount > 0
-    val tableNames =
-      if (filter.tableId != 0) listOfNotNull(tableNameById[filter.tableId])
-      else tableNameById.values.toList()
+    val matchFilter = if (hasMatchFilter) filter else null
 
     val entries =
-      tableNames
-        .mapNotNull { tables[it] }
-        .flatMap { entries ->
-          // P4Runtime spec §9.1: match key + priority uniquely identify an entry,
-          // so at most one entry can match a filter with match fields.
-          if (hasMatchFilter) listOfNotNull(entries.find { it.sameKey(filter) }) else entries
+      tableNames.flatMap { tableName ->
+        val hasDirectCounter = tableName in directCounterTables
+        val hasDirectMeter = tableName in directMeterTables
+        filteredEntries(tableName, matchFilter).map { entry ->
+          val builder = entry.toBuilder()
+          // P4Runtime spec §9.1: table entry reads include inline direct resource data.
+          // Counters default to zero; meters are only included if explicitly configured.
+          if (hasDirectCounter) {
+            builder.setCounterData(
+              directCounterData[entry] ?: P4RuntimeOuterClass.CounterData.getDefaultInstance()
+            )
+          }
+          if (hasDirectMeter) directMeterData[entry]?.let { builder.setMeterConfig(it) }
+          P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(builder).build()
         }
-        .map { P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(it).build() }
+      }
 
     // P4Runtime spec §11.1: wildcard reads (no match filter) include the default entry.
     if (hasMatchFilter) return entries
-
     return entries + tableNames.mapNotNull { defaultEntryByTable[it] }
   }
 


### PR DESCRIPTION
## Summary

Closes 4 P4Runtime compliance gaps, bringing coverage from 111 → 115 tested requirements (out of 128).

- **§7.12 — Const table entries at load time**: test verifies `static_entries` from `DeviceConfig` are readable and immutable after pipeline load.
- **§7.6 — Primary controller check on SetPipeline**: `requirePrimaryOrNoArbitration()` now enforced on `SetForwardingPipelineConfig`, matching the existing Write RPC guard.
- **§14.4 — StreamError on unrecognized messages**: `else` branch in the `streamChannel` `when` expression returns `StreamError(INVALID_ARGUMENT)` instead of silently dropping.
- **§9.29 — Direct counter/meter data in table entry reads**: `readEntities()` now attaches inline `counter_data` (defaulting to zeros) and `meter_config` (only when explicitly set) per P4Runtime spec §9.1.

Also refactored the three table-read methods (`readEntities`, `readDirectCounterEntries`, `readDirectMeterEntries`) to share `resolveTableNames` / `filteredEntries` helpers, eliminating duplicated table resolution and entry filtering logic.

7 new conformance tests (#65–71).

## Test plan

- [x] `bazel test //p4runtime:P4RuntimeConformanceTest` — 44 tests pass
- [x] `bazel test //simulator:TableStoreTest` — passes
- [x] `./tools/format.sh` and `./tools/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)