### PR TITLE
Update stale status indicators in README and ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ plane.
 
 | | BMv2 | 4ward goal | Status |
 |---|---|---|---|
-| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | 🚧 [119/120 requirements](docs/P4RUNTIME_COMPLIANCE.md) |
+| P4Runtime support | outdated | [**100% spec-compliant**](docs/ROADMAP.md#track-4-p4runtime-reference-implementation) | ✅ [132/132 requirements](docs/P4RUNTIME_COMPLIANCE.md) |
 | Trace format | text | [**proto/JSON**](e2e_tests/trace_tree/clone_with_egress.golden.txtpb) | ✅ |
 | All possible traces | not natively | [**trace trees!**](docs/ROADMAP.md#track-3-trace-trees) | ✅ |
 | `@p4runtime_translation` | no | [**built-in translation engine**](#p4runtime_translation-done-right) | ✅ |
-| Architecture-generic | no | [**by design**](docs/ROADMAP.md#track-6-multi-architecture-support) | 🚧 v1model done, PSA 20/26 |
+| Architecture-generic | no | [**by design**](docs/ROADMAP.md#track-6-multi-architecture-support) | ✅ v1model + PSA (PNA next) |
 | Architecture customization | no | [**by design**](docs/ROADMAP.md#track-5-architecture-customization) | ✅ |
 | Interactive playground | no | [**browser-based IDE with trace playback & packet decoding**](#web-playground) | ✅ |
 | Easy to extend | ehh | [**if AI can extend it, anyone can**](docs/ROADMAP.md#why-4ward-is-easier-to-extend) | ✅ |
@@ -66,7 +66,7 @@ We have an **[ambitious roadmap](docs/ROADMAP.md)**: to build the **definitive P
 We are driving development by building towards two demanding real-world applications as forcing functions:
 
 1. **[SAI P4](https://github.com/sonic-net/sonic-pins/tree/main/sai_p4)**
-   — A 27-table program that exercises `@p4runtime_translation` with string port names, `@entry_restriction`, and everything the ecosystem currently papers over with hardcoded workarounds.
+   — A 30-table program that exercises `@p4runtime_translation` with string port names, `@entry_restriction`, and everything the ecosystem currently papers over with hardcoded workarounds.
 2. **[DVaaS](https://github.com/sonic-net/sonic-pins/tree/main/dvaas)**
    — SONiC's dataplane validation service. We are building 4ward to be a modern, highly capable drop-in replacement for its current BMv2 backend.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -289,10 +289,10 @@ testing may not be reliable.
 
 **Done when:** 26 PSA corpus tests pass.
 
-**Current status:** 20/26 corpus tests pass. Implemented: two-pipeline
+**Current status:** 26/26 corpus tests pass. Implemented: two-pipeline
 orchestration, multicast replication, registers, counters, Hash, Meter (stub),
-InternetChecksum. Remaining 6 tests blocked on I2E/E2E cloning, resubmit,
-recirculate, and one lookahead edge case.
+InternetChecksum, parser errors, metadata handling, drop-by-default, resubmit,
+recirculate, cloning (I2E and E2E).
 
 #### Phase 3: PNA (Portable NIC Architecture)
 
@@ -387,7 +387,7 @@ operations.
               │                           │    │          │    │          │
   Track 5     │ arch customization        │    │          │    │          │
               │                           │    │          │    │          │
-  Track 6     │ refactor, PSA 20/26       │    │ PSA 6/6  │    │   PNA    │
+  Track 6     │ refactor, PSA 26/26 ✓     │    │          │    │   PNA    │
               │                           │    │          │    │          │
   Track 7     │ standalone CLI            │    │          │    │          │
               │                           │    │          │    │          │
@@ -399,7 +399,7 @@ operations.
 - Tracks 1, 3, 4, 5, 7, and 8 are complete.
 - Track 5 subsumes Track 4C and 4E.
 - Track 2 is picked up opportunistically.
-- Track 6 phase 1 (refactoring) is complete. Phase 2 (PSA) is 20/26 — six
-  tests remain. Phase 3 (PNA) depends on phase 2.
+- Track 6 phases 1 (refactoring) and 2 (PSA, 26/26) are complete. Phase 3
+  (PNA) is next.
 - Track 8 (interfaces) is complete: gRPC services, CLI, and playground with
   visual pipeline diagrams and animated trace playback.


### PR DESCRIPTION
## Summary

The "Why 4ward?" table in the README had two stale 🚧 indicators that should be ✅:

- **P4Runtime**: 119/120 → **132/132** applicable requirements tested (3 out-of-scope items: digest, idle timeout)
- **Architecture**: "PSA 20/26" → **PSA 26/26** — all corpus tests passing
- **SAI P4 table count**: 27 → **30** (25 middleblock + 5 TOR/FBR-only)

The ROADMAP had matching stale numbers (PSA status, sequencing diagram, key dependencies).

## Test plan

- [ ] Doc-only changes — verify rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)