### PR TITLE
Implement SetForwardingPipelineConfig actions (P4Runtime §7.2)

### DIFF
--- a/p4runtime/EntityReader.kt
+++ b/p4runtime/EntityReader.kt
@@ -100,6 +100,9 @@ private constructor(
   }
 
   companion object {
+    /** Placeholder for [PipelineState] before the simulator has loaded the pipeline. */
+    val EMPTY = EntityReader(emptyMap(), emptyMap(), emptyMap(), 0)
+
     /**
      * Builds an [EntityReader] from p4info and name resolution maps.
      *

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -1333,6 +1333,66 @@ class P4RuntimeConformanceTest {
     }
   }
 
+  // =========================================================================
+  // SetForwardingPipelineConfig actions (§7.2)
+  // =========================================================================
+
+  /** P4Runtime spec §7.2: VERIFY validates without applying. */
+  @Test
+  fun `75 - VERIFY validates without activating pipeline`() {
+    sendPipelineAction(SetForwardingPipelineConfigRequest.Action.VERIFY)
+
+    // Pipeline should not be active — reads should fail.
+    assertGrpcError(Status.Code.FAILED_PRECONDITION) { harness.readEntries() }
+  }
+
+  /** P4Runtime spec §7.2: VERIFY rejects invalid config. */
+  @Test
+  fun `76 - VERIFY rejects invalid config`() {
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) {
+      sendPipelineAction(
+        SetForwardingPipelineConfigRequest.Action.VERIFY,
+        PipelineConfig.getDefaultInstance(),
+      )
+    }
+  }
+
+  /** P4Runtime spec §7.2: VERIFY_AND_SAVE stores config without activating. */
+  @Test
+  fun `77 - VERIFY_AND_SAVE saves without activating`() {
+    sendPipelineAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_SAVE)
+
+    // Pipeline should not be active — reads should fail.
+    assertGrpcError(Status.Code.FAILED_PRECONDITION) { harness.readEntries() }
+  }
+
+  /** P4Runtime spec §7.2: COMMIT activates a previously saved pipeline. */
+  @Test
+  fun `78 - VERIFY_AND_SAVE then COMMIT activates pipeline`() {
+    sendPipelineAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_SAVE)
+    sendPipelineAction(SetForwardingPipelineConfigRequest.Action.COMMIT)
+
+    // Pipeline should now be active.
+    val entries = harness.readEntries()
+    assertNotNull(entries)
+  }
+
+  /** P4Runtime spec §7.2: COMMIT without prior VERIFY_AND_SAVE fails. */
+  @Test
+  fun `79 - COMMIT without saved pipeline returns FAILED_PRECONDITION`() {
+    assertGrpcError(Status.Code.FAILED_PRECONDITION) {
+      sendPipelineAction(SetForwardingPipelineConfigRequest.Action.COMMIT)
+    }
+  }
+
+  /** P4Runtime spec §7.2: RECONCILE_AND_COMMIT is not supported. */
+  @Test
+  fun `80 - RECONCILE_AND_COMMIT returns UNIMPLEMENTED`() {
+    assertGrpcError(Status.Code.UNIMPLEMENTED) {
+      sendPipelineAction(SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT)
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Test helpers
   // ---------------------------------------------------------------------------
@@ -1347,6 +1407,24 @@ class P4RuntimeConformanceTest {
         .setDeviceId(1)
         .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
         .setConfig(config)
+        .build()
+    )
+  }
+
+  /** Sends a SetForwardingPipelineConfig with a specific action. */
+  private fun sendPipelineAction(
+    action: SetForwardingPipelineConfigRequest.Action,
+    config: PipelineConfig = loadBasicTableConfig(),
+  ) = runBlocking {
+    val fwdConfig =
+      ForwardingPipelineConfig.newBuilder()
+        .setP4Info(config.p4Info)
+        .setP4DeviceConfig(config.device.toByteString())
+    harness.stub.setForwardingPipelineConfig(
+      SetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setAction(action)
+        .setConfig(fwdConfig)
         .build()
     )
   }

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -77,6 +77,9 @@ class P4RuntimeService(
 
   @Volatile private var pipeline: PipelineState? = null
 
+  // Only accessed under lock; @Volatile not needed.
+  private var savedPipeline: PipelineState? = null
+
   // ---------------------------------------------------------------------------
   // Arbitration state (P4Runtime spec §5)
   // ---------------------------------------------------------------------------
@@ -110,53 +113,94 @@ class P4RuntimeService(
     lock.withLock {
       requireDeviceId(request.deviceId)
       requirePrimaryOrNoArbitration(request.electionId)
-      val fwdConfig = request.config
-      if (!fwdConfig.hasP4Info() || fwdConfig.p4DeviceConfig.isEmpty) {
-        throw Status.INVALID_ARGUMENT.withDescription(
-            "ForwardingPipelineConfig must include p4info and p4_device_config"
-          )
-          .asException()
-      }
-
-      val deviceConfig =
-        try {
-          DeviceConfig.parseFrom(fwdConfig.p4DeviceConfig)
-        } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
-          throw Status.INVALID_ARGUMENT.withDescription(
-              "p4_device_config is not a valid DeviceConfig: ${e.message}"
-            )
-            .withCause(e)
-            .asException()
+      when (request.action) {
+        SetForwardingPipelineConfigRequest.Action.VERIFY ->
+          verifyPipeline(request.config).also { it.constraintValidator?.close() }
+        SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT ->
+          commitPipeline(verifyPipeline(request.config))
+        SetForwardingPipelineConfigRequest.Action.VERIFY_AND_SAVE -> {
+          savedPipeline?.constraintValidator?.close()
+          savedPipeline = verifyPipeline(request.config)
         }
+        SetForwardingPipelineConfigRequest.Action.COMMIT -> {
+          val saved =
+            savedPipeline
+              ?: throw Status.FAILED_PRECONDITION.withDescription(
+                  "COMMIT requires a previously saved pipeline (VERIFY_AND_SAVE)"
+                )
+                .asException()
+          commitPipeline(saved)
+          savedPipeline = null
+        }
+        SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT ->
+          throw Status.UNIMPLEMENTED.withDescription("RECONCILE_AND_COMMIT is not supported")
+            .asException()
+        SetForwardingPipelineConfigRequest.Action.UNSPECIFIED,
+        SetForwardingPipelineConfigRequest.Action.UNRECOGNIZED ->
+          throw Status.INVALID_ARGUMENT.withDescription(
+              "unrecognized SetForwardingPipelineConfig action"
+            )
+            .asException()
+      }
+      SetForwardingPipelineConfigResponse.getDefaultInstance()
+    }
 
-      val pipelineConfig =
-        PipelineConfig.newBuilder().setP4Info(fwdConfig.p4Info).setDevice(deviceConfig).build()
+  /**
+   * Validates the forwarding pipeline config and builds a [PipelineState] without activating it.
+   * Used by VERIFY, VERIFY_AND_COMMIT, and VERIFY_AND_SAVE.
+   */
+  private fun verifyPipeline(fwdConfig: ForwardingPipelineConfig): PipelineState {
+    if (!fwdConfig.hasP4Info() || fwdConfig.p4DeviceConfig.isEmpty) {
+      throw Status.INVALID_ARGUMENT.withDescription(
+          "ForwardingPipelineConfig must include p4info and p4_device_config"
+        )
+        .asException()
+    }
 
+    val deviceConfig =
       try {
-        simulator.loadPipeline(pipelineConfig)
-      } catch (e: IllegalArgumentException) {
-        throw Status.INTERNAL.withDescription("Simulator rejected pipeline: ${e.message}")
+        DeviceConfig.parseFrom(fwdConfig.p4DeviceConfig)
+      } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
+        throw Status.INVALID_ARGUMENT.withDescription(
+            "p4_device_config is not a valid DeviceConfig: ${e.message}"
+          )
           .withCause(e)
           .asException()
       }
 
-      pipeline?.constraintValidator?.close()
-      val entityReader =
-        EntityReader.create(fwdConfig.p4Info, simulator.tableNameById, simulator.actionNameById)
-      pipeline =
-        PipelineState(
-          config = pipelineConfig,
-          cookie = fwdConfig.cookie,
-          typeTranslator = TypeTranslator.create(fwdConfig.p4Info, deviceConfig.translationsList),
-          writeValidator = WriteValidator(pipelineConfig.p4Info),
-          referenceValidator = ReferenceValidator.create(fwdConfig.p4Info),
-          constraintValidator =
-            constraintValidatorBinary?.let { ConstraintValidator.create(fwdConfig.p4Info, it) },
-          packetHeaderCodec = PacketHeaderCodec.create(fwdConfig.p4Info, deviceConfig.behavioral),
-          entityReader = entityReader,
-        )
-      SetForwardingPipelineConfigResponse.getDefaultInstance()
+    val pipelineConfig =
+      PipelineConfig.newBuilder().setP4Info(fwdConfig.p4Info).setDevice(deviceConfig).build()
+
+    return PipelineState(
+      config = pipelineConfig,
+      cookie = fwdConfig.cookie,
+      typeTranslator = TypeTranslator.create(fwdConfig.p4Info, deviceConfig.translationsList),
+      writeValidator = WriteValidator(pipelineConfig.p4Info),
+      referenceValidator = ReferenceValidator.create(fwdConfig.p4Info),
+      constraintValidator =
+        constraintValidatorBinary?.let { ConstraintValidator.create(fwdConfig.p4Info, it) },
+      packetHeaderCodec = PacketHeaderCodec.create(fwdConfig.p4Info, deviceConfig.behavioral),
+      // Placeholder — EntityReader needs simulator name maps that are only
+      // available after loadPipeline; commitPipeline creates the real one.
+      entityReader = EntityReader.EMPTY,
+    )
+  }
+
+  /** Loads a verified pipeline into the simulator and activates it. */
+  private fun commitPipeline(state: PipelineState) {
+    try {
+      simulator.loadPipeline(state.config)
+    } catch (e: IllegalArgumentException) {
+      throw Status.INTERNAL.withDescription("Simulator rejected pipeline: ${e.message}")
+        .withCause(e)
+        .asException()
     }
+    pipeline?.constraintValidator?.close()
+    // EntityReader needs simulator name maps that are only populated after loadPipeline.
+    val entityReader =
+      EntityReader.create(state.config.p4Info, simulator.tableNameById, simulator.actionNameById)
+    pipeline = state.copy(entityReader = entityReader)
+  }
 
   // ---------------------------------------------------------------------------
   // Write
@@ -600,6 +644,7 @@ class P4RuntimeService(
 
   override fun close() {
     pipeline?.constraintValidator?.close()
+    savedPipeline?.constraintValidator?.close()
   }
 
   companion object {


### PR DESCRIPTION
## Summary

The \`action\` field on \`SetForwardingPipelineConfig\` was silently ignored — every
request behaved as VERIFY_AND_COMMIT regardless of what the client asked for.
This violates design invariant #5 (fail loudly on unsupported features).

Now properly dispatches on all action variants: VERIFY (dry run),
VERIFY_AND_SAVE + COMMIT (two-phase commit), and RECONCILE_AND_COMMIT
(rejected with UNIMPLEMENTED). Refactors the monolithic handler into
composable \`verifyPipeline()\` + \`commitPipeline()\` helpers.

Resource management: VERIFY closes its ConstraintValidator immediately (no
subprocess leak); COMMIT clears savedPipeline only after successful commit
(no lost state on failure).

6 new conformance tests (#75-80).

## Test plan

- [x] All 13 P4Runtime test targets pass (80 conformance tests)
- [x] Tests #75-76: VERIFY validates without activating, rejects invalid config
- [x] Tests #77-78: VERIFY_AND_SAVE + COMMIT two-phase flow
- [x] Test #79: COMMIT without prior save → FAILED_PRECONDITION
- [x] Test #80: RECONCILE_AND_COMMIT → UNIMPLEMENTED

🤖 Generated with [Claude Code](https://claude.com/claude-code)