### PR TITLE
Reject unsupported P4Runtime features instead of silently accepting

### DIFF
--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -16,9 +16,10 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 7.4 | Invalid p4_device_config bytes → INVALID_ARGUMENT | Y | ConformanceTest #37 |
 | 7.5 | Missing p4_device_config → INVALID_ARGUMENT | Y | ConformanceTest #38 |
 | 7.6 | Requires primary controller when arbitration is active | Y | ConformanceTest #66 |
-| 7.7 | VERIFY action validates without applying | N | |
+| 7.7 | VERIFY action validates without applying | Y | ConformanceTest #75 |
 | 7.8 | VERIFY_AND_COMMIT applies atomically | Y | ConformanceTest #1 |
-| 7.9 | VERIFY_AND_SAVE / COMMIT / RECONCILE_AND_COMMIT | N/A | Two-phase commit not meaningful for a reference simulator |
+| 7.9 | VERIFY_AND_SAVE + COMMIT two-phase pipeline load | Y | ConformanceTest #77-78 |
+| 7.9a | RECONCILE_AND_COMMIT rejected | Y | ConformanceTest #80 |
 | 7.10 | Cookie stored and returned | Y | ConformanceTest #59 |
 | 7.11 | Pipeline reload clears table entries | Y | ConformanceTest #58 |
 | 7.12 | Const table entries populated at load time | Y | ConformanceTest #65 |
@@ -116,9 +117,9 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 
 | # | Requirement | Status | Test |
 |---|-------------|--------|------|
-| 9.70 | ValueSetEntry | N/A | No parser value set support in simulator |
-| 9.71 | DigestEntry configuration | N/A | Digests out of scope (no real packet rates) |
-| 9.72 | ExternEntry | N/A | No standard v1model extern entities |
+| 9.70 | ValueSetEntry | Y | Rejected with UNIMPLEMENTED; ConformanceTest #81 |
+| 9.71 | DigestEntry configuration | Y | Rejected with UNIMPLEMENTED; ConformanceTest #83 |
+| 9.72 | ExternEntry | Y | Rejected with UNIMPLEMENTED; ConformanceTest #82 |
 
 ## Write RPC — atomicity (§12)
 
@@ -126,7 +127,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 |---|-------------|--------|------|
 | 9.80 | CONTINUE_ON_ERROR: process all updates, per-update errors | Y | WriteErrorTest |
 | 9.81 | ROLLBACK_ON_ERROR: undo on failure | Y | WriteErrorTest |
-| 9.82 | DATAPLANE_ATOMIC | N/A | Not meaningful for a reference simulator |
+| 9.82 | DATAPLANE_ATOMIC | Y | Handled as ROLLBACK_ON_ERROR; WriteErrorTest |
 | 9.83 | Per-update error reporting in WriteResponse | Y | WriteErrorTest |
 
 ## Write RPC — general (§12)
@@ -147,7 +148,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 10.5 | Demotion notification to displaced primary | Y | ConformanceTest #73 |
 | 10.6 | Automatic promotion on primary disconnect | Y | ConformanceTest #74 |
 | 10.7 | Zero election_id: backup semantics (cannot be primary) | Y | ConformanceTest #72 |
-| 10.8 | Role-based access control | N/A | Single default role sufficient for reference simulator |
+| 10.8 | Role-based access control | Y | Non-default role rejected with UNIMPLEMENTED; ConformanceTest #84 |
 
 ## Read RPC (§11)
 
@@ -193,7 +194,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 14.5 | Digest delivery | N/A | Out of scope — no real packet rates to trigger digests |
 | 14.6 | DigestListAck handling | N/A | Digests out of scope |
 | 14.7 | Idle timeout notifications | N/A | Out of scope — no wall-clock time in a reference simulator |
-| 14.8 | Architecture-specific `other` messages | N/A | No v1model stream extensions |
+| 14.8 | Architecture-specific `other` messages | Y | Rejected with StreamError; ConformanceTest #67 |
 
 ## @p4runtime_translation (§8.3)
 
@@ -230,22 +231,22 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 
 | Category | Tested | Not tested | N/A |
 |----------|--------|------------|-----|
-| SetForwardingPipelineConfig | 9 | 0 | 1 |
+| SetForwardingPipelineConfig | 12 | 0 | 0 |
 | General encoding | 7 | 0 | 0 |
 | Write — tables | 29 | 0 | 0 |
 | Write — profiles | 8 | 0 | 0 |
 | Write — registers | 5 | 0 | 0 |
 | Write — counters/meters | 4 | 0 | 0 |
 | Write — PRE | 6 | 0 | 0 |
-| Write — other entities | 0 | 0 | 3 |
-| Write — atomicity | 3 | 0 | 1 |
+| Write — other entities | 3 | 0 | 0 |
+| Write — atomicity | 4 | 0 | 0 |
 | Write — general | 2 | 0 | 0 |
-| Arbitration | 7 | 0 | 1 |
+| Arbitration | 8 | 0 | 0 |
 | Read | 11 | 0 | 0 |
 | GetForwardingPipelineConfig | 6 | 0 | 0 |
 | Capabilities | 1 | 0 | 0 |
-| StreamChannel | 4 | 0 | 4 |
+| StreamChannel | 5 | 0 | 3 |
 | Translation | 6 | 0 | 0 |
 | @refers_to | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **118** | **0** | **10** |
+| **Total** | **127** | **0** | **3** |

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -9,6 +9,7 @@ import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildMemberEntity
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.uint128
 import io.grpc.Status
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -1390,6 +1391,74 @@ class P4RuntimeConformanceTest {
   fun `80 - RECONCILE_AND_COMMIT returns UNIMPLEMENTED`() {
     assertGrpcError(Status.Code.UNIMPLEMENTED) {
       sendPipelineAction(SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unsupported entity types (P4Runtime spec §9.6, §9.8, §15)
+  // ---------------------------------------------------------------------------
+
+  /** P4Runtime spec §9.6: reading a ValueSetEntry should fail with UNIMPLEMENTED. */
+  @Test
+  fun `81 - read ValueSetEntry rejected as UNIMPLEMENTED`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val request =
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setValueSetEntry(P4RuntimeOuterClass.ValueSetEntry.newBuilder().setValueSetId(1))
+        )
+        .build()
+    assertGrpcError(Status.Code.UNIMPLEMENTED) { harness.readEntries(request) }
+  }
+
+  /** P4Runtime spec §9.9: reading an ExternEntry should fail with UNIMPLEMENTED. */
+  @Test
+  fun `82 - read ExternEntry rejected as UNIMPLEMENTED`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val request =
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setExternEntry(P4RuntimeOuterClass.ExternEntry.newBuilder().setExternTypeId(1))
+        )
+        .build()
+    assertGrpcError(Status.Code.UNIMPLEMENTED) { harness.readEntries(request) }
+  }
+
+  /** P4Runtime spec §9.8: reading a DigestEntry should fail with UNIMPLEMENTED. */
+  @Test
+  fun `83 - read DigestEntry rejected as UNIMPLEMENTED`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val request =
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setDigestEntry(P4RuntimeOuterClass.DigestEntry.newBuilder().setDigestId(1))
+        )
+        .build()
+    assertGrpcError(Status.Code.UNIMPLEMENTED) { harness.readEntries(request) }
+  }
+
+  /** P4Runtime spec §15: non-default role on arbitration → UNIMPLEMENTED. */
+  @Test
+  fun `84 - arbitration with non-default role rejected as UNIMPLEMENTED`() {
+    assertGrpcError(Status.Code.UNIMPLEMENTED) {
+      runBlocking {
+        val request =
+          StreamMessageRequest.newBuilder()
+            .setArbitration(
+              P4RuntimeOuterClass.MasterArbitrationUpdate.newBuilder()
+                .setDeviceId(1)
+                .setElectionId(Uint128.newBuilder().setHigh(0).setLow(1))
+                .setRole(P4RuntimeOuterClass.Role.newBuilder().setName("custom_role"))
+            )
+            .build()
+        harness.stub.streamChannel(flowOf(request)).collect {}
+      }
     }
   }
 

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -326,6 +326,7 @@ class P4RuntimeService(
         // all other entity types are read directly from the simulator.
         val entities =
           request.entitiesList.flatMap { entity ->
+            rejectUnsupportedEntity(entity)
             if (entity.hasTableEntry()) {
               state.entityReader.readTableEntities(entity.tableEntry, simulator)
             } else {
@@ -511,6 +512,11 @@ class P4RuntimeService(
     arbitration: MasterArbitrationUpdate,
     notifications: SendChannel<StreamMessageResponse>,
   ): StreamMessageResponse {
+    // P4Runtime spec §15: role-based access control. We only support the default role.
+    val role = arbitration.role
+    if (role.name.isNotEmpty() || role.hasConfig()) {
+      throw Status.UNIMPLEMENTED.withDescription(ROLE_NOT_SUPPORTED).asException()
+    }
     val incomingId = arbitration.electionId
 
     return arbitrationMutex.withLock {
@@ -614,8 +620,13 @@ class P4RuntimeService(
 
   /** Rejects entity types that are documented but not implemented. */
   private fun rejectUnsupportedEntity(entity: P4RuntimeOuterClass.Entity) {
-    if (entity.hasDigestEntry()) {
-      throw Status.UNIMPLEMENTED.withDescription(DIGEST_NOT_SUPPORTED).asException()
+    when {
+      entity.hasDigestEntry() ->
+        throw Status.UNIMPLEMENTED.withDescription(DIGEST_NOT_SUPPORTED).asException()
+      entity.hasValueSetEntry() ->
+        throw Status.UNIMPLEMENTED.withDescription(VALUE_SET_NOT_SUPPORTED).asException()
+      entity.hasExternEntry() ->
+        throw Status.UNIMPLEMENTED.withDescription(EXTERN_ENTRY_NOT_SUPPORTED).asException()
     }
   }
 
@@ -661,6 +672,10 @@ class P4RuntimeService(
       "No pipeline loaded; call SetForwardingPipelineConfig first"
 
     private const val DIGEST_NOT_SUPPORTED = "digest is not supported"
+    private const val VALUE_SET_NOT_SUPPORTED = "ValueSetEntry is not supported"
+    private const val EXTERN_ENTRY_NOT_SUPPORTED = "ExternEntry is not supported"
+    private const val ROLE_NOT_SUPPORTED =
+      "role-based access control is not supported; omit the role field or use the default role"
 
     private const val OK_CODE = com.google.rpc.Code.OK_VALUE
 

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -152,7 +152,7 @@ class Simulator : TableDataReader {
         entity.hasDirectMeterEntry() -> tableStore.readDirectMeterEntries(entity.directMeterEntry)
         entity.hasPacketReplicationEngineEntry() ->
           tableStore.readPreEntries(entity.packetReplicationEngineEntry)
-        else -> emptyList()
+        else -> error("unsupported entity type for read: ${entity.entityCase}")
       }
     }
 


### PR DESCRIPTION
## Summary

Scrutinizes the 10 N/A items in the P4Runtime compliance matrix and fixes 4
silent acceptance bugs that violate design invariant #5 ("fail loudly on
unsupported features"):

- **ValueSetEntry / ExternEntry / DigestEntry on Read** now return
  `UNIMPLEMENTED` instead of silently returning empty results
- **Non-default role on arbitration** now returns `UNIMPLEMENTED` instead of
  silently ignoring the `role` field
- **Simulator `readEntries` catch-all** replaced `else -> emptyList()` with an
  explicit error for unknown entity types

Also reclassifies items that are already handled correctly:

- **DATAPLANE_ATOMIC** (§12): was N/A, actually handled as ROLLBACK_ON_ERROR
- **Architecture-specific `other` stream messages** (§16): was N/A, already
  rejected with StreamError (PR #291)
- **Pipeline actions** (§7.7, §7.9): updates compliance matrix for VERIFY /
  two-phase commit implemented in PR #296

Compliance matrix: **127/130 tested**, 0 not tested, 3 genuinely N/A (digest
delivery, digest ack, idle timeout — not meaningful for a reference simulator).

## Test plan

- [x] 4 new conformance tests (#81-84): ValueSetEntry read, ExternEntry read,
  DigestEntry read, non-default role arbitration
- [x] All 47 test targets pass (`bazel test //... --test_tag_filters=-heavy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)