### PR TITLE
feat: PSA resubmit support (25/26 corpus tests)

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -12,15 +12,15 @@ guilt — just write it down so someone can find it later.
 
 ## Architecture support
 
-- **PSA: pipeline, registers, multicast, cloning, recirculate, Hash, Meter,
-  InternetChecksum.** The PSA two-pipeline architecture (ingress + egress) is
-  implemented with support for `send_to_port`, `ingress_drop`, `egress_drop`,
+- **PSA: pipeline, registers, multicast, cloning, recirculate, resubmit, Hash,
+  Meter, InternetChecksum.** The PSA two-pipeline architecture (ingress + egress)
+  is implemented with support for `send_to_port`, `ingress_drop`, `egress_drop`,
   `multicast`, I2E/E2E cloning (via `ostd.clone` + `clone_session_id`),
-  recirculate (`PSA_PORT_RECIRCULATE`), registers, `Hash.get_hash`,
-  `Meter.execute` (stub GREEN), `InternetChecksum`
+  recirculate (`PSA_PORT_RECIRCULATE`), resubmit (`ostd.resubmit`), registers,
+  `Hash.get_hash`, `Meter.execute` (stub GREEN), `InternetChecksum`
   (clear/add/subtract/get/get_state/set_state), basic counters, and top-level
-  assignments. 23 of 26 PSA corpus tests pass. Missing: resubmit,
-  `lookahead` type resolution. PNA and TNA are not implemented.
+  assignments. 25 of 26 PSA corpus tests pass. Missing: `lookahead` type
+  resolution. PNA and TNA are not implemented.
 
 ## Externs
 

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -238,6 +238,7 @@ corpus_test_suite(
         "psa-drop-all-bmv2",
         "psa-drop-all-corrected-bmv2",
         "psa-e2e-cloning-basic-bmv2",
+        "psa-end-of-ingress-test-bmv2",
         "psa-example-register2-bmv2",
         "psa-fwd-bmv2",
         "psa-i2e-cloning-basic-bmv2",
@@ -251,6 +252,7 @@ corpus_test_suite(
         "psa-register-complex-bmv2",
         "psa-register-read-write-2-bmv2",
         "psa-register-read-write-bmv2",
+        "psa-resubmit-bmv2",
         "psa-top-level-assignments-bmv2",
         "psa-unicast-or-drop-bmv2",
         "psa-unicast-or-drop-corrected-bmv2",
@@ -264,9 +266,7 @@ corpus_test_suite(
     name = "psa_manual_stf_corpus_test",
     tags = ["manual"],
     tests = [
-        "psa-end-of-ingress-test-bmv2",  # Resubmit (packet_path=RESUBMIT)
         "psa-example-dpdk-varbit-bmv2",  # lookahead type resolution
-        "psa-resubmit-bmv2",  # Resubmit
     ],
 )
 

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -86,18 +86,32 @@ class PSAArchitecture : Architecture {
     // === Ingress pipeline ===
     val ingress = runIngressPipeline(pipeline, payload, ingressPort, packetPath)
 
-    // === I2E clone: uses ORIGINAL input bytes (pre-ingress), independent of drop decision ===
-    val i2eCloneBranches = buildI2ECloneBranches(pipeline, payload, ingress.output)
+    // === End-of-ingress decisions (PSA spec §6.2, Table 4) ===
+    // Priority: drop > resubmit > {I2E clone, multicast/unicast}.
+    // I2E clone is independent of drop but suppressed by resubmit.
 
     if (ingress.dropped) {
+      val i2eCloneBranches = buildI2ECloneBranches(pipeline, payload, ingress.output)
       if (i2eCloneBranches.isNotEmpty()) {
-        // Dropped but cloned: emit only the clone branches.
         return buildForkTree(ingress.events, ForkReason.CLONE, i2eCloneBranches)
       }
       return buildDropTrace(ingress.events, ingress.dropReason)
     }
 
-    // === Traffic Manager: multicast vs. unicast ===
+    // Resubmit: loop original bytes back to ingress. Suppresses I2E clone.
+    val resubmit = (ingress.output?.fields?.get("resubmit") as? BoolVal)?.value == true
+    if (resubmit) {
+      val resubmitTree =
+        processPacketRecursive(pipeline, payload, ingressPort, PACKET_PATH_RESUBMIT, depth + 1)
+      return buildForkTree(
+        ingress.events,
+        ForkReason.RESUBMIT,
+        listOf(ForkBranch.newBuilder().setLabel("resubmit").setSubtree(resubmitTree).build()),
+      )
+    }
+
+    // === Traffic Manager: I2E clone + multicast/unicast ===
+    val i2eCloneBranches = buildI2ECloneBranches(pipeline, payload, ingress.output)
     val originalTree = buildOriginalEgressPath(pipeline, ingress, depth)
 
     if (i2eCloneBranches.isNotEmpty()) {
@@ -849,6 +863,7 @@ class PSAArchitecture : Architecture {
     const val PACKET_PATH_NORMAL_MULTICAST = "NORMAL_MULTICAST"
     const val PACKET_PATH_CLONE_I2E = "CLONE_I2E"
     const val PACKET_PATH_CLONE_E2E = "CLONE_E2E"
+    const val PACKET_PATH_RESUBMIT = "RESUBMIT"
     const val PACKET_PATH_RECIRCULATE = "RECIRCULATE"
 
     /** Architecture-level packet I/O types that are not user-visible parameters. */

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -94,6 +94,7 @@ class PSAArchitectureTest {
           .addFields(boolField("clone"))
           .addFields(field("clone_session_id", 16))
           .addFields(boolField("drop"))
+          .addFields(boolField("resubmit"))
           .addFields(field("multicast_group", 32))
           .addFields(field("egress_port", 32))
       )
@@ -958,6 +959,115 @@ class PSAArchitectureTest {
     // No clone session 0 → clone silently ignored, original output normally.
     assertEquals(1, outputs.size)
     assertEquals(2, outputs[0].egressPort)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Resubmit tests
+  // ---------------------------------------------------------------------------
+
+  /** Sets ostd.resubmit = true. */
+  private fun resubmitStmt(): Stmt = assignField("ostd", "resubmit", boolLit(true))
+
+  @Test
+  fun `resubmit loops back to ingress with RESUBMIT packet path`() {
+    // First ingress: set resubmit=true, send_to_port(3) (port is ignored on resubmit).
+    // Second ingress (packet_path==RESUBMIT): send_to_port(7).
+    val isResubmit = eq(fieldAccess("istd", "packet_path"), enumLit("RESUBMIT"))
+    val config =
+      psaConfig(
+        ingressStmts =
+          listOf(
+            ifStmt(
+              condition = isResubmit,
+              thenStmts = listOf(sendToPort(7)),
+              elseStmts = listOf(resubmitStmt(), sendToPort(3)),
+            )
+          )
+      )
+    val result =
+      PSAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, TableStore())
+    val outputs = collectOutputsFromTrace(result.trace)
+
+    assertEquals(1, outputs.size)
+    assertEquals(7, outputs[0].egressPort)
+    assertTrue(result.trace.hasForkOutcome())
+    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
+    assertEquals("resubmit", result.trace.forkOutcome.branchesList[0].label)
+  }
+
+  @Test
+  fun `resubmit uses original pre-ingress bytes`() {
+    // Verify that the resubmitted packet sees the original input bytes, not ingress-modified state.
+    // Both passes send to port 1 — if resubmit used modified bytes, parsing could differ.
+    val isResubmit = eq(fieldAccess("istd", "packet_path"), enumLit("RESUBMIT"))
+    val config =
+      psaConfig(
+        ingressStmts =
+          listOf(
+            ifStmt(
+              condition = isResubmit,
+              thenStmts = listOf(sendToPort(1)),
+              elseStmts = listOf(resubmitStmt(), sendToPort(1)),
+            )
+          )
+      )
+    val result =
+      PSAArchitecture().processPacket(0u, byteArrayOf(0xBB.toByte()), config, TableStore())
+    val outputs = collectOutputsFromTrace(result.trace)
+
+    // Resubmitted packet exits on port 1 with original bytes.
+    assertEquals(1, outputs.size)
+    assertEquals(0xBB.toByte(), outputs[0].payload.byteAt(0))
+  }
+
+  @Test
+  fun `drop overrides resubmit`() {
+    // PSA spec §6.2: drop has highest priority. resubmit=true with drop=true → dropped.
+    val config =
+      psaConfig(ingressStmts = listOf(resubmitStmt())) // drop=true by default, resubmit=true
+    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+
+    assertTrue(result.trace.hasPacketOutcome())
+    assertTrue(result.trace.packetOutcome.hasDrop())
+  }
+
+  @Test
+  fun `resubmit suppresses I2E clone`() {
+    // PSA spec §6.2: resubmit takes priority over I2E clone.
+    val isResubmit = eq(fieldAccess("istd", "packet_path"), enumLit("RESUBMIT"))
+    val config =
+      psaConfig(
+        ingressStmts =
+          listOf(
+            ifStmt(
+              condition = isResubmit,
+              thenStmts = listOf(sendToPort(5)),
+              elseStmts = cloneStmts(100) + listOf(resubmitStmt(), sendToPort(2)),
+            )
+          )
+      )
+    val store = TableStore()
+    writeCloneSession(store, 100, listOf(0 to 9))
+
+    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val outputs = collectOutputsFromTrace(result.trace)
+
+    // Resubmit wins: packet loops back, then exits on port 5. No clone on port 9.
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].egressPort)
+    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
+  }
+
+  @Test
+  fun `resubmit depth limit is enforced`() {
+    // Unconditional resubmit causes infinite loop — simulator must enforce depth limit.
+    val config = psaConfig(ingressStmts = listOf(resubmitStmt(), sendToPort(1)))
+    try {
+      PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+      fail("expected recirculation depth exception")
+    } catch (e: IllegalStateException) {
+      assertTrue(e.message!!.contains("PSA recirculation depth exceeded"))
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

PSA corpus coverage reaches **25/26** — only `lookahead` type resolution remains. Resubmit completes the full set of PSA packet-path operations (clone, recirculate, resubmit).

Implementation is minimal: check `ostd.resubmit` after ingress, recursively re-enter `processPacketRecursive` with original bytes and `packet_path=RESUBMIT`. The end-of-ingress priority chain follows PSA spec §6.2 Table 4: **drop > resubmit > {I2E clone, multicast/unicast}**. Resubmit suppresses I2E clone and shares the existing depth limit (16 passes max).

## Test plan

- [x] 5 new unit tests: basic resubmit, original bytes preserved, drop overrides resubmit, resubmit suppresses I2E clone, depth limit enforced
- [x] 2 corpus tests promoted: `psa-resubmit-bmv2`, `psa-end-of-ingress-test-bmv2`
- [x] Full test suite passes (48/48, `--test_tag_filters=-heavy`)
- [x] LIMITATIONS.md updated (23/26 → 25/26)
- [x] detekt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)