### PR TITLE
Track 9 Phase 4: coverage-guided P4Runtime tests

### DIFF
--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -1848,6 +1848,116 @@ class P4RuntimeConformanceTest {
     }
   }
 
+  // =========================================================================
+  // Coverage-guided tests (Phase 4)
+  // =========================================================================
+
+  /** P4Runtime spec §7: UNSPECIFIED pipeline action must be rejected. */
+  @Test
+  fun `100 - UNSPECIFIED pipeline action returns INVALID_ARGUMENT`() {
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "unrecognized") {
+      sendPipelineAction(SetForwardingPipelineConfigRequest.Action.UNSPECIFIED)
+    }
+  }
+
+  /** StreamChannel: digest ack is not supported and must be explicitly rejected. */
+  @Test
+  fun `101 - digest ack via stream returns UNIMPLEMENTED`() {
+    assertGrpcError(Status.Code.UNIMPLEMENTED, "digest") {
+      runBlocking {
+        val request =
+          StreamMessageRequest.newBuilder()
+            .setDigestAck(P4RuntimeOuterClass.DigestListAck.newBuilder().setDigestId(1))
+            .build()
+        harness.stub.streamChannel(flowOf(request)).collect {}
+      }
+    }
+  }
+
+  /** P4Runtime spec §5: when primary self-demotes, backup receives a promotion notification. */
+  @Test
+  fun `102 - backup promoted when primary self-demotes`() {
+    harness.openStream().use { streamA ->
+      harness.openStream().use { streamB ->
+        // A becomes primary with electionId=5.
+        val a1 = streamA.arbitrate(electionId = 5)
+        assertEquals(com.google.rpc.Code.OK_VALUE, a1.arbitration.status.code)
+        // B is backup with electionId=3.
+        val b1 = streamB.arbitrate(electionId = 3)
+        assertEquals(com.google.rpc.Code.ALREADY_EXISTS_VALUE, b1.arbitration.status.code)
+        // A self-demotes by re-arbitrating with electionId=1.
+        val a2 = streamA.arbitrate(electionId = 1)
+        assertEquals(
+          "A should now be backup",
+          com.google.rpc.Code.ALREADY_EXISTS_VALUE,
+          a2.arbitration.status.code,
+        )
+        // B should receive a promotion notification.
+        val promotion = streamB.receiveNext()
+        assertNotNull("backup should receive promotion", promotion)
+        assertTrue("should be arbitration", promotion!!.hasArbitration())
+        assertEquals(
+          "B should now be primary",
+          com.google.rpc.Code.OK_VALUE,
+          promotion.arbitration.status.code,
+        )
+      }
+    }
+  }
+
+  /** P4Runtime spec §15: named-role entity access check covers action profile member. */
+  @Test
+  fun `103 - named-role write denied for action profile member`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val member =
+      P4RuntimeTestHarness.buildMemberEntity(actionProfileId = 1, memberId = 1, actionId = 1)
+    assertGrpcError(Status.Code.PERMISSION_DENIED, "cannot access") {
+      harness.installEntry(member, role = "sdn_controller")
+    }
+  }
+
+  /** P4Runtime spec §15: named-role entity access check covers direct counter. */
+  @Test
+  fun `104 - named-role write denied for direct counter entity`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val directCounter =
+      Entity.newBuilder()
+        .setDirectCounterEntry(
+          P4RuntimeOuterClass.DirectCounterEntry.newBuilder()
+            .setTableEntry(P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(1))
+        )
+        .build()
+    assertGrpcError(Status.Code.PERMISSION_DENIED, "cannot access") {
+      harness.installEntry(directCounter, role = "sdn_controller")
+    }
+  }
+
+  /** P4Runtime spec §15: unscoped entities (counters, meters, registers) pass role checks. */
+  @Test
+  fun `105 - named-role read allows unscoped counter entity`() {
+    harness.loadPipeline(loadConfigWithCounter())
+    val request =
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .setRole("sdn_controller")
+        .addEntities(
+          Entity.newBuilder()
+            .setCounterEntry(P4RuntimeOuterClass.CounterEntry.newBuilder().setCounterId(CTR_ID))
+        )
+        .build()
+    val results = harness.readEntries(request)
+    assertEquals("named-role read of unscoped counter should succeed", CTR_SIZE, results.size)
+  }
+
+  /** DataplaneService: processPacketWithTraceTree returns both output packets and trace. */
+  @Test
+  fun `106 - processPacketWithTraceTree returns output and trace`() {
+    harness.loadPipeline(loadPassthroughConfig())
+    val resp = harness.simulatePacketWithTrace(0, byteArrayOf(0x01, 0x02))
+    assertTrue("should have output packets", resp.outputPacketsList.isNotEmpty())
+    assertTrue("trace should be present", resp.hasTrace())
+  }
+
   // ---------------------------------------------------------------------------
   // Test helpers
   // ---------------------------------------------------------------------------

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -5,6 +5,7 @@ import fourward.ir.v1.PipelineConfig
 import fourward.sim.v1.DataplaneGrpcKt.DataplaneCoroutineStub
 import fourward.sim.v1.SimulatorProto.OutputPacket
 import fourward.sim.v1.SimulatorProto.ProcessPacketRequest
+import fourward.sim.v1.SimulatorProto.ProcessPacketWithTraceTreeResponse
 import fourward.simulator.Simulator
 import io.grpc.ManagedChannel
 import io.grpc.Status
@@ -136,6 +137,19 @@ class P4RuntimeTestHarness(constraintValidatorBinary: Path? = null) : Closeable 
           .build()
       )
       .outputPacketsList
+  }
+
+  /** Sends a packet and returns both output packets and the trace tree. */
+  fun simulatePacketWithTrace(
+    ingressPort: Int,
+    payload: ByteArray,
+  ): ProcessPacketWithTraceTreeResponse = runBlocking {
+    dataplaneStub.processPacketWithTraceTree(
+      ProcessPacketRequest.newBuilder()
+        .setIngressPort(ingressPort)
+        .setPayload(ByteString.copyFrom(payload))
+        .build()
+    )
   }
 
   // ---------------------------------------------------------------------------

--- a/p4runtime/P4RuntimeWriteErrorTest.kt
+++ b/p4runtime/P4RuntimeWriteErrorTest.kt
@@ -458,6 +458,53 @@ class P4RuntimeWriteErrorTest {
   }
 
   // =========================================================================
+  // Unimplemented entity guards (coverage gaps)
+  // =========================================================================
+
+  // P4Runtime spec §9.6: value_set only supports MODIFY, not INSERT or DELETE.
+  @Test
+  fun `write ValueSetEntry with INSERT returns INVALID_ARGUMENT`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val entity =
+      Entity.newBuilder()
+        .setValueSetEntry(p4.v1.P4RuntimeOuterClass.ValueSetEntry.newBuilder().setValueSetId(1))
+        .build()
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "MODIFY") { harness.installEntry(entity) }
+  }
+
+  @Test
+  fun `write ExternEntry returns UNIMPLEMENTED`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val entity =
+      Entity.newBuilder()
+        .setExternEntry(
+          p4.v1.P4RuntimeOuterClass.ExternEntry.newBuilder().setExternTypeId(1).setExternId(1)
+        )
+        .build()
+    assertGrpcError(Status.Code.UNIMPLEMENTED, "ExternEntry") { harness.installEntry(entity) }
+  }
+
+  // =========================================================================
+  // Write atomicity edge cases (coverage gaps)
+  // =========================================================================
+
+  // P4Runtime spec §12.2: unrecognized atomicity must be rejected.
+  @Test
+  fun `UNRECOGNIZED write atomicity returns INVALID_ARGUMENT`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    @Suppress("MagicNumber")
+    val request =
+      WriteRequest.newBuilder()
+        .setDeviceId(1)
+        .setAtomicityValue(999)
+        .addUpdates(Update.newBuilder().setType(Update.Type.INSERT).setEntity(badTableEntity()))
+        .build()
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "unrecognized write atomicity") {
+      harness.writeRaw(request)
+    }
+  }
+
+  // =========================================================================
   // Helpers
   // =========================================================================
 


### PR DESCRIPTION
## Summary

First batch of Track 9 Phase 4 — **10 new tests targeting uncovered branches** identified from the gh-pages coverage reports.

Coverage gaps addressed in P4RuntimeService.kt:
- **SetForwardingPipelineConfig**: UNSPECIFIED/UNRECOGNIZED action rejection
- **StreamChannel**: digest ack → UNIMPLEMENTED
- **Arbitration**: backup promotion notification when primary self-demotes
- **Role access**: `entityIdForRole` branches for action profiles, direct counters, and unscoped entity types
- **Write atomicity**: UNRECOGNIZED atomicity rejection
- **Entity guards**: ValueSetEntry INSERT rejection (§9.6) and ExternEntry write rejection

Coverage gap in DataplaneService.kt:
- **processPacketWithTraceTree**: was entirely untested

## Test plan

- [x] `bazel test //p4runtime:all` — 14/14 pass
- [x] `./tools/format.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)