### PR TITLE
chore: migrate to p4c //p4include package, drop //:core_p4

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,16 +27,16 @@ bazel_dep(name = "grpc_kotlin", version = "1.5.0")
 bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
 
 # p4c provides the compiler frontend and midend that our backend builds on.
-# The git_override adds two targets not yet in upstream p4c:
-#   - //:core_p4 (filegroup anchor for p4include path in genrules)
+# The git_override adds targets not yet in upstream p4c:
+#   - //p4include package (exports_files + filegroup for individual includes)
 #   - //testdata/p4_16_samples:* (exports_files for corpus/BMv2 tests)
-# Both are only used by e2e_tests/. Non-test targets use //:p4include, //:lib,
-# etc. which exist in BCR p4c, so consumers resolve the dep from BCR normally.
-# TODO(upstream): land these two targets in p4lang/p4c, then drop the override.
+#   - macOS build fix (HAVE_PIPE2 / HAVE_UCONTEXT_H)
+# Upstream PR: https://github.com/p4lang/p4c/pull/5533
+# Once merged and released to BCR, drop the git_override.
 bazel_dep(name = "p4c", version = "1.2.5.11")
 git_override(
     module_name = "p4c",
-    commit = "f36edeb88709fc6f5e44c3b6c40a666a0af2313a",
+    commit = "2a38af86afbee54d656a041e125a2d14945b9215",
     remote = "https://github.com/smolkaj/p4c.git",
 )
 

--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -24,7 +24,7 @@ kt_jvm_binary(
     name = "4ward",
     data = [
         "//p4c_backend:p4c-4ward",
-        "@p4c//:p4include",
+        "@p4c//p4include",
     ],
     main_class = "fourward.cli.MainKt",
     visibility = ["//visibility:public"],

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -11,15 +11,12 @@ Blocked on buf support for proto edition 2024.
 
 ---
 
-## Upstream p4c build targets
+## Drop p4c fork
 
-The `smolkaj/p4c` fork adds two targets not in upstream `p4lang/p4c`:
-`//:core_p4` (filegroup anchor for the `p4include/` path in genrules) and
-`//testdata/p4_16_samples:*` (`exports_files` for corpus/BMv2 diff tests).
-Both are only used by `e2e_tests/` — non-test code uses `//:p4include`,
-`//:lib`, etc. which exist in BCR p4c. This is not a BCR blocker for
-downstream consumers, but upstreaming these targets would let us drop the
-`git_override` entirely.
+The `smolkaj/p4c` fork adds `//p4include` package, `//testdata/p4_16_samples`
+exports, and a macOS build fix. Upstream PR:
+https://github.com/p4lang/p4c/pull/5533. Once merged and released to BCR,
+drop the `git_override` in `MODULE.bazel`.
 
 ---
 
@@ -29,8 +26,8 @@ Three deps use `git_override` with pinned commits. `behavioral_model` and
 `bazel_clang_tidy` are dev-only (`dev_dependency = True`) and invisible to
 BCR consumers.
 
-- **p4c** (`smolkaj/p4c` fork, `f36edeb`): adds `//:core_p4` and testdata
-  `exports_files`. See "Upstream p4c build targets" above.
+- **p4c** (`smolkaj/p4c` fork, `2a38af8`): adds `//p4include` package,
+  testdata exports, macOS build fix. See "Drop p4c fork" above.
 - **bazel_clang_tidy** (`9e54bbb`): pinned before a commit (`c4d35e0`) that
   broke `-isystem` include ordering. Upstream bug never fixed — permanent
   workaround. Re-check if upstream ever resolves the issue.

--- a/e2e_tests/bmv2_diff.bzl
+++ b/e2e_tests/bmv2_diff.bzl
@@ -79,12 +79,12 @@ def _add_test_genrules(test, p4_src, stf_src, includes, tags, data):
         name = test + "_json",
         srcs = [p4_src] + includes,
         outs = [test + ".json"],
-        cmd = "$(execpath @p4c//:p4c_bmv2) -I $$(dirname $(execpath @p4c//:core_p4))" + include_flags + " -o $@ $(execpath " + p4_src + ")",
+        cmd = "$(execpath @p4c//:p4c_bmv2) -I $$(dirname $(execpath @p4c//p4include:core.p4))" + include_flags + " -o $@ $(execpath " + p4_src + ")",
         tags = tags,
         tools = [
             "@p4c//:p4c_bmv2",
-            "@p4c//:core_p4",
-            "@p4c//:p4include",
+            "@p4c//p4include:core.p4",
+            "@p4c//p4include",
         ],
     )
 

--- a/e2e_tests/constrained_table/BUILD.bazel
+++ b/e2e_tests/constrained_table/BUILD.bazel
@@ -2,11 +2,11 @@ genrule(
     name = "constrained_table_pb",
     srcs = ["constrained_table.p4"],
     outs = ["constrained_table.txtpb"],
-    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//:core_p4)) -o $@ $(SRCS)",
+    cmd = "$(execpath //p4c_backend:p4c-4ward) -I $$(dirname $(execpath @p4c//p4include:core.p4)) -o $@ $(SRCS)",
     tools = [
         "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
+        "@p4c//p4include",
+        "@p4c//p4include:core.p4",
     ],
     visibility = ["//p4runtime:__pkg__"],
 )

--- a/e2e_tests/p4c.bzl
+++ b/e2e_tests/p4c.bzl
@@ -29,11 +29,11 @@ def p4c_compile(name, src_p4, includes = [], tags = [], visibility = None, defin
         outs = [name + ".txtpb"],
         # Custom includes come first so they can shadow standard library files
         # (e.g. a modified v1model.p4 with wider port fields).
-        cmd = "$(execpath //p4c_backend:p4c-4ward)" + include_flags + " -I $$(dirname $(execpath @p4c//:core_p4))" + define_flags + " -o $@ $(execpath " + src_p4 + ")",
+        cmd = "$(execpath //p4c_backend:p4c-4ward)" + include_flags + " -I $$(dirname $(execpath @p4c//p4include:core.p4))" + define_flags + " -o $@ $(execpath " + src_p4 + ")",
         tools = [
             "//p4c_backend:p4c-4ward",
-            "@p4c//:core_p4",
-            "@p4c//:p4include",
+            "@p4c//p4include:core.p4",
+            "@p4c//p4include",
         ],
         tags = tags,
         visibility = visibility,

--- a/e2e_tests/p4testgen.bzl
+++ b/e2e_tests/p4testgen.bzl
@@ -80,11 +80,11 @@ _p4testgen_stfs = rule(
             cfg = "exec",
         ),
         "_core_p4": attr.label(
-            default = "@p4c//:core_p4",
+            default = "@p4c//p4include:core.p4",
             allow_single_file = True,
         ),
         "_p4include": attr.label(
-            default = "@p4c//:p4include",
+            default = "@p4c//p4include",
         ),
     },
     toolchains = use_cc_toolchain(),

--- a/e2e_tests/sai_p4/BUILD.bazel
+++ b/e2e_tests/sai_p4/BUILD.bazel
@@ -31,14 +31,14 @@ genrule(
     outs = ["sai_middleblock.txtpb"],
     cmd = " ".join([
         "$(execpath //p4c_backend:p4c-4ward)",
-        "-I $$(dirname $(execpath @p4c//:core_p4))",
+        "-I $$(dirname $(execpath @p4c//p4include:core.p4))",
         "-o $@",
         "$(execpath instantiations/google/middleblock.p4)",
     ]),
     tools = [
         "//p4c_backend:p4c-4ward",
-        "@p4c//:core_p4",
-        "@p4c//:p4include",
+        "@p4c//p4include",
+        "@p4c//p4include:core.p4",
     ],
     visibility = ["//p4runtime:__pkg__"],
 )

--- a/e2e_tests/wide_port/BUILD.bazel
+++ b/e2e_tests/wide_port/BUILD.bazel
@@ -5,10 +5,10 @@ load("//e2e_tests:p4c.bzl", "p4c_compile")
 # This guarantees our test always tracks upstream with exactly one change.
 genrule(
     name = "wide_v1model",
-    srcs = ["@p4c//:p4include"],
+    srcs = ["@p4c//p4include"],
     outs = ["v1model.p4"],
-    cmd = "sed 's/bit<9>/bit<16>/g' $$(dirname $(execpath @p4c//:core_p4))/v1model.p4 > $@",
-    tools = ["@p4c//:core_p4"],
+    cmd = "sed 's/bit<9>/bit<16>/g' $$(dirname $(execpath @p4c//p4include:core.p4))/v1model.p4 > $@",
+    tools = ["@p4c//p4include:core.p4"],
 )
 
 p4c_compile(

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -17,7 +17,7 @@ cram_test(
         "//cli:4ward",
         "//examples:basic_table.p4",
         "//examples:passthrough.p4",
-        "@p4c//:p4include",
+        "@p4c//p4include",
     ],
     env_args = [
         "FOURWARD=$(rootpath //cli:4ward)",

--- a/p4c_backend/BUILD.bazel
+++ b/p4c_backend/BUILD.bazel
@@ -26,7 +26,7 @@ cc_binary(
     # p4include provides core.p4, v1model.p4, etc. The binary resolves them via
     # CONFIG_PKGDATADIR = "external/p4c+" (set at build time in config.h), so
     # the files must be present in the runfiles tree under that path.
-    data = ["@p4c//:p4include"],
+    data = ["@p4c//p4include"],
     visibility = ["//visibility:public"],
     deps = [
         ":p4c_backend_lib",

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -29,7 +29,7 @@ kt_jvm_binary(
     srcs = ["PlaygroundServer.kt"],
     data = [
         "//p4c_backend:p4c-4ward",
-        "@p4c//:p4include",
+        "@p4c//p4include",
     ] + glob(["frontend/**"]),
     main_class = "fourward.web.PlaygroundServerKt",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## Summary

Migrates all p4c references to the new target layout, aligning with the
upstream PR ([p4lang/p4c#5533](https://github.com/p4lang/p4c/pull/5533)):

- **`@p4c//:core_p4`** → **`@p4c//p4include:core.p4`** — proper package with
  `exports_files`, no more single-file filegroup hack
- **`@p4c//:p4include`** → **`@p4c//p4include`** — avoids the deprecated alias
- Fork commit updated to `2a38af8` which matches the upstream PR exactly

Once p4lang/p4c#5533 lands and hits BCR, we drop the `git_override` — one-line
change in MODULE.bazel.

## Test plan

- [x] `bazel test //... --test_tag_filters=-heavy` — 49/49 pass
- [x] `./tools/format.sh` + `./tools/lint.sh` clean
- [ ] CI green (Ubuntu + macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)