### PR TITLE
Implement P4Runtime role-based access control (§15)

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -35,11 +35,11 @@ guilt — just write it down so someone can find it later.
 
 ## P4Runtime server
 
-- **Basic multi-controller arbitration.** The highest `election_id` becomes
-  primary and may write; all controllers may read (P4Runtime spec §10).
-  Not implemented: demotion notifications to existing non-primary controllers
-  when a new primary is elected, and automatic promotion of the next-highest
-  controller when the primary disconnects.
+- **Full multi-controller arbitration with role-based access control.**
+  Per-role primary election, demotion/promotion notifications, automatic
+  promotion on disconnect, and `@p4runtime_role` enforcement for reads and
+  writes (P4Runtime spec §5, §15). `Role.config` (target-specific policy)
+  is rejected with UNIMPLEMENTED.
 - **`@p4runtime_translation`: fully integrated for action params, match fields,
   and PacketIO metadata.** The `TypeTranslator` supports `sdn_bitwidth` and
   `sdn_string` with explicit, auto-allocate, and hybrid mapping modes.

--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -148,7 +148,12 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | 10.5 | Demotion notification to displaced primary | Y | ConformanceTest #73 |
 | 10.6 | Automatic promotion on primary disconnect | Y | ConformanceTest #74 |
 | 10.7 | Zero election_id: backup semantics (cannot be primary) | Y | ConformanceTest #72 |
-| 10.8 | Role-based access control | Y | Non-default role rejected with UNIMPLEMENTED; ConformanceTest #84 |
+| 10.8 | Per-role primary election | Y | ConformanceTest #84, #86 |
+| 10.9 | Role-based write access control | Y | ConformanceTest #87, #89 |
+| 10.10 | Role-based read access control (specific + wildcard) | Y | ConformanceTest #88, #88a |
+| 10.11 | Role.config rejected | Y | ConformanceTest #85 |
+| 10.12 | No ghost primary after disconnect | Y | ConformanceTest #90 |
+| 10.13 | Role change clears old role's primary | Y | ConformanceTest #91 |
 
 ## Read RPC (§11)
 
@@ -241,7 +246,7 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Write — other entities | 3 | 0 | 0 |
 | Write — atomicity | 4 | 0 | 0 |
 | Write — general | 2 | 0 | 0 |
-| Arbitration | 8 | 0 | 0 |
+| Arbitration | 13 | 0 | 0 |
 | Read | 11 | 0 | 0 |
 | GetForwardingPipelineConfig | 6 | 0 | 0 |
 | Capabilities | 1 | 0 | 0 |
@@ -249,4 +254,4 @@ Legend: **Y** = tested, **N** = not tested, **N/A** = out of scope
 | Translation | 6 | 0 | 0 |
 | @refers_to | 6 | 0 | 0 |
 | p4-constraints | 4 | 0 | 0 |
-| **Total** | **127** | **0** | **3** |
+| **Total** | **132** | **0** | **3** |

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -179,6 +179,18 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "RoleMapTest",
+    srcs = ["RoleMapTest.kt"],
+    test_class = "fourward.p4runtime.RoleMapTest",
+    deps = [
+        ":p4info_java_proto",
+        ":p4runtime_lib",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "TypeTranslatorTest",
     srcs = ["TypeTranslatorTest.kt"],
     test_class = "fourward.p4runtime.TypeTranslatorTest",

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -1,5 +1,6 @@
 package fourward.p4runtime
 
+import com.google.protobuf.Any as ProtoAny
 import fourward.ir.v1.PipelineConfig
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.assertGrpcError
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildEthernetFrame
@@ -1443,9 +1444,19 @@ class P4RuntimeConformanceTest {
     assertGrpcError(Status.Code.UNIMPLEMENTED) { harness.readEntries(request) }
   }
 
-  /** P4Runtime spec §15: non-default role on arbitration → UNIMPLEMENTED. */
+  /** P4Runtime spec §15: arbitration with a named role succeeds. */
   @Test
-  fun `84 - arbitration with non-default role rejected as UNIMPLEMENTED`() {
+  fun `84 - arbitration with named role succeeds`() {
+    harness.openStream().use { session ->
+      val response = session.arbitrate(roleName = "sdn_controller")
+      assertTrue(response.hasArbitration())
+      assertEquals("sdn_controller", response.arbitration.role.name)
+    }
+  }
+
+  /** P4Runtime spec §15: Role.config is rejected with UNIMPLEMENTED. */
+  @Test
+  fun `85 - arbitration with Role config rejected as UNIMPLEMENTED`() {
     assertGrpcError(Status.Code.UNIMPLEMENTED) {
       runBlocking {
         val request =
@@ -1454,11 +1465,115 @@ class P4RuntimeConformanceTest {
               P4RuntimeOuterClass.MasterArbitrationUpdate.newBuilder()
                 .setDeviceId(1)
                 .setElectionId(Uint128.newBuilder().setHigh(0).setLow(1))
-                .setRole(P4RuntimeOuterClass.Role.newBuilder().setName("custom_role"))
+                .setRole(
+                  P4RuntimeOuterClass.Role.newBuilder()
+                    .setName("sdn_controller")
+                    .setConfig(ProtoAny.getDefaultInstance())
+                )
             )
             .build()
         harness.stub.streamChannel(flowOf(request)).collect {}
       }
+    }
+  }
+
+  /** P4Runtime spec §15: different roles have independent primary elections. */
+  @Test
+  fun `86 - per-role independent primary election`() {
+    harness.openStream().use { role1Primary ->
+      harness.openStream().use { role2Primary ->
+        // Both become primary for their respective roles.
+        val r1 = role1Primary.arbitrate(electionId = 1, roleName = "role_a")
+        val r2 = role2Primary.arbitrate(electionId = 1, roleName = "role_b")
+        assertEquals(com.google.rpc.Code.OK_VALUE, r1.arbitration.status.code)
+        assertEquals(com.google.rpc.Code.OK_VALUE, r2.arbitration.status.code)
+      }
+    }
+  }
+
+  /** P4Runtime spec §15: named-role controller cannot write entities outside its role. */
+  @Test
+  fun `87 - named-role write denied for non-matching entity`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    // basic_table has no @p4runtime_role annotations → all entities belong to default role.
+    harness.openStream().use { session -> session.arbitrate(roleName = "sdn_controller") }
+    val entry = buildExactEntry(loadBasicTableConfig(), 1, 1)
+    assertGrpcError(Status.Code.PERMISSION_DENIED, "role 'sdn_controller'") {
+      harness.installEntry(entry, role = "sdn_controller")
+    }
+  }
+
+  /** P4Runtime spec §15: wildcard read filters out entities not matching the controller's role. */
+  @Test
+  fun `88 - named-role wildcard read returns empty for non-matching entities`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    // basic_table has no @p4runtime_role annotations → all entities belong to default role.
+    // A named-role wildcard read returns empty (not PERMISSION_DENIED).
+    harness.installEntry(buildExactEntry(loadBasicTableConfig(), 1, 1))
+    val entries = harness.readTableEntries(0, role = "sdn_controller")
+    assertTrue("wildcard read for non-matching role should return empty", entries.isEmpty())
+  }
+
+  /** P4Runtime spec §15: specific-entity read denied for non-matching role. */
+  @Test
+  fun `88a - named-role specific read denied for non-matching entity`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val tableId = config.p4Info.tablesList.first().preamble.id
+    assertGrpcError(Status.Code.PERMISSION_DENIED, "role 'sdn_controller'") {
+      harness.readTableEntries(tableId, role = "sdn_controller")
+    }
+  }
+
+  /** P4Runtime spec §15: default-role controller has full access to all entities. */
+  @Test
+  fun `89 - default-role controller has full access`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    // Default role (empty) can write and read everything.
+    val entry = buildExactEntry(loadBasicTableConfig(), 1, 1)
+    harness.installEntry(entry)
+    val entries = harness.readEntries()
+    assertFalse("should have entries", entries.isEmpty())
+  }
+
+  /** P4Runtime spec §5: writes rejected after all controllers for a role disconnect. */
+  @Test
+  fun `90 - write rejected after last controller disconnects`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    // Arbitrate, then close the stream — no active primary remains.
+    harness.openStream().use { session -> session.arbitrate() }
+    val entry = buildExactEntry(loadBasicTableConfig(), 1, 1)
+    assertGrpcError(Status.Code.PERMISSION_DENIED) {
+      harness.installEntry(entry, electionId = uint128(low = 1))
+    }
+  }
+
+  /** P4Runtime spec §15: re-arbitration with a different role updates old role's primary. */
+  @Test
+  fun `91 - role change on re-arbitration clears old role primary`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    harness.openStream().use { session ->
+      // Become primary for role_a.
+      val r1 = session.arbitrate(roleName = "role_a")
+      assertEquals(com.google.rpc.Code.OK_VALUE, r1.arbitration.status.code)
+      // Switch to role_b — should clear role_a's primary.
+      val r2 = session.arbitrate(roleName = "role_b")
+      assertEquals(com.google.rpc.Code.OK_VALUE, r2.arbitration.status.code)
+      // role_a should have no primary anymore. A write claiming role_a primary should fail.
+      val entry = buildExactEntry(loadBasicTableConfig(), 1, 1)
+      assertGrpcError(Status.Code.PERMISSION_DENIED) {
+        harness.installEntry(entry, electionId = uint128(low = 1), role = "role_a")
+      }
+    }
+  }
+
+  /** P4Runtime spec §5: election_id=0 with a named role is a backup, cannot be primary. */
+  @Test
+  fun `92 - zero election_id with named role is backup`() {
+    harness.openStream().use { session ->
+      val response = session.arbitrate(electionId = 0, roleName = "sdn_controller")
+      // Status should be ALREADY_EXISTS (non-primary) since election_id=0 cannot be primary.
+      assertEquals(com.google.rpc.Code.ALREADY_EXISTS_VALUE, response.arbitration.status.code)
     }
   }
 

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -73,6 +73,7 @@ class P4RuntimeService(
     val constraintValidator: ConstraintValidator?,
     val packetHeaderCodec: PacketHeaderCodec?,
     val entityReader: EntityReader,
+    val roleMap: RoleMap,
   )
 
   @Volatile private var pipeline: PipelineState? = null
@@ -86,19 +87,24 @@ class P4RuntimeService(
 
   /** Per-stream controller state, tracked for demotion/promotion notifications. */
   private data class ControllerStream(
+    val roleName: String, // empty = default role
     val electionId: Uint128,
     val notifications: SendChannel<StreamMessageResponse>,
+  )
+
+  /** Per-role arbitration state. Each role has its own independent primary election. */
+  private data class RoleElection(
+    val primaryElectionId: Uint128? = null,
+    val arbitrationOccurred: Boolean = false,
   )
 
   private val arbitrationMutex = Mutex()
   private val controllers = mutableMapOf<Any, ControllerStream>()
 
-  // True once any controller has sent MasterArbitrationUpdate. Once set, writes require
-  // a matching primary election_id (even if all controllers later disconnect).
-  @Volatile private var arbitrationOccurred: Boolean = false
-
-  // Highest non-zero election_id among active controllers, or null if none.
-  @Volatile private var primaryElectionId: Uint128? = null
+  // Per-role election state: key is role name (empty = default role).
+  // Modified under arbitrationMutex, but read without it by requirePrimaryOrNoArbitration
+  // (which runs under the write lock). ConcurrentHashMap ensures safe concurrent reads.
+  private val roleElections = java.util.concurrent.ConcurrentHashMap<String, RoleElection>()
 
   private fun requirePipeline(): PipelineState =
     pipeline ?: throw Status.FAILED_PRECONDITION.withDescription(NO_PIPELINE_MESSAGE).asException()
@@ -112,7 +118,7 @@ class P4RuntimeService(
   ): SetForwardingPipelineConfigResponse =
     lock.withLock {
       requireDeviceId(request.deviceId)
-      requirePrimaryOrNoArbitration(request.electionId)
+      requirePrimaryOrNoArbitration(request.electionId, request.role)
       when (request.action) {
         SetForwardingPipelineConfigRequest.Action.VERIFY ->
           verifyPipeline(request.config).also { it.constraintValidator?.close() }
@@ -183,6 +189,7 @@ class P4RuntimeService(
       // Placeholder — EntityReader needs simulator name maps that are only
       // available after loadPipeline; commitPipeline creates the real one.
       entityReader = EntityReader.EMPTY,
+      roleMap = RoleMap.create(fwdConfig.p4Info),
     )
   }
 
@@ -210,15 +217,17 @@ class P4RuntimeService(
     lock.withLock {
       requireDeviceId(request.deviceId)
       val state = requirePipeline()
-      requirePrimaryOrNoArbitration(request.electionId)
+      val roleName = request.role // empty = default role
+      requirePrimaryOrNoArbitration(request.electionId, roleName)
       when (request.atomicity) {
         WriteRequest.Atomicity.CONTINUE_ON_ERROR,
-        WriteRequest.Atomicity.UNRECOGNIZED -> writeContinueOnError(request.updatesList, state)
+        WriteRequest.Atomicity.UNRECOGNIZED ->
+          writeContinueOnError(request.updatesList, state, roleName)
         // P4Runtime spec §12.2: ROLLBACK_ON_ERROR and DATAPLANE_ATOMIC both guarantee
         // all-or-none semantics. DATAPLANE_ATOMIC additionally requires data-plane atomicity,
         // which we get for free because the write lock serializes all operations.
         WriteRequest.Atomicity.ROLLBACK_ON_ERROR,
-        WriteRequest.Atomicity.DATAPLANE_ATOMIC -> writeAtomic(request.updatesList, state)
+        WriteRequest.Atomicity.DATAPLANE_ATOMIC -> writeAtomic(request.updatesList, state, roleName)
       }
     }
 
@@ -228,12 +237,16 @@ class P4RuntimeService(
    * Per §12.3: if any update fails, the gRPC status is UNKNOWN with one [P4RuntimeOuterClass.Error]
    * per update packed into `google.rpc.Status.details`.
    */
-  private fun writeContinueOnError(updates: List<Update>, state: PipelineState): WriteResponse {
+  private fun writeContinueOnError(
+    updates: List<Update>,
+    state: PipelineState,
+    roleName: String,
+  ): WriteResponse {
     val errors = ArrayList<P4RuntimeOuterClass.Error>(updates.size)
     var hasError = false
     for (rawUpdate in updates) {
       try {
-        processUpdate(rawUpdate, state)
+        processUpdate(rawUpdate, state, roleName)
         errors.add(P4RuntimeOuterClass.Error.newBuilder().setCanonicalCode(OK_CODE).build())
       } catch (e: StatusException) {
         hasError = true
@@ -256,11 +269,15 @@ class P4RuntimeService(
    *
    * Snapshots write-state before the batch and restores it if any update fails.
    */
-  private fun writeAtomic(updates: List<Update>, state: PipelineState): WriteResponse {
+  private fun writeAtomic(
+    updates: List<Update>,
+    state: PipelineState,
+    roleName: String,
+  ): WriteResponse {
     val snapshot = simulator.snapshotWriteState()
     try {
       for (rawUpdate in updates) {
-        processUpdate(rawUpdate, state)
+        processUpdate(rawUpdate, state, roleName)
       }
     } catch (e: StatusException) {
       simulator.restoreWriteState(snapshot)
@@ -270,8 +287,9 @@ class P4RuntimeService(
   }
 
   /** Validates and applies a single update. Throws [StatusException] on failure. */
-  private fun processUpdate(rawUpdate: Update, state: PipelineState) {
+  private fun processUpdate(rawUpdate: Update, state: PipelineState, roleName: String) {
     rejectUnsupportedEntity(rawUpdate.entity)
+    requireEntityAccess(rawUpdate.entity, state.roleMap, roleName)
     // Validate against p4info before type translation so SDN-visible values
     // are checked at canonical widths (P4Runtime spec §8.3, §9.1).
     if (rawUpdate.entity.hasTableEntry()) {
@@ -322,23 +340,32 @@ class P4RuntimeService(
       lock.withLock {
         requireDeviceId(request.deviceId)
         val state = requirePipeline()
+        val roleName = request.role // empty = default role
         // Table entries are assembled by EntityReader (P4Runtime presentation layer);
         // all other entity types are read directly from the simulator.
         val entities =
           request.entitiesList.flatMap { entity ->
             rejectUnsupportedEntity(entity)
+            // For specific (non-wildcard) entities, check access upfront so the controller
+            // gets a clear PERMISSION_DENIED. For wildcards, results are filtered post-read.
+            requireEntityAccess(entity, state.roleMap, roleName)
             if (entity.hasTableEntry()) {
               state.entityReader.readTableEntities(entity.tableEntry, simulator)
             } else {
               simulator.readEntries(listOf(entity))
             }
           }
-        if (entities.isNotEmpty()) {
+        // Filter results by role for named-role controllers. This handles wildcard reads
+        // (where the request entity doesn't carry a specific ID) by returning only entities
+        // the controller's role can access.
+        val filtered =
+          if (roleName.isNotEmpty()) filterByRole(entities, state.roleMap, roleName) else entities
+        if (filtered.isNotEmpty()) {
           val translator = state.typeTranslator?.takeIf { it.hasTranslations }
           if (translator != null) {
-            entities.map { translator.translateForRead(it) }
+            filtered.map { translator.translateForRead(it) }
           } else {
-            entities
+            filtered
           }
         } else {
           null
@@ -481,19 +508,23 @@ class P4RuntimeService(
     CapabilitiesResponse.newBuilder().setP4RuntimeApiVersion(P4RUNTIME_API_VERSION).build()
 
   /**
-   * Ensures the requester is the primary controller, or that no arbitration has occurred.
+   * Ensures the requester is the primary controller for the given role, or that no arbitration has
+   * occurred for that role.
    *
-   * P4Runtime spec §5: only the primary (highest non-zero election_id) may write. If no arbitration
-   * has occurred, writes are allowed for backward compatibility with single-controller clients.
+   * P4Runtime spec §5, §15: only the primary (highest non-zero election_id) for a given role may
+   * write. If no arbitration has occurred for the role, writes are allowed for backward
+   * compatibility with single-controller clients.
    */
-  private fun requirePrimaryOrNoArbitration(requestElectionId: Uint128) {
-    if (!arbitrationOccurred) return
-    val primary = primaryElectionId
+  private fun requirePrimaryOrNoArbitration(requestElectionId: Uint128, roleName: String = "") {
+    val election = roleElections[roleName]
+    if (election == null || !election.arbitrationOccurred) return
+    val primary = election.primaryElectionId
     if (primary == null || requestElectionId != primary) {
       val id =
         primary?.let { if (it.high == 0L) "${it.low}" else "(${it.high}, ${it.low})" } ?: "none"
+      val roleDesc = if (roleName.isEmpty()) "default role" else "role '$roleName'"
       throw Status.PERMISSION_DENIED.withDescription(
-          "only the primary controller (election_id=$id) may write"
+          "only the primary controller for $roleDesc (election_id=$id) may write"
         )
         .asException()
     }
@@ -506,80 +537,109 @@ class P4RuntimeService(
   /**
    * Processes a MasterArbitrationUpdate from a stream, updating controller tracking and sending
    * demotion/promotion notifications as needed.
+   *
+   * P4Runtime spec §15: each role has its own independent primary election.
    */
   private suspend fun handleArbitration(
     streamId: Any,
     arbitration: MasterArbitrationUpdate,
     notifications: SendChannel<StreamMessageResponse>,
   ): StreamMessageResponse {
-    // P4Runtime spec §15: role-based access control. We only support the default role.
-    val role = arbitration.role
-    if (role.name.isNotEmpty() || role.hasConfig()) {
-      throw Status.UNIMPLEMENTED.withDescription(ROLE_NOT_SUPPORTED).asException()
+    // P4Runtime spec §15: Role.config is target-specific policy we don't support.
+    if (arbitration.role.hasConfig()) {
+      throw Status.UNIMPLEMENTED.withDescription(ROLE_CONFIG_NOT_SUPPORTED).asException()
     }
+    val roleName = arbitration.role.name // empty = default role
     val incomingId = arbitration.electionId
 
     return arbitrationMutex.withLock {
-      val oldPrimaryId = primaryElectionId
-      controllers[streamId] = ControllerStream(incomingId, notifications)
-      arbitrationOccurred = true
+      // If this controller was previously arbitrating under a different role, recompute
+      // the old role's primary before overwriting the entry.
+      val previousEntry = controllers[streamId]
+      if (previousEntry != null && previousEntry.roleName != roleName) {
+        recomputeRolePrimary(previousEntry.roleName, excludeStreamId = streamId)
+      }
 
-      val newPrimaryId = computePrimary()
-      if (newPrimaryId != null) primaryElectionId = newPrimaryId
+      val election = roleElections.getOrPut(roleName) { RoleElection() }
+      val oldPrimaryId = election.primaryElectionId
+      controllers[streamId] = ControllerStream(roleName, incomingId, notifications)
 
-      // If primary changed, send demotion/promotion notifications to other streams.
+      val newPrimaryId = computePrimary(roleName)
+      roleElections[roleName] =
+        election.copy(arbitrationOccurred = true, primaryElectionId = newPrimaryId)
+
+      // If primary changed, send demotion/promotion notifications to other streams with this role.
       if (newPrimaryId != oldPrimaryId) {
-        notifyRoleChanges(streamId, oldPrimaryId, newPrimaryId)
+        notifyRoleChanges(roleName, streamId, oldPrimaryId, newPrimaryId)
       }
 
       val isPrimary =
         !isZeroElectionId(incomingId) && newPrimaryId != null && incomingId == newPrimaryId
-      buildArbitrationResponse(arbitration.deviceId, incomingId, isPrimary)
+      buildArbitrationResponse(arbitration.deviceId, incomingId, isPrimary, roleName)
     }
   }
 
   /** Handles stream disconnect: removes the controller and promotes the next primary if needed. */
   private suspend fun handleDisconnect(streamId: Any) {
     arbitrationMutex.withLock {
-      controllers.remove(streamId) ?: return
+      val removed = controllers.remove(streamId) ?: return
+      recomputeRolePrimary(removed.roleName)
+    }
+  }
 
-      val oldPrimaryId = primaryElectionId
-      val newPrimaryId = computePrimary()
-      if (newPrimaryId != null) primaryElectionId = newPrimaryId
+  /**
+   * Recomputes the primary for [roleName] after a controller leaves or changes role, sends
+   * promotion notifications, and cleans up empty role elections.
+   *
+   * When [excludeStreamId] is set, the controller is still in [controllers] but about to switch
+   * roles, so it is excluded from the primary computation for the old role.
+   */
+  private fun recomputeRolePrimary(roleName: String, excludeStreamId: Any? = null) {
+    val election = roleElections[roleName] ?: return
+    val oldPrimaryId = election.primaryElectionId
+    val newPrimaryId = computePrimary(roleName, excludeStreamId)
+    roleElections[roleName] = election.copy(primaryElectionId = newPrimaryId)
 
-      // If the disconnected controller was primary, notify the promoted controller.
-      if (oldPrimaryId != null && newPrimaryId != oldPrimaryId && newPrimaryId != null) {
-        for ((_, ctrl) in controllers) {
-          if (ctrl.electionId == newPrimaryId) {
-            ctrl.notifications.trySend(buildArbitrationResponse(deviceId, ctrl.electionId, true))
-          }
+    // If the primary changed, notify the promoted controller.
+    if (oldPrimaryId != null && newPrimaryId != oldPrimaryId && newPrimaryId != null) {
+      for ((id, ctrl) in controllers) {
+        if (id != excludeStreamId && ctrl.roleName == roleName && ctrl.electionId == newPrimaryId) {
+          ctrl.notifications.trySend(
+            buildArbitrationResponse(deviceId, ctrl.electionId, true, roleName)
+          )
         }
       }
     }
   }
 
-  /** Returns the highest non-zero election_id among active controllers, or null. */
-  private fun computePrimary(): Uint128? =
-    controllers.values
-      .map { it.electionId }
+  /** Returns the highest non-zero election_id among controllers with the given role, or null. */
+  private fun computePrimary(roleName: String, excludeStreamId: Any? = null): Uint128? =
+    controllers.entries
+      .filter { (id, ctrl) -> id != excludeStreamId && ctrl.roleName == roleName }
+      .map { it.value.electionId }
       .filter { !isZeroElectionId(it) }
       .maxWithOrNull(Comparator { a, b -> compareUint128(a, b) })
 
-  /** Sends demotion/promotion notifications to other streams when the primary changes. */
+  /** Sends demotion/promotion notifications to other streams with the same role. */
   private fun notifyRoleChanges(
+    roleName: String,
     excludeStreamId: Any,
     oldPrimaryId: Uint128?,
     newPrimaryId: Uint128?,
   ) {
     for ((id, ctrl) in controllers) {
-      if (id == excludeStreamId) continue
+      if (id == excludeStreamId || ctrl.roleName != roleName) continue
       val wasPrimary = oldPrimaryId != null && ctrl.electionId == oldPrimaryId
       val isNowPrimary = newPrimaryId != null && ctrl.electionId == newPrimaryId
       when {
         wasPrimary && !isNowPrimary ->
-          ctrl.notifications.trySend(buildArbitrationResponse(deviceId, ctrl.electionId, false))
+          ctrl.notifications.trySend(
+            buildArbitrationResponse(deviceId, ctrl.electionId, false, roleName)
+          )
         !wasPrimary && isNowPrimary ->
-          ctrl.notifications.trySend(buildArbitrationResponse(deviceId, ctrl.electionId, true))
+          ctrl.notifications.trySend(
+            buildArbitrationResponse(deviceId, ctrl.electionId, true, roleName)
+          )
       }
     }
   }
@@ -588,21 +648,24 @@ class P4RuntimeService(
     deviceId: Long,
     electionId: Uint128,
     isPrimary: Boolean,
-  ): StreamMessageResponse =
-    StreamMessageResponse.newBuilder()
-      .setArbitration(
-        MasterArbitrationUpdate.newBuilder()
-          .setDeviceId(deviceId)
-          .setElectionId(electionId)
-          .setStatus(
-            com.google.rpc.Status.newBuilder()
-              .setCode(
-                if (isPrimary) com.google.rpc.Code.OK_VALUE
-                else com.google.rpc.Code.ALREADY_EXISTS_VALUE
-              )
-          )
-      )
-      .build()
+    roleName: String = "",
+  ): StreamMessageResponse {
+    val arb =
+      MasterArbitrationUpdate.newBuilder()
+        .setDeviceId(deviceId)
+        .setElectionId(electionId)
+        .setStatus(
+          com.google.rpc.Status.newBuilder()
+            .setCode(
+              if (isPrimary) com.google.rpc.Code.OK_VALUE
+              else com.google.rpc.Code.ALREADY_EXISTS_VALUE
+            )
+        )
+    if (roleName.isNotEmpty()) {
+      arb.setRole(P4RuntimeOuterClass.Role.newBuilder().setName(roleName))
+    }
+    return StreamMessageResponse.newBuilder().setArbitration(arb).build()
+  }
 
   /** Rejects requests targeting a different device (P4Runtime spec §6.3). */
   private fun requireDeviceId(requestDeviceId: Long) {
@@ -617,6 +680,80 @@ class P4RuntimeService(
   // ---------------------------------------------------------------------------
   // Unsupported feature guards
   // ---------------------------------------------------------------------------
+
+  /**
+   * Checks that the controller's role grants access to the entity.
+   *
+   * Default-role controllers (empty `roleName`) have access to all entities. Named-role controllers
+   * can only access entities whose `@p4runtime_role` matches their role.
+   *
+   * Wildcard requests (entity ID = 0) are skipped here — results are filtered post-read by
+   * [filterByRole] instead.
+   */
+  private fun requireEntityAccess(
+    entity: P4RuntimeOuterClass.Entity,
+    roleMap: RoleMap,
+    roleName: String,
+  ) {
+    if (roleName.isEmpty()) return // default role = full access
+    val entityId =
+      entityIdForRole(entity) ?: return // unknown entity type — let later validation handle it
+    if (entityId == 0) return // wildcard — filtering happens post-read
+    val entityRole = roleMap.role(entityId)
+    if (entityRole != roleName) {
+      val entityDesc = entityRole ?: "default role"
+      throw Status.PERMISSION_DENIED.withDescription(
+          "role '$roleName' cannot access entity belonging to $entityDesc"
+        )
+        .asException()
+    }
+  }
+
+  /**
+   * Filters read results to only include entities the controller's role can access.
+   *
+   * Used for wildcard reads where the request entity doesn't specify a particular ID.
+   */
+  private fun filterByRole(
+    entities: List<P4RuntimeOuterClass.Entity>,
+    roleMap: RoleMap,
+    roleName: String,
+  ): List<P4RuntimeOuterClass.Entity> =
+    entities.filter { entity ->
+      val id = entityIdForRole(entity) ?: return@filter true // unscoped types (counters, etc.)
+      roleMap.role(id) == roleName
+    }
+
+  /**
+   * Extracts the p4info ID to use for role checking.
+   *
+   * For table entries and direct resources, this is the table ID (since `@p4runtime_role` is on
+   * tables). For action profiles, this is the action profile ID (which inherits its role from its
+   * associated tables in [RoleMap]). Returns null for entity types that don't have role annotations
+   * (standalone counters, meters, registers, PRE entries).
+   */
+  private fun entityIdForRole(entity: P4RuntimeOuterClass.Entity): Int? =
+    when (entity.entityCase) {
+      P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY -> entity.tableEntry.tableId
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER ->
+        entity.actionProfileMember.actionProfileId
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_GROUP ->
+        entity.actionProfileGroup.actionProfileId
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_COUNTER_ENTRY ->
+        entity.directCounterEntry.tableEntry.tableId
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_METER_ENTRY ->
+        entity.directMeterEntry.tableEntry.tableId
+      // Standalone counters, meters, registers, PRE, and unimplemented types: no role annotations.
+      P4RuntimeOuterClass.Entity.EntityCase.COUNTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.METER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.REGISTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.VALUE_SET_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIGEST_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.EXTERN_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.ENTITY_NOT_SET,
+      null -> null
+    }
 
   /** Rejects entity types that are documented but not implemented. */
   private fun rejectUnsupportedEntity(entity: P4RuntimeOuterClass.Entity) {
@@ -674,8 +811,8 @@ class P4RuntimeService(
     private const val DIGEST_NOT_SUPPORTED = "digest is not supported"
     private const val VALUE_SET_NOT_SUPPORTED = "ValueSetEntry is not supported"
     private const val EXTERN_ENTRY_NOT_SUPPORTED = "ExternEntry is not supported"
-    private const val ROLE_NOT_SUPPORTED =
-      "role-based access control is not supported; omit the role field or use the default role"
+    private const val ROLE_CONFIG_NOT_SUPPORTED =
+      "Role.config is not supported; use @p4runtime_role annotations in p4info instead"
 
     private const val OK_CODE = com.google.rpc.Code.OK_VALUE
 

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -142,14 +142,14 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
   // Table entry management
   // ---------------------------------------------------------------------------
 
-  fun installEntry(entity: Entity, electionId: Uint128? = null): WriteResponse =
-    writeEntity(Update.Type.INSERT, entity, electionId)
+  fun installEntry(entity: Entity, electionId: Uint128? = null, role: String = ""): WriteResponse =
+    writeEntity(Update.Type.INSERT, entity, electionId, role)
 
-  fun modifyEntry(entity: Entity, electionId: Uint128? = null): WriteResponse =
-    writeEntity(Update.Type.MODIFY, entity, electionId)
+  fun modifyEntry(entity: Entity, electionId: Uint128? = null, role: String = ""): WriteResponse =
+    writeEntity(Update.Type.MODIFY, entity, electionId, role)
 
-  fun deleteEntry(entity: Entity, electionId: Uint128? = null): WriteResponse =
-    writeEntity(Update.Type.DELETE, entity, electionId)
+  fun deleteEntry(entity: Entity, electionId: Uint128? = null, role: String = ""): WriteResponse =
+    writeEntity(Update.Type.DELETE, entity, electionId, role)
 
   /** Sends a raw [WriteRequest] — use for testing request-level fields like atomicity. */
   fun writeRaw(request: WriteRequest): WriteResponse = runBlocking { stub.write(request) }
@@ -161,16 +161,23 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
       .apply { entities.forEach { addUpdates(Update.newBuilder().setType(type).setEntity(it)) } }
       .build()
 
-  private fun writeEntity(type: Update.Type, entity: Entity, electionId: Uint128?): WriteResponse =
-    runBlocking {
-      stub.write(
-        WriteRequest.newBuilder()
-          .setDeviceId(1)
-          .apply { if (electionId != null) setElectionId(electionId) }
-          .addUpdates(Update.newBuilder().setType(type).setEntity(entity))
-          .build()
-      )
-    }
+  private fun writeEntity(
+    type: Update.Type,
+    entity: Entity,
+    electionId: Uint128?,
+    role: String = "",
+  ): WriteResponse = runBlocking {
+    stub.write(
+      WriteRequest.newBuilder()
+        .setDeviceId(1)
+        .apply {
+          if (electionId != null) setElectionId(electionId)
+          if (role.isNotEmpty()) setRole(role)
+        }
+        .addUpdates(Update.newBuilder().setType(type).setEntity(entity))
+        .build()
+    )
+  }
 
   /** Wildcard read: returns all table entries including defaults (table_id=0). */
   fun readEntries(): List<Entity> = readTableEntries(0)
@@ -183,10 +190,11 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
     readTableEntries(tableId).filter { !it.tableEntry.isDefaultAction }
 
   /** Per-table read: returns entries from a single table (or all tables if tableId is 0). */
-  fun readTableEntries(tableId: Int): List<Entity> =
+  fun readTableEntries(tableId: Int, role: String = ""): List<Entity> =
     readEntries(
       ReadRequest.newBuilder()
         .setDeviceId(1)
+        .apply { if (role.isNotEmpty()) setRole(role) }
         .addEntities(Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(tableId)))
         .build()
     )
@@ -349,16 +357,19 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
         stub.streamChannel(requestChannel.consumeAsFlow()).collect { responseChannel.send(it) }
       }
 
-    fun arbitrate(deviceId: Long = 1, electionId: Long = 1): StreamMessageResponse = runBlocking {
-      requestChannel.send(
-        StreamMessageRequest.newBuilder()
-          .setArbitration(
-            MasterArbitrationUpdate.newBuilder()
-              .setDeviceId(deviceId)
-              .setElectionId(Uint128.newBuilder().setHigh(0).setLow(electionId))
-          )
-          .build()
-      )
+    fun arbitrate(
+      deviceId: Long = 1,
+      electionId: Long = 1,
+      roleName: String = "",
+    ): StreamMessageResponse = runBlocking {
+      val arb =
+        MasterArbitrationUpdate.newBuilder()
+          .setDeviceId(deviceId)
+          .setElectionId(Uint128.newBuilder().setHigh(0).setLow(electionId))
+      if (roleName.isNotEmpty()) {
+        arb.setRole(P4RuntimeOuterClass.Role.newBuilder().setName(roleName))
+      }
+      requestChannel.send(StreamMessageRequest.newBuilder().setArbitration(arb).build())
       withTimeout(STREAM_TIMEOUT_MS) { responseChannel.receive() }
     }
 

--- a/p4runtime/RoleMap.kt
+++ b/p4runtime/RoleMap.kt
@@ -1,0 +1,68 @@
+package fourward.p4runtime
+
+import p4.config.v1.P4InfoOuterClass
+
+/**
+ * Maps P4 entity IDs to their `@p4runtime_role` (P4Runtime spec §15).
+ *
+ * Built at pipeline load time from p4info annotations. Tables declare their role via
+ * `@p4runtime_role("role_name")`; direct counters/meters inherit the role of their parent table;
+ * action profiles inherit from their associated tables.
+ *
+ * Entities without a `@p4runtime_role` annotation belong to the **default role** (empty string).
+ * Controllers that arbitrate with no role (empty `Role.name`) have full access to all entities.
+ */
+class RoleMap private constructor(private val entityRoles: Map<Int, String>) {
+
+  /** Returns the role for the given entity ID, or null if it belongs to the default role. */
+  fun role(entityId: Int): String? = entityRoles[entityId]
+
+  /** True if any entity in the pipeline has a `@p4runtime_role` annotation. */
+  val hasRoles: Boolean
+    get() = entityRoles.isNotEmpty()
+
+  companion object {
+    // Matches @p4runtime_role("role_name") in unstructured p4info annotations.
+    // The quotes are escaped in protobuf text format: @p4runtime_role(\"role_name\")
+    private val ROLE_PATTERN = Regex("""@p4runtime_role\("(.+?)"\)""")
+
+    /** Parses `@p4runtime_role` annotations from p4info and builds entity-to-role mappings. */
+    fun create(p4info: P4InfoOuterClass.P4Info): RoleMap {
+      val roles = mutableMapOf<Int, String>()
+
+      // Tables: direct annotation.
+      for (table in p4info.tablesList) {
+        val role = parseRole(table.preamble.annotationsList) ?: continue
+        roles[table.preamble.id] = role
+      }
+
+      // Direct counters: inherit from parent table.
+      for (dc in p4info.directCountersList) {
+        val tableRole = roles[dc.directTableId]
+        if (tableRole != null) roles[dc.preamble.id] = tableRole
+      }
+
+      // Direct meters: inherit from parent table.
+      for (dm in p4info.directMetersList) {
+        val tableRole = roles[dm.directTableId]
+        if (tableRole != null) roles[dm.preamble.id] = tableRole
+      }
+
+      // Action profiles: inherit from associated tables.
+      for (ap in p4info.actionProfilesList) {
+        val tableRole = ap.tableIdsList.firstNotNullOfOrNull { roles[it] }
+        if (tableRole != null) roles[ap.preamble.id] = tableRole
+      }
+
+      return RoleMap(roles)
+    }
+
+    private fun parseRole(annotations: List<String>): String? {
+      for (annotation in annotations) {
+        val match = ROLE_PATTERN.find(annotation)
+        if (match != null) return match.groupValues[1]
+      }
+      return null
+    }
+  }
+}

--- a/p4runtime/RoleMapTest.kt
+++ b/p4runtime/RoleMapTest.kt
@@ -1,0 +1,194 @@
+package fourward.p4runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import p4.config.v1.P4InfoOuterClass
+import p4.config.v1.P4InfoOuterClass.P4Info
+
+/** Unit tests for [RoleMap]. */
+class RoleMapTest {
+
+  @Test
+  fun `empty p4info has no roles`() {
+    val roleMap = RoleMap.create(P4Info.getDefaultInstance())
+    assertFalse(roleMap.hasRoles)
+  }
+
+  @Test
+  fun `table without annotation belongs to default role`() {
+    val p4info = p4info { table(id = 1, name = "my_table") }
+    val roleMap = RoleMap.create(p4info)
+    assertFalse(roleMap.hasRoles)
+    assertNull(roleMap.role(1))
+  }
+
+  @Test
+  fun `table with role annotation is mapped`() {
+    val p4info = p4info { table(id = 1, name = "my_table", role = "sdn_controller") }
+    val roleMap = RoleMap.create(p4info)
+    assertTrue(roleMap.hasRoles)
+    assertEquals("sdn_controller", roleMap.role(1))
+  }
+
+  @Test
+  fun `multiple tables with different roles`() {
+    val p4info = p4info {
+      table(id = 1, name = "routing_table", role = "sdn_controller")
+      table(id = 2, name = "clone_table", role = "packet_replication_engine_manager")
+      table(id = 3, name = "misc_table")
+    }
+    val roleMap = RoleMap.create(p4info)
+    assertEquals("sdn_controller", roleMap.role(1))
+    assertEquals("packet_replication_engine_manager", roleMap.role(2))
+    assertNull(roleMap.role(3))
+  }
+
+  @Test
+  fun `direct counter inherits role from parent table`() {
+    val p4info = p4info {
+      table(id = 1, name = "my_table", role = "sdn_controller")
+      directCounter(id = 100, directTableId = 1)
+    }
+    val roleMap = RoleMap.create(p4info)
+    assertEquals("sdn_controller", roleMap.role(100))
+  }
+
+  @Test
+  fun `direct counter without parent role has no role`() {
+    val p4info = p4info {
+      table(id = 1, name = "my_table")
+      directCounter(id = 100, directTableId = 1)
+    }
+    val roleMap = RoleMap.create(p4info)
+    assertNull(roleMap.role(100))
+  }
+
+  @Test
+  fun `direct meter inherits role from parent table`() {
+    val p4info = p4info {
+      table(id = 1, name = "my_table", role = "sdn_controller")
+      directMeter(id = 200, directTableId = 1)
+    }
+    val roleMap = RoleMap.create(p4info)
+    assertEquals("sdn_controller", roleMap.role(200))
+  }
+
+  @Test
+  fun `action profile inherits role from associated table`() {
+    val p4info = p4info {
+      table(id = 1, name = "my_table", role = "sdn_controller")
+      actionProfile(id = 300, tableIds = listOf(1))
+    }
+    val roleMap = RoleMap.create(p4info)
+    assertEquals("sdn_controller", roleMap.role(300))
+  }
+
+  @Test
+  fun `action profile without associated role has no role`() {
+    val p4info = p4info {
+      table(id = 1, name = "my_table")
+      actionProfile(id = 300, tableIds = listOf(1))
+    }
+    val roleMap = RoleMap.create(p4info)
+    assertNull(roleMap.role(300))
+  }
+
+  @Test
+  fun `action profile with conflicting table roles uses first`() {
+    // Action profile shared across tables with different roles — picks the first found.
+    val p4info = p4info {
+      table(id = 1, name = "table_a", role = "role_a")
+      table(id = 2, name = "table_b", role = "role_b")
+      actionProfile(id = 300, tableIds = listOf(1, 2))
+    }
+    val roleMap = RoleMap.create(p4info)
+    // Non-deterministic per proto ordering, but should get one of the roles.
+    val role = roleMap.role(300)
+    assertTrue("expected role_a or role_b, got $role", role == "role_a" || role == "role_b")
+  }
+
+  @Test
+  fun `action profile skips roleless tables to find role`() {
+    val p4info = p4info {
+      table(id = 1, name = "default_table") // no role
+      table(id = 2, name = "roled_table", role = "sdn_controller")
+      actionProfile(id = 300, tableIds = listOf(1, 2))
+    }
+    val roleMap = RoleMap.create(p4info)
+    assertEquals("sdn_controller", roleMap.role(300))
+  }
+
+  @Test
+  fun `standalone counter has no role`() {
+    val p4info = p4info { table(id = 1, name = "my_table", role = "sdn_controller") }
+    val roleMap = RoleMap.create(p4info)
+    // Counter ID 500 isn't in the map at all.
+    assertNull(roleMap.role(500))
+  }
+
+  @Test
+  fun `role annotation with other annotations present`() {
+    // Table has multiple annotations — role should still be parsed.
+    val p4info =
+      P4Info.newBuilder()
+        .addTables(
+          P4InfoOuterClass.Table.newBuilder()
+            .setPreamble(
+              P4InfoOuterClass.Preamble.newBuilder()
+                .setId(1)
+                .setName("acl_table")
+                .addAnnotations("""@sai_acl(INGRESS)""")
+                .addAnnotations("""@p4runtime_role("sdn_controller")""")
+                .addAnnotations("""@entry_restriction("priority > 0")""")
+            )
+        )
+        .build()
+    val roleMap = RoleMap.create(p4info)
+    assertEquals("sdn_controller", roleMap.role(1))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  private class P4InfoBuilder {
+    private val builder = P4Info.newBuilder()
+
+    fun table(id: Int, name: String, role: String? = null) {
+      val preamble = P4InfoOuterClass.Preamble.newBuilder().setId(id).setName(name)
+      if (role != null) preamble.addAnnotations("""@p4runtime_role("$role")""")
+      builder.addTables(P4InfoOuterClass.Table.newBuilder().setPreamble(preamble))
+    }
+
+    fun directCounter(id: Int, directTableId: Int) {
+      builder.addDirectCounters(
+        P4InfoOuterClass.DirectCounter.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName("dc_$id"))
+          .setDirectTableId(directTableId)
+      )
+    }
+
+    fun directMeter(id: Int, directTableId: Int) {
+      builder.addDirectMeters(
+        P4InfoOuterClass.DirectMeter.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName("dm_$id"))
+          .setDirectTableId(directTableId)
+      )
+    }
+
+    fun actionProfile(id: Int, tableIds: List<Int>) {
+      val ap =
+        P4InfoOuterClass.ActionProfile.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName("ap_$id"))
+      tableIds.forEach { ap.addTableIds(it) }
+      builder.addActionProfiles(ap.build())
+    }
+
+    fun build(): P4Info = builder.build()
+  }
+
+  private fun p4info(block: P4InfoBuilder.() -> Unit): P4Info = P4InfoBuilder().apply(block).build()
+}

--- a/p4runtime/SaiP4E2ETest.kt
+++ b/p4runtime/SaiP4E2ETest.kt
@@ -573,6 +573,71 @@ class SaiP4E2ETest {
   }
 
   // =========================================================================
+  // Role-based access control (§15)
+  //
+  // SAI P4 tables declare @p4runtime_role("sdn_controller") (most tables) or
+  // @p4runtime_role("packet_replication_engine_manager") (ingress_clone_table).
+  // =========================================================================
+
+  @Test
+  fun `named-role controller can write and read entities matching its role`() {
+    val eid = P4RuntimeTestHarness.uint128(low = 1)
+    // Keep stream open for the duration of the test so the controller stays primary.
+    harness.openStream().use { session ->
+      session.arbitrate(roleName = "sdn_controller")
+      // vrf_table has @p4runtime_role("sdn_controller") — write should succeed.
+      harness.installEntry(buildVrfEntry("vrf-role"), electionId = eid, role = "sdn_controller")
+
+      val vrfTable = findTable("vrf_table")
+      val entries =
+        harness.readTableEntries(vrfTable.preamble.id, role = "sdn_controller").filter {
+          !it.tableEntry.isDefaultAction
+        }
+      assertEquals("expected one vrf_table entry", 1, entries.size)
+      assertEquals("vrf-role", entries[0].tableEntry.matchList.first().exact.value.toStringUtf8())
+    }
+  }
+
+  @Test
+  fun `wrong-role controller cannot write to another role's table`() {
+    val eid = P4RuntimeTestHarness.uint128(low = 1)
+    harness.openStream().use { session ->
+      session.arbitrate(roleName = "packet_replication_engine_manager")
+      // vrf_table belongs to "sdn_controller", not "packet_replication_engine_manager".
+      P4RuntimeTestHarness.assertGrpcError(Status.Code.PERMISSION_DENIED, "role") {
+        harness.installEntry(
+          buildVrfEntry("vrf-denied"),
+          electionId = eid,
+          role = "packet_replication_engine_manager",
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `wildcard read with role returns only matching tables`() {
+    val eid = P4RuntimeTestHarness.uint128(low = 1)
+    harness.openStream().use { session ->
+      session.arbitrate(roleName = "sdn_controller")
+      harness.installEntry(buildVrfEntry("vrf-wildcard"), electionId = eid, role = "sdn_controller")
+
+      // Wildcard read (table_id=0) with role="sdn_controller" should return entries
+      // only from sdn_controller tables, filtering out other roles.
+      val roleMap = RoleMap.create(config.p4Info)
+      val entities = harness.readTableEntries(0, role = "sdn_controller")
+      for (entity in entities) {
+        val tableId = entity.tableEntry.tableId
+        val table = config.p4Info.tablesList.find { it.preamble.id == tableId }!!
+        assertEquals(
+          "table '${table.preamble.alias}' should belong to sdn_controller",
+          "sdn_controller",
+          roleMap.role(tableId),
+        )
+      }
+    }
+  }
+
+  // =========================================================================
   // Delete: verify translated entries can be removed
   // =========================================================================
 


### PR DESCRIPTION
## Summary

Adds full support for P4Runtime role-based access control (§15), bringing us
to 132/132 tested requirements in the compliance matrix (up from 127).

- **`RoleMap`** parses `@p4runtime_role` annotations from p4info at pipeline
  load time — tables declare roles directly; direct counters/meters and action
  profiles inherit from parent tables.
- **Per-role primary election** — each role has independent arbitration state,
  so controllers with different roles don't compete for primary.
- **Write and Read enforcement** — named-role controllers can only access
  entities matching their role; wildcard reads filter results by role rather
  than rejecting outright. Default-role controllers retain full access.
- **`Role.config` rejected** with `UNIMPLEMENTED` (target-specific policy we
  don't implement).
- **Thread safety** — `roleElections` uses `ConcurrentHashMap` since it's
  accessed under two different locks (arbitration mutex and write lock).

Three bugs caught and fixed during review: ghost primary after disconnect,
stale election state on role change, and wildcard reads rejected instead of
filtered.

This is the mechanism SAI P4 already uses (`sdn_controller`,
`packet_replication_engine_manager`), so it's directly exercised by the
existing SAI E2E tests — plus 3 new role-specific E2E tests.

## Test plan

- [x] 13 unit tests for `RoleMap` (annotation parsing, inheritance, edge cases)
- [x] 10 new conformance tests (#84-92): role arbitration, Role.config rejection,
  per-role election independence, write/read access control, default-role full
  access, ghost primary prevention, role change cleanup, zero election_id backup
- [x] 3 new SAI P4 E2E role tests (named-role write/read, wrong-role denied,
  wildcard filtering)
- [x] All 14 p4runtime tests pass locally
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)