### PR TITLE
fix: populate extern type on MethodCall target

### DIFF
--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -5,82 +5,9 @@ tech debt — not a history of past refactors.
 
 ---
 
-## Corpus tests: opt-out instead of opt-in
-
-**Files**: `e2e_tests/corpus/BUILD.bazel`, new `e2e_tests/corpus_ext.bzl`,
-`MODULE.bazel`
-
-**Problem**: `e2e_tests/corpus/BUILD.bazel` is an explicit allow-list — adding
-a newly-passing corpus test requires a BUILD edit. It's easy to forget, and
-the list gives no signal about how many tests are still failing.
-
-**Fix**: Replace the allow-list with a Bazel module extension that discovers
-all `*-bmv2.p4`/`*-bmv2.stf` pairs in `@p4c//testdata/p4_16_samples/` at
-load time and generates a `p4_stf_test` for each. Known failures are listed
-in a `corpus.skip()` call in `MODULE.bazel` and get `tags = ["manual"]`
-(excluded from `//...`). Enabling a newly-passing test then means removing it
-from the skip list rather than adding to BUILD.
-
-Sketch:
-
-```python
-# MODULE.bazel
-corpus = use_extension("//e2e_tests:corpus_ext.bzl", "corpus_extension")
-corpus.skip(tests = [
-    "currently_failing_test-bmv2",
-    # ...
-])
-use_repo(corpus, "p4c_corpus")
-```
-
-```python
-# e2e_tests/corpus_ext.bzl
-def _corpus_impl(mctx):
-    skip = {}
-    for mod in mctx.modules:
-        for tag in mod.tags.skip:
-            for t in tag.tests:
-                skip[t] = True
-
-    # Walk @p4c//testdata/p4_16_samples/ and collect *-bmv2 test names.
-    # Generate a BUILD with p4_stf_test for each; tag skipped ones ["manual"].
-    ...
-
-corpus_extension = module_extension(
-    implementation = _corpus_impl,
-    tag_classes = {"skip": tag_class(attrs = {"tests": attr.string_list()})},
-)
-```
-
-The module extension has read access to the p4c source tree (via
-`git_override`) and can enumerate files with
-`mctx.path(Label("@p4c//:MODULE.bazel")).dirname`. The generated repo replaces
-`e2e_tests/corpus/BUILD.bazel` entirely.
-
----
-
 ## Re-enable buf lint
 
 Blocked on buf support for proto edition 2024.
-
----
-
-## p4c backend: populate extern type on MethodCall target
-
-**Files**: `p4c_backend/`
-
-**Problem**: The p4c backend emits an empty `type {}` on the `MethodCall`
-target `Expr` for some extern instances (observed with `direct_meter`). The
-simulator expects `type { named: "direct_meter" }` to dispatch extern method
-calls correctly.
-
-**Current workaround**: The simulator disambiguates `read` calls by argument
-count (1 arg = `direct_meter.read`, 2 args = `register.read`). Marked with
-`WORKAROUND` and `TODO(p4c backend)` in `V1ModelArchitecture.kt`.
-
-A related issue: the backend emits unsized integer literals (no type) for
-`*_preserving_field_list` field list ID arguments. The simulator handles both
-`BitVal` and `InfIntVal` via `evalIntArg`.
 
 ---
 
@@ -118,3 +45,29 @@ no cloning or recirculation.
 ## Upstream p4c backend
 
 Land the 4ward backend in the p4c repository. Blocked on upstream review.
+Once merged, switch `MODULE.bazel` from `smolkaj/p4c` fork to `p4lang/p4c`.
+
+---
+
+## Unpin gutil override
+
+**File**: `MODULE.bazel`
+
+`gutil` is pinned to commit `20c8d2e` to pick up Bazel 9 compatibility
+(google/gutil#42). Check if this fix has landed in a tagged BCR release —
+if so, replace the `git_override` with a regular `bazel_dep` version pin.
+
+---
+
+## Pinned dependencies inventory
+
+Several deps use `git_override` with pinned commits. This is tracked here as
+a reminder to periodically check for upstream updates:
+
+- **bazel_clang_tidy** (`9e54bbb`): pinned before a commit (`c4d35e0`) that
+  broke `-isystem` include ordering. Upstream bug never fixed — permanent
+  workaround. Re-check if upstream ever resolves the issue.
+- **behavioral_model** (`6c7c93e` + Bazel build patch): upstream uses Autotools;
+  our patch adds native Bazel rules. The patch needs updating when we bump BMv2.
+- **p4_constraints** (`cbcc7b1`): standard pin from `p4lang/p4-constraints`.
+  Check for updates when bumping p4c.

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -81,6 +81,10 @@ fourward::ir::v1::Type FourWardBackend::emitType(const IR::Type* type) {
     // Extern object types (Hash, Meter, Register, etc.) — emit as named so the
     // simulator can identify the extern type in method call targets.
     out.set_named(ext->name.name.c_str());
+  } else if (const auto* spec = type->to<IR::Type_SpecializedCanonical>()) {
+    // Specialized generic extern (e.g. register<bit<8>>, direct_meter<bit<2>>).
+    // Emit the base type name so the simulator can identify the extern.
+    return emitType(spec->baseType);
   } else {
     LOG1("WARNING: unhandled type " << type->node_type_name()
                                     << "; emitting as unnamed");

--- a/simulator/InterpreterControlTest.kt
+++ b/simulator/InterpreterControlTest.kt
@@ -44,27 +44,44 @@ class InterpreterControlTest {
     when (call) {
       is ExternCall.FreeFunction -> error("unexpected extern call: ${call.name}")
       is ExternCall.Method ->
-        when (call.method) {
-          "read" -> {
-            if (call.externType == "direct_meter" || eval.argCount() == 1) {
-              eval.writeOutArg(0, eval.defaultValue(eval.argType(0)))
-            } else {
-              val index = (eval.evalArg(1) as BitVal).bits.value.toInt()
-              val stored = tableStore.registerRead(call.instanceName, index)
-              eval.writeOutArg(0, stored ?: eval.defaultValue(eval.argType(0)))
+        when (call.externType) {
+          "register" ->
+            when (call.method) {
+              "read" -> {
+                val index = (eval.evalArg(1) as BitVal).bits.value.toInt()
+                val stored = tableStore.registerRead(call.instanceName, index)
+                eval.writeOutArg(0, stored ?: eval.defaultValue(eval.argType(0)))
+                UnitVal
+              }
+              "write" -> {
+                val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
+                tableStore.registerWrite(call.instanceName, index, eval.evalArg(1))
+                UnitVal
+              }
+              else -> error("unhandled register method: ${call.method}")
             }
-            UnitVal
-          }
-          "execute_meter" -> {
-            eval.writeOutArg(1, eval.defaultValue(eval.argType(1)))
-            UnitVal
-          }
-          "write" -> {
-            val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
-            tableStore.registerWrite(call.instanceName, index, eval.evalArg(1))
-            UnitVal
-          }
-          "count" -> UnitVal
+          "direct_meter" ->
+            when (call.method) {
+              "read" -> {
+                eval.writeOutArg(0, eval.defaultValue(eval.argType(0)))
+                UnitVal
+              }
+              else -> error("unhandled direct_meter method: ${call.method}")
+            }
+          "meter" ->
+            when (call.method) {
+              "execute_meter" -> {
+                eval.writeOutArg(1, eval.defaultValue(eval.argType(1)))
+                UnitVal
+              }
+              else -> error("unhandled meter method: ${call.method}")
+            }
+          "counter",
+          "direct_counter" ->
+            when (call.method) {
+              "count" -> UnitVal
+              else -> error("unhandled counter method: ${call.method}")
+            }
           else ->
             error(
               "unhandled extern method: ${call.externType}.${call.method}" +
@@ -520,26 +537,15 @@ class InterpreterControlTest {
   }
 
   @Test
-  fun `direct_meter read with empty extern type falls back to arg count`() {
-    // p4c sometimes emits an empty type on the MethodCall target for direct_meter.
-    // The simulator disambiguates by arg count: 1 arg = direct_meter, 2 = register.
+  fun `execute_meter writes GREEN to out parameter`() {
     val stmt =
       methodCallStmt(
         "my_meter",
-        "read",
-        nameRef("color", bitType(2)),
-        // targetType omitted → empty type, exercising the workaround path
+        "execute_meter",
+        bit(0, 32),
+        nameRef("color", bitType(8)),
+        targetType = namedType("meter"),
       )
-    val config = controlConfig(stmt)
-    val env = emptyEnv
-    env.define("color", BitVal(3, 2))
-    interp(config).runControl("MyControl", env)
-    assertEquals(BitVal(0, 2), env.lookup("color"))
-  }
-
-  @Test
-  fun `execute_meter writes GREEN to out parameter`() {
-    val stmt = methodCallStmt("my_meter", "execute_meter", bit(0, 32), nameRef("color", bitType(8)))
     val config = controlConfig(stmt)
     val env = emptyEnv
     env.define("color", BitVal(0xFF, 8))
@@ -587,7 +593,7 @@ class InterpreterControlTest {
       assertThrows(IllegalStateException::class.java) {
         interp(config).runControl("MyControl", emptyEnv)
       }
-    assertEquals("unhandled extern method: register.unknown_method on obj", e.message)
+    assertEquals("unhandled register method: unknown_method", e.message)
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -864,39 +864,47 @@ class V1ModelArchitecture : Architecture {
     eval: ExternEvaluator,
     tableStore: TableStore,
   ): Value =
-    when (call.method) {
-      // register.read(out dst, index) / direct_meter.read(out color)
-      "read" -> {
-        // direct_meter.read has 1 arg; register.read has 2.
-        // WORKAROUND: p4c emits an empty externType for direct_meter instances
-        // (the MethodCall target Expr carries `type {}` instead of
-        // `type { named: "direct_meter" }`). The proper fix is to populate
-        // the type in the p4c backend; until then, disambiguate by arg count.
-        // TODO(p4c backend): populate extern type on MethodCall target Expr.
-        if (call.externType == "direct_meter" || eval.argCount() == 1) {
-          // direct_meter.read(out color): always GREEN (no real rates in simulator).
-          eval.writeOutArg(0, eval.defaultValue(eval.argType(0)))
-        } else {
-          // register.read(out dst, index)
-          val index = (eval.evalArg(1) as BitVal).bits.value.toInt()
-          val stored = tableStore.registerRead(call.instanceName, index)
-          eval.writeOutArg(0, stored ?: eval.defaultValue(eval.argType(0)))
+    when (call.externType) {
+      "register" ->
+        when (call.method) {
+          "read" -> {
+            val index = (eval.evalArg(1) as BitVal).bits.value.toInt()
+            val stored = tableStore.registerRead(call.instanceName, index)
+            eval.writeOutArg(0, stored ?: eval.defaultValue(eval.argType(0)))
+            UnitVal
+          }
+          "write" -> {
+            val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
+            tableStore.registerWrite(call.instanceName, index, eval.evalArg(1))
+            UnitVal
+          }
+          else -> error("unhandled register method: ${call.method} on ${call.instanceName}")
         }
-        UnitVal
-      }
-      // meter.execute_meter(in index, out color): always GREEN.
-      "execute_meter" -> {
-        eval.writeOutArg(1, eval.defaultValue(eval.argType(1)))
-        UnitVal
-      }
-      // register.write(index, value)
-      "write" -> {
-        val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
-        tableStore.registerWrite(call.instanceName, index, eval.evalArg(1))
-        UnitVal
-      }
-      // counter.count(index): fire-and-forget side-effect, invisible to data plane.
-      "count" -> UnitVal
+      "counter",
+      "direct_counter" ->
+        when (call.method) {
+          // fire-and-forget side-effect, invisible to data plane.
+          "count" -> UnitVal
+          else -> error("unhandled counter method: ${call.method} on ${call.instanceName}")
+        }
+      "meter" ->
+        when (call.method) {
+          // execute_meter(in index, out color): always GREEN (no real rates in simulator).
+          "execute_meter" -> {
+            eval.writeOutArg(1, eval.defaultValue(eval.argType(1)))
+            UnitVal
+          }
+          else -> error("unhandled meter method: ${call.method} on ${call.instanceName}")
+        }
+      "direct_meter" ->
+        when (call.method) {
+          // read(out color): always GREEN (no real rates in simulator).
+          "read" -> {
+            eval.writeOutArg(0, eval.defaultValue(eval.argType(0)))
+            UnitVal
+          }
+          else -> error("unhandled direct_meter method: ${call.method} on ${call.instanceName}")
+        }
       else ->
         error(
           "unhandled v1model extern method: ${call.externType}.${call.method}" +

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -370,7 +370,13 @@ class V1ModelArchitectureTest {
           listOf(VarDecl.newBuilder().setName("color").setType(bitType(8)).build()),
         ingressStmts =
           listOf(
-            methodCallStmt("my_meter", "execute_meter", bit(0, 32), nameRef("color", bitType(8))),
+            methodCallStmt(
+              "my_meter",
+              "execute_meter",
+              bit(0, 32),
+              nameRef("color", bitType(8)),
+              targetType = namedType("meter"),
+            ),
             assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
           ),
       )


### PR DESCRIPTION
## Summary

Fixes a long-standing bug where the p4c backend emitted empty `type {}` on
MethodCall target Exprs for all locally-declared generic extern instances
(register, direct_meter, counter, meter). The simulator had to resort to
argument-count heuristics to disambiguate `register.read` from
`direct_meter.read`.

- **Root cause**: `Type_SpecializedCanonical` (p4c's resolved type for generic
  externs like `register<bit<8>>`) wasn't handled in `emitType()`. Three-line
  fix: delegate to the base type.
- **Simulator cleanup**: removed the `WORKAROUND`/`TODO(p4c backend)` in
  V1ModelArchitecture. Extern method dispatch now uses `externType` as the
  primary discriminator instead of method name, which is cleaner and
  future-proof.
- **REFACTORING.md**: resolved the p4c backend entry, dropped the corpus
  opt-out proposal (opt-in is explicit and sufficient), added a
  pinned-dependencies inventory for periodic review.

## Test plan

- [x] Compiled a probe P4 program with both register and direct_meter — both
  targets now emit `type { named: "register" }` / `type { named: "direct_meter" }`
- [x] All 48 tests pass (`bazel test //... --test_tag_filters=-heavy`)
- [x] Format and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)