### PR TITLE
feat: assert, assume, and log_msg support

### DIFF
--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -69,6 +69,11 @@ object TraceFormatter {
       }
       event.hasMarkToDrop() -> appendLine("${prefix}mark_to_drop()")
       event.hasClone() -> appendLine("${prefix}clone session ${event.clone.sessionId}")
+      event.hasLogMessage() -> appendLine("${prefix}log_msg: ${event.logMessage.message}")
+      event.hasAssertion() -> {
+        val result = if (event.assertion.passed) "passed" else "FAILED"
+        appendLine("${prefix}assert: $result")
+      }
     }
   }
 
@@ -82,6 +87,7 @@ object TraceFormatter {
       DropReason.MARK_TO_DROP -> "mark_to_drop"
       DropReason.PARSER_REJECT -> "parser reject"
       DropReason.PIPELINE_EXECUTION_LIMIT_REACHED -> "execution limit"
+      DropReason.ASSERTION_FAILURE -> "assertion failure"
       else -> "unknown"
     }
 

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -2,11 +2,13 @@ package fourward.cli
 
 import com.google.protobuf.ByteString
 import fourward.sim.v1.SimulatorProto.ActionExecutionEvent
+import fourward.sim.v1.SimulatorProto.AssertionEvent
 import fourward.sim.v1.SimulatorProto.Drop
 import fourward.sim.v1.SimulatorProto.DropReason
 import fourward.sim.v1.SimulatorProto.Fork
 import fourward.sim.v1.SimulatorProto.ForkBranch
 import fourward.sim.v1.SimulatorProto.ForkReason
+import fourward.sim.v1.SimulatorProto.LogMessageEvent
 import fourward.sim.v1.SimulatorProto.MarkToDropEvent
 import fourward.sim.v1.SimulatorProto.OutputPacket
 import fourward.sim.v1.SimulatorProto.PacketOutcome
@@ -175,6 +177,76 @@ class TraceFormatterTest {
       |"""
         .trimMargin(),
       output,
+    )
+  }
+
+  @Test
+  fun logMessageEvent() {
+    val tree =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setLogMessage(LogMessageEvent.newBuilder().setMessage("TTL = 64, port = 1"))
+        )
+        .setPacketOutcome(
+          PacketOutcome.newBuilder()
+            .setOutput(OutputPacket.newBuilder().setEgressPort(1).setPayload(ByteString.EMPTY))
+        )
+        .build()
+
+    assertEquals(
+      """
+      |log_msg: TTL = 64, port = 1
+      |output port 1, 0 bytes
+      |"""
+        .trimMargin(),
+      TraceFormatter.format(tree),
+    )
+  }
+
+  @Test
+  fun assertionPassedEvent() {
+    val tree =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder().setAssertion(AssertionEvent.newBuilder().setPassed(true))
+        )
+        .setPacketOutcome(
+          PacketOutcome.newBuilder()
+            .setOutput(OutputPacket.newBuilder().setEgressPort(1).setPayload(ByteString.EMPTY))
+        )
+        .build()
+
+    assertEquals(
+      """
+      |assert: passed
+      |output port 1, 0 bytes
+      |"""
+        .trimMargin(),
+      TraceFormatter.format(tree),
+    )
+  }
+
+  @Test
+  fun assertionFailedDrop() {
+    val tree =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder().setAssertion(AssertionEvent.newBuilder().setPassed(false))
+        )
+        .setPacketOutcome(
+          PacketOutcome.newBuilder()
+            .setDrop(Drop.newBuilder().setReason(DropReason.ASSERTION_FAILURE))
+        )
+        .build()
+
+    assertEquals(
+      """
+      |assert: FAILED
+      |drop (reason: assertion failure)
+      |"""
+        .trimMargin(),
+      TraceFormatter.format(tree),
     )
   }
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -109,6 +109,7 @@ exceptions:
       - ExitException
       - EOFException
       - PacketTooShortException
+      - AssertionFailureException
       - FileNotFoundException
       - NoSuchFileException
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -30,7 +30,7 @@ guilt — just write it down so someone can find it later.
 - **Meters always return GREEN.** `meter.execute_meter()` and
   `direct_meter.read()` always return GREEN (0). Rate limiting is not
   simulated — there are no real packet rates in STF tests.
-- **`digest`, `log_msg` not implemented.** No corpus tests depend on these.
+- **`digest` not implemented.** No corpus tests depend on it.
 
 ## P4Runtime server
 

--- a/e2e_tests/assert_log_msg/AssertLogMsgTest.kt
+++ b/e2e_tests/assert_log_msg/AssertLogMsgTest.kt
@@ -1,0 +1,16 @@
+package fourward.e2e.assertlogmsg
+
+import fourward.e2e.TestResult
+import fourward.e2e.runStfTest
+import org.junit.Assert.fail
+import org.junit.Test
+
+/** End-to-end test for assert(), assume(), and log_msg() extern support. */
+class AssertLogMsgTest {
+
+  @Test
+  fun `assert and log_msg pass through correctly`() {
+    val result = runStfTest("assert_log_msg")
+    if (result is TestResult.Failure) fail(result.message)
+  }
+}

--- a/e2e_tests/assert_log_msg/BUILD.bazel
+++ b/e2e_tests/assert_log_msg/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//e2e_tests:p4c.bzl", "p4c_compile")
+
+p4c_compile(
+    name = "assert_log_msg",
+    src_p4 = "assert_log_msg.p4",
+)
+
+kt_jvm_test(
+    name = "assert_log_msg_test",
+    srcs = ["AssertLogMsgTest.kt"],
+    data = [
+        "assert_log_msg.stf",
+        ":assert_log_msg_pb",
+    ],
+    test_class = "fourward.e2e.assertlogmsg.AssertLogMsgTest",
+    deps = [
+        "//e2e_tests/stf:stf_runner",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:junit_junit",
+    ],
+)

--- a/e2e_tests/assert_log_msg/assert_log_msg.p4
+++ b/e2e_tests/assert_log_msg/assert_log_msg.p4
@@ -1,0 +1,82 @@
+/* assert_log_msg.p4 — exercises assert(), assume(), and log_msg().
+ *
+ * Ingress:
+ *  - log_msg prints a debug message
+ *  - assert checks that ingress_port != 5
+ *  - assume checks that dstAddr is valid (always true after parser)
+ *  - forwards to port 1
+ *
+ * Packets on port 0: passes all assertions, forwarded to port 1.
+ * Packets on port 5: assert fails, packet dropped.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+struct metadata_t {}
+
+parser MyParser(
+    packet_in packet,
+    out headers_t hdr,
+    inout metadata_t meta,
+    inout standard_metadata_t standard_metadata)
+{
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {}
+}
+
+control MyIngress(
+    inout headers_t hdr,
+    inout metadata_t meta,
+    inout standard_metadata_t standard_metadata)
+{
+    apply {
+        log_msg("ingress port = {}", {standard_metadata.ingress_port});
+        assert(standard_metadata.ingress_port != 9w5);
+        assume(hdr.ethernet.isValid());
+        standard_metadata.egress_spec = 1;
+    }
+}
+
+control MyEgress(
+    inout headers_t hdr,
+    inout metadata_t meta,
+    inout standard_metadata_t standard_metadata)
+{
+    apply {}
+}
+
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {}
+}
+
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+V1Switch(
+    MyParser(),
+    MyVerifyChecksum(),
+    MyIngress(),
+    MyEgress(),
+    MyComputeChecksum(),
+    MyDeparser()
+) main;

--- a/e2e_tests/assert_log_msg/assert_log_msg.stf
+++ b/e2e_tests/assert_log_msg/assert_log_msg.stf
@@ -1,0 +1,10 @@
+# assert_log_msg.stf — STF test for assert_log_msg.p4
+#
+# Packet on port 0: passes all assertions, forwarded to port 1.
+# Packet on port 5: assert(ingress_port != 5) fails, packet dropped.
+
+packet 0 FFFFFFFFFFFF 000000000001 0800
+expect 1 FFFFFFFFFFFF 000000000001 0800
+
+# Assertion failure → drop (no expect line).
+packet 5 FFFFFFFFFFFF 000000000002 0800

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -130,6 +130,8 @@ fourward::ir::v1::Expr FourWardBackend::emitExpr(const IR::Expression* expr) {
     }
   } else if (const auto* b = expr->to<IR::BoolLiteral>()) {
     out.mutable_literal()->set_boolean(b->value);
+  } else if (const auto* sl = expr->to<IR::StringLiteral>()) {
+    out.mutable_literal()->set_string_literal(sl->value.c_str());
   } else if (const auto* pe = expr->to<IR::PathExpression>()) {
     out.mutable_name_ref()->set_name(pe->path->name.name.c_str());
   } else if (const auto* mem = expr->to<IR::Member>()) {

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -16,6 +16,7 @@ import fourward.ir.v1.TableBehavior
 import fourward.ir.v1.Type
 import fourward.ir.v1.UnaryOperator
 import fourward.sim.v1.SimulatorProto.ActionExecutionEvent
+import fourward.sim.v1.SimulatorProto.AssertionEvent
 import fourward.sim.v1.SimulatorProto.BranchEvent
 import fourward.sim.v1.SimulatorProto.ParserTransitionEvent
 import fourward.sim.v1.SimulatorProto.TableLookupEvent
@@ -316,6 +317,7 @@ class Interpreter(
       lit.hasBoolean() -> BoolVal(lit.boolean)
       lit.hasErrorMember() -> ErrorVal(lit.errorMember)
       lit.hasEnumMember() -> EnumVal(lit.enumMember)
+      lit.hasStringLiteral() -> StringVal(lit.stringLiteral)
       lit.hasInteger() -> {
         val v = BigInteger.valueOf(lit.integer.toLong())
         when {
@@ -858,6 +860,18 @@ class Interpreter(
       return UnitVal
     }
 
+    // assert(condition) / assume(condition): P4 spec §12.9.
+    // At runtime, assume behaves identically to assert — the distinction is for
+    // static analysis tools. On failure, emit a trace event and abort processing.
+    if (funcName == "assert" || funcName == "assume") {
+      val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
+      packetCtx?.addTraceEvent(
+        traceEventBuilder().setAssertion(AssertionEvent.newBuilder().setPassed(condition)).build()
+      )
+      if (!condition) throw AssertionFailureException("$funcName failed")
+      return UnitVal
+    }
+
     // All other externs are architecture-specific — delegate to the handler.
     val handler = externHandler ?: error("no extern handler for: $funcName")
     return handler.handle(ExternCall.FreeFunction(funcName), createExternEvaluator(call, env))
@@ -1167,6 +1181,9 @@ class Interpreter(
  * Thrown by an `exit` statement; unwinds the call stack to the top of the current pipeline stage.
  */
 class ExitException : Exception()
+
+/** Thrown when assert() or assume() fails. The architecture catches this and drops the packet. */
+class AssertionFailureException(message: String) : Exception(message)
 
 /** Thrown by a `return` statement inside an action or function. */
 class ReturnException(val value: Value) : Exception()

--- a/simulator/InterpreterTestDsl.kt
+++ b/simulator/InterpreterTestDsl.kt
@@ -35,6 +35,10 @@ fun boolLit(v: Boolean): Expr =
     .setType(Type.newBuilder().setBoolean(true))
     .build()
 
+/** String literal expression, e.g. for log_msg format strings. */
+fun stringLit(value: String): Expr =
+  Expr.newBuilder().setLiteral(Literal.newBuilder().setStringLiteral(value)).build()
+
 fun nameRef(name: String, type: Type? = null): Expr =
   Expr.newBuilder()
     .setNameRef(NameRef.newBuilder().setName(name))

--- a/simulator/InterpreterTraceEventTest.kt
+++ b/simulator/InterpreterTraceEventTest.kt
@@ -13,6 +13,7 @@ import fourward.sim.v1.SimulatorProto.DropReason
 import fourward.sim.v1.SimulatorProto.MarkToDropEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -232,5 +233,50 @@ class InterpreterTraceEventTest {
     assertEquals(10, branchEvent.sourceInfo.line)
     assertEquals("mark_to_drop(sm)", markToDropEvent.sourceInfo.sourceFragment)
     assertEquals(20, markToDropEvent.sourceInfo.line)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 8: assert(true) emits AssertionEvent with passed=true
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `assert true emits passing AssertionEvent`() {
+    val config = controlConfig("MyIngress", externCall("assert", boolLit(true)))
+    val pktCtx = PacketContext(byteArrayOf())
+    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
+
+    val events = pktCtx.getEvents().filter { it.hasAssertion() }
+    assertEquals(1, events.size)
+    assertTrue(events[0].assertion.passed)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 9: assert(false) emits AssertionEvent with passed=false and throws
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `assert false emits failing AssertionEvent and throws`() {
+    val config = controlConfig("MyIngress", externCall("assert", boolLit(false)))
+    val pktCtx = PacketContext(byteArrayOf())
+    assertThrows(AssertionFailureException::class.java) {
+      Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
+    }
+
+    val events = pktCtx.getEvents().filter { it.hasAssertion() }
+    assertEquals(1, events.size)
+    assertFalse(events[0].assertion.passed)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 10: assume behaves identically to assert at runtime
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `assume false throws AssertionFailureException`() {
+    val config = controlConfig("MyIngress", externCall("assume", boolLit(false)))
+    val pktCtx = PacketContext(byteArrayOf())
+    assertThrows(AssertionFailureException::class.java) {
+      Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
+    }
   }
 }

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -66,7 +66,7 @@ class PSAArchitecture : Architecture {
 
     // === Ingress pipeline ===
     val ingress = runIngressPipeline(pipeline, payload, ingressPort)
-    if (ingress.dropped) return buildDropResult(ingress.events)
+    if (ingress.dropped) return buildDropResult(ingress.events, ingress.dropReason)
 
     // === Traffic Manager: multicast vs. unicast ===
     val egressState = EgressState(pipeline, ingress.output)
@@ -101,6 +101,7 @@ class PSAArchitecture : Architecture {
     val output: StructVal?,
     val deparsedBytes: ByteArray,
     val dropped: Boolean,
+    val dropReason: DropReason = DropReason.MARK_TO_DROP,
   )
 
   private fun runIngressPipeline(
@@ -135,21 +136,32 @@ class PSAArchitecture : Architecture {
       }
     }
 
-    // --- Ingress Control ---
-    val controlStage = pipeline.stages.first { it.name == "ingress" }
-    bindStageParams(env, controlStage.blockName, pipeline.blockParams, values)
-    runControlStage(interpreter, ctx, env, controlStage)
+    // An assert()/assume() failure anywhere in the pipeline drops the packet.
+    try {
+      // --- Ingress Control ---
+      val controlStage = pipeline.stages.first { it.name == "ingress" }
+      bindStageParams(env, controlStage.blockName, pipeline.blockParams, values)
+      runControlStage(interpreter, ctx, env, controlStage)
 
-    // --- Ingress drop check (PSA: drop=true by default) ---
-    val dropped = (output?.fields?.get("drop") as? BoolVal)?.value != false
-    if (dropped) {
-      return IngressResult(ctx.getEvents(), output, byteArrayOf(), dropped = true)
+      // --- Ingress drop check (PSA: drop=true by default) ---
+      val dropped = (output?.fields?.get("drop") as? BoolVal)?.value != false
+      if (dropped) {
+        return IngressResult(ctx.getEvents(), output, byteArrayOf(), dropped = true)
+      }
+
+      // --- Ingress Deparser ---
+      val deparserStage = pipeline.stages.first { it.name == "ingress_deparser" }
+      bindStageParams(env, deparserStage.blockName, pipeline.blockParams, values)
+      runControlStage(interpreter, ctx, env, deparserStage)
+    } catch (_: AssertionFailureException) {
+      return IngressResult(
+        ctx.getEvents(),
+        output,
+        byteArrayOf(),
+        dropped = true,
+        dropReason = DropReason.ASSERTION_FAILURE,
+      )
     }
-
-    // --- Ingress Deparser ---
-    val deparserStage = pipeline.stages.first { it.name == "ingress_deparser" }
-    bindStageParams(env, deparserStage.blockName, pipeline.blockParams, values)
-    runControlStage(interpreter, ctx, env, deparserStage)
 
     val deparsedBytes = ctx.outputPayload() + ctx.drainRemainingInput()
     return IngressResult(ctx.getEvents(), output, deparsedBytes, dropped = false)
@@ -167,7 +179,7 @@ class PSAArchitecture : Architecture {
     val group =
       egressState.pipeline.tableStore.getMulticastGroup(multicastGroup)
         ?: // BMv2 psa_switch: unknown multicast group → silently drop.
-        return buildDropResult(ingress.events)
+        return buildDropResult(ingress.events, ingress.dropReason)
 
     val branches =
       group.replicasList.map { replica ->
@@ -233,20 +245,24 @@ class PSAArchitecture : Architecture {
       }
     }
 
-    // --- Egress Control ---
-    val egressStage = p.stages.first { it.name == "egress" }
-    bindStageParams(egressEnv, egressStage.blockName, p.blockParams, egressValues)
-    runControlStage(egressInterpreter, egressCtx, egressEnv, egressStage)
+    try {
+      // --- Egress Control ---
+      val egressStage = p.stages.first { it.name == "egress" }
+      bindStageParams(egressEnv, egressStage.blockName, p.blockParams, egressValues)
+      runControlStage(egressInterpreter, egressCtx, egressEnv, egressStage)
 
-    // --- Egress drop check (PSA: egress does NOT drop by default) ---
-    if ((egressOutput?.fields?.get("drop") as? BoolVal)?.value == true) {
-      return buildDropTrace(egressCtx.getEvents())
+      // --- Egress drop check (PSA: egress does NOT drop by default) ---
+      if ((egressOutput?.fields?.get("drop") as? BoolVal)?.value == true) {
+        return buildDropTrace(egressCtx.getEvents())
+      }
+
+      // --- Egress Deparser ---
+      val egressDeparserStage = p.stages.first { it.name == "egress_deparser" }
+      bindStageParams(egressEnv, egressDeparserStage.blockName, p.blockParams, egressValues)
+      runControlStage(egressInterpreter, egressCtx, egressEnv, egressDeparserStage)
+    } catch (_: AssertionFailureException) {
+      return buildDropTrace(egressCtx.getEvents(), DropReason.ASSERTION_FAILURE)
     }
-
-    // --- Egress Deparser ---
-    val egressDeparserStage = p.stages.first { it.name == "egress_deparser" }
-    bindStageParams(egressEnv, egressDeparserStage.blockName, p.blockParams, egressValues)
-    runControlStage(egressInterpreter, egressCtx, egressEnv, egressDeparserStage)
 
     val outputBytes = egressCtx.outputPayload() + egressCtx.drainRemainingInput()
     return buildOutputTrace(egressCtx.getEvents(), egressPort, outputBytes)
@@ -583,14 +599,16 @@ class PSAArchitecture : Architecture {
   // Trace helpers
   // ---------------------------------------------------------------------------
 
-  private fun buildDropResult(events: List<TraceEvent>): PipelineResult =
-    PipelineResult(buildDropTrace(events))
+  private fun buildDropResult(
+    events: List<TraceEvent>,
+    reason: DropReason = DropReason.MARK_TO_DROP,
+  ): PipelineResult = PipelineResult(buildDropTrace(events, reason))
 
-  private fun buildDropTrace(events: List<TraceEvent>): TraceTree {
-    val outcome =
-      PacketOutcome.newBuilder()
-        .setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
-        .build()
+  private fun buildDropTrace(
+    events: List<TraceEvent>,
+    reason: DropReason = DropReason.MARK_TO_DROP,
+  ): TraceTree {
+    val outcome = PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(reason)).build()
     return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
   }
 

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -11,6 +11,7 @@ import fourward.sim.v1.SimulatorProto.DropReason
 import fourward.sim.v1.SimulatorProto.Fork
 import fourward.sim.v1.SimulatorProto.ForkBranch
 import fourward.sim.v1.SimulatorProto.ForkReason
+import fourward.sim.v1.SimulatorProto.LogMessageEvent
 import fourward.sim.v1.SimulatorProto.MarkToDropEvent
 import fourward.sim.v1.SimulatorProto.PacketIngressEvent
 import fourward.sim.v1.SimulatorProto.PacketOutcome
@@ -396,49 +397,54 @@ class V1ModelArchitecture : Architecture {
 
     val parserEventCount = s.packetCtx.getEvents().size
 
-    // --- Ingress controls (verify checksum, ingress) ---
-    // I2E clone branch: skip ingress — the clone gets the original parsed packet,
-    // not the version modified by ingress (BMv2 simple_switch semantics).
-    if (decisions.branchMode !is BranchMode.I2EClone) {
-      runControlStages(s, s.ingressControls)
-    }
+    // An assert()/assume() failure anywhere in the pipeline drops the packet.
+    try {
+      // --- Ingress controls (verify checksum, ingress) ---
+      // I2E clone branch: skip ingress — the clone gets the original parsed packet,
+      // not the version modified by ingress (BMv2 simple_switch semantics).
+      if (decisions.branchMode !is BranchMode.I2EClone) {
+        runControlStages(s, s.ingressControls)
+      }
 
-    // --- Ingress→egress boundary (traffic manager) ---
-    ingressEgressBoundary(ctx, s, decisions, parserEventCount)
-    if (egressPortIsDropPort(s)) {
-      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-    }
+      // --- Ingress→egress boundary (traffic manager) ---
+      ingressEgressBoundary(ctx, s, decisions, parserEventCount)
+      if (egressPortIsDropPort(s)) {
+        return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+      }
 
-    // --- Egress controls (egress, compute checksum) ---
-    // BMv2: egress_spec starts matching egress_port for each egress run. This
-    // ensures mark_to_drop() during egress is the only way to set the drop port,
-    // regardless of what ingress or a prior egress run left in egress_spec.
-    resetEgressSpec(s)
-    runControlStages(s, s.egressControls)
-
-    // --- Post-egress boundary (E2E clone / recirculate) ---
-    postEgressBoundary(ctx, s, decisions)
-
-    // E2E clone branch: postEgressBoundary set up clone metadata — run egress again.
-    if (decisions.branchMode is BranchMode.E2EClone) {
+      // --- Egress controls (egress, compute checksum) ---
+      // BMv2: egress_spec starts matching egress_port for each egress run. This
+      // ensures mark_to_drop() during egress is the only way to set the drop port,
+      // regardless of what ingress or a prior egress run left in egress_spec.
       resetEgressSpec(s)
       runControlStages(s, s.egressControls)
-    }
 
-    // mark_to_drop() called during egress (or the E2E clone's second egress run)
-    // sets egress_spec to the drop port.
-    if (egressSpecIsDropPort(s)) {
-      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-    }
+      // --- Post-egress boundary (E2E clone / recirculate) ---
+      postEgressBoundary(ctx, s, decisions)
 
-    // --- Deparser ---
-    if (s.deparserStage != null) {
-      s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.ENTER))
-      try {
-        s.interpreter.runControl(s.deparserStage.blockName, s.env)
-      } finally {
-        s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.EXIT))
+      // E2E clone branch: postEgressBoundary set up clone metadata — run egress again.
+      if (decisions.branchMode is BranchMode.E2EClone) {
+        resetEgressSpec(s)
+        runControlStages(s, s.egressControls)
       }
+
+      // mark_to_drop() called during egress (or the E2E clone's second egress run)
+      // sets egress_spec to the drop port.
+      if (egressSpecIsDropPort(s)) {
+        return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+      }
+
+      // --- Deparser ---
+      if (s.deparserStage != null) {
+        s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.ENTER))
+        try {
+          s.interpreter.runControl(s.deparserStage.blockName, s.env)
+        } finally {
+          s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.EXIT))
+        }
+      }
+    } catch (_: AssertionFailureException) {
+      return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
     }
 
     // Append any bytes the parser did not extract (the un-parsed packet body).
@@ -825,6 +831,19 @@ class V1ModelArchitecture : Architecture {
         eval.writeOutArg(0, BitVal(BitVector(result, resultWidth)))
         UnitVal
       }
+      // log_msg(msg) / log_msg(msg, data): debug output with {} placeholders.
+      // Defined in v1model.p4 — emits a trace event with the interpolated message.
+      "log_msg" -> {
+        val format = (eval.evalArg(0) as StringVal).value
+        val message = if (eval.argCount() > 1) formatLogMessage(format, eval.evalArg(1)) else format
+        eval.addTraceEvent(
+          eval
+            .traceEventBuilder()
+            .setLogMessage(LogMessageEvent.newBuilder().setMessage(message))
+            .build()
+        )
+        UnitVal
+      }
       else -> error("unhandled v1model extern: $name")
     }
 
@@ -1033,3 +1052,42 @@ internal class RecirculateFork(
   eventsBeforeFork: List<TraceEvent>,
   val preservedMetadata: Map<String, Value>? = null,
 ) : ForkException(eventsBeforeFork)
+
+// =============================================================================
+// log_msg formatting helpers
+// =============================================================================
+
+/** Substitutes `{}` placeholders in a log_msg format string with struct field values. */
+private fun formatLogMessage(format: String, data: Value): String {
+  val values =
+    when (data) {
+      is StructVal -> data.fields.values.toList()
+      else -> listOf(data)
+    }
+  val sb = StringBuilder()
+  var valueIdx = 0
+  var i = 0
+  while (i < format.length) {
+    if (i + 1 < format.length && format[i] == '{' && format[i + 1] == '}') {
+      sb.append(if (valueIdx < values.size) formatValue(values[valueIdx++]) else "{}")
+      i += 2
+    } else {
+      sb.append(format[i])
+      i++
+    }
+  }
+  return sb.toString()
+}
+
+/** Formats a runtime value for log_msg output. */
+private fun formatValue(value: Value): String =
+  when (value) {
+    is BitVal -> value.bits.value.toString()
+    is IntVal -> value.bits.value.toString()
+    is BoolVal -> value.value.toString()
+    is InfIntVal -> value.value.toString()
+    is EnumVal -> value.member
+    is ErrorVal -> value.member
+    is StringVal -> value.value
+    else -> value.toString()
+  }

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -1074,4 +1074,97 @@ class V1ModelArchitectureTest {
     // Clone should NOT drop: not_preserved was reset to 0, so 0x1234 check is false.
     assertEquals(2, outputs.size)
   }
+
+  // ---------------------------------------------------------------------------
+  // assert / assume tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `assert true passes through normally`() {
+    val config =
+      v1modelConfig(
+        externCall("assert", boolLit(true)),
+        assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val outputs = collectOutputsFromTrace(result.trace)
+
+    assertEquals(1, outputs.size)
+    assertEquals(1, outputs[0].egressPort)
+    // Trace should contain a passing assertion event.
+    assertTrue(result.trace.eventsList.any { it.hasAssertion() && it.assertion.passed })
+  }
+
+  @Test
+  fun `assert false drops packet with ASSERTION_FAILURE reason`() {
+    val config = v1modelConfig(externCall("assert", boolLit(false)))
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+
+    assertTrue(result.trace.hasPacketOutcome())
+    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertEquals(DropReason.ASSERTION_FAILURE, result.trace.packetOutcome.drop.reason)
+    // Trace should contain a failing assertion event.
+    assertTrue(result.trace.eventsList.any { it.hasAssertion() && !it.assertion.passed })
+  }
+
+  @Test
+  fun `assume false drops packet with ASSERTION_FAILURE reason`() {
+    val config = v1modelConfig(externCall("assume", boolLit(false)))
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+
+    assertTrue(result.trace.hasPacketOutcome())
+    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertEquals(DropReason.ASSERTION_FAILURE, result.trace.packetOutcome.drop.reason)
+  }
+
+  // ---------------------------------------------------------------------------
+  // log_msg tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `log_msg emits LogMessageEvent with format string`() {
+    val config =
+      v1modelConfig(
+        externCall("log_msg", stringLit("hello world")),
+        assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val outputs = collectOutputsFromTrace(result.trace)
+
+    assertEquals(1, outputs.size)
+    val logEvents = result.trace.eventsList.filter { it.hasLogMessage() }
+    assertEquals(1, logEvents.size)
+    assertEquals("hello world", logEvents[0].logMessage.message)
+  }
+
+  @Test
+  fun `log_msg substitutes placeholders from arg`() {
+    val config =
+      v1modelConfig(
+        externCall("log_msg", stringLit("value = {}"), bit(42, 8)),
+        assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val outputs = collectOutputsFromTrace(result.trace)
+
+    assertEquals(1, outputs.size)
+    val logEvents = result.trace.eventsList.filter { it.hasLogMessage() }
+    assertEquals(1, logEvents.size)
+    assertEquals("value = 42", logEvents[0].logMessage.message)
+  }
+
+  @Test
+  fun `egress assert false drops packet with ASSERTION_FAILURE reason`() {
+    val config =
+      v1modelConfig(
+        ingressStmts =
+          listOf(assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS)),
+        egressStmts = listOf(externCall("assert", boolLit(false))),
+      )
+    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+
+    assertTrue(result.trace.hasPacketOutcome())
+    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertEquals(DropReason.ASSERTION_FAILURE, result.trace.packetOutcome.drop.reason)
+  }
 }

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -51,6 +51,9 @@ data class ErrorVal(val member: String) : Value()
 /** A plain (non-serializable) P4 enum value, e.g. HashAlgorithm.crc16. */
 data class EnumVal(val member: String) : Value()
 
+/** A string value, used by log_msg format strings. */
+data class StringVal(val value: String) : Value()
+
 /**
  * A header instance.
  *

--- a/simulator/ir.proto
+++ b/simulator/ir.proto
@@ -495,6 +495,7 @@ message Literal {
     string error_member = 4;  // e.g. "NoError", "PacketTooShort"
     string enum_member =
         5;  // plain (non-serializable) enum member, e.g. "crc16"
+    string string_literal = 6;  // string literal, e.g. log_msg format string
   }
 }
 

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -132,6 +132,8 @@ message TraceEvent {
     PacketIngressEvent packet_ingress = 8;
     PipelineStageEvent pipeline_stage = 9;
     CloneSessionLookupEvent clone_session_lookup = 10;
+    LogMessageEvent log_message = 11;
+    AssertionEvent assertion = 12;
   }
 
   fourward.ir.v1.SourceInfo source_info = 100;
@@ -218,10 +220,21 @@ message PipelineStageEvent {
   Direction direction = 3;
 }
 
+// Fired when the P4 program calls log_msg().
+message LogMessageEvent {
+  string message = 1;
+}
+
+// Fired when the P4 program calls assert() or assume(). P4 spec §12.9.
+message AssertionEvent {
+  bool passed = 1;  // true = condition held; false = assertion failed
+}
+
 enum DropReason {
   DROP_REASON_UNSPECIFIED = 0;
   MARK_TO_DROP = 1;   // explicit mark_to_drop()
   PARSER_REJECT = 2;  // parser transitioned to reject state
   PIPELINE_EXECUTION_LIMIT_REACHED =
-      3;  // too many fork branches (exponential blowup guard)
+      3;                  // too many fork branches (exponential blowup guard)
+  ASSERTION_FAILURE = 4;  // assert() or assume() failed
 }

--- a/web/frontend/js/trace-render.js
+++ b/web/frontend/js/trace-render.js
@@ -109,7 +109,8 @@ function formatActionParams(ae) {
 }
 
 function isActionEffect(event) {
-  return event.mark_to_drop || event.extern_call || event.clone || event.clone_session_lookup;
+  return event.mark_to_drop || event.extern_call || event.clone || event.clone_session_lookup
+    || event.log_message || event.assertion;
 }
 
 function renderStageEvents(events) {
@@ -197,6 +198,12 @@ function renderTraceEvent(event) {
       : `Clone session ${csl.session_id} not found (dropped)`;
     const cls = csl.session_found ? 'clone-session-hit' : 'clone-session-miss';
     return `<div ${attr} class="trace-event ${cls}">${text}</div>`;
+  } else if (event.log_message) {
+    return `<div ${attr} class="trace-event log-msg">log_msg: ${escapeHtml(event.log_message.message)}</div>`;
+  } else if (event.assertion) {
+    const result = event.assertion.passed ? 'passed' : 'FAILED';
+    const cls = event.assertion.passed ? 'assert-pass' : 'assert-fail';
+    return `<div ${attr} class="trace-event ${cls}">assert: ${result}</div>`;
   } else {
     return '';
   }

--- a/web/frontend/style.css
+++ b/web/frontend/style.css
@@ -698,6 +698,9 @@ input:focus, select:focus, textarea:focus {
 .trace-event.stage-enter { color: var(--text-muted); font-weight: 600; }
 .trace-event.stage-exit { color: var(--text-muted); }
 .trace-event.ingress { color: var(--text-primary); font-weight: 600; }
+.trace-event.log-msg { color: #8b949e; font-style: italic; }
+.trace-event.assert-pass { color: var(--success); }
+.trace-event.assert-fail { color: var(--error); font-weight: 600; }
 
 .trace-outcome {
   padding: 2px 6px;


### PR DESCRIPTION
## Summary

End-to-end support for P4's three debugging externs — `assert()`, `assume()`,
and `log_msg()` — rendered across CLI traces and the web playground.

- **`assert`/`assume`** (P4 spec §12.9): core language constructs in the
  Interpreter. Failure drops the packet with `ASSERTION_FAILURE` reason in both
  v1model and PSA architectures.
- **`log_msg`**: v1model-specific extern with `{}` placeholder substitution,
  backed by `StringVal` runtime values and `string_literal` in the proto IR.
- Both architectures wrap ingress-through-deparser in a single try/catch,
  ensuring consistent assertion-failure drops regardless of pipeline stage.
- PSA previously had no assertion handling at all — this fixes a latent crash.

## Test plan

- [x] Unit tests: Interpreter (assert/assume throw), V1ModelArchitecture (log_msg
  formatting, ingress/egress assertion drops), TraceFormatter (CLI rendering)
- [x] E2E STF test: `assert_log_msg` (happy path + assertion-failure drop)
- [x] Web playground: log_msg and assertion events render with appropriate styling
- [x] All existing tests pass (`bazel test //...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)