### PR TITLE
PSA multicast replication (17/26 corpus tests)

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -12,11 +12,11 @@ guilt — just write it down so someone can find it later.
 
 ## Architecture support
 
-- **PSA: basic pipeline + registers.** The PSA two-pipeline architecture
+- **PSA: pipeline, registers, multicast.** The PSA two-pipeline architecture
   (ingress + egress) is implemented with support for `send_to_port`,
-  `ingress_drop`, `egress_drop`, registers, basic counters, and top-level
-  assignments. 14 of 26 PSA corpus tests pass. Missing:
-  `Hash`/`InternetChecksum`/`Meter` externs, multicast, I2E/E2E cloning,
+  `ingress_drop`, `egress_drop`, `multicast`, registers, basic counters, and
+  top-level assignments. 17 of 26 PSA corpus tests pass. Missing:
+  `Hash`/`InternetChecksum`/`Meter` externs, I2E/E2E cloning,
   resubmit, recirculate, `end_of_ingress`, `lookahead` type resolution.
   PNA and TNA are not implemented.
 

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -226,7 +226,8 @@ corpus_test_suite(
 )
 
 # PSA corpus STF tests that pass in CI. Covers basic PSA pipeline: ingress/egress
-# parsing, drop-by-default, send_to_port, counters, metadata, parser errors.
+# parsing, drop-by-default, send_to_port, counters, metadata, parser errors,
+# registers, and multicast.
 corpus_test_suite(
     name = "psa_stf_corpus_test",
     tests = [
@@ -237,6 +238,9 @@ corpus_test_suite(
         "psa-example-register2-bmv2",
         "psa-fwd-bmv2",
         "psa-metadata-bmv2",
+        "psa-multicast-basic-2-bmv2",
+        "psa-multicast-basic-bmv2",
+        "psa-multicast-basic-corrected-bmv2",
         "psa-parser-error-test-bmv2",
         "psa-register-complex-bmv2",
         "psa-register-read-write-2-bmv2",
@@ -261,9 +265,6 @@ corpus_test_suite(
         "psa-example-dpdk-varbit-bmv2",  # lookahead type resolution
         "psa-i2e-cloning-basic-bmv2",  # I2E cloning
         "psa-meter7-bmv2",  # Meter extern (execute method)
-        "psa-multicast-basic-2-bmv2",  # Multicast
-        "psa-multicast-basic-bmv2",  # Multicast
-        "psa-multicast-basic-corrected-bmv2",  # Multicast
         "psa-recirculate-no-meta-bmv2",  # Recirculate
         "psa-resubmit-bmv2",  # Resubmit
     ],

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -207,6 +207,7 @@ kt_jvm_test(
     deps = [
         ":interpreter_test_dsl",
         ":ir_java_proto",
+        ":p4runtime_java_proto",
         ":simulator_java_proto",
         ":simulator_lib",
         "@maven//:com_google_protobuf_protobuf_java",

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -5,6 +5,9 @@ import fourward.ir.v1.PipelineStage
 import fourward.ir.v1.TypeDecl
 import fourward.sim.v1.SimulatorProto.Drop
 import fourward.sim.v1.SimulatorProto.DropReason
+import fourward.sim.v1.SimulatorProto.Fork
+import fourward.sim.v1.SimulatorProto.ForkBranch
+import fourward.sim.v1.SimulatorProto.ForkReason
 import fourward.sim.v1.SimulatorProto.PacketIngressEvent
 import fourward.sim.v1.SimulatorProto.PacketOutcome
 import fourward.sim.v1.SimulatorProto.PipelineStageEvent
@@ -41,70 +44,183 @@ class PSAArchitecture : Architecture {
   ): PipelineResult {
     val typesByName = config.typesList.associateBy { it.name }
     val stages = config.architecture.stagesList
-
-    // Build a lookup from block name → params for per-stage parameter binding.
     val blockParams = buildBlockParamsMap(config)
 
     // === Ingress pipeline ===
-    val ingressCtx = PacketContext(payload)
-    val ingressEnv = Environment()
-    val ingressValues = createDefaultValues(config, typesByName)
+    val ingress =
+      runIngressPipeline(config, tableStore, stages, blockParams, typesByName, payload, ingressPort)
+    if (ingress.dropped) return buildDropResult(ingress.events)
 
-    initIngressMetadata(ingressValues, ingressPort)
-    val ingressOutput = ingressValues["psa_ingress_output_metadata_t"] as? StructVal
+    // === Traffic Manager: multicast vs. unicast ===
+    val egressState =
+      EgressState(config, typesByName, stages, blockParams, tableStore, ingress.output)
+    val multicastGroup =
+      (ingress.output?.fields?.get("multicast_group") as? BitVal)?.bits?.value?.toInt() ?: 0
 
-    val ingressInterpreter =
-      Interpreter(config, tableStore, ingressCtx, emptyMap(), createPsaExternHandler(tableStore))
+    if (multicastGroup != 0) {
+      return multicastFork(egressState, ingress, multicastGroup)
+    }
 
-    ingressCtx.addTraceEvent(packetIngressEvent(ingressPort))
+    val egressPort =
+      (ingress.output?.fields?.get("egress_port") as? BitVal)?.bits?.value?.toInt() ?: 0
+
+    // === Unicast egress ===
+    val egressTrace =
+      runEgressPipeline(egressState, ingress.deparsedBytes, egressPort, 0, "NORMAL_UNICAST")
+
+    // Flatten ingress + egress events into a single trace.
+    val tree =
+      TraceTree.newBuilder().addAllEvents(ingress.events).addAllEvents(egressTrace.eventsList)
+    if (egressTrace.hasPacketOutcome()) tree.setPacketOutcome(egressTrace.packetOutcome)
+    return PipelineResult(tree.build())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ingress pipeline
+  // ---------------------------------------------------------------------------
+
+  /** Result of running the ingress pipeline (parser → control → drop check → deparser). */
+  private class IngressResult(
+    val events: List<TraceEvent>,
+    val output: StructVal?,
+    val deparsedBytes: ByteArray,
+    val dropped: Boolean,
+  )
+
+  private fun runIngressPipeline(
+    config: BehavioralConfig,
+    tableStore: TableStore,
+    stages: List<PipelineStage>,
+    blockParams: Map<String, List<BlockParam>>,
+    typesByName: Map<String, TypeDecl>,
+    payload: ByteArray,
+    ingressPort: UInt,
+  ): IngressResult {
+    val ctx = PacketContext(payload)
+    val env = Environment()
+    val values = createDefaultValues(config, typesByName)
+
+    initIngressMetadata(values, ingressPort)
+    val output = values["psa_ingress_output_metadata_t"] as? StructVal
+
+    val interpreter =
+      Interpreter(config, tableStore, ctx, emptyMap(), createPsaExternHandler(tableStore))
+
+    ctx.addTraceEvent(packetIngressEvent(ingressPort))
 
     // --- Ingress Parser ---
-    val ingressParserStage = stages.first { it.name == "ingress_parser" }
-    bindStageParams(ingressEnv, ingressParserStage.blockName, blockParams, ingressValues)
-    runParserStage(ingressInterpreter, ingressCtx, ingressEnv, ingressParserStage) { e ->
-      (ingressValues["psa_ingress_input_metadata_t"] as? StructVal)?.let {
+    val parserStage = stages.first { it.name == "ingress_parser" }
+    bindStageParams(env, parserStage.blockName, blockParams, values)
+    runParserStage(interpreter, ctx, env, parserStage) { e ->
+      (values["psa_ingress_input_metadata_t"] as? StructVal)?.let {
         it.fields["parser_error"] = ErrorVal(e.errorName)
       }
     }
 
     // --- Ingress Control ---
-    val ingressStage = stages.first { it.name == "ingress" }
-    bindStageParams(ingressEnv, ingressStage.blockName, blockParams, ingressValues)
-    runControlStage(ingressInterpreter, ingressCtx, ingressEnv, ingressStage)
+    val controlStage = stages.first { it.name == "ingress" }
+    bindStageParams(env, controlStage.blockName, blockParams, values)
+    runControlStage(interpreter, ctx, env, controlStage)
 
     // --- Ingress drop check (PSA: drop=true by default) ---
-    if ((ingressOutput?.fields?.get("drop") as? BoolVal)?.value != false) {
-      return buildDropResult(ingressCtx.getEvents())
+    val dropped = (output?.fields?.get("drop") as? BoolVal)?.value != false
+    if (dropped) {
+      return IngressResult(ctx.getEvents(), output, byteArrayOf(), dropped = true)
     }
 
-    val egressPort =
-      (ingressOutput?.fields?.get("egress_port") as? BitVal)?.bits?.value?.toInt() ?: 0
-
     // --- Ingress Deparser ---
-    val ingressDeparserStage = stages.first { it.name == "ingress_deparser" }
-    bindStageParams(ingressEnv, ingressDeparserStage.blockName, blockParams, ingressValues)
-    runControlStage(ingressInterpreter, ingressCtx, ingressEnv, ingressDeparserStage)
+    val deparserStage = stages.first { it.name == "ingress_deparser" }
+    bindStageParams(env, deparserStage.blockName, blockParams, values)
+    runControlStage(interpreter, ctx, env, deparserStage)
 
-    val deparsedBytes = ingressCtx.outputPayload() + ingressCtx.drainRemainingInput()
-    val ingressEvents = ingressCtx.getEvents()
+    val deparsedBytes = ctx.outputPayload() + ctx.drainRemainingInput()
+    return IngressResult(ctx.getEvents(), output, deparsedBytes, dropped = false)
+  }
 
-    // === Egress pipeline (re-parses the deparsed packet) ===
+  // ---------------------------------------------------------------------------
+  // Traffic Manager: multicast
+  // ---------------------------------------------------------------------------
+
+  private fun multicastFork(
+    egressState: EgressState,
+    ingress: IngressResult,
+    multicastGroup: Int,
+  ): PipelineResult {
+    val group =
+      egressState.tableStore.getMulticastGroup(multicastGroup)
+        ?: // BMv2 psa_switch: unknown multicast group → silently drop.
+        return buildDropResult(ingress.events)
+
+    val branches =
+      group.replicasList.map { replica ->
+        val subtree =
+          runEgressPipeline(
+            egressState,
+            ingress.deparsedBytes,
+            replica.egressPort,
+            replica.instance,
+            "NORMAL_MULTICAST",
+          )
+        ForkBranch.newBuilder()
+          .setLabel("replica_${replica.instance}_port_${replica.egressPort}")
+          .setSubtree(subtree)
+          .build()
+      }
+    val tree =
+      TraceTree.newBuilder()
+        .addAllEvents(ingress.events)
+        .setForkOutcome(Fork.newBuilder().setReason(ForkReason.MULTICAST).addAllBranches(branches))
+        .build()
+    return PipelineResult(tree)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Egress pipeline (runs once per unicast, once per multicast replica)
+  // ---------------------------------------------------------------------------
+
+  /** Shared state needed to run the egress pipeline. Avoids long parameter lists. */
+  private class EgressState(
+    val config: BehavioralConfig,
+    val typesByName: Map<String, TypeDecl>,
+    val stages: List<PipelineStage>,
+    val blockParams: Map<String, List<BlockParam>>,
+    val tableStore: TableStore,
+    val ingressOutput: StructVal?,
+  )
+
+  /**
+   * Runs the full egress pipeline (parser → control → deparser) and returns its TraceTree.
+   *
+   * For multicast, this is called once per replica. For unicast, called once. The returned trace
+   * contains only egress events — the caller composes the full trace (unicast: flat merge,
+   * multicast: fork branches).
+   */
+  private fun runEgressPipeline(
+    state: EgressState,
+    deparsedBytes: ByteArray,
+    egressPort: Int,
+    instance: Int,
+    packetPath: String,
+  ): TraceTree {
     val egressCtx = PacketContext(deparsedBytes)
     val egressEnv = Environment()
-    val egressValues = createDefaultValues(config, typesByName)
+    val egressValues = createDefaultValues(state.config, state.typesByName)
 
-    initEgressMetadata(egressValues, egressPort, ingressOutput)
+    initEgressMetadata(egressValues, egressPort, instance, packetPath, state.ingressOutput)
     val egressOutput = egressValues["psa_egress_output_metadata_t"] as? StructVal
 
     val egressInterpreter =
-      Interpreter(config, tableStore, egressCtx, emptyMap(), createPsaExternHandler(tableStore))
-
-    // Carry ingress trace events into the egress context.
-    for (event in ingressEvents) egressCtx.addTraceEvent(event)
+      Interpreter(
+        state.config,
+        state.tableStore,
+        egressCtx,
+        emptyMap(),
+        createPsaExternHandler(state.tableStore),
+      )
 
     // --- Egress Parser ---
-    val egressParserStage = stages.first { it.name == "egress_parser" }
-    bindStageParams(egressEnv, egressParserStage.blockName, blockParams, egressValues)
+    val egressParserStage = state.stages.first { it.name == "egress_parser" }
+    bindStageParams(egressEnv, egressParserStage.blockName, state.blockParams, egressValues)
     runParserStage(egressInterpreter, egressCtx, egressEnv, egressParserStage) { e ->
       (egressValues["psa_egress_input_metadata_t"] as? StructVal)?.let {
         it.fields["parser_error"] = ErrorVal(e.errorName)
@@ -112,22 +228,22 @@ class PSAArchitecture : Architecture {
     }
 
     // --- Egress Control ---
-    val egressStage = stages.first { it.name == "egress" }
-    bindStageParams(egressEnv, egressStage.blockName, blockParams, egressValues)
+    val egressStage = state.stages.first { it.name == "egress" }
+    bindStageParams(egressEnv, egressStage.blockName, state.blockParams, egressValues)
     runControlStage(egressInterpreter, egressCtx, egressEnv, egressStage)
 
     // --- Egress drop check (PSA: egress does NOT drop by default) ---
     if ((egressOutput?.fields?.get("drop") as? BoolVal)?.value == true) {
-      return buildDropResult(egressCtx.getEvents())
+      return buildDropTrace(egressCtx.getEvents())
     }
 
     // --- Egress Deparser ---
-    val egressDeparserStage = stages.first { it.name == "egress_deparser" }
-    bindStageParams(egressEnv, egressDeparserStage.blockName, blockParams, egressValues)
+    val egressDeparserStage = state.stages.first { it.name == "egress_deparser" }
+    bindStageParams(egressEnv, egressDeparserStage.blockName, state.blockParams, egressValues)
     runControlStage(egressInterpreter, egressCtx, egressEnv, egressDeparserStage)
 
     val outputBytes = egressCtx.outputPayload() + egressCtx.drainRemainingInput()
-    return buildOutputResult(egressCtx.getEvents(), egressPort, outputBytes)
+    return buildOutputTrace(egressCtx.getEvents(), egressPort, outputBytes)
   }
 
   // ---------------------------------------------------------------------------
@@ -153,18 +269,23 @@ class PSAArchitecture : Architecture {
   private fun initEgressMetadata(
     values: Map<String, Value>,
     egressPort: Int,
+    instance: Int,
+    packetPath: String,
     ingressOutput: StructVal?,
   ) {
     val cos =
       (ingressOutput?.fields?.get("class_of_service") as? BitVal)?.bits?.value?.toLong() ?: 0
     (values["psa_egress_parser_input_metadata_t"] as? StructVal)?.let {
       it.setBitField("egress_port", egressPort.toLong())
-      it.fields["packet_path"] = EnumVal("NORMAL_UNICAST")
+      it.fields["packet_path"] = EnumVal(packetPath)
     }
     (values["psa_egress_input_metadata_t"] as? StructVal)?.let {
       it.setBitField("class_of_service", cos)
       it.setBitField("egress_port", egressPort.toLong())
-      it.fields["packet_path"] = EnumVal("NORMAL_UNICAST")
+      it.fields["packet_path"] = EnumVal(packetPath)
+      // PSA spec §6.5: instance identifies the replica within a multicast group.
+      // Only set if the program declares the field (not all PSA programs use it).
+      if (it.fields.containsKey("instance")) it.setBitField("instance", instance.toLong())
       it.fields["parser_error"] = ErrorVal("NoError")
     }
     // PSA spec: egress output metadata defaults to drop=false.
@@ -289,12 +410,7 @@ class PSAArchitecture : Architecture {
   // PSA extern handler
   // ---------------------------------------------------------------------------
 
-  /**
-   * Creates a minimal PSA extern handler.
-   *
-   * Currently handles `send_to_port` (sets egress_port and drop=false on the ingress output
-   * metadata). Additional PSA externs will be added as tests require them.
-   */
+  /** PSA extern handler: `send_to_port`, `multicast`, `ingress_drop`/`egress_drop`, registers. */
   private fun createPsaExternHandler(tableStore: TableStore): ExternHandler =
     ExternHandler { call, eval ->
       when (call) {
@@ -307,6 +423,15 @@ class PSAArchitecture : Architecture {
               val port = eval.evalArg(1) as BitVal
               ostd.fields["drop"] = BoolVal(false)
               ostd.fields["egress_port"] = port
+              UnitVal
+            }
+            // multicast(inout ostd, in MulticastGroup_t group)
+            // PSA spec §6.2: marks the packet for multicast replication.
+            "multicast" -> {
+              val ostd = eval.evalArg(0) as StructVal
+              val group = eval.evalArg(1) as BitVal
+              ostd.fields["drop"] = BoolVal(false)
+              ostd.fields["multicast_group"] = group
               UnitVal
             }
             "ingress_drop",
@@ -344,30 +469,25 @@ class PSAArchitecture : Architecture {
   // Trace helpers
   // ---------------------------------------------------------------------------
 
-  private fun buildDropResult(events: List<TraceEvent>): PipelineResult {
+  private fun buildDropResult(events: List<TraceEvent>): PipelineResult =
+    PipelineResult(buildDropTrace(events))
+
+  private fun buildDropTrace(events: List<TraceEvent>): TraceTree {
     val outcome =
       PacketOutcome.newBuilder()
         .setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
         .build()
-    return PipelineResult(
-      TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
-    )
+    return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
   }
 
-  private fun buildOutputResult(
-    events: List<TraceEvent>,
-    port: Int,
-    payload: ByteArray,
-  ): PipelineResult {
+  private fun buildOutputTrace(events: List<TraceEvent>, port: Int, payload: ByteArray): TraceTree {
     val output =
       fourward.sim.v1.SimulatorProto.OutputPacket.newBuilder()
         .setEgressPort(port)
         .setPayload(com.google.protobuf.ByteString.copyFrom(payload))
         .build()
     val outcome = PacketOutcome.newBuilder().setOutput(output).build()
-    return PipelineResult(
-      TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
-    )
+    return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
   }
 
   private fun packetIngressEvent(ingressPort: UInt): TraceEvent =

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -20,10 +20,12 @@ import fourward.ir.v1.Transition
 import fourward.ir.v1.Type
 import fourward.ir.v1.TypeDecl
 import fourward.sim.v1.SimulatorProto.DropReason
+import fourward.sim.v1.SimulatorProto.ForkReason
 import fourward.sim.v1.SimulatorProto.PipelineStageEvent.Direction
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import p4.v1.P4RuntimeOuterClass
 
 /**
  * Unit tests for [PSAArchitecture].
@@ -194,10 +196,10 @@ class PSAArchitectureTest {
       )
       .build()
 
-  private fun noopControl(name: String, vararg paramPairs: Pair<String, String>): ControlDecl =
+  private fun noopControl(name: String, params: List<Pair<String, String>>): ControlDecl =
     ControlDecl.newBuilder()
       .setName(name)
-      .addAllParams(paramPairs.map { (n, t) -> param(n, t) })
+      .addAllParams(params.map { (n, t) -> param(n, t) })
       .build()
 
   private fun control(
@@ -258,14 +260,44 @@ class PSAArchitectureTest {
       .addParsers(noopParser)
       .addParsers(egressParser)
       .addControls(control("Ingress", ingressParams, ingressStmts))
-      .addControls(noopControl("IngressDeparser", *ingressDeparserParams.toTypedArray()))
+      .addControls(noopControl("IngressDeparser", ingressDeparserParams))
       .addControls(control("Egress", egressParams, egressStmts))
-      .addControls(noopControl("EgressDeparser", *egressDeparserParams.toTypedArray()))
+      .addControls(noopControl("EgressDeparser", egressDeparserParams))
       .build()
 
   /** send_to_port(ostd, port) — sets drop=false and egress_port on the output metadata. */
   private fun sendToPort(port: Long): Stmt =
     externCall("send_to_port", nameRef("ostd"), bit(port, 32))
+
+  /** multicast(ostd, group) — marks packet for multicast replication. */
+  private fun multicast(group: Long): Stmt =
+    externCall("multicast", nameRef("ostd"), bit(group, 32))
+
+  private fun writeMulticastGroup(store: TableStore, groupId: Int, replicas: List<Pair<Int, Int>>) {
+    store.write(
+      P4RuntimeOuterClass.Update.newBuilder()
+        .setType(P4RuntimeOuterClass.Update.Type.INSERT)
+        .setEntity(
+          P4RuntimeOuterClass.Entity.newBuilder()
+            .setPacketReplicationEngineEntry(
+              P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+                .setMulticastGroupEntry(
+                  P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
+                    .setMulticastGroupId(groupId)
+                    .addAllReplicas(
+                      replicas.map { (rid, port) ->
+                        P4RuntimeOuterClass.Replica.newBuilder()
+                          .setInstance(rid)
+                          .setEgressPort(port)
+                          .build()
+                      }
+                    )
+                )
+            )
+        )
+        .build()
+    )
+  }
 
   /** PSA register.read method call expression: reg.read(index). */
   private fun registerReadExpr(regName: String, index: Long, returnWidth: Int): Expr =
@@ -388,5 +420,51 @@ class PSAArchitectureTest {
     // Should not crash — the read returns a default zero value.
     val outputs = collectOutputsFromTrace(result.trace)
     assertEquals(1, outputs.size)
+  }
+
+  @Test
+  fun `multicast replicates packet to all group members`() {
+    val config = psaConfig(ingressStmts = listOf(multicast(1)))
+    val tableStore = TableStore()
+    writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 5, 1 to 6, 2 to 7))
+
+    val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
+    val result = PSAArchitecture().processPacket(0u, payload, config, tableStore)
+    val outputs = collectOutputsFromTrace(result.trace)
+
+    assertEquals(3, outputs.size)
+    assertEquals(5, outputs[0].egressPort)
+    assertEquals(6, outputs[1].egressPort)
+    assertEquals(7, outputs[2].egressPort)
+    // All replicas carry the same payload.
+    for (output in outputs) {
+      assertEquals(ByteString.copyFrom(payload), output.payload)
+    }
+  }
+
+  @Test
+  fun `multicast trace has fork node with MULTICAST reason`() {
+    val config = psaConfig(ingressStmts = listOf(multicast(1)))
+    val tableStore = TableStore()
+    writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 1 to 3))
+
+    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+
+    assertTrue(result.trace.hasForkOutcome())
+    assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
+    assertEquals(2, result.trace.forkOutcome.branchesCount)
+    assertEquals("replica_0_port_2", result.trace.forkOutcome.branchesList[0].label)
+    assertEquals("replica_1_port_3", result.trace.forkOutcome.branchesList[1].label)
+  }
+
+  @Test
+  fun `multicast with unknown group drops packet`() {
+    // multicast(group=99) but no group 99 is configured — should drop.
+    val config = psaConfig(ingressStmts = listOf(multicast(99)))
+    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+
+    assertTrue(result.trace.hasPacketOutcome())
+    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
   }
 }


### PR DESCRIPTION
## Summary

PSA multicast is live — the simulator now replicates packets to all members of a multicast group when `multicast()` is called in ingress, bringing PSA corpus coverage from 14/26 to **17/26**.

The key design choice: extract the egress pipeline into `runEgressPipeline()` so it can run once for unicast or N times for multicast replicas, each with independent metadata (`egress_port`, `instance`, `packet_path=NORMAL_MULTICAST`).

## Changes

- **`multicast()` extern**: sets `ostd.drop = false` and `ostd.multicast_group`
- **Traffic manager fork**: checks `multicast_group` after ingress deparser, looks up PRE group, forks into replicas with `ForkReason.MULTICAST` trace tree
- **`EgressState` class**: bundles shared params to keep `runEgressPipeline()` clean
- **`instance` metadata**: set on each replica's `psa_egress_input_metadata_t` (conditional on field existence)
- 3 unit tests: replication output, fork trace structure, unknown group → drop
- Fixed pre-existing SpreadOperator lint warning

## What's missing (9/26)

| Feature | Tests | Blocker |
|---|---|---|
| Hash extern | 1 | `get_hash` method |
| InternetChecksum | 1 | `clear/add/get` methods |
| I2E/E2E cloning | 2 | Clone session handling |
| Meter | 1 | `execute` method |
| Resubmit | 1 | Ingress re-entry loop |
| Recirculate | 1 | Egress→ingress loop |
| `end_of_ingress` | 1 | Extern stub |
| `lookahead` type | 1 | Parser type inference |

## Test plan

- [x] 3 PSA multicast corpus tests pass (`psa-multicast-basic-*`)
- [x] 3 new unit tests in PSAArchitectureTest
- [x] 44/44 tests pass (no regressions)
- [x] Format + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)