### PR TITLE
feat: lookahead<bit<N>> — PSA 26/26 corpus tests pass

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -12,15 +12,13 @@ guilt — just write it down so someone can find it later.
 
 ## Architecture support
 
-- **PSA: pipeline, registers, multicast, cloning, recirculate, resubmit, Hash,
-  Meter, InternetChecksum.** The PSA two-pipeline architecture (ingress + egress)
-  is implemented with support for `send_to_port`, `ingress_drop`, `egress_drop`,
-  `multicast`, I2E/E2E cloning (via `ostd.clone` + `clone_session_id`),
-  recirculate (`PSA_PORT_RECIRCULATE`), resubmit (`ostd.resubmit`), registers,
-  `Hash.get_hash`, `Meter.execute` (stub GREEN), `InternetChecksum`
-  (clear/add/subtract/get/get_state/set_state), basic counters, and top-level
-  assignments. 25 of 26 PSA corpus tests pass. Missing: `lookahead` type
-  resolution. PNA and TNA are not implemented.
+- **PSA: all 26 corpus tests pass.** The PSA two-pipeline architecture
+  (ingress + egress) is implemented with support for `send_to_port`,
+  `ingress_drop`, `egress_drop`, `multicast`, I2E/E2E cloning (via
+  `ostd.clone` + `clone_session_id`), recirculate (`PSA_PORT_RECIRCULATE`),
+  resubmit (`ostd.resubmit`), registers, `Hash.get_hash`, `Meter.execute`
+  (stub GREEN), `InternetChecksum` (clear/add/subtract/get/get_state/set_state),
+  basic counters, and top-level assignments. PNA and TNA are not implemented.
 
 ## Externs
 

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -239,6 +239,7 @@ corpus_test_suite(
         "psa-drop-all-corrected-bmv2",
         "psa-e2e-cloning-basic-bmv2",
         "psa-end-of-ingress-test-bmv2",
+        "psa-example-dpdk-varbit-bmv2",
         "psa-example-register2-bmv2",
         "psa-fwd-bmv2",
         "psa-i2e-cloning-basic-bmv2",
@@ -256,17 +257,6 @@ corpus_test_suite(
         "psa-top-level-assignments-bmv2",
         "psa-unicast-or-drop-bmv2",
         "psa-unicast-or-drop-corrected-bmv2",
-    ],
-)
-
-# PSA tests blocked on missing features. Each entry has an inline comment
-# explaining the blocker.
-# Run manually: bazel test //e2e_tests/corpus:psa_manual_stf_corpus_test
-corpus_test_suite(
-    name = "psa_manual_stf_corpus_test",
-    tags = ["manual"],
-    tests = [
-        "psa-example-dpdk-varbit-bmv2",  # lookahead type resolution
     ],
 )
 

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -953,6 +953,15 @@ class Interpreter(
 
   /** P4 spec §12.8.2: peek at packet bits and construct a value of type T without consuming. */
   private fun execLookahead(returnType: Type): Value {
+    // Primitive bit<N> lookahead: peek N bits and return a BitVal.
+    if (returnType.hasBit()) {
+      val width = returnType.bit.width
+      val raw = BigInteger(1, packet.peekBytes((width + 7) / 8))
+      // Mask to exactly N bits (peekBytes may return extra high bits from byte alignment).
+      val mask = BigInteger.ONE.shiftLeft(width).subtract(BigInteger.ONE)
+      return BitVal(BitVector(raw.and(mask), width))
+    }
+
     val typeName = returnType.named
     val typeDecl = types[typeName] ?: error("type not found for lookahead: $typeName")
     val fields =

--- a/simulator/InterpreterPacketTest.kt
+++ b/simulator/InterpreterPacketTest.kt
@@ -486,6 +486,40 @@ class InterpreterPacketTest {
   }
 
   @Test
+  fun `lookahead with bit type returns BitVal`() {
+    val pktCtx = PacketContext(byteArrayOf(0xAB.toByte(), 0xCD.toByte()))
+    val env = Environment()
+    // lookahead<bit<16>>() — return type is bit<16>, not a named type.
+    val call =
+      Expr.newBuilder()
+        .setMethodCall(MethodCall.newBuilder().setTarget(nameRef("pkt")).setMethod("lookahead"))
+        .setType(bitType(16))
+        .build()
+    val result = interp(pktCtx).evalExpr(call, env)
+
+    assertEquals(BitVal(0xABCD, 16), result)
+  }
+
+  @Test
+  fun `lookahead with bit type does not consume bytes`() {
+    val pktCtx = PacketContext(byteArrayOf(0x42, 0xFF.toByte()))
+    val env = Environment()
+    val call =
+      Expr.newBuilder()
+        .setMethodCall(MethodCall.newBuilder().setTarget(nameRef("pkt")).setMethod("lookahead"))
+        .setType(bitType(8))
+        .build()
+    val interp = interp(pktCtx)
+
+    val peek = interp.evalExpr(call, env)
+    assertEquals(BitVal(0x42, 8), peek)
+
+    // Second lookahead should return the same value — bytes not consumed.
+    val peek2 = interp.evalExpr(call, env)
+    assertEquals(BitVal(0x42, 8), peek2)
+  }
+
+  @Test
   fun `lookahead throws PacketTooShort when not enough bytes`() {
     val type = structType("big", "f" to 32)
     val pktCtx = PacketContext(byteArrayOf(0x01, 0x02)) // only 2 bytes, need 4


### PR DESCRIPTION
## Summary

**All 26 PSA corpus tests now pass.** The last blocker was `lookahead<bit<N>>()` — the parser's peek method only handled named types (headers/structs), failing on primitive `bit<N>` types with "type not found for lookahead:".

The fix is 9 lines: check for a `bit` return type first and peek N bits directly, bypassing the header/struct field unpacking path. The empty PSA manual test suite is removed.

## Test plan

- [x] 2 new unit tests: `lookahead with bit type returns BitVal`, `lookahead with bit type does not consume bytes`
- [x] Last corpus test promoted: `psa-example-dpdk-varbit-bmv2`
- [x] PSA manual test suite removed (empty)
- [x] Full test suite passes (48/48, `--test_tag_filters=-heavy`)
- [x] LIMITATIONS.md updated (25/26 → 26/26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)