### PR TITLE
Decouple Simulator.processPacket from gRPC wire type

### DIFF
--- a/cli/Simulate.kt
+++ b/cli/Simulate.kt
@@ -7,7 +7,6 @@ import fourward.e2e.installStfEntries
 import fourward.e2e.loadPipelineConfig
 import fourward.e2e.matchOutputAgainstExpects
 import fourward.simulator.Simulator
-import fourward.simulator.collectOutputsFromTrace
 import java.io.FileNotFoundException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
@@ -59,16 +58,15 @@ fun simulate(pipelinePath: Path, stfPath: Path, format: OutputFormat): Int {
   val textProtoPrinter = TextFormat.printer()
 
   for (packet in stf.packets) {
-    val resp = sim.processPacket(packet.ingressPort, packet.payload)
-    val trace = resp.trace
+    val result = sim.processPacket(packet.ingressPort, packet.payload)
     when (format) {
       OutputFormat.HUMAN -> {
         println("packet received: port ${packet.ingressPort}, ${packet.payload.size} bytes")
-        println(TraceFormatter.format(trace).trim().prependIndent("  "))
+        println(TraceFormatter.format(result.trace).trim().prependIndent("  "))
       }
-      OutputFormat.TEXTPROTO -> print(textProtoPrinter.printToString(trace))
+      OutputFormat.TEXTPROTO -> print(textProtoPrinter.printToString(result.trace))
     }
-    val pkts = resp.outputPacketsList.ifEmpty { collectOutputsFromTrace(trace) }
+    val pkts = result.outputPackets
     for (pkt in pkts) {
       outputQueue += ReceivedPacket(pkt.egressPort, pkt.payload.toByteArray())
     }

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -65,27 +65,6 @@ Blocked on buf support for proto edition 2024.
 
 ---
 
-## Separate simulator return type from gRPC wire type
-
-**Files**: `simulator/Simulator.kt`, `p4runtime/DataplaneService.kt`,
-`simulator/simulator.proto`
-
-**Problem**: `Simulator.processPacket` returns `ProcessPacketResponse` (a proto
-message that also serves as the Dataplane gRPC wire type). This forces
-`DataplaneService.processPacket` to rebuild the response just to strip the
-`trace` field — the unary RPC shouldn't expose the trace, but the proto
-carries it because the simulator populates it internally.
-
-**Fix**: Have `Simulator.processPacket` return a plain Kotlin data class
-(e.g. `ProcessPacketResult(outputPackets, trace)`) and let each gRPC method
-build its own proto response. This decouples the simulator's internal
-representation from the wire format.
-
-**Trigger**: when a third consumer of `processPacket` appears, or when the
-response fields diverge further between the two Dataplane RPCs.
-
----
-
 ## Upstream p4c backend
 
 Land the 4ward backend in the p4c repository. Blocked on upstream review.

--- a/e2e_tests/bmv2_diff/Bmv2DiffTest.kt
+++ b/e2e_tests/bmv2_diff/Bmv2DiffTest.kt
@@ -5,7 +5,6 @@ import fourward.e2e.hex
 import fourward.e2e.installStfEntries
 import fourward.e2e.loadPipelineConfig
 import fourward.simulator.Simulator
-import fourward.simulator.collectOutputsFromTrace
 import java.io.File
 import java.nio.file.Paths
 import org.junit.Assert
@@ -54,9 +53,8 @@ class Bmv2DiffTest(private val testName: String) {
     sim.loadPipeline(config)
     installStfEntries(sim, stf, config.p4Info)
     for (packet in stf.packets) {
-      val resp = sim.processPacket(packet.ingressPort, packet.payload)
-      val pkts = resp.outputPacketsList.ifEmpty { collectOutputsFromTrace(resp.trace) }
-      for (pkt in pkts) {
+      val result = sim.processPacket(packet.ingressPort, packet.payload)
+      for (pkt in result.outputPackets) {
         fourwardOutputs.add(pkt.egressPort to pkt.payload.toByteArray())
       }
     }

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -5,7 +5,6 @@ import com.google.protobuf.TextFormat
 import fourward.ir.v1.PipelineConfig
 import fourward.simulator.Simulator
 import fourward.simulator.WriteResult
-import fourward.simulator.collectOutputsFromTrace
 import java.math.BigInteger
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -63,16 +62,13 @@ class StfRunner(private val pipelineConfigPath: Path) {
     val outputQueue = mutableListOf<ReceivedPacket>()
 
     for (packet in stf.packets) {
-      val resp = sim.processPacket(packet.ingressPort, packet.payload)
+      val result = sim.processPacket(packet.ingressPort, packet.payload)
       if (System.getenv("PRINT_TRACE") != null) {
         println("--- Trace tree (port ${packet.ingressPort}) ---")
-        print(TextFormat.printer().printToString(resp.trace))
+        print(TextFormat.printer().printToString(result.trace))
         println("--- End trace tree ---")
       }
-      // For non-forking programs, output_packets is populated. For forking
-      // programs (multicast, clone, action selector), outputs live only in
-      // trace tree leaves — collect them recursively.
-      val pkts = resp.outputPacketsList.ifEmpty { collectOutputsFromTrace(resp.trace) }
+      val pkts = result.outputPackets
       for (pkt in pkts) {
         outputQueue += ReceivedPacket(pkt.egressPort, pkt.payload.toByteArray())
       }

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -5,8 +5,8 @@ import fourward.e2e.StfFile
 import fourward.e2e.installStfEntries
 import fourward.e2e.loadPipelineConfig
 import fourward.sim.v1.SimulatorProto.PacketOutcome
-import fourward.sim.v1.SimulatorProto.ProcessPacketResponse
 import fourward.sim.v1.SimulatorProto.TraceTree
+import fourward.simulator.ProcessPacketResult
 import fourward.simulator.Simulator
 import java.nio.file.Paths
 import org.junit.Assert.assertEquals
@@ -17,8 +17,8 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
 /**
- * Verifies that output packets from [ProcessPacketResponse] are consistent with the leaf outcomes
- * in the trace tree.
+ * Verifies that output packets from [ProcessPacketResult] are consistent with the leaf outcomes in
+ * the trace tree.
  *
  * The output_packets list should exactly match the union of all non-drop packet_outcome leaves,
  * whether the trace forks (multicast, clone, action selectors) or not.
@@ -59,13 +59,13 @@ class TraceTreeConsistencyTest(private val testName: String) {
     }
   }
 
-  private fun verifyConsistency(response: ProcessPacketResponse) {
-    val trace = response.trace
+  private fun verifyConsistency(result: ProcessPacketResult) {
+    val trace = result.trace
     val leafOutcomes = collectLeafOutcomes(trace)
 
     assertTrue("Trace tree for $testName has no leaf outcomes", leafOutcomes.isNotEmpty())
 
-    val outputsFromResponse = response.outputPacketsList.map { it.egressPort to it.payload }
+    val outputsFromResult = result.outputPackets.map { it.egressPort to it.payload }
 
     val outputsFromTree =
       leafOutcomes.filter { it.hasOutput() }.map { it.output.egressPort to it.output.payload }
@@ -74,7 +74,7 @@ class TraceTreeConsistencyTest(private val testName: String) {
     assertEquals(
       "Output packets vs trace tree mismatch for $testName.\n" +
         "Trace:\n${TextFormat.printer().printToString(trace)}",
-      outputsFromResponse,
+      outputsFromResult,
       outputsFromTree,
     )
   }

--- a/p4runtime/DataplaneService.kt
+++ b/p4runtime/DataplaneService.kt
@@ -22,21 +22,19 @@ class DataplaneService(private val simulator: Simulator, private val lock: Mutex
   DataplaneGrpcKt.DataplaneCoroutineImplBase() {
 
   override suspend fun processPacket(request: ProcessPacketRequest): ProcessPacketResponse {
-    val response =
+    val result =
       lock.withLock { simulator.processPacket(request.ingressPort, request.payload.toByteArray()) }
-    return ProcessPacketResponse.newBuilder()
-      .addAllOutputPackets(response.outputPacketsList)
-      .build()
+    return ProcessPacketResponse.newBuilder().addAllOutputPackets(result.outputPackets).build()
   }
 
   override suspend fun processPacketWithTraceTree(
     request: ProcessPacketRequest
   ): ProcessPacketWithTraceTreeResponse {
-    val response =
+    val result =
       lock.withLock { simulator.processPacket(request.ingressPort, request.payload.toByteArray()) }
     return ProcessPacketWithTraceTreeResponse.newBuilder()
-      .addAllOutputPackets(response.outputPacketsList)
-      .setTrace(response.trace)
+      .addAllOutputPackets(result.outputPackets)
+      .setTrace(result.trace)
       .build()
   }
 }

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -370,9 +370,9 @@ class P4RuntimeService(
         extractIngressPort(packetOut.metadataList) to packetOut.payload.toByteArray()
       }
 
-    val response = simulator.processPacket(ingressPort, payload)
+    val result = simulator.processPacket(ingressPort, payload)
 
-    return response.outputPacketsList.map { outputPacket ->
+    return result.outputPackets.map { outputPacket ->
       val rawPacketIn =
         if (codec != null) {
           val metadata = codec.buildPacketInMetadata(ingressPort, outputPacket.egressPort)

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -2,8 +2,15 @@ package fourward.simulator
 
 import fourward.ir.v1.PipelineConfig
 import fourward.sim.v1.SimulatorProto.OutputPacket
-import fourward.sim.v1.SimulatorProto.ProcessPacketResponse
 import fourward.sim.v1.SimulatorProto.TraceTree
+
+/**
+ * Result of processing a single packet through the pipeline.
+ *
+ * Decouples the simulator from the gRPC wire format ([fourward.sim.v1.SimulatorProto
+ * .ProcessPacketResponse]). Each RPC method builds its own wire proto from this data class.
+ */
+data class ProcessPacketResult(val outputPackets: List<OutputPacket>, val trace: TraceTree)
 
 /**
  * The top-level simulator state machine.
@@ -48,7 +55,7 @@ class Simulator : TableDataReader {
    *
    * @throws IllegalStateException if no pipeline is loaded.
    */
-  fun processPacket(ingressPort: Int, payload: ByteArray): ProcessPacketResponse {
+  fun processPacket(ingressPort: Int, payload: ByteArray): ProcessPacketResult {
     val config = checkNotNull(pipeline) { "no pipeline loaded" }
     val arch = checkNotNull(architecture) { "no pipeline loaded" }
 
@@ -64,10 +71,7 @@ class Simulator : TableDataReader {
     // of truth for packet outcomes. Non-forking trees have a single leaf; forking trees
     // (multicast, clone) have multiple leaves whose outputs are collected recursively.
     val trace = result.trace
-    return ProcessPacketResponse.newBuilder()
-      .setTrace(trace)
-      .addAllOutputPackets(collectOutputsFromTrace(trace))
-      .build()
+    return ProcessPacketResult(outputPackets = collectOutputsFromTrace(trace), trace = trace)
   }
 
   /**

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -194,11 +194,11 @@ class WebServer(
       extractJsonString(body, "payload_hex") ?: throw badRequest("Missing payload_hex")
     val payload = hexToBytes(payloadHex)
 
-    val response = runBlocking { lock.withLock { simulator.processPacket(ingressPort, payload) } }
+    val result = runBlocking { lock.withLock { simulator.processPacket(ingressPort, payload) } }
 
-    val outputsJson = response.outputPacketsList.joinToString(",") { jsonPrinter.print(it) }
-    val traceJson = jsonPrinter.print(response.trace)
-    val traceProto = textPrinter.printToString(response.trace)
+    val outputsJson = result.outputPackets.joinToString(",") { jsonPrinter.print(it) }
+    val traceJson = jsonPrinter.print(result.trace)
+    val traceProto = textPrinter.printToString(result.trace)
     sendJson(
       exchange,
       HTTP_OK,


### PR DESCRIPTION
## Summary

`Simulator.processPacket` now returns a Kotlin data class (`ProcessPacketResult`)
instead of the `ProcessPacketResponse` proto that doubles as the Dataplane gRPC wire type.

- Each consumer (DataplaneService, P4RuntimeService, WebServer, CLI, test runners) builds its own wire proto from the data class fields
- Eliminates the rebuild-to-strip-trace pattern in `DataplaneService.processPacket`
- Closes the "Separate simulator return type from gRPC wire type" item in REFACTORING.md
- 9 files touched, net -27 lines

## Test plan

- [x] All 45 tests pass (`bazel test //... --test_tag_filters=-heavy`)
- [x] Format and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)