### PR TITLE
chore: BCR readiness — real p4c version, behavioral_model dev_dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,9 +27,13 @@ bazel_dep(name = "grpc_kotlin", version = "1.5.0")
 bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
 
 # p4c provides the compiler frontend and midend that our backend builds on.
-# Point this at your fork during development; remove the override when
-# the 4ward backend has been upstreamed into p4c proper.
-bazel_dep(name = "p4c", version = "head")
+# The git_override adds two targets not yet in upstream p4c:
+#   - //:core_p4 (filegroup anchor for p4include path in genrules)
+#   - //testdata/p4_16_samples:* (exports_files for corpus/BMv2 tests)
+# Both are only used by e2e_tests/. Non-test targets use //:p4include, //:lib,
+# etc. which exist in BCR p4c, so consumers resolve the dep from BCR normally.
+# TODO(upstream): land these two targets in p4lang/p4c, then drop the override.
+bazel_dep(name = "p4c", version = "1.2.5.11")
 git_override(
     module_name = "p4c",
     commit = "f36edeb88709fc6f5e44c3b6c40a666a0af2313a",
@@ -41,7 +45,8 @@ bazel_dep(name = "p4_constraints", version = "20260311.0")
 
 # BMv2 (behavioral-model) — v1model reference simulator for differential testing.
 # Patched to add native Bazel build rules (no Thrift, no nanomsg).
-bazel_dep(name = "behavioral_model", version = "head")
+# Dev-only: not needed by downstream consumers of the 4ward module.
+bazel_dep(name = "behavioral_model", version = "head", dev_dependency = True)
 git_override(
     module_name = "behavioral_model",
     commit = "6c7c93e5484e069c539b5c990bf37c531599894a",

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -11,18 +11,26 @@ Blocked on buf support for proto edition 2024.
 
 ---
 
-## Upstream p4c backend
+## Upstream p4c build targets
 
-Land the 4ward backend in the p4c repository. Blocked on upstream review.
-Once merged, switch `MODULE.bazel` from `smolkaj/p4c` fork to `p4lang/p4c`.
+The `smolkaj/p4c` fork adds two targets not in upstream `p4lang/p4c`:
+`//:core_p4` (filegroup anchor for the `p4include/` path in genrules) and
+`//testdata/p4_16_samples:*` (`exports_files` for corpus/BMv2 diff tests).
+Both are only used by `e2e_tests/` — non-test code uses `//:p4include`,
+`//:lib`, etc. which exist in BCR p4c. This is not a BCR blocker for
+downstream consumers, but upstreaming these targets would let us drop the
+`git_override` entirely.
 
 ---
 
 ## Pinned dependencies inventory
 
-Several deps use `git_override` with pinned commits. This is tracked here as
-a reminder to periodically check for upstream updates:
+Three deps use `git_override` with pinned commits. `behavioral_model` and
+`bazel_clang_tidy` are dev-only (`dev_dependency = True`) and invisible to
+BCR consumers.
 
+- **p4c** (`smolkaj/p4c` fork, `f36edeb`): adds `//:core_p4` and testdata
+  `exports_files`. See "Upstream p4c build targets" above.
 - **bazel_clang_tidy** (`9e54bbb`): pinned before a commit (`c4d35e0`) that
   broke `-isystem` include ordering. Upstream bug never fixed — permanent
   workaround. Re-check if upstream ever resolves the issue.


### PR DESCRIPTION
## Summary

Two changes toward a publishable BCR module:

- **behavioral_model → `dev_dependency`**: only used by `e2e_tests/bmv2_diff`
  for differential testing. Invisible to downstream BCR consumers. The
  `git_override` is already root-module-only.

- **p4c version `"head"` → `"1.2.5.11"`** (current BCR version): the
  `git_override` still points to the fork for two test-only targets
  (`//:core_p4` and `//testdata/p4_16_samples:*`), but downstream BCR
  consumers now resolve p4c normally. All non-test targets use `//:p4include`,
  `//:lib`, `//:ir_frontend_midend_control_plane`, etc. which exist in BCR p4c.

### Remaining path to plain `bazel_dep` for p4c

The fork adds two small build targets not yet upstream:
1. `//:core_p4` — single-file filegroup (`p4include/core.p4`) used as a
   `$(execpath)` anchor for genrules in `e2e_tests/`
2. `//testdata/p4_16_samples:*` — `exports_files` for corpus/BMv2 diff tests

Both are trivial additions (~6 lines total). Once upstreamed to `p4lang/p4c`
and released to BCR, the `git_override` can be dropped entirely.

## Test plan

- [x] `bazel test //... --test_tag_filters=-heavy` — 49/49 pass
- [x] `./tools/format.sh` + `./tools/lint.sh` clean
- [ ] CI green (Ubuntu + macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)