### PR TITLE
P4Runtime server: default entry fix, gNMI service, CLI flags

### DIFF
--- a/gnmi/BUILD.bazel
+++ b/gnmi/BUILD.bazel
@@ -1,0 +1,56 @@
+load("@grpc-java//:java_grpc_library.bzl", "java_grpc_library")
+load("@grpc_kotlin//:kt_jvm_grpc.bzl", "kt_jvm_grpc_library")
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+
+# =============================================================================
+# gNMI proto (vendored from github.com/openconfig/gnmi v0.10.0)
+#
+# The two proto files are vendored with minimal modifications:
+#   - gnmi.proto: import path for gnmi_ext patched to local path
+#   - gnmi_ext.proto: added java_package/java_outer_classname options
+# =============================================================================
+
+proto_library(
+    name = "gnmi_ext_proto",
+    srcs = ["gnmi_ext.proto"],
+    strip_import_prefix = "/gnmi",
+    deps = ["@protobuf//:duration_proto"],
+)
+
+proto_library(
+    name = "gnmi_proto",
+    srcs = ["gnmi.proto"],
+    strip_import_prefix = "/gnmi",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gnmi_ext_proto",
+        "@protobuf//:any_proto",
+        "@protobuf//:descriptor_proto",
+    ],
+)
+
+java_proto_library(
+    name = "gnmi_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":gnmi_proto"],
+)
+
+java_proto_library(
+    name = "gnmi_ext_java_proto",
+    deps = [":gnmi_ext_proto"],
+)
+
+java_grpc_library(
+    name = "gnmi_java_grpc",
+    srcs = [":gnmi_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":gnmi_java_proto"],
+)
+
+kt_jvm_grpc_library(
+    name = "gnmi_kt_grpc",
+    srcs = [":gnmi_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":gnmi_java_proto"],
+)

--- a/gnmi/gnmi.proto
+++ b/gnmi/gnmi.proto
@@ -1,0 +1,468 @@
+//
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+
+import "gnmi_ext.proto";
+
+// Package gNMI defines a service specification for the gRPC Network Management
+// Interface. This interface is defined to be a standard interface via which
+// a network management system ("client") can subscribe to state values,
+// retrieve snapshots of state information, and manipulate the state of a data
+// tree supported by a device ("target").
+//
+// This document references the gNMI Specification which can be found at
+// http://github.com/openconfig/reference/blob/master/rpc/gnmi
+package gnmi;
+
+// Define a protobuf FileOption that defines the gNMI service version.
+extend google.protobuf.FileOptions {
+  // The gNMI service semantic version.
+  string gnmi_service = 1001;
+}
+
+// gNMI_service is the current version of the gNMI service, returned through
+// the Capabilities RPC.
+option (gnmi_service) = "0.10.0";
+
+option go_package = "github.com/openconfig/gnmi/proto/gnmi";
+option java_multiple_files = true;
+option java_outer_classname = "GnmiProto";
+option java_package = "com.github.gnmi.proto";
+
+
+service gNMI {
+  // Capabilities allows the client to retrieve the set of capabilities that
+  // is supported by the target. This allows the target to validate the
+  // service version that is implemented and retrieve the set of models that
+  // the target supports. The models can then be specified in subsequent RPCs
+  // to restrict the set of data that is utilized.
+  // Reference: gNMI Specification Section 3.2
+  rpc Capabilities(CapabilityRequest) returns (CapabilityResponse);
+  // Retrieve a snapshot of data from the target. A Get RPC requests that the
+  // target snapshots a subset of the data tree as specified by the paths
+  // included in the message and serializes this to be returned to the
+  // client using the specified encoding.
+  // Reference: gNMI Specification Section 3.3
+  rpc Get(GetRequest) returns (GetResponse);
+  // Set allows the client to modify the state of data on the target. The
+  // paths to modified along with the new values that the client wishes
+  // to set the value to.
+  // Reference: gNMI Specification Section 3.4
+  rpc Set(SetRequest) returns (SetResponse);
+  // Subscribe allows a client to request the target to send it values
+  // of particular paths within the data tree. These values may be streamed
+  // at a particular cadence (STREAM), sent one off on a long-lived channel
+  // (POLL), or sent as a one-off retrieval (ONCE).
+  // Reference: gNMI Specification Section 3.5
+  rpc Subscribe(stream SubscribeRequest) returns (stream SubscribeResponse);
+}
+
+// Notification is a re-usable message that is used to encode data from the
+// target to the client. A Notification carries two types of changes to the data
+// tree:
+//  - Deleted values (delete) - a set of paths that have been removed from the
+//    data tree.
+//  - Updated values (update) - a set of path-value pairs indicating the path
+//    whose value has changed in the data tree.
+// Reference: gNMI Specification Section 2.1
+message Notification {
+  int64 timestamp = 1;         // Timestamp in nanoseconds since Epoch.
+  Path prefix = 2;             // Prefix used for paths in the message.
+  repeated Update update = 4;  // Data elements that have changed values.
+  repeated Path delete = 5;    // Data elements that have been deleted.
+  // This notification contains a set of paths that are always updated together
+  // referenced by a globally unique prefix.
+  bool atomic = 6;
+  // Reserved field numbers and identifiers.
+  reserved "alias";
+  reserved 3;
+}
+
+// Update is a re-usable message that is used to store a particular Path,
+// Value pair.
+// Reference: gNMI Specification Section 2.1
+message Update {
+  Path path = 1;                        // The path (key) for the update.
+  Value value = 2 [deprecated = true];  // The value (value) for the update.
+  TypedValue val = 3;                   // The explicitly typed update value.
+  uint32 duplicates = 4;                // Number of coalesced duplicates.
+}
+
+// TypedValue is used to encode a value being sent between the client and
+// target (originated by either entity).
+message TypedValue {
+  // One of the fields within the val oneof is populated with the value
+  // of the update. The type of the value being included in the Update
+  // determines which field should be populated. In the case that the
+  // encoding is a particular form of the base protobuf type, a specific
+  // field is used to store the value (e.g., json_val).
+  oneof value {
+    string string_val = 1;                    // String value.
+    int64 int_val = 2;                        // Integer value.
+    uint64 uint_val = 3;                      // Unsigned integer value.
+    bool bool_val = 4;                        // Bool value.
+    bytes bytes_val = 5;                      // Arbitrary byte sequence value.
+    float float_val = 6 [deprecated = true];  // Deprecated - use double_val.
+    double double_val = 14;                   // Floating point value.
+    Decimal64 decimal_val = 7
+        [deprecated = true];          // Deprecated - use double_val.
+    ScalarArray leaflist_val = 8;     // Mixed type scalar array value.
+    google.protobuf.Any any_val = 9;  // protobuf.Any encoded bytes.
+    bytes json_val = 10;              // JSON-encoded text.
+    bytes json_ietf_val = 11;         // JSON-encoded text per RFC7951.
+    string ascii_val = 12;            // Arbitrary ASCII text.
+    // Protobuf binary encoded bytes. The message type is not included.
+    // See the specification at
+    // github.com/openconfig/reference/blob/master/rpc/gnmi/protobuf-vals.md
+    // for a complete specification. [Experimental]
+    bytes proto_bytes = 13;
+  }
+}
+
+// Path encodes a data tree path as a series of repeated strings, with
+// each element of the path representing a data tree node name and the
+// associated attributes.
+// Reference: gNMI Specification Section 2.2.2.
+message Path {
+  // Elements of the path are no longer encoded as a string, but rather within
+  // the elem field as a PathElem message.
+  repeated string element = 1 [deprecated = true];
+  string origin = 2;           // Label to disambiguate path.
+  repeated PathElem elem = 3;  // Elements of the path.
+  string target = 4;           // The name of the target
+                               // (Sec. 2.2.2.1)
+}
+
+// PathElem encodes an element of a gNMI path, along with any attributes (keys)
+// that may be associated with it.
+// Reference: gNMI Specification Section 2.2.2.
+message PathElem {
+  string name = 1;              // The name of the element in the path.
+  map<string, string> key = 2;  // Map of key (attribute) name to value.
+}
+
+// Value encodes a data tree node's value - along with the way in which
+// the value is encoded. This message is deprecated by gNMI 0.3.0.
+// Reference: gNMI Specification Section 2.2.3.
+message Value {
+  option deprecated = true;
+
+  bytes value = 1;    // Value of the variable being transmitted.
+  Encoding type = 2;  // Encoding used for the value field.
+}
+
+// Encoding defines the value encoding formats that are supported by the gNMI
+// protocol. These encodings are used by both the client (when sending Set
+// messages to modify the state of the target) and the target when serializing
+// data to be returned to the client (in both Subscribe and Get RPCs).
+// Reference: gNMI Specification Section 2.3
+enum Encoding {
+  JSON = 0;       // JSON encoded text.
+  BYTES = 1;      // Arbitrarily encoded bytes.
+  PROTO = 2;      // Encoded according to scalar values of TypedValue.
+  ASCII = 3;      // ASCII text of an out-of-band agreed format.
+  JSON_IETF = 4;  // JSON encoded text as per RFC7951.
+}
+
+// Error message previously utilised to return errors to the client. Deprecated
+// in favour of using the google.golang.org/genproto/googleapis/rpc/status
+// message in the RPC response.
+// Reference: gNMI Specification Section 2.5
+message Error {
+  option deprecated = true;
+
+  uint32 code = 1;               // Canonical gRPC error code.
+  string message = 2;            // Human readable error.
+  google.protobuf.Any data = 3;  // Optional additional information.
+}
+
+// Decimal64 is used to encode a fixed precision decimal number. The value
+// is expressed as a set of digits with the precision specifying the
+// number of digits following the decimal point in the digit set.
+// This message is deprecated in favor of encoding all floating point types
+// as double precision.
+message Decimal64 {
+  option deprecated = true;
+
+  int64 digits = 1;      // Set of digits.
+  uint32 precision = 2;  // Number of digits following the decimal point.
+}
+
+// ScalarArray is used to encode a mixed-type array of values.
+message ScalarArray {
+  // The set of elements within the array. Each TypedValue message should
+  // specify only elements that have a field identifier of 1-7 (i.e., the
+  // values are scalar values).
+  repeated TypedValue element = 1;
+}
+
+// SubscribeRequest is the message sent by the client to the target when
+// initiating a subscription to a set of paths within the data tree. The
+// request field must be populated and the initial message must specify a
+// SubscriptionList to initiate a subscription.
+// Reference: gNMI Specification Section 3.5.1.1
+message SubscribeRequest {
+  oneof request {
+    SubscriptionList subscribe = 1;  // Specify the paths within a subscription.
+    Poll poll = 3;                   // Trigger a polled update.
+  }
+  // Extension messages associated with the SubscribeRequest. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 5;
+  // Reserved field numbers and identifiers.
+  reserved 4;
+  reserved "aliases";
+}
+
+// Poll is sent within a SubscribeRequest to trigger the device to
+// send telemetry updates for the paths that are associated with the
+// subscription.
+// Reference: gNMI Specification Section Section 3.5.1.4
+message Poll {}
+
+// SubscribeResponse is the message used by the target within a Subscribe RPC.
+// The target includes a Notification message which is used to transmit values
+// of the path(s) that are associated with the subscription. The same message
+// is to indicate that the target has sent all data values once (is
+// synchronized).
+// Reference: gNMI Specification Section 3.5.1.4
+message SubscribeResponse {
+  oneof response {
+    Notification update = 1;  // Changed or sampled value for a path.
+    // Indicate target has sent all values associated with the subscription
+    // at least once.
+    bool sync_response = 3;
+    // Deprecated in favour of google.golang.org/genproto/googleapis/rpc/status
+    Error error = 4 [deprecated = true];
+  }
+  // Extension messages associated with the SubscribeResponse. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 5;
+}
+
+// SubscriptionList is used within a Subscribe message to specify the list of
+// paths that the client wishes to subscribe to. The message consists of a
+// list of (possibly prefixed) paths, and options that relate to the
+// subscription.
+// Reference: gNMI Specification Section 3.5.1.2
+message SubscriptionList {
+  Path prefix = 1;                         // Prefix used for paths.
+  repeated Subscription subscription = 2;  // Set of subscriptions to create.
+  QOSMarking qos = 4;                      // DSCP marking to be used.
+  // Mode of the subscription.
+  enum Mode {
+    STREAM = 0;  // Values streamed by the target (Sec. 3.5.1.5.2).
+    ONCE = 1;    // Values sent once-off by the target (Sec. 3.5.1.5.1).
+    POLL = 2;    // Values sent in response to a poll request (Sec. 3.5.1.5.3).
+  }
+  Mode mode = 5;
+  // Whether elements of the schema that are marked as eligible for aggregation
+  // should be aggregated or not.
+  bool allow_aggregation = 6;
+  // The set of schemas that define the elements of the data tree that should
+  // be sent by the target.
+  repeated ModelData use_models = 7;
+  // The encoding that the target should use within the Notifications generated
+  // corresponding to the SubscriptionList.
+  Encoding encoding = 8;
+  // An optional field to specify that only updates to current state should be
+  // sent to a client. If set, the initial state is not sent to the client but
+  // rather only the sync message followed by any subsequent updates to the
+  // current state. For ONCE and POLL modes, this causes the server to send only
+  // the sync message (Sec. 3.5.2.3).
+  bool updates_only = 9;
+  // Reserved field numbers and identifiers.
+  reserved 3;
+  reserved "use_aliases";
+}
+
+// Subscription is a single request within a SubscriptionList. The path
+// specified is interpreted (along with the prefix) as the elements of the data
+// tree that the client is subscribing to. The mode determines how the target
+// should trigger updates to be sent.
+// Reference: gNMI Specification Section 3.5.1.3
+message Subscription {
+  Path path = 1;               // The data tree path.
+  SubscriptionMode mode = 2;   // Subscription mode to be used.
+  uint64 sample_interval = 3;  // ns between samples in SAMPLE mode.
+  // Indicates whether values that have not changed should be sent in a SAMPLE
+  // subscription.
+  bool suppress_redundant = 4;
+  // 1. A heartbeat interval MAY be specified along with an “on change”
+  // subscription - in this case, the value of the data item(s) MUST be re-sent
+  // once per heartbeat interval regardless of whether the value has changed or
+  // not.
+  // 2. A heartbeat_interval MAY be specified to modify the behavior of
+  // suppress_redundant in a sampled subscription. In this case, the
+  // target MUST generate one telemetry update per heartbeat interval,
+  // regardless of whether the suppress_redundant flag is set to true.
+  // This value is specified as an unsigned 64-bit integer in nanoseconds
+  uint64 heartbeat_interval = 5;
+}
+
+// SubscriptionMode is the mode of the subscription, specifying how the
+// target must return values in a subscription.
+// Reference: gNMI Specification Section 3.5.1.3
+enum SubscriptionMode {
+  TARGET_DEFINED = 0;  // The target selects the relevant mode for each element.
+  ON_CHANGE = 1;       // The target sends an update on element value change.
+  SAMPLE = 2;          // The target samples values according to the interval.
+}
+
+// QOSMarking specifies the DSCP value to be set on transmitted telemetry
+// updates from the target.
+// Reference: gNMI Specification Section 3.5.1.2
+message QOSMarking {
+  uint32 marking = 1;
+}
+
+// SetRequest is sent from a client to the target to update values in the data
+// tree. Paths are either deleted by the client, or modified by means of being
+// updated, or replaced. Where a replace is used, unspecified values are
+// considered to be replaced, whereas when update is used the changes are
+// considered to be incremental. The set of changes that are specified within
+// a single SetRequest are considered to be a transaction.
+// Reference: gNMI Specification Section 3.4.1
+message SetRequest {
+  Path prefix = 1;              // Prefix used for paths in the message.
+  repeated Path delete = 2;     // Paths to be deleted from the data tree.
+  repeated Update replace = 3;  // Updates specifying elements to be replaced.
+  repeated Update update = 4;   // Updates specifying elements to updated.
+  // Updates specifying elements to union and then replace the data tree.
+  // See the gNMI specification at
+  // https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md
+  // for details.
+  repeated Update union_replace = 6;
+  // Extension messages associated with the SetRequest. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 5;
+}
+
+// SetResponse is the response to a SetRequest, sent from the target to the
+// client. It reports the result of the modifications to the data tree that were
+// specified by the client. Errors for this RPC should be reported using the
+// https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
+// message in the RPC return. The gnmi.Error message can be used to add
+// additional details where required. Reference: gNMI Specification
+// Section 3.4.2
+message SetResponse {
+  Path prefix = 1;  // Prefix used for paths.
+  // A set of responses specifying the result of the operations specified in
+  // the SetRequest.
+  repeated UpdateResult response = 2;
+  Error message = 3
+      [deprecated = true];  // The overall status of the transaction.
+  int64 timestamp = 4;      // Timestamp of transaction (ns since epoch).
+  // Extension messages associated with the SetResponse. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 5;
+}
+
+// UpdateResult is used within the SetResponse message to communicate the
+// result of an operation specified within a SetRequest message.
+// Reference: gNMI Specification Section 3.4.2
+message UpdateResult {
+  // The operation that was associated with the Path specified.
+  enum Operation {
+    INVALID = 0;
+    DELETE = 1;         // The result relates to a delete of Path.
+    REPLACE = 2;        // The result relates to a replace of Path.
+    UPDATE = 3;         // The result relates to an update of Path.
+    UNION_REPLACE = 4;  // The result of a union_replace of Path or CLI origin.
+  }
+  // Deprecated timestamp for the UpdateResult, this field has been
+  // replaced by the timestamp within the SetResponse message, since
+  // all mutations effected by a set should be applied as a single
+  // transaction.
+  int64 timestamp = 1 [deprecated = true];
+  Path path = 2;                          // Path associated with the update.
+  Error message = 3 [deprecated = true];  // Status of the update operation.
+  Operation op = 4;                       // Update operation type.
+}
+
+// GetRequest is sent when a client initiates a Get RPC. It is used to specify
+// the set of data elements for which the target should return a snapshot of
+// data. The use_models field specifies the set of schema modules that are to
+// be used by the target - where use_models is not specified then the target
+// must use all schema models that it has.
+// Reference: gNMI Specification Section 3.3.1
+message GetRequest {
+  Path prefix = 1;         // Prefix used for paths.
+  repeated Path path = 2;  // Paths requested by the client.
+  // Type of elements within the data tree.
+  enum DataType {
+    ALL = 0;     // All data elements.
+    CONFIG = 1;  // Config (rw) only elements.
+    STATE = 2;   // State (ro) only elements.
+    // Data elements marked in the schema as operational. This refers to data
+    // elements whose value relates to the state of processes or interactions
+    // running on the device.
+    OPERATIONAL = 3;
+  }
+  DataType type = 3;                  // The type of data being requested.
+  Encoding encoding = 5;              // Encoding to be used.
+  repeated ModelData use_models = 6;  // The schema models to be used.
+  // Extension messages associated with the GetRequest. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 7;
+}
+
+// GetResponse is used by the target to respond to a GetRequest from a client.
+// The set of Notifications corresponds to the data values that are requested
+// by the client in the GetRequest.
+// Reference: gNMI Specification Section 3.3.2
+message GetResponse {
+  repeated Notification notification = 1;  // Data values.
+  Error error = 2 [deprecated = true];     // Errors that occurred in the Get.
+  // Extension messages associated with the GetResponse. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 3;
+}
+
+// CapabilityRequest is sent by the client in the Capabilities RPC to request
+// that the target reports its capabilities.
+// Reference: gNMI Specification Section 3.2.1
+message CapabilityRequest {
+  // Extension messages associated with the CapabilityRequest. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 1;
+}
+
+// CapabilityResponse is used by the target to report its capabilities to the
+// client within the Capabilities RPC.
+// Reference: gNMI Specification Section 3.2.2
+message CapabilityResponse {
+  repeated ModelData supported_models = 1;    // Supported schema models.
+  repeated Encoding supported_encodings = 2;  // Supported encodings.
+  string gNMI_version = 3;                    // Supported gNMI version.
+  // Extension messages associated with the CapabilityResponse. See the
+  // gNMI extension specification for further definition.
+  repeated gnmi_ext.Extension extension = 4;
+}
+
+// ModelData is used to describe a set of schema modules. It can be used in a
+// CapabilityResponse where a target reports the set of modules that it
+// supports, and within the SubscribeRequest and GetRequest messages to specify
+// the set of models from which data tree elements should be reported.
+// Reference: gNMI Specification Section 3.2.3
+message ModelData {
+  string name = 1;          // Name of the model.
+  string organization = 2;  // Organization publishing the model.
+  string version = 3;       // Semantic version of the model.
+}

--- a/gnmi/gnmi.proto
+++ b/gnmi/gnmi.proto
@@ -45,7 +45,6 @@ option java_multiple_files = true;
 option java_outer_classname = "GnmiProto";
 option java_package = "com.github.gnmi.proto";
 
-
 service gNMI {
   // Capabilities allows the client to retrieve the set of capabilities that
   // is supported by the target. This allows the target to validate the

--- a/gnmi/gnmi_ext.proto
+++ b/gnmi/gnmi_ext.proto
@@ -30,13 +30,14 @@ option java_outer_classname = "GnmiExtProto";
 // The Extension message contains a single gNMI extension.
 message Extension {
   oneof ext {
-    RegisteredExtension registered_ext = 1;     // A registered extension.
+    RegisteredExtension registered_ext = 1;  // A registered extension.
     // Well known extensions.
-    MasterArbitration master_arbitration = 2;   // Master arbitration extension.
-    History history = 3;                        // History extension.
-    Commit commit = 4;                          // Commit confirmed extension.
-    Depth depth = 5;                            // Depth extension.
-    ConfigSubscription config_subscription = 6; // Config Subscription extension.
+    MasterArbitration master_arbitration = 2;  // Master arbitration extension.
+    History history = 3;                       // History extension.
+    Commit commit = 4;                         // Commit confirmed extension.
+    Depth depth = 5;                           // Depth extension.
+    ConfigSubscription config_subscription =
+        6;  // Config Subscription extension.
   }
 }
 
@@ -119,9 +120,9 @@ message Commit {
     // cancel action will cancel an on-going commit, the ID provided during
     // cancel should match the on-going commit ID.
     CommitCancel cancel = 4;
-    // set rollback duration action sets the rollback duration of an on-going commit
-    // to a new value.
-    // The ID provided with the Commit message should match the on-going commit ID.
+    // set rollback duration action sets the rollback duration of an on-going
+    // commit to a new value. The ID provided with the Commit message should
+    // match the on-going commit ID.
     CommitSetRollbackDuration set_rollback_duration = 5;
   }
 }
@@ -188,7 +189,7 @@ message ConfigSubscriptionSyncDone {
   // ID of a commit as might be assigned by the server
   // when registering a commit operation.
   string server_commit_id = 2;
-  // If true indicates that the server is done processing the updates related to the
-  // commit_confirm_id and/or server_commit_id.
+  // If true indicates that the server is done processing the updates related to
+  // the commit_confirm_id and/or server_commit_id.
   bool done = 3;
 }

--- a/gnmi/gnmi_ext.proto
+++ b/gnmi/gnmi_ext.proto
@@ -1,0 +1,194 @@
+//
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+syntax = "proto3";
+
+import "google/protobuf/duration.proto";
+
+// Package gnmi_ext defines a set of extensions messages which can be optionally
+// included with the request and response messages of gNMI RPCs. A set of
+// well-known extensions are defined within this file, along with a registry for
+// extensions defined outside of this package.
+package gnmi_ext;
+
+option go_package = "github.com/openconfig/gnmi/proto/gnmi_ext";
+option java_package = "com.github.gnmi_ext.proto";
+option java_outer_classname = "GnmiExtProto";
+
+// The Extension message contains a single gNMI extension.
+message Extension {
+  oneof ext {
+    RegisteredExtension registered_ext = 1;     // A registered extension.
+    // Well known extensions.
+    MasterArbitration master_arbitration = 2;   // Master arbitration extension.
+    History history = 3;                        // History extension.
+    Commit commit = 4;                          // Commit confirmed extension.
+    Depth depth = 5;                            // Depth extension.
+    ConfigSubscription config_subscription = 6; // Config Subscription extension.
+  }
+}
+
+// The RegisteredExtension message defines an extension which is defined outside
+// of this file.
+message RegisteredExtension {
+  ExtensionID id = 1;  // The unique ID assigned to this extension.
+  bytes msg = 2;       // The binary-marshalled protobuf extension payload.
+}
+
+// RegisteredExtension is an enumeration acting as a registry for extensions
+// defined by external sources.
+enum ExtensionID {
+  EID_UNSET = 0;
+  // New extensions are to be defined within this enumeration - their definition
+  // MUST link to a reference describing their implementation.
+
+  // An experimental extension that may be used during prototyping of a new
+  // extension.
+  EID_EXPERIMENTAL = 999;
+}
+
+// MasterArbitration is used to select the master among multiple gNMI clients
+// with the same Roles. The client with the largest election_id is honored as
+// the master.
+// The document about gNMI master arbitration can be found at
+// https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-master-arbitration.md
+message MasterArbitration {
+  Role role = 1;
+  Uint128 election_id = 2;
+}
+
+// Representation of unsigned 128-bit integer.
+message Uint128 {
+  uint64 high = 1;
+  uint64 low = 2;
+}
+
+// There can be one master for each role. The role is identified by its id.
+message Role {
+  string id = 1;
+  // More fields can be added if needed, for example, to specify what paths the
+  // role can read/write.
+}
+
+// The History extension allows clients to request historical data. Its
+// spec can be found at
+// https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-history.md
+message History {
+  oneof request {
+    int64 snapshot_time = 1;  // Nanoseconds since the epoch
+    TimeRange range = 2;
+  }
+}
+
+message TimeRange {
+  int64 start = 1;  // Nanoseconds since the epoch
+  int64 end = 2;    // Nanoseconds since the epoch
+}
+
+// Commit confirmed extension allows automated revert of the configuration after
+// certain duration if an explicit confirmation is not issued. It allows
+// explicit cancellation of the commit during the rollback window. There cannot
+// be more than one commit active at a given time. The document about gNMI
+// commit confirmed can be found at
+// https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-commit-confirmed.md
+message Commit {
+  // ID is provided by the client during the commit request. During confirm and
+  // cancel actions the provided ID should match the ID provided during commit.
+  // If ID is not passed in any actions server shall return error.
+  // Required.
+  string id = 1;
+  oneof action {
+    // commit action creates a new commit. If a commit is on-going, server
+    // returns error.
+    CommitRequest commit = 2;
+    // confirm action will confirm an on-going commit, the ID provided during
+    // confirm should match the on-going commit ID.
+    CommitConfirm confirm = 3;
+    // cancel action will cancel an on-going commit, the ID provided during
+    // cancel should match the on-going commit ID.
+    CommitCancel cancel = 4;
+    // set rollback duration action sets the rollback duration of an on-going commit
+    // to a new value.
+    // The ID provided with the Commit message should match the on-going commit ID.
+    CommitSetRollbackDuration set_rollback_duration = 5;
+  }
+}
+
+// CommitRequest is used to create a new confirmed commit. It hold additional
+// parameter requried for commit action.
+message CommitRequest {
+  // Maximum duration to wait for a confirmaton before reverting the commit.
+  google.protobuf.Duration rollback_duration = 1;
+}
+
+// CommitConfirm is used to confirm an on-going commit. It hold additional
+// parameter requried for confirm action.
+message CommitConfirm {}
+
+// CommitCancel is used to cancel an on-going commit. It hold additional
+// parameter requried for cancel action.
+message CommitCancel {}
+
+// CommitSetRollbackDuration is used to set the existing rollback duration value
+// of an on-going commit to a new desired value.
+message CommitSetRollbackDuration {
+  // Maximum duration to wait for a confirmaton before reverting the commit.
+  google.protobuf.Duration rollback_duration = 1;
+}
+
+// Depth allows clients to specify the depth of the subtree to be returned in
+// the response. The depth is specified as the number of levels below the
+// specified path.
+// The depth is applied to all paths in the Get or Subscribe request.
+// The document about gNMI depth can be found at
+// https://github.com/openconfig/reference/tree/master/rpc/gnmi/gnmi-depth.md
+message Depth {
+  // The level of the subtree to be returned in the response.
+  // Value of 0 means no depth limit and behaves the same as if the extension
+  // was not specified.
+  // Value of 1 means only the specified path and its direct children will be
+  // returned.
+  uint32 level = 1;
+}
+
+// ConfigSubscription extension allows clients to subscribe to configuration
+// schema nodes only.
+message ConfigSubscription {
+  oneof action {
+    // ConfigSubscriptionStart is sent by the client in the SubscribeRequest
+    ConfigSubscriptionStart start = 1;
+    // ConfigSubscriptionSyncDone is sent by the server in the SubscribeResponse
+    ConfigSubscriptionSyncDone sync_done = 2;
+  }
+}
+
+// ConfigSubscriptionStart is used to indicate to a target that for a given set
+// of paths in the SubscribeRequest, the client wishes to receive updates
+// for the configuration schema nodes only.
+message ConfigSubscriptionStart {}
+
+// ConfigSubscriptionSyncDone is sent by the server in the SubscribeResponse
+// after all the updates for the configuration schema nodes have been sent.
+message ConfigSubscriptionSyncDone {
+  // ID of a commit confirm operation as assigned by the client
+  // see Commit Confirm extension for more details.
+  string commit_confirm_id = 1;
+  // ID of a commit as might be assigned by the server
+  // when registering a commit operation.
+  string server_commit_id = 2;
+  // If true indicates that the server is done processing the updates related to the
+  // commit_confirm_id and/or server_commit_id.
+  bool done = 3;
+}

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -91,6 +91,8 @@ kt_jvm_library(
         ":p4runtime_java_grpc",
         ":p4runtime_java_proto",
         ":p4runtime_kt_grpc",
+        "//gnmi:gnmi_java_proto",
+        "//gnmi:gnmi_kt_grpc",
         "//simulator:ir_java_proto",
         "//simulator:p4runtime_java_proto",
         "//simulator:simulator_java_proto",
@@ -397,6 +399,24 @@ kt_jvm_test(
         "//simulator:simulator_java_proto",
         "@grpc-java//api",
         "@grpc-java//inprocess",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_grpc_grpc_kotlin_stub",
+        "@maven//:junit_junit",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+    ],
+)
+
+kt_jvm_test(
+    name = "GnmiServiceTest",
+    srcs = ["GnmiServiceTest.kt"],
+    test_class = "fourward.p4runtime.GnmiServiceTest",
+    deps = [
+        ":p4runtime_lib",
+        "//gnmi:gnmi_java_proto",
+        "//gnmi:gnmi_kt_grpc",
+        "@grpc-java//api",
+        "@grpc-java//inprocess",
+        "@grpc-java//testing",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_grpc_grpc_kotlin_stub",
         "@maven//:junit_junit",

--- a/p4runtime/EntityReader.kt
+++ b/p4runtime/EntityReader.kt
@@ -47,8 +47,9 @@ private constructor(
         result.add(buildTableEntryEntity(entry, hasDirectCounter, hasDirectMeter, tables))
       }
 
-      // P4Runtime spec §11.1: wildcard and per-table reads include the default entry.
-      if (!hasMatchFilter) {
+      // P4Runtime spec §9.1.2: only return default entries that have been explicitly
+      // configured via Write. Pipeline-loaded defaults are not included in reads.
+      if (!hasMatchFilter && tables.isDefaultModified(tableName)) {
         buildDefaultEntryEntity(tableName, tableId, tables)?.let { result.add(it) }
       }
     }

--- a/p4runtime/EntityReaderTest.kt
+++ b/p4runtime/EntityReaderTest.kt
@@ -34,9 +34,17 @@ class EntityReaderTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  fun `wildcard read with no entries returns only default entries`() {
+  fun `wildcard read with no entries and no modified defaults returns empty`() {
+    val result = readWildcard()
+    assertTrue("unmodified defaults should not appear in reads", result.isEmpty())
+  }
+
+  @Test
+  fun `wildcard read returns modified default entries`() {
+    stub.modifiedDefaults.add(TABLE_A_NAME)
     val result = readWildcard()
     assertTrue("should only contain defaults", result.all { it.tableEntry.isDefaultAction })
+    assertEquals(1, result.size)
   }
 
   @Test
@@ -65,12 +73,22 @@ class EntityReaderTest {
   }
 
   @Test
-  fun `per-table read includes default entry`() {
+  fun `per-table read includes modified default entry`() {
+    stub.modifiedDefaults.add(TABLE_A_NAME)
     val result = readTable(TABLE_A_ID)
     val defaults = result.filter { it.tableEntry.isDefaultAction }
     assertEquals(1, defaults.size)
     assertEquals(TABLE_A_ID, defaults[0].tableEntry.tableId)
     assertEquals(DROP_ACTION_ID, defaults[0].tableEntry.action.action.actionId)
+  }
+
+  @Test
+  fun `per-table read excludes unmodified default entry`() {
+    val result = readTable(TABLE_A_ID)
+    assertTrue(
+      "unmodified defaults should not appear",
+      result.none { it.tableEntry.isDefaultAction },
+    )
   }
 
   // ---------------------------------------------------------------------------
@@ -113,6 +131,7 @@ class EntityReaderTest {
 
   @Test
   fun `default entry has correct table_id and is_default_action`() {
+    stub.modifiedDefaults.add(TABLE_A_NAME)
     val defaults = readTable(TABLE_A_ID).filter { it.tableEntry.isDefaultAction }
     assertEquals(1, defaults.size)
     val entry = defaults[0].tableEntry
@@ -129,6 +148,7 @@ class EntityReaderTest {
         P4RuntimeOuterClass.Action.Param.newBuilder().setParamId(2).setValue(bytes(7)).build(),
       )
     stub.defaults[TABLE_A_NAME] = DefaultAction("drop", params)
+    stub.modifiedDefaults.add(TABLE_A_NAME)
 
     val defaults = readTable(TABLE_A_ID).filter { it.tableEntry.isDefaultAction }
     assertEquals(1, defaults.size)
@@ -142,8 +162,9 @@ class EntityReaderTest {
   }
 
   @Test
-  fun `table with no explicit default uses NoAction`() {
-    // Table B has no default action set, so it falls back to NoAction.
+  fun `modified default with no explicit action uses NoAction`() {
+    // Table B has no default action set but is marked as modified — falls back to NoAction.
+    stub.modifiedDefaults.add(TABLE_B_NAME)
     val defaults = readTable(TABLE_B_ID).filter { it.tableEntry.isDefaultAction }
     assertEquals(1, defaults.size)
     assertEquals(NO_ACTION_ID, defaults[0].tableEntry.action.action.actionId)
@@ -262,6 +283,7 @@ class EntityReaderTest {
   private class StubTableData : TableDataReader {
     val entries = mutableMapOf<String, MutableList<TableEntry>>()
     val defaults = mutableMapOf<String, DefaultAction>()
+    val modifiedDefaults = mutableSetOf<String>()
     val directCounters = mutableSetOf<String>()
     val directMeters = mutableSetOf<String>()
     val counterData = mutableMapOf<TableEntry, P4RuntimeOuterClass.CounterData>()
@@ -292,6 +314,8 @@ class EntityReaderTest {
     override fun getTableEntries(tableName: String) = entries[tableName] ?: emptyList()
 
     override fun getDefaultAction(tableName: String) = defaults[tableName]
+
+    override fun isDefaultModified(tableName: String) = tableName in modifiedDefaults
 
     override fun getDirectCounterData(entry: TableEntry) = counterData[entry]
 

--- a/p4runtime/GnmiService.kt
+++ b/p4runtime/GnmiService.kt
@@ -1,0 +1,255 @@
+// Copyright 2026 4ward Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fourward.p4runtime
+
+import com.github.gnmi.proto.CapabilityRequest
+import com.github.gnmi.proto.CapabilityResponse
+import com.github.gnmi.proto.gNMIGrpcKt
+import com.github.gnmi.proto.GetRequest
+import com.github.gnmi.proto.GetResponse
+import com.github.gnmi.proto.Notification
+import com.github.gnmi.proto.Path
+import com.github.gnmi.proto.SetRequest
+import com.github.gnmi.proto.SetResponse
+import com.github.gnmi.proto.SubscribeRequest
+import com.github.gnmi.proto.SubscribeResponse
+import com.github.gnmi.proto.TypedValue
+import com.github.gnmi.proto.Update
+import com.github.gnmi.proto.UpdateResult
+import com.google.protobuf.ByteString
+import io.grpc.Status
+import io.grpc.StatusException
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Minimal gNMI stub server for upstream sonic-pins DVaaS mirror testbed support.
+ *
+ * Models a configurable set of Ethernet interfaces, each with a P4RT port ID, enabled state, and
+ * operational status. DVaaS uses gNMI to discover switch ports and map them between the SUT and
+ * control switch.
+ *
+ * **Supported RPCs:**
+ * - `Get`: returns interface config or state as JSON_IETF.
+ * - `Set`: modifies P4RT port ID assignments.
+ * - `Capabilities` / `Subscribe`: return UNIMPLEMENTED.
+ *
+ * **Supported OpenConfig paths:**
+ * - `interfaces` (config/state) — full interface list.
+ * - `interfaces/interface[name=X]/config/openconfig-p4rt:id` — per-interface P4RT port ID.
+ * - Empty path with CONFIG type — full device config.
+ *
+ * @param interfaces Initial interface configurations. If empty, a default set of 8 Ethernet
+ *   interfaces is created.
+ */
+class GnmiService(
+  interfaces: List<InterfaceConfig> = defaultInterfaces(),
+) : gNMIGrpcKt.gNMICoroutineImplBase() {
+
+  /** Mutable interface state. Thread-safe: gRPC serializes calls. */
+  private val interfaces = interfaces.map { it.copy() }.associateBy { it.name }.toMutableMap()
+
+  /** Configuration for a single Ethernet interface. */
+  data class InterfaceConfig(
+    val name: String,
+    val p4rtId: Int? = null,
+    val enabled: Boolean = true,
+    val operStatus: String = "UP",
+  )
+
+  // ---------------------------------------------------------------------------
+  // gNMI Get
+  // ---------------------------------------------------------------------------
+
+  override suspend fun get(request: GetRequest): GetResponse {
+    val dataType = request.type
+    val path = request.pathList.firstOrNull() ?: Path.getDefaultInstance()
+    val pathStr = pathToString(path)
+
+    val json =
+      when {
+        // Full device config (empty path)
+        pathStr.isEmpty() && dataType == GetRequest.DataType.CONFIG -> buildFullConfig()
+        // Interfaces config or state
+        pathStr == "interfaces" || pathStr.isEmpty() ->
+          when (dataType) {
+            GetRequest.DataType.CONFIG -> buildInterfacesConfigJson()
+            GetRequest.DataType.STATE -> buildInterfacesStateJson()
+            else -> buildInterfacesStateJson()
+          }
+        else ->
+          throw StatusException(
+            Status.UNIMPLEMENTED.withDescription("unsupported gNMI path: $pathStr")
+          )
+      }
+
+    val update =
+      Update.newBuilder()
+        .setPath(path)
+        .setVal(TypedValue.newBuilder().setJsonIetfVal(ByteString.copyFromUtf8(json)))
+        .build()
+
+    val notification = Notification.newBuilder().addUpdate(update).build()
+
+    return GetResponse.newBuilder().addNotification(notification).build()
+  }
+
+  // ---------------------------------------------------------------------------
+  // gNMI Set
+  // ---------------------------------------------------------------------------
+
+  override suspend fun set(request: SetRequest): SetResponse {
+    val results = mutableListOf<UpdateResult>()
+
+    // Handle deletes (remove P4RT port ID assignments).
+    for (delete in request.deleteList) {
+      val pathStr = pathToString(delete)
+      val ifaceName = extractInterfaceName(delete)
+      if (ifaceName != null && pathStr.endsWith("openconfig-p4rt:id")) {
+        interfaces[ifaceName]?.let { interfaces[ifaceName] = it.copy(p4rtId = null) }
+        results.add(
+          UpdateResult.newBuilder()
+            .setPath(delete)
+            .setOp(UpdateResult.Operation.DELETE)
+            .build()
+        )
+      }
+    }
+
+    // Handle updates (set P4RT port ID assignments).
+    for (update in request.updateList + request.replaceList) {
+      val pathStr = pathToString(update.path)
+      val ifaceName = extractInterfaceName(update.path)
+      if (ifaceName != null && pathStr.endsWith("openconfig-p4rt:id")) {
+        val portId = extractP4rtIdFromJson(update.getVal())
+        if (portId != null) {
+          interfaces[ifaceName]?.let { interfaces[ifaceName] = it.copy(p4rtId = portId) }
+        }
+        results.add(
+          UpdateResult.newBuilder()
+            .setPath(update.path)
+            .setOp(UpdateResult.Operation.UPDATE)
+            .build()
+        )
+      } else if (pathStr.isEmpty()) {
+        // Full config replace — accept but ignore (DVaaS uses this for config push).
+        results.add(
+          UpdateResult.newBuilder()
+            .setPath(update.path)
+            .setOp(UpdateResult.Operation.REPLACE)
+            .build()
+        )
+      }
+    }
+
+    return SetResponse.newBuilder().addAllResponse(results).build()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unimplemented RPCs
+  // ---------------------------------------------------------------------------
+
+  override suspend fun capabilities(request: CapabilityRequest): CapabilityResponse {
+    throw StatusException(Status.UNIMPLEMENTED.withDescription("gNMI Capabilities not supported"))
+  }
+
+  override fun subscribe(requests: Flow<SubscribeRequest>): Flow<SubscribeResponse> {
+    throw StatusException(Status.UNIMPLEMENTED.withDescription("gNMI Subscribe not supported"))
+  }
+
+  // ---------------------------------------------------------------------------
+  // JSON builders (OpenConfig YANG-aligned format)
+  // ---------------------------------------------------------------------------
+
+  /** Builds the full interfaces config JSON in OpenConfig format. */
+  private fun buildInterfacesConfigJson(): String {
+    val ifaceEntries =
+      interfaces.values
+        .sortedBy { it.name }
+        .joinToString(",\n") { iface ->
+          val idField = iface.p4rtId?.let { ""","openconfig-p4rt:id":$it""" } ?: ""
+          """{
+        "name":"${iface.name}",
+        "config":{
+          "name":"${iface.name}",
+          "type":"iana-if-type:ethernetCsmacd",
+          "enabled":${iface.enabled}$idField
+        }
+      }"""
+        }
+    return """{"openconfig-interfaces:interfaces":{"interface":[$ifaceEntries]}}"""
+  }
+
+  /** Builds the full interfaces state JSON in OpenConfig format. */
+  private fun buildInterfacesStateJson(): String {
+    val ifaceEntries =
+      interfaces.values
+        .sortedBy { it.name }
+        .joinToString(",\n") { iface ->
+          val idField = iface.p4rtId?.let { ""","openconfig-p4rt:id":$it""" } ?: ""
+          """{
+        "name":"${iface.name}",
+        "state":{
+          "name":"${iface.name}",
+          "type":"iana-if-type:ethernetCsmacd",
+          "enabled":${iface.enabled},
+          "oper-status":"${iface.operStatus}"$idField
+        }
+      }"""
+        }
+    return """{"openconfig-interfaces:interfaces":{"interface":[$ifaceEntries]}}"""
+  }
+
+  /** Builds a full device config (wraps interfaces config). */
+  private fun buildFullConfig(): String = buildInterfacesConfigJson()
+
+  // ---------------------------------------------------------------------------
+  // Path helpers
+  // ---------------------------------------------------------------------------
+
+  /** Converts a gNMI Path to a string like "interfaces/interface[name=Ethernet0]/config". */
+  private fun pathToString(path: Path): String =
+    path.elemList.joinToString("/") { elem ->
+      if (elem.keyMap.isEmpty()) {
+        elem.name
+      } else {
+        val keys = elem.keyMap.entries.joinToString(",") { (k, v) -> "$k=$v" }
+        "${elem.name}[$keys]"
+      }
+    }
+
+  /** Extracts the interface name from a path like interfaces/interface[name=X]/... */
+  private fun extractInterfaceName(path: Path): String? =
+    path.elemList.find { it.name == "interface" }?.keyMap?.get("name")
+
+  /** Extracts the P4RT port ID from a JSON_IETF value like {"openconfig-p4rt:id":42}. */
+  @Suppress("MagicNumber")
+  private fun extractP4rtIdFromJson(value: TypedValue): Int? {
+    if (value.hasJsonIetfVal()) {
+      val json = value.jsonIetfVal.toStringUtf8()
+      val match = Regex(""""openconfig-p4rt:id"\s*:\s*(\d+)""").find(json)
+      return match?.groupValues?.get(1)?.toIntOrNull()
+    }
+    if (value.hasUintVal()) return value.uintVal.toInt()
+    if (value.hasIntVal()) return value.intVal.toInt()
+    return null
+  }
+
+  companion object {
+    /** Creates a default set of 8 Ethernet interfaces with sequential P4RT port IDs. */
+    @Suppress("MagicNumber")
+    fun defaultInterfaces(): List<InterfaceConfig> =
+      (0 until 8).map { i -> InterfaceConfig(name = "Ethernet$i", p4rtId = i + 1) }
+  }
+}

--- a/p4runtime/GnmiService.kt
+++ b/p4runtime/GnmiService.kt
@@ -16,7 +16,6 @@ package fourward.p4runtime
 
 import com.github.gnmi.proto.CapabilityRequest
 import com.github.gnmi.proto.CapabilityResponse
-import com.github.gnmi.proto.gNMIGrpcKt
 import com.github.gnmi.proto.GetRequest
 import com.github.gnmi.proto.GetResponse
 import com.github.gnmi.proto.Notification
@@ -28,6 +27,7 @@ import com.github.gnmi.proto.SubscribeResponse
 import com.github.gnmi.proto.TypedValue
 import com.github.gnmi.proto.Update
 import com.github.gnmi.proto.UpdateResult
+import com.github.gnmi.proto.gNMIGrpcKt
 import com.google.protobuf.ByteString
 import io.grpc.Status
 import io.grpc.StatusException
@@ -53,9 +53,8 @@ import kotlinx.coroutines.flow.Flow
  * @param interfaces Initial interface configurations. If empty, a default set of 8 Ethernet
  *   interfaces is created.
  */
-class GnmiService(
-  interfaces: List<InterfaceConfig> = defaultInterfaces(),
-) : gNMIGrpcKt.gNMICoroutineImplBase() {
+class GnmiService(interfaces: List<InterfaceConfig> = defaultInterfaces()) :
+  gNMIGrpcKt.gNMICoroutineImplBase() {
 
   /** Mutable interface state. Thread-safe: gRPC serializes calls. */
   private val interfaces = interfaces.map { it.copy() }.associateBy { it.name }.toMutableMap()
@@ -119,10 +118,7 @@ class GnmiService(
       if (ifaceName != null && pathStr.endsWith("openconfig-p4rt:id")) {
         interfaces[ifaceName]?.let { interfaces[ifaceName] = it.copy(p4rtId = null) }
         results.add(
-          UpdateResult.newBuilder()
-            .setPath(delete)
-            .setOp(UpdateResult.Operation.DELETE)
-            .build()
+          UpdateResult.newBuilder().setPath(delete).setOp(UpdateResult.Operation.DELETE).build()
         )
       }
     }

--- a/p4runtime/GnmiServiceTest.kt
+++ b/p4runtime/GnmiServiceTest.kt
@@ -16,7 +16,6 @@ import io.grpc.inprocess.InProcessServerBuilder
 import io.grpc.testing.GrpcCleanupRule
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -37,9 +36,7 @@ class GnmiServiceTest {
         .start()
     )
     val channel: ManagedChannel =
-      grpcCleanup.register(
-        InProcessChannelBuilder.forName(serverName).directExecutor().build()
-      )
+      grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build())
     return gNMIGrpcKt.gNMICoroutineStub(channel)
   }
 
@@ -86,9 +83,7 @@ class GnmiServiceTest {
   @Test
   fun `get state includes oper-status`() = runBlocking {
     val stub =
-      setup(
-        listOf(GnmiService.InterfaceConfig("Ethernet0", p4rtId = 1, operStatus = "DOWN"))
-      )
+      setup(listOf(GnmiService.InterfaceConfig("Ethernet0", p4rtId = 1, operStatus = "DOWN")))
     val response =
       stub.get(
         GetRequest.newBuilder()
@@ -104,10 +99,7 @@ class GnmiServiceTest {
   @Test
   fun `get full config with empty path`() = runBlocking {
     val stub = setup()
-    val response =
-      stub.get(
-        GetRequest.newBuilder().setType(GetRequest.DataType.CONFIG).build()
-      )
+    val response = stub.get(GetRequest.newBuilder().setType(GetRequest.DataType.CONFIG).build())
 
     val json = response.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
     assertTrue("should be full config", json.contains("openconfig-interfaces"))
@@ -117,11 +109,7 @@ class GnmiServiceTest {
   fun `get unsupported path returns UNIMPLEMENTED`() = runBlocking {
     val stub = setup()
     try {
-      stub.get(
-        GetRequest.newBuilder()
-          .addPath(path("system", "config"))
-          .build()
-      )
+      stub.get(GetRequest.newBuilder().addPath(path("system", "config")).build())
       assertTrue("should have thrown", false)
     } catch (e: StatusException) {
       assertEquals(Status.Code.UNIMPLEMENTED, e.status.code)
@@ -169,12 +157,7 @@ class GnmiServiceTest {
     val stub = setup()
 
     // Delete Ethernet0's P4RT ID.
-    val setResponse =
-      stub.set(
-        SetRequest.newBuilder()
-          .addDelete(p4rtIdPath("Ethernet0"))
-          .build()
-      )
+    val setResponse = stub.set(SetRequest.newBuilder().addDelete(p4rtIdPath("Ethernet0")).build())
 
     assertEquals(1, setResponse.responseCount)
 
@@ -287,9 +270,7 @@ class GnmiServiceTest {
   // ---------------------------------------------------------------------------
 
   private fun path(vararg elems: String): Path =
-    Path.newBuilder()
-      .addAllElem(elems.map { PathElem.newBuilder().setName(it).build() })
-      .build()
+    Path.newBuilder().addAllElem(elems.map { PathElem.newBuilder().setName(it).build() }).build()
 
   private fun p4rtIdPath(ifaceName: String): Path =
     Path.newBuilder()

--- a/p4runtime/GnmiServiceTest.kt
+++ b/p4runtime/GnmiServiceTest.kt
@@ -1,0 +1,304 @@
+package fourward.p4runtime
+
+import com.github.gnmi.proto.GetRequest
+import com.github.gnmi.proto.Path
+import com.github.gnmi.proto.PathElem
+import com.github.gnmi.proto.SetRequest
+import com.github.gnmi.proto.TypedValue
+import com.github.gnmi.proto.Update
+import com.github.gnmi.proto.gNMIGrpcKt
+import com.google.protobuf.ByteString
+import io.grpc.ManagedChannel
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.testing.GrpcCleanupRule
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class GnmiServiceTest {
+
+  @get:Rule val grpcCleanup = GrpcCleanupRule()
+
+  private fun setup(
+    interfaces: List<GnmiService.InterfaceConfig> = GnmiService.defaultInterfaces()
+  ): gNMIGrpcKt.gNMICoroutineStub {
+    val serverName = InProcessServerBuilder.generateName()
+    grpcCleanup.register(
+      InProcessServerBuilder.forName(serverName)
+        .directExecutor()
+        .addService(GnmiService(interfaces))
+        .build()
+        .start()
+    )
+    val channel: ManagedChannel =
+      grpcCleanup.register(
+        InProcessChannelBuilder.forName(serverName).directExecutor().build()
+      )
+    return gNMIGrpcKt.gNMICoroutineStub(channel)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Get — interfaces
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `get interfaces state returns all interfaces`() = runBlocking {
+    val stub = setup()
+    val response =
+      stub.get(
+        GetRequest.newBuilder()
+          .setType(GetRequest.DataType.STATE)
+          .addPath(path("interfaces"))
+          .build()
+      )
+
+    assertEquals(1, response.notificationCount)
+    val json = response.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
+    assertTrue("should contain openconfig-interfaces", json.contains("openconfig-interfaces"))
+    // Default: 8 interfaces, Ethernet0–Ethernet7.
+    for (i in 0 until 8) {
+      assertTrue("should contain Ethernet$i", json.contains("Ethernet$i"))
+    }
+  }
+
+  @Test
+  fun `get interfaces config returns config with P4RT IDs`() = runBlocking {
+    val stub = setup()
+    val response =
+      stub.get(
+        GetRequest.newBuilder()
+          .setType(GetRequest.DataType.CONFIG)
+          .addPath(path("interfaces"))
+          .build()
+      )
+
+    val json = response.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
+    assertTrue("should contain config block", json.contains(""""config":"""))
+    assertTrue("should contain P4RT IDs", json.contains("openconfig-p4rt:id"))
+  }
+
+  @Test
+  fun `get state includes oper-status`() = runBlocking {
+    val stub =
+      setup(
+        listOf(GnmiService.InterfaceConfig("Ethernet0", p4rtId = 1, operStatus = "DOWN"))
+      )
+    val response =
+      stub.get(
+        GetRequest.newBuilder()
+          .setType(GetRequest.DataType.STATE)
+          .addPath(path("interfaces"))
+          .build()
+      )
+
+    val json = response.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
+    assertTrue("should contain DOWN status", json.contains(""""oper-status":"DOWN""""))
+  }
+
+  @Test
+  fun `get full config with empty path`() = runBlocking {
+    val stub = setup()
+    val response =
+      stub.get(
+        GetRequest.newBuilder().setType(GetRequest.DataType.CONFIG).build()
+      )
+
+    val json = response.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
+    assertTrue("should be full config", json.contains("openconfig-interfaces"))
+  }
+
+  @Test
+  fun `get unsupported path returns UNIMPLEMENTED`() = runBlocking {
+    val stub = setup()
+    try {
+      stub.get(
+        GetRequest.newBuilder()
+          .addPath(path("system", "config"))
+          .build()
+      )
+      assertTrue("should have thrown", false)
+    } catch (e: StatusException) {
+      assertEquals(Status.Code.UNIMPLEMENTED, e.status.code)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Set — P4RT port ID
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `set updates P4RT port ID`() = runBlocking {
+    val stub = setup()
+
+    // Update Ethernet0's P4RT ID to 42.
+    val setResponse =
+      stub.set(
+        SetRequest.newBuilder()
+          .addUpdate(
+            Update.newBuilder()
+              .setPath(p4rtIdPath("Ethernet0"))
+              .setVal(jsonIetfValue("""{"openconfig-p4rt:id":42}"""))
+              .build()
+          )
+          .build()
+      )
+
+    assertEquals(1, setResponse.responseCount)
+
+    // Verify via Get.
+    val getResponse =
+      stub.get(
+        GetRequest.newBuilder()
+          .setType(GetRequest.DataType.CONFIG)
+          .addPath(path("interfaces"))
+          .build()
+      )
+
+    val json = getResponse.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
+    assertTrue("Ethernet0 should have P4RT ID 42", json.contains(""""openconfig-p4rt:id":42"""))
+  }
+
+  @Test
+  fun `set delete removes P4RT port ID`() = runBlocking {
+    val stub = setup()
+
+    // Delete Ethernet0's P4RT ID.
+    val setResponse =
+      stub.set(
+        SetRequest.newBuilder()
+          .addDelete(p4rtIdPath("Ethernet0"))
+          .build()
+      )
+
+    assertEquals(1, setResponse.responseCount)
+
+    // Verify via Get — Ethernet0 should have no P4RT ID, but Ethernet1 still should.
+    val getResponse =
+      stub.get(
+        GetRequest.newBuilder()
+          .setType(GetRequest.DataType.CONFIG)
+          .addPath(path("interfaces"))
+          .build()
+      )
+
+    val json = getResponse.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
+    // Ethernet1 has p4rtId=2 by default, so JSON should still contain an ID.
+    assertTrue("should still have other P4RT IDs", json.contains("openconfig-p4rt:id"))
+  }
+
+  @Test
+  fun `set full config replace is accepted`() = runBlocking {
+    val stub = setup()
+
+    val setResponse =
+      stub.set(
+        SetRequest.newBuilder()
+          .addReplace(
+            Update.newBuilder()
+              .setPath(Path.getDefaultInstance())
+              .setVal(jsonIetfValue("{}"))
+              .build()
+          )
+          .build()
+      )
+
+    assertEquals(1, setResponse.responseCount)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unimplemented RPCs
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `capabilities returns UNIMPLEMENTED`() = runBlocking {
+    val stub = setup()
+    try {
+      stub.capabilities(com.github.gnmi.proto.CapabilityRequest.getDefaultInstance())
+      assertTrue("should have thrown", false)
+    } catch (e: StatusException) {
+      assertEquals(Status.Code.UNIMPLEMENTED, e.status.code)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Custom interfaces
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `custom interfaces are reflected in Get response`() = runBlocking {
+    val stub =
+      setup(
+        listOf(
+          GnmiService.InterfaceConfig("Ethernet100", p4rtId = 100),
+          GnmiService.InterfaceConfig("Ethernet200", p4rtId = null, enabled = false),
+        )
+      )
+
+    val response =
+      stub.get(
+        GetRequest.newBuilder()
+          .setType(GetRequest.DataType.STATE)
+          .addPath(path("interfaces"))
+          .build()
+      )
+
+    val json = response.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
+    assertTrue(json.contains("Ethernet100"))
+    assertTrue(json.contains("Ethernet200"))
+    assertTrue(json.contains(""""openconfig-p4rt:id":100"""))
+    assertTrue("disabled interface", json.contains(""""enabled":false"""))
+  }
+
+  @Test
+  fun `set with uint_val updates P4RT port ID`() = runBlocking {
+    val stub = setup()
+
+    stub.set(
+      SetRequest.newBuilder()
+        .addUpdate(
+          Update.newBuilder()
+            .setPath(p4rtIdPath("Ethernet0"))
+            .setVal(TypedValue.newBuilder().setUintVal(99).build())
+            .build()
+        )
+        .build()
+    )
+
+    val getResponse =
+      stub.get(
+        GetRequest.newBuilder()
+          .setType(GetRequest.DataType.CONFIG)
+          .addPath(path("interfaces"))
+          .build()
+      )
+
+    val json = getResponse.getNotification(0).getUpdate(0).getVal().jsonIetfVal.toStringUtf8()
+    assertTrue("should have P4RT ID 99", json.contains(""""openconfig-p4rt:id":99"""))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private fun path(vararg elems: String): Path =
+    Path.newBuilder()
+      .addAllElem(elems.map { PathElem.newBuilder().setName(it).build() })
+      .build()
+
+  private fun p4rtIdPath(ifaceName: String): Path =
+    Path.newBuilder()
+      .addElem(PathElem.newBuilder().setName("interfaces").build())
+      .addElem(PathElem.newBuilder().setName("interface").putKey("name", ifaceName).build())
+      .addElem(PathElem.newBuilder().setName("config").build())
+      .addElem(PathElem.newBuilder().setName("openconfig-p4rt:id").build())
+      .build()
+
+  private fun jsonIetfValue(json: String): TypedValue =
+    TypedValue.newBuilder().setJsonIetfVal(ByteString.copyFromUtf8(json)).build()
+}

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -199,12 +199,11 @@ class P4RuntimeConformanceTest {
   }
 
   @Test
-  fun `10 - read empty table returns only default entry`() {
+  fun `10 - read empty table with unmodified default returns empty`() {
     harness.loadPipeline(loadBasicTableConfig())
     val entities = harness.readEntries()
-    // P4Runtime spec §11.1: wildcard reads include the default entry even when no
-    // regular entries exist.
-    assertTrue("expected only default entries", entities.all { it.tableEntry.isDefaultAction })
+    // P4Runtime spec §9.1.2: pipeline-loaded defaults are not included in reads.
+    assertTrue("unmodified defaults should not appear", entities.isEmpty())
   }
 
   @Test
@@ -715,19 +714,7 @@ class P4RuntimeConformanceTest {
     // P4Runtime spec §9.1.2: only explicitly modified defaults appear in reads.
     // MODIFY the default on each table so they show up.
     for (table in config.p4Info.tablesList) {
-      harness.modifyEntry(
-        Entity.newBuilder()
-          .setTableEntry(
-            P4RuntimeOuterClass.TableEntry.newBuilder()
-              .setTableId(table.preamble.id)
-              .setIsDefaultAction(true)
-              .setAction(
-                P4RuntimeOuterClass.TableAction.newBuilder()
-                  .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(dropId))
-              )
-          )
-          .build()
-      )
+      harness.modifyEntry(P4RuntimeTestHarness.buildDefaultActionEntity(table.preamble.id, dropId))
     }
 
     val results = harness.readEntries()
@@ -1321,19 +1308,7 @@ class P4RuntimeConformanceTest {
 
     // MODIFY the default action (re-set it to drop).
     harness.modifyEntry(
-      Entity.newBuilder()
-        .setTableEntry(
-          P4RuntimeOuterClass.TableEntry.newBuilder()
-            .setTableId(tableId)
-            .setIsDefaultAction(true)
-            .setAction(
-              P4RuntimeOuterClass.TableAction.newBuilder()
-                .setAction(
-                  P4RuntimeOuterClass.Action.newBuilder().setActionId(dropAction.preamble.id)
-                )
-            )
-        )
-        .build()
+      P4RuntimeTestHarness.buildDefaultActionEntity(tableId, dropAction.preamble.id)
     )
 
     val results = harness.readEntries()
@@ -1367,19 +1342,7 @@ class P4RuntimeConformanceTest {
     val noActionId = config.p4Info.actionsList.find { it.preamble.name == "NoAction" }!!.preamble.id
 
     // Change default from drop() to NoAction.
-    val defaultEntity =
-      Entity.newBuilder()
-        .setTableEntry(
-          P4RuntimeOuterClass.TableEntry.newBuilder()
-            .setTableId(tableId)
-            .setIsDefaultAction(true)
-            .setAction(
-              P4RuntimeOuterClass.TableAction.newBuilder()
-                .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(noActionId))
-            )
-        )
-        .build()
-    harness.modifyEntry(defaultEntity)
+    harness.modifyEntry(P4RuntimeTestHarness.buildDefaultActionEntity(tableId, noActionId))
 
     // Read back and verify.
     val defaults = harness.readEntries().filter { it.tableEntry.isDefaultAction }
@@ -1399,19 +1362,9 @@ class P4RuntimeConformanceTest {
     val tableId = config.p4Info.tablesList.first().preamble.id
     val dropId = P4RuntimeTestHarness.findAction(config, "drop").preamble.id
 
-    val defaultEntity =
-      Entity.newBuilder()
-        .setTableEntry(
-          P4RuntimeOuterClass.TableEntry.newBuilder()
-            .setTableId(tableId)
-            .setIsDefaultAction(true)
-            .setAction(
-              P4RuntimeOuterClass.TableAction.newBuilder()
-                .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(dropId))
-            )
-        )
-        .build()
-    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.installEntry(defaultEntity) }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) {
+      harness.installEntry(P4RuntimeTestHarness.buildDefaultActionEntity(tableId, dropId))
+    }
   }
 
   /** P4Runtime spec §9.1: DELETE of a default entry is rejected. */
@@ -1421,13 +1374,9 @@ class P4RuntimeConformanceTest {
     harness.loadPipeline(config)
     val tableId = config.p4Info.tablesList.first().preamble.id
 
-    val defaultEntity =
-      Entity.newBuilder()
-        .setTableEntry(
-          P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(tableId).setIsDefaultAction(true)
-        )
-        .build()
-    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.deleteEntry(defaultEntity) }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) {
+      harness.deleteEntry(P4RuntimeTestHarness.buildDefaultActionEntity(tableId))
+    }
   }
 
   // =========================================================================

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -406,7 +406,8 @@ class P4RuntimeConformanceTest {
 
     val tableId = config.p4Info.tablesList.first().preamble.id
     val matching = harness.readTableEntries(tableId)
-    assertEquals("matching table ID (1 regular + 1 default)", 2, matching.size)
+    // P4Runtime spec §9.1.2: pipeline-loaded defaults are not included in reads.
+    assertEquals("matching table ID (1 regular, no unmodified default)", 1, matching.size)
     assertTrue("non-matching table ID", harness.readTableEntries(99999).isEmpty())
   }
 
@@ -706,13 +707,31 @@ class P4RuntimeConformanceTest {
   }
 
   @Test
-  fun `96 - wildcard read returns default entries for all tables`() {
+  fun `96 - wildcard read returns modified default entries for all tables`() {
     val config = loadMultiTableConfig()
     harness.loadPipeline(config)
-    // Don't install any regular entries — just check defaults.
+    val dropId = P4RuntimeTestHarness.findAction(config, "drop").preamble.id
+
+    // P4Runtime spec §9.1.2: only explicitly modified defaults appear in reads.
+    // MODIFY the default on each table so they show up.
+    for (table in config.p4Info.tablesList) {
+      harness.modifyEntry(
+        Entity.newBuilder()
+          .setTableEntry(
+            P4RuntimeOuterClass.TableEntry.newBuilder()
+              .setTableId(table.preamble.id)
+              .setIsDefaultAction(true)
+              .setAction(
+                P4RuntimeOuterClass.TableAction.newBuilder()
+                  .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(dropId))
+              )
+          )
+          .build()
+      )
+    }
+
     val results = harness.readEntries()
     val defaults = results.filter { it.tableEntry.isDefaultAction }
-    // Each table with a default action contributes one default entry.
     assertTrue("should have multiple default entries", defaults.size >= 2)
     val tableIds = defaults.map { it.tableEntry.tableId }.toSet()
     assertTrue("defaults should span multiple tables", tableIds.size >= 2)
@@ -1279,31 +1298,55 @@ class P4RuntimeConformanceTest {
   // Default entry in wildcard reads (scenario 64)
   // =========================================================================
 
-  /** P4Runtime spec §11.1: wildcard table reads include the default entry. */
+  /**
+   * P4Runtime spec §9.1.2: wildcard reads include default entries that have been explicitly
+   * modified via Write. Pipeline-loaded defaults are not included.
+   */
   @Test
-  fun `64 - wildcard read includes default entry`() {
+  fun `64 - wildcard read includes modified default entry`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
+    val tableId = config.p4Info.tablesList.first().preamble.id
+    val dropAction = config.p4Info.actionsList.find { it.preamble.name.contains("drop") }!!
 
-    // Install one regular entry so we can verify both are returned.
-    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
-    harness.installEntry(entry)
+    // Install one regular entry.
+    harness.installEntry(buildExactEntry(config, matchValue = 0x0800, port = 1))
+
+    // Before modifying the default, it should not appear in reads.
+    val beforeModify = harness.readEntries()
+    assertTrue(
+      "unmodified default should not appear",
+      beforeModify.none { it.tableEntry.isDefaultAction },
+    )
+
+    // MODIFY the default action (re-set it to drop).
+    harness.modifyEntry(
+      Entity.newBuilder()
+        .setTableEntry(
+          P4RuntimeOuterClass.TableEntry.newBuilder()
+            .setTableId(tableId)
+            .setIsDefaultAction(true)
+            .setAction(
+              P4RuntimeOuterClass.TableAction.newBuilder()
+                .setAction(
+                  P4RuntimeOuterClass.Action.newBuilder().setActionId(dropAction.preamble.id)
+                )
+            )
+        )
+        .build()
+    )
 
     val results = harness.readEntries()
     val defaultEntries = results.filter { it.tableEntry.isDefaultAction }
     val regularEntries = results.filter { !it.tableEntry.isDefaultAction }
 
     assertEquals("should have 1 regular entry", 1, regularEntries.size)
-    assertTrue("should have at least 1 default entry", defaultEntries.isNotEmpty())
+    assertTrue("should have 1 modified default entry", defaultEntries.isNotEmpty())
 
-    // The basic_table program has `default_action = drop()`.
     val defaultEntry = defaultEntries.first().tableEntry
-    val tableId = config.p4Info.tablesList.first().preamble.id
     assertEquals("default entry should have correct table_id", tableId, defaultEntry.tableId)
     assertTrue("default entry should have is_default_action set", defaultEntry.isDefaultAction)
     assertTrue("default entry should have an action", defaultEntry.hasAction())
-
-    val dropAction = config.p4Info.actionsList.find { it.preamble.name.contains("drop") }!!
     assertEquals(
       "default action should be drop",
       dropAction.preamble.id,

--- a/p4runtime/P4RuntimeServer.kt
+++ b/p4runtime/P4RuntimeServer.kt
@@ -1,13 +1,32 @@
 package fourward.p4runtime
 
+import com.google.protobuf.TextFormat
+import fourward.ir.PipelineConfig
 import fourward.simulator.Simulator
+import io.grpc.ManagedChannelBuilder
 import io.grpc.Server
 import io.grpc.netty.NettyServerBuilder
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
+import p4.v1.P4RuntimeGrpcKt
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.MasterArbitrationUpdate
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.StreamMessageRequest
+import p4.v1.P4RuntimeOuterClass.Uint128
 
 /** Wraps a P4Runtime + Dataplane gRPC server backed by a 4ward [Simulator]. */
 class P4RuntimeServer(
   private val port: Int = DEFAULT_PORT,
+  private val deviceId: Long = DEFAULT_DEVICE_ID,
   dropPortOverride: Int? = null,
   cpuPortConfig: CpuPortConfig = CpuPortConfig.Auto,
 ) {
@@ -16,7 +35,13 @@ class P4RuntimeServer(
   private val lock = Mutex()
   private val broker = PacketBroker(simulator::processPacket)
   private val service =
-    P4RuntimeService(simulator, broker, lock = lock, cpuPortConfig = cpuPortConfig)
+    P4RuntimeService(
+      simulator,
+      broker,
+      lock = lock,
+      deviceId = deviceId,
+      cpuPortConfig = cpuPortConfig,
+    )
   private val dataplaneService = DataplaneService(broker, lock)
   private lateinit var server: Server
 
@@ -37,6 +62,72 @@ class P4RuntimeServer(
     }
   }
 
+  /**
+   * Loads a pre-compiled pipeline via P4Runtime. Connects as a loopback client, performs master
+   * arbitration, and sends [SetForwardingPipelineConfigRequest] with VERIFY_AND_COMMIT — the same
+   * path any external client would use. The server must be [start]ed first.
+   */
+  fun loadPipelineViaP4Runtime(path: Path) {
+    val configText = Files.readString(path)
+    val pipelineConfig =
+      PipelineConfig.newBuilder().also { TextFormat.merge(configText, it) }.build()
+    val fwdConfig =
+      ForwardingPipelineConfig.newBuilder()
+        .setP4Info(pipelineConfig.p4Info)
+        .setP4DeviceConfig(pipelineConfig.device.toByteString())
+        .build()
+
+    val channel = ManagedChannelBuilder.forAddress("localhost", server.port).usePlaintext().build()
+    try {
+      val stub = P4RuntimeGrpcKt.P4RuntimeCoroutineStub(channel)
+      val electionId = Uint128.newBuilder().setHigh(0).setLow(1).build()
+
+      runBlocking {
+        coroutineScope {
+          val requests = Channel<StreamMessageRequest>(Channel.BUFFERED)
+          val arbitrated = CompletableDeferred<Unit>()
+
+          // Keep the stream channel open so the session stays primary.
+          val streamJob = launch {
+            var first = true
+            stub.streamChannel(requests.consumeAsFlow()).collect {
+              if (first) {
+                arbitrated.complete(Unit)
+                first = false
+              }
+            }
+          }
+
+          // Perform master arbitration.
+          requests.send(
+            StreamMessageRequest.newBuilder()
+              .setArbitration(
+                MasterArbitrationUpdate.newBuilder().setDeviceId(deviceId).setElectionId(electionId)
+              )
+              .build()
+          )
+          arbitrated.await()
+
+          // Push the pipeline via the standard P4RT RPC.
+          stub.setForwardingPipelineConfig(
+            SetForwardingPipelineConfigRequest.newBuilder()
+              .setDeviceId(deviceId)
+              .setElectionId(electionId)
+              .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+              .setConfig(fwdConfig)
+              .build()
+          )
+
+          // Close the stream and end the session.
+          requests.close()
+          streamJob.cancel()
+        }
+      }
+    } finally {
+      channel.shutdownNow()
+    }
+  }
+
   fun blockUntilShutdown() {
     server.awaitTermination()
   }
@@ -45,16 +136,40 @@ class P4RuntimeServer(
 
   companion object {
     const val DEFAULT_PORT = 9559
+    const val DEFAULT_DEVICE_ID = 1L
   }
 }
 
 fun main(args: Array<String>) {
   val port = flagValue(args, "--port")?.toIntOrNull() ?: P4RuntimeServer.DEFAULT_PORT
+  val deviceId = flagValue(args, "--device-id")?.toLongOrNull() ?: P4RuntimeServer.DEFAULT_DEVICE_ID
   val dropPort = flagValue(args, "--drop-port")?.toIntOrNull()
   val cpuPortConfig = CpuPortConfig.fromFlag(flagValue(args, "--cpu-port"))
-  val server = P4RuntimeServer(port, dropPort, cpuPortConfig).start()
+  val pipelinePath = flagValue(args, "--pipeline")
+
+  val server = P4RuntimeServer(port, deviceId, dropPort, cpuPortConfig).start()
+
+  if (pipelinePath != null) {
+    val resolved = resolveUserPath(pipelinePath)
+    server.loadPipelineViaP4Runtime(resolved)
+    println("Loaded pipeline from $resolved")
+  }
+
   println("P4Runtime server listening on port ${server.port()}")
   server.blockUntilShutdown()
+}
+
+/**
+ * Resolves a user-supplied path against the original working directory.
+ *
+ * `bazel run` changes cwd to the runfiles tree, so relative paths won't resolve without this. Bazel
+ * sets `BUILD_WORKING_DIRECTORY` to the user's actual cwd.
+ */
+private fun resolveUserPath(arg: String): Path {
+  val p = Path.of(arg)
+  if (p.isAbsolute) return p
+  val bwd = System.getenv("BUILD_WORKING_DIRECTORY") ?: return p
+  return Path.of(bwd).resolve(p)
 }
 
 private fun flagValue(args: Array<String>, flag: String): String? =

--- a/p4runtime/P4RuntimeServer.kt
+++ b/p4runtime/P4RuntimeServer.kt
@@ -43,6 +43,7 @@ class P4RuntimeServer(
       cpuPortConfig = cpuPortConfig,
     )
   private val dataplaneService = DataplaneService(broker, lock)
+  private val gnmiService = GnmiService()
   private lateinit var server: Server
 
   fun start(): P4RuntimeServer {
@@ -50,6 +51,7 @@ class P4RuntimeServer(
       NettyServerBuilder.forPort(port)
         .addService(service)
         .addService(dataplaneService)
+        .addService(gnmiService)
         .build()
         .start()
     Runtime.getRuntime().addShutdownHook(Thread { stop() })

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -640,6 +640,21 @@ class P4RuntimeTestHarness(
         )
         .build()
 
+    /**
+     * Builds a default-action Entity for the given table. Used to MODIFY/INSERT/DELETE defaults.
+     */
+    fun buildDefaultActionEntity(tableId: Int, actionId: Int? = null): Entity {
+      val builder =
+        P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(tableId).setIsDefaultAction(true)
+      if (actionId != null) {
+        builder.setAction(
+          P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(actionId))
+        )
+      }
+      return Entity.newBuilder().setTableEntry(builder).build()
+    }
+
     /** Builds an Entity wrapping a RegisterEntry. */
     @Suppress("MagicNumber")
     fun buildRegisterEntry(registerId: Int, index: Long, value: Long, byteLen: Int = 4): Entity =

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -126,6 +126,8 @@ class Simulator(
 
   override fun getDefaultAction(tableName: String) = tableStore.getDefaultAction(tableName)
 
+  override fun isDefaultModified(tableName: String) = tableStore.isDefaultModified(tableName)
+
   override fun getDirectCounterData(entry: p4.v1.P4RuntimeOuterClass.TableEntry) =
     tableStore.getDirectCounterData(entry)
 

--- a/simulator/TableDataReader.kt
+++ b/simulator/TableDataReader.kt
@@ -13,6 +13,9 @@ interface TableDataReader {
 
   fun getDefaultAction(tableName: String): DefaultAction?
 
+  /** True if the default action for [tableName] was explicitly modified via P4Runtime Write. */
+  fun isDefaultModified(tableName: String): Boolean
+
   fun getDirectCounterData(entry: P4RuntimeOuterClass.TableEntry): P4RuntimeOuterClass.CounterData?
 
   fun getDirectMeterData(entry: P4RuntimeOuterClass.TableEntry): P4RuntimeOuterClass.MeterConfig?

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -166,6 +166,9 @@ class TableStore : TableDataReader {
   private val defaultActions
     get() = writeState.defaultActions
 
+  private val modifiedDefaults
+    get() = writeState.modifiedDefaults
+
   private val profileMembers
     get() = writeState.profileMembers
 
@@ -378,8 +381,7 @@ class TableStore : TableDataReader {
 
   override fun getDefaultAction(tableName: String): DefaultAction? = defaultActions[tableName]
 
-  override fun isDefaultModified(tableName: String): Boolean =
-    tableName in writeState.modifiedDefaults
+  override fun isDefaultModified(tableName: String): Boolean = tableName in modifiedDefaults
 
   override fun getDirectCounterData(entry: TableEntry): P4RuntimeOuterClass.CounterData? =
     directCounterData[entry]
@@ -767,7 +769,7 @@ class TableStore : TableDataReader {
     if (entry.isDefaultAction) {
       val actionName = resolveActionName(entry.action.action.actionId)
       defaultActions[tableName] = DefaultAction(actionName, entry.action.action.paramsList)
-      writeState.modifiedDefaults.add(tableName)
+      modifiedDefaults.add(tableName)
       return WriteResult.Success
     }
 

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -108,6 +108,8 @@ class TableStore : TableDataReader {
     internal val directCounterData = IdentityHashMap<TableEntry, P4RuntimeOuterClass.CounterData>()
     internal val directMeterData = IdentityHashMap<TableEntry, P4RuntimeOuterClass.MeterConfig>()
     internal val defaultActions: MutableMap<String, DefaultAction> = mutableMapOf()
+    /** Tables whose default action has been explicitly modified via P4Runtime Write. */
+    internal val modifiedDefaults: MutableSet<String> = mutableSetOf()
     internal val profileMembers:
       MutableMap<Int, MutableMap<Int, P4RuntimeOuterClass.ActionProfileMember>> =
       mutableMapOf()
@@ -137,6 +139,7 @@ class TableStore : TableDataReader {
         copy.directCounterData.putAll(directCounterData)
         copy.directMeterData.putAll(directMeterData)
         copy.defaultActions.putAll(defaultActions)
+        copy.modifiedDefaults.addAll(modifiedDefaults)
         profileMembers.forEach { (k, v) -> copy.profileMembers[k] = v.toMutableMap() }
         profileGroups.forEach { (k, v) -> copy.profileGroups[k] = v.toMutableMap() }
         registers.forEach { (k, v) -> copy.registers[k] = v.toMutableMap() }
@@ -374,6 +377,9 @@ class TableStore : TableDataReader {
     tables[tableName] ?: emptyList()
 
   override fun getDefaultAction(tableName: String): DefaultAction? = defaultActions[tableName]
+
+  override fun isDefaultModified(tableName: String): Boolean =
+    tableName in writeState.modifiedDefaults
 
   override fun getDirectCounterData(entry: TableEntry): P4RuntimeOuterClass.CounterData? =
     directCounterData[entry]
@@ -761,6 +767,7 @@ class TableStore : TableDataReader {
     if (entry.isDefaultAction) {
       val actionName = resolveActionName(entry.action.action.actionId)
       defaultActions[tableName] = DefaultAction(actionName, entry.action.action.paramsList)
+      writeState.modifiedDefaults.add(tableName)
       return WriteResult.Success
     }
 

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -588,6 +588,36 @@ class TableStoreTest {
     assertEquals(1, defaultAction.params.size)
   }
 
+  @Test
+  fun `isDefaultModified returns false before any Write`() {
+    assertFalse(store.isDefaultModified(TABLE_NAME))
+  }
+
+  @Test
+  fun `isDefaultModified returns true after MODIFY default entry`() {
+    store.setDefaultAction(TABLE_NAME, "drop")
+    assertFalse("pipeline-loaded default is not 'modified'", store.isDefaultModified(TABLE_NAME))
+
+    store.write(
+      Update.newBuilder()
+        .setType(Update.Type.MODIFY)
+        .setEntity(
+          Entity.newBuilder()
+            .setTableEntry(
+              TableEntry.newBuilder()
+                .setTableId(TABLE_ID)
+                .setIsDefaultAction(true)
+                .setAction(
+                  P4RuntimeOuterClass.TableAction.newBuilder()
+                    .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(42))
+                )
+            )
+        )
+        .build()
+    )
+    assertTrue("should be modified after Write", store.isDefaultModified(TABLE_NAME))
+  }
+
   // ---------------------------------------------------------------------------
   // Action profiles
   // ---------------------------------------------------------------------------
@@ -2387,8 +2417,26 @@ class TableStoreTest {
         .build()
     )
 
-    // defaultActions
+    // defaultActions + modifiedDefaults
     s.setDefaultAction(TABLE_NAME, "drop")
+    s.write(
+      Update.newBuilder()
+        .setType(Update.Type.MODIFY)
+        .setEntity(
+          Entity.newBuilder()
+            .setTableEntry(
+              TableEntry.newBuilder()
+                .setTableId(TABLE_ID)
+                .setIsDefaultAction(true)
+                .setAction(
+                  P4RuntimeOuterClass.TableAction.newBuilder()
+                    .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(42))
+                )
+            )
+        )
+        .build()
+    )
+    assertTrue("default should be marked modified", s.isDefaultModified(TABLE_NAME))
 
     // profileMembers
     writeMember(s, memberId = 1, actionId = 10, paramValue = 1)
@@ -2471,8 +2519,11 @@ class TableStoreTest {
     val meterData = s.readDirectMeterEntries().single().directMeterEntry.config
     assertEquals(1000, meterData.cir)
 
-    // defaultActions: should be "drop", not "forward"
-    assertEquals("drop", s.lookup(TABLE_NAME, emptyList()).actionName)
+    // defaultActions: should be "action42" (set by Write RPC above), not "forward"
+    assertEquals("action42", s.lookup(TABLE_NAME, emptyList()).actionName)
+
+    // modifiedDefaults: should still be marked modified (was modified before snapshot)
+    assertTrue("modifiedDefaults should survive restore", s.isDefaultModified(TABLE_NAME))
 
     // profileMembers: should have 1 member, not 2
     assertEquals(1, s.readProfileMembers().size)

--- a/web/PlaygroundServer.kt
+++ b/web/PlaygroundServer.kt
@@ -1,6 +1,7 @@
 package fourward.web
 
 import fourward.p4runtime.DataplaneService
+import fourward.p4runtime.GnmiService
 import fourward.p4runtime.P4RuntimeService
 import fourward.p4runtime.PacketBroker
 import fourward.simulator.Simulator
@@ -32,11 +33,14 @@ fun main(args: Array<String>) {
   val service = P4RuntimeService(simulator, broker, lock = lock, cpuPortConfig = cpuPortConfig)
   val dataplaneService = DataplaneService(broker, lock)
 
+  val gnmiService = GnmiService()
+
   // Start gRPC server.
   val grpcServer =
     NettyServerBuilder.forPort(grpcPort)
       .addService(service)
       .addService(dataplaneService)
+      .addService(gnmiService)
       .build()
       .start()
 


### PR DESCRIPTION
## Summary

Split from #339 — keeps the pieces needed for DVaaS integration, drops the
Kotlin-side DVaaS implementation that the
[direct integration design](designs/dvaas_integration.md) supersedes.

**What's here:**

- **P4Runtime spec §9.1.2 compliance.** Unmodified default table entries
  (loaded from the pipeline, never touched by Write) are excluded from Read
  responses. Fixes a crash in DVaaS's `ClearEntities` which tried to DELETE
  pipeline-loaded defaults.
- **gNMI stub server.** Minimal gNMI service reporting port configuration.
  DVaaS queries this to discover port mappings.
- **`--pipeline` and `--device-id` CLI flags.** Needed for subprocess usage —
  DVaaS spawns 4ward with a pre-compiled pipeline and a specific device ID.

**What's dropped (from #339):**

The entire `dvaas/` directory (~3,500 lines): `DvaasService`, `SonicPinsAdapter`,
`TestVectorValidator`, `MirrorTestbedTest`, `dvaas.proto`. This was a Kotlin-side
DVaaS implementation. Per the design doc, this logic belongs in sonic-pins (C++),
integrated directly into `dataplane_validation.cc`.

Supersedes #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)