### PR TITLE
Implement full P4Runtime arbitration state machine (§5)

### DIFF
--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -144,9 +144,9 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 10.2 | Higher election_id becomes primary | Y | ConformanceTest #40-41 |
 | 10.3 | Non-primary writes → PERMISSION_DENIED | Y | ConformanceTest #42-44 |
 | 10.4 | All controllers may read regardless of role | Y | ConformanceTest #45 |
-| 10.5 | Demotion notification to displaced primary | N | |
-| 10.6 | Automatic promotion on primary disconnect | N | |
-| 10.7 | Zero election_id: backup semantics (cannot be primary) | N | |
+| 10.5 | Demotion notification to displaced primary | Y | ConformanceTest #73 |
+| 10.6 | Automatic promotion on primary disconnect | Y | ConformanceTest #74 |
+| 10.7 | Zero election_id: backup semantics (cannot be primary) | Y | ConformanceTest #72 |
 | 10.8 | Role-based access control | N/A | Single default role sufficient for reference simulator |
 
 ## Read RPC (§11)
@@ -240,7 +240,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Write — other entities | 0 | 0 | 3 |
 | Write — atomicity | 3 | 0 | 1 |
 | Write — general | 2 | 0 | 0 |
-| Arbitration | 4 | 3 | 1 |
+| Arbitration | 7 | 0 | 1 |
 | Read | 11 | 0 | 0 |
 | GetForwardingPipelineConfig | 6 | 0 | 0 |
 | Capabilities | 1 | 0 | 0 |
@@ -248,4 +248,4 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Translation | 6 | 0 | 0 |
 | @refers_to | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **115** | **3** | **10** |
+| **Total** | **118** | **0** | **10** |

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -631,17 +631,19 @@ class P4RuntimeConformanceTest {
     }
   }
 
-  /** P4Runtime spec §10.2: lower election_id is non-primary. */
+  /** P4Runtime spec §5: lower election_id is non-primary. */
   @Test
   fun `41 - lower election_id is non-primary`() {
-    harness.openStream().use { stream ->
-      stream.arbitrate(electionId = 5)
-      val resp = stream.arbitrate(electionId = 1)
-      assertEquals(
-        "lower election_id should get ALREADY_EXISTS",
-        com.google.rpc.Code.ALREADY_EXISTS_VALUE,
-        resp.arbitration.status.code,
-      )
+    harness.openStream().use { primary ->
+      primary.arbitrate(electionId = 5)
+      harness.openStream().use { backup ->
+        val resp = backup.arbitrate(electionId = 1)
+        assertEquals(
+          "lower election_id should get ALREADY_EXISTS",
+          com.google.rpc.Code.ALREADY_EXISTS_VALUE,
+          resp.arbitration.status.code,
+        )
+      }
     }
   }
 
@@ -655,17 +657,18 @@ class P4RuntimeConformanceTest {
     assertGrpcError(Status.Code.PERMISSION_DENIED) { harness.installEntry(entry, uint128(low = 3)) }
   }
 
-  /** P4Runtime spec §10.3: primary write succeeds. */
+  /** P4Runtime spec §5: primary write succeeds. */
   @Test
   fun `43 - primary write succeeds`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    harness.openStream().use { stream -> stream.arbitrate(electionId = 5) }
-    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
-    harness.installEntry(entry, uint128(low = 5))
-    // Verify the entry was written.
-    val results = harness.readRegularEntries()
-    assertEquals(1, results.size)
+    harness.openStream().use { stream ->
+      stream.arbitrate(electionId = 5)
+      val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+      harness.installEntry(entry, uint128(low = 5))
+      val results = harness.readRegularEntries()
+      assertEquals(1, results.size)
+    }
   }
 
   /** Backward compatibility: write without any prior arbitration succeeds. */
@@ -680,15 +683,17 @@ class P4RuntimeConformanceTest {
     assertEquals(1, regular.size)
   }
 
-  /** P4Runtime spec §10.4: all controllers may read regardless of role. */
+  /** P4Runtime spec §5: all controllers may read regardless of role. */
   @Test
   fun `45 - all controllers may read regardless of role`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    harness.openStream().use { stream -> stream.arbitrate(electionId = 5) }
-    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
-    harness.installEntry(entry, uint128(low = 5))
-    // Read with no election_id (any controller) should succeed.
+    harness.openStream().use { stream ->
+      stream.arbitrate(electionId = 5)
+      val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+      harness.installEntry(entry, uint128(low = 5))
+    }
+    // Read with no election_id (any controller) should succeed even after stream closes.
     val results = harness.readRegularEntries()
     assertEquals("read should return the installed entry", 1, results.size)
   }
@@ -1248,6 +1253,84 @@ class P4RuntimeConformanceTest {
       "should not have meter_config without explicit write",
       results[0].tableEntry.hasMeterConfig(),
     )
+  }
+
+  // =========================================================================
+  // Arbitration: demotion, promotion, zero election_id (scenarios 72-74)
+  // =========================================================================
+
+  /** P4Runtime spec §5: election_id=0 is a backup controller, cannot become primary. */
+  @Test
+  fun `72 - zero election_id cannot become primary`() {
+    harness.openStream().use { stream ->
+      val resp = stream.arbitrate(electionId = 0)
+      assertEquals(
+        "zero election_id should always be non-primary",
+        com.google.rpc.Code.ALREADY_EXISTS_VALUE,
+        resp.arbitration.status.code,
+      )
+    }
+  }
+
+  /** P4Runtime spec §5: displaced primary receives demotion notification. */
+  @Test
+  fun `73 - demotion notification sent to displaced primary`() {
+    harness.openStream().use { oldPrimary ->
+      oldPrimary.arbitrate(electionId = 3)
+      harness.openStream().use { newPrimary ->
+        // New controller with higher election_id displaces the old primary.
+        val resp = newPrimary.arbitrate(electionId = 7)
+        assertEquals(
+          "higher election_id should be primary",
+          com.google.rpc.Code.OK_VALUE,
+          resp.arbitration.status.code,
+        )
+        // Old primary should receive an async demotion notification.
+        val demotion = oldPrimary.receiveNext()
+        assertNotNull("old primary should receive demotion notification", demotion)
+        assertTrue("should be an arbitration message", demotion!!.hasArbitration())
+        assertEquals(
+          "demotion should include the old primary's election_id",
+          3,
+          demotion.arbitration.electionId.low,
+        )
+        assertEquals(
+          "demotion status should be ALREADY_EXISTS",
+          com.google.rpc.Code.ALREADY_EXISTS_VALUE,
+          demotion.arbitration.status.code,
+        )
+      }
+    }
+  }
+
+  /** P4Runtime spec §5: when primary disconnects, next highest is promoted. */
+  @Test
+  fun `74 - automatic promotion when primary disconnects`() {
+    val backup = harness.openStream()
+    backup.arbitrate(electionId = 3)
+    harness.openStream().use { primary ->
+      primary.arbitrate(electionId = 7)
+      // Drain the demotion notification from backup's channel.
+      backup.receiveNext()
+    }
+    // Primary (election_id=7) has disconnected. Backup should be promoted.
+    try {
+      val promotion = backup.receiveNext()
+      assertNotNull("backup should receive promotion notification", promotion)
+      assertTrue("should be an arbitration message", promotion!!.hasArbitration())
+      assertEquals(
+        "promotion should include the backup's election_id",
+        3,
+        promotion.arbitration.electionId.low,
+      )
+      assertEquals(
+        "promotion status should be OK",
+        com.google.rpc.Code.OK_VALUE,
+        promotion.arbitration.status.code,
+      )
+    } finally {
+      backup.close()
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -1,6 +1,6 @@
 package fourward.p4runtime
 
-import com.google.protobuf.Any
+import com.google.protobuf.Any as ProtoAny
 import fourward.ir.v1.DeviceConfig
 import fourward.ir.v1.PipelineConfig
 import fourward.simulator.Simulator
@@ -10,8 +10,12 @@ import io.grpc.Status
 import io.grpc.StatusException
 import java.io.Closeable
 import java.nio.file.Path
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import p4.v1.P4RuntimeGrpcKt
@@ -47,9 +51,10 @@ fun compareUint128(a: Uint128, b: Uint128): Int {
 /**
  * P4Runtime gRPC service backed by a 4ward [Simulator].
  *
- * Supports basic multi-controller arbitration: the controller with the highest election_id is
- * primary and may write; all controllers may read. No demotion notifications or disconnect
- * handling.
+ * Supports multi-controller arbitration per P4Runtime spec §5: the controller with the highest
+ * non-zero election_id is primary and may write; all controllers may read. Demotion notifications
+ * are sent when a higher election_id displaces the current primary, and automatic promotion occurs
+ * when the primary disconnects.
  */
 class P4RuntimeService(
   private val simulator: Simulator,
@@ -71,8 +76,24 @@ class P4RuntimeService(
 
   @Volatile private var pipeline: PipelineState? = null
 
-  // P4Runtime spec §10: highest election_id is the primary controller.
-  // null = no arbitration has occurred; writes are allowed for backward compatibility.
+  // ---------------------------------------------------------------------------
+  // Arbitration state (P4Runtime spec §5)
+  // ---------------------------------------------------------------------------
+
+  /** Per-stream controller state, tracked for demotion/promotion notifications. */
+  private data class ControllerStream(
+    val electionId: Uint128,
+    val notifications: SendChannel<StreamMessageResponse>,
+  )
+
+  private val arbitrationMutex = Mutex()
+  private val controllers = mutableMapOf<Any, ControllerStream>()
+
+  // True once any controller has sent MasterArbitrationUpdate. Once set, writes require
+  // a matching primary election_id (even if all controllers later disconnect).
+  @Volatile private var arbitrationOccurred: Boolean = false
+
+  // Highest non-zero election_id among active controllers, or null if none.
   @Volatile private var primaryElectionId: Uint128? = null
 
   private fun requirePipeline(): PipelineState =
@@ -275,47 +296,41 @@ class P4RuntimeService(
   // ---------------------------------------------------------------------------
 
   override fun streamChannel(requests: Flow<StreamMessageRequest>): Flow<StreamMessageResponse> =
-    flow {
-      requests.collect { msg ->
-        when {
-          msg.hasArbitration() -> {
-            val incomingId = msg.arbitration.electionId
-            val current = primaryElectionId
-            val isPrimary = current == null || compareUint128(incomingId, current) >= 0
-            if (isPrimary) primaryElectionId = incomingId
-            val statusCode =
-              if (isPrimary) com.google.rpc.Code.OK_VALUE
-              else com.google.rpc.Code.ALREADY_EXISTS_VALUE
-            emit(
-              StreamMessageResponse.newBuilder()
-                .setArbitration(
-                  MasterArbitrationUpdate.newBuilder()
-                    .setDeviceId(msg.arbitration.deviceId)
-                    .setElectionId(incomingId)
-                    .setStatus(com.google.rpc.Status.newBuilder().setCode(statusCode))
-                )
-                .build()
-            )
+    channelFlow {
+      val streamId = Any()
+      val notifications = Channel<StreamMessageResponse>(Channel.UNLIMITED)
+
+      // Forward async notifications (demotion/promotion) to the stream output.
+      launch { for (msg in notifications) send(msg) }
+
+      try {
+        requests.collect { msg ->
+          when {
+            msg.hasArbitration() ->
+              send(handleArbitration(streamId, msg.arbitration, notifications))
+            msg.hasPacket() -> {
+              val packetIns = lock.withLock { handlePacketOut(msg.packet) }
+              packetIns?.forEach { send(it) }
+            }
+            msg.hasDigestAck() ->
+              throw Status.UNIMPLEMENTED.withDescription(DIGEST_NOT_SUPPORTED).asException()
+            // P4Runtime spec §16: unrecognized stream messages get an error response.
+            else ->
+              send(
+                StreamMessageResponse.newBuilder()
+                  .setError(
+                    P4RuntimeOuterClass.StreamError.newBuilder()
+                      .setCanonicalCode(com.google.rpc.Code.INVALID_ARGUMENT_VALUE)
+                      .setMessage("unrecognized stream message")
+                      .setOther(P4RuntimeOuterClass.StreamOtherError.getDefaultInstance())
+                  )
+                  .build()
+              )
           }
-          msg.hasPacket() -> {
-            val packetIns = lock.withLock { handlePacketOut(msg.packet) }
-            packetIns?.forEach { emit(it) }
-          }
-          msg.hasDigestAck() ->
-            throw Status.UNIMPLEMENTED.withDescription(DIGEST_NOT_SUPPORTED).asException()
-          // P4Runtime spec §16: unrecognized stream messages get an error response.
-          else ->
-            emit(
-              StreamMessageResponse.newBuilder()
-                .setError(
-                  P4RuntimeOuterClass.StreamError.newBuilder()
-                    .setCanonicalCode(com.google.rpc.Code.INVALID_ARGUMENT_VALUE)
-                    .setMessage("unrecognized stream message")
-                    .setOther(P4RuntimeOuterClass.StreamOtherError.getDefaultInstance())
-                )
-                .build()
-            )
         }
+      } finally {
+        notifications.close()
+        handleDisconnect(streamId)
       }
     }
 
@@ -410,19 +425,121 @@ class P4RuntimeService(
   /**
    * Ensures the requester is the primary controller, or that no arbitration has occurred.
    *
-   * P4Runtime spec §10: only the primary (highest election_id) may write. If no arbitration has
-   * occurred, writes are allowed for backward compatibility with single-controller clients.
+   * P4Runtime spec §5: only the primary (highest non-zero election_id) may write. If no arbitration
+   * has occurred, writes are allowed for backward compatibility with single-controller clients.
    */
   private fun requirePrimaryOrNoArbitration(requestElectionId: Uint128) {
-    val primary = primaryElectionId ?: return
-    if (requestElectionId != primary) {
-      val id = if (primary.high == 0L) "${primary.low}" else "(${primary.high}, ${primary.low})"
+    if (!arbitrationOccurred) return
+    val primary = primaryElectionId
+    if (primary == null || requestElectionId != primary) {
+      val id =
+        primary?.let { if (it.high == 0L) "${it.low}" else "(${it.high}, ${it.low})" } ?: "none"
       throw Status.PERMISSION_DENIED.withDescription(
           "only the primary controller (election_id=$id) may write"
         )
         .asException()
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Arbitration logic (P4Runtime spec §5)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Processes a MasterArbitrationUpdate from a stream, updating controller tracking and sending
+   * demotion/promotion notifications as needed.
+   */
+  private suspend fun handleArbitration(
+    streamId: Any,
+    arbitration: MasterArbitrationUpdate,
+    notifications: SendChannel<StreamMessageResponse>,
+  ): StreamMessageResponse {
+    val incomingId = arbitration.electionId
+
+    return arbitrationMutex.withLock {
+      val oldPrimaryId = primaryElectionId
+      controllers[streamId] = ControllerStream(incomingId, notifications)
+      arbitrationOccurred = true
+
+      val newPrimaryId = computePrimary()
+      if (newPrimaryId != null) primaryElectionId = newPrimaryId
+
+      // If primary changed, send demotion/promotion notifications to other streams.
+      if (newPrimaryId != oldPrimaryId) {
+        notifyRoleChanges(streamId, oldPrimaryId, newPrimaryId)
+      }
+
+      val isPrimary =
+        !isZeroElectionId(incomingId) && newPrimaryId != null && incomingId == newPrimaryId
+      buildArbitrationResponse(arbitration.deviceId, incomingId, isPrimary)
+    }
+  }
+
+  /** Handles stream disconnect: removes the controller and promotes the next primary if needed. */
+  private suspend fun handleDisconnect(streamId: Any) {
+    arbitrationMutex.withLock {
+      controllers.remove(streamId) ?: return
+
+      val oldPrimaryId = primaryElectionId
+      val newPrimaryId = computePrimary()
+      if (newPrimaryId != null) primaryElectionId = newPrimaryId
+
+      // If the disconnected controller was primary, notify the promoted controller.
+      if (oldPrimaryId != null && newPrimaryId != oldPrimaryId && newPrimaryId != null) {
+        for ((_, ctrl) in controllers) {
+          if (ctrl.electionId == newPrimaryId) {
+            ctrl.notifications.trySend(buildArbitrationResponse(deviceId, ctrl.electionId, true))
+          }
+        }
+      }
+    }
+  }
+
+  /** Returns the highest non-zero election_id among active controllers, or null. */
+  private fun computePrimary(): Uint128? =
+    controllers.values
+      .map { it.electionId }
+      .filter { !isZeroElectionId(it) }
+      .maxWithOrNull(Comparator { a, b -> compareUint128(a, b) })
+
+  /** Sends demotion/promotion notifications to other streams when the primary changes. */
+  private fun notifyRoleChanges(
+    excludeStreamId: Any,
+    oldPrimaryId: Uint128?,
+    newPrimaryId: Uint128?,
+  ) {
+    for ((id, ctrl) in controllers) {
+      if (id == excludeStreamId) continue
+      val wasPrimary = oldPrimaryId != null && ctrl.electionId == oldPrimaryId
+      val isNowPrimary = newPrimaryId != null && ctrl.electionId == newPrimaryId
+      when {
+        wasPrimary && !isNowPrimary ->
+          ctrl.notifications.trySend(buildArbitrationResponse(deviceId, ctrl.electionId, false))
+        !wasPrimary && isNowPrimary ->
+          ctrl.notifications.trySend(buildArbitrationResponse(deviceId, ctrl.electionId, true))
+      }
+    }
+  }
+
+  private fun buildArbitrationResponse(
+    deviceId: Long,
+    electionId: Uint128,
+    isPrimary: Boolean,
+  ): StreamMessageResponse =
+    StreamMessageResponse.newBuilder()
+      .setArbitration(
+        MasterArbitrationUpdate.newBuilder()
+          .setDeviceId(deviceId)
+          .setElectionId(electionId)
+          .setStatus(
+            com.google.rpc.Status.newBuilder()
+              .setCode(
+                if (isPrimary) com.google.rpc.Code.OK_VALUE
+                else com.google.rpc.Code.ALREADY_EXISTS_VALUE
+              )
+          )
+      )
+      .build()
 
   /** Rejects requests targeting a different device (P4Runtime spec §6.3). */
   private fun requireDeviceId(requestDeviceId: Long) {
@@ -461,7 +578,7 @@ class P4RuntimeService(
         .setCode(com.google.rpc.Code.UNKNOWN_VALUE)
         .setMessage("Write failure.")
     for (error in errors) {
-      rpcStatus.addDetails(Any.pack(error))
+      rpcStatus.addDetails(ProtoAny.pack(error))
     }
     val metadata = Metadata()
     metadata.put(STATUS_DETAILS_KEY, rpcStatus.build().toByteArray())
@@ -488,6 +605,8 @@ class P4RuntimeService(
     private const val DIGEST_NOT_SUPPORTED = "digest is not supported"
 
     private const val OK_CODE = com.google.rpc.Code.OK_VALUE
+
+    private fun isZeroElectionId(id: Uint128): Boolean = id.high == 0L && id.low == 0L
 
     // Standard gRPC binary trailer for rich error details (P4Runtime spec §10).
     private val STATUS_DETAILS_KEY: Metadata.Key<ByteArray> =

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -392,6 +392,11 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
       withTimeoutOrNull(STREAM_TIMEOUT_MS) { responseChannel.receive() }
     }
 
+    /** Receives the next unsolicited message (e.g., demotion/promotion notification). */
+    fun receiveNext(): StreamMessageResponse? = runBlocking {
+      withTimeoutOrNull(STREAM_TIMEOUT_MS) { responseChannel.receive() }
+    }
+
     override fun close() {
       requestChannel.close()
       scope.cancel()


### PR DESCRIPTION
## Summary

Completes P4Runtime compliance — all 118 applicable requirements are now tested (0 remaining gaps).

The arbitration state machine in `P4RuntimeService` now supports the full P4Runtime spec §5 multi-controller lifecycle:

- **Demotion notifications** (§5, 10.5): when a controller with a higher election_id connects, the displaced primary receives an unsolicited `MasterArbitrationUpdate` with `ALREADY_EXISTS` status.
- **Automatic promotion** (§5, 10.6): when the primary disconnects, the controller with the next-highest election_id is automatically promoted and notified with `OK` status.
- **Zero election_id backup semantics** (§5, 10.7): controllers with `election_id=0` are backup-only — they can never become primary, even when no other controllers are connected.

### Architecture

`streamChannel` now uses `channelFlow` (instead of `flow`) with a per-stream `Channel<StreamMessageResponse>` for async notifications. A `controllers` map tracks active streams by identity, enabling the service to push demotion/promotion messages to other streams when the primary changes. An `arbitrationOccurred` flag distinguishes "no arbitration yet" (backward-compatible, writes allowed) from "arbitration active but no primary" (writes denied).

Existing tests #41, #43, #45 were tightened to use proper multi-stream patterns instead of relying on stale primary state after stream close.

## Test plan

- [x] 3 new conformance tests (#72-74): zero election_id, demotion notification, automatic promotion
- [x] All 74 conformance tests pass
- [x] All 44 test targets pass (`bazel test //... --test_tag_filters=-heavy`)
- [x] `./tools/format.sh` and `./tools/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)