### PR TITLE
Auto-install copy-to-CPU clone infrastructure at pipeline load

### DIFF
--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -1,6 +1,7 @@
 package fourward.p4runtime
 
 import com.google.protobuf.Any as ProtoAny
+import com.google.protobuf.ByteString
 import fourward.ir.DeviceConfig
 import fourward.ir.PipelineConfig
 import fourward.sim.SimulatorProto.OutputPacket
@@ -228,6 +229,101 @@ class P4RuntimeService(
     val entityReader =
       EntityReader.create(state.config.p4Info, simulator.tableNameById, simulator.actionNameById)
     pipeline = state.copy(entityReader = entityReader)
+
+    // On real SAI hardware, copy/trap-to-CPU is built in. On v1model (which 4ward simulates),
+    // it requires explicit ingress_clone_table entries and a CloneSessionEntry. Auto-install
+    // them so 4ward behaves like real hardware for integration tests (DVaaS, etc.).
+    autoInstallCopyToCpuClone(state)
+  }
+
+  /**
+   * Auto-installs clone-to-CPU infrastructure if the pipeline has `ingress_clone_table`.
+   *
+   * SAI P4's `acl_copy`/`acl_trap` actions set `marked_to_copy = true`, but the actual clone
+   * happens in `ingress_clone_table` which must have entries installed. On real SAI switches this
+   * logic is built in; on v1model it must be explicit. This method bridges the gap by installing
+   * the punt-only entry and clone session at pipeline load time.
+   */
+  private fun autoInstallCopyToCpuClone(state: PipelineState) {
+    val p4info = state.config.p4Info
+    val cloneTable = p4info.tablesList.find { it.preamble.alias == "ingress_clone_table" } ?: return
+    val cloneAction = p4info.actionsList.find { it.preamble.alias == "ingress_clone" } ?: return
+    val cpuPort = state.packetHeaderCodec?.cpuPort ?: return
+
+    val markedToCopyId =
+      cloneTable.matchFieldsList.find { it.name == "marked_to_copy" }?.id ?: return
+    val markedToMirrorId =
+      cloneTable.matchFieldsList.find { it.name == "marked_to_mirror" }?.id ?: return
+    val cloneSessionParamId =
+      cloneAction.paramsList.find { it.name == "clone_session" }?.id ?: return
+
+    // ingress_clone_table entry: marked_to_copy=1, marked_to_mirror=0 → ingress_clone(session).
+    val tableEntry =
+      P4RuntimeOuterClass.TableEntry.newBuilder()
+        .setTableId(cloneTable.preamble.id)
+        .addMatch(exactMatch(markedToCopyId, byteArrayOf(1)))
+        .addMatch(exactMatch(markedToMirrorId, byteArrayOf(0)))
+        .setAction(
+          P4RuntimeOuterClass.TableAction.newBuilder()
+            .setAction(
+              P4RuntimeOuterClass.Action.newBuilder()
+                .setActionId(cloneAction.preamble.id)
+                .addParams(
+                  P4RuntimeOuterClass.Action.Param.newBuilder()
+                    .setParamId(cloneSessionParamId)
+                    .setValue(ByteString.copyFrom(intToBytes(PUNT_CLONE_SESSION_ID, 4)))
+                )
+            )
+        )
+        .setPriority(1)
+        .build()
+
+    simulator.writeEntry(
+      P4RuntimeOuterClass.Update.newBuilder()
+        .setType(P4RuntimeOuterClass.Update.Type.INSERT)
+        .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(tableEntry))
+        .build()
+    )
+
+    // CloneSessionEntry: session → CPU port replica.
+    val cloneSession =
+      P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
+        .setSessionId(PUNT_CLONE_SESSION_ID)
+        .addReplicas(
+          P4RuntimeOuterClass.Replica.newBuilder()
+            .setPort(ByteString.copyFrom(intToBytes(cpuPort, 2)))
+            .setInstance(0)
+        )
+        .build()
+
+    simulator.writeEntry(
+      P4RuntimeOuterClass.Update.newBuilder()
+        .setType(P4RuntimeOuterClass.Update.Type.INSERT)
+        .setEntity(
+          P4RuntimeOuterClass.Entity.newBuilder()
+            .setPacketReplicationEngineEntry(
+              P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+                .setCloneSessionEntry(cloneSession)
+            )
+        )
+        .build()
+    )
+  }
+
+  private fun exactMatch(fieldId: Int, value: ByteArray): P4RuntimeOuterClass.FieldMatch =
+    P4RuntimeOuterClass.FieldMatch.newBuilder()
+      .setFieldId(fieldId)
+      .setExact(
+        P4RuntimeOuterClass.FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(value))
+      )
+      .build()
+
+  private fun intToBytes(value: Int, width: Int): ByteArray {
+    val bytes = ByteArray(width)
+    for (i in 0 until width) {
+      bytes[width - 1 - i] = (value shr (i * 8) and 0xFF).toByte()
+    }
+    return bytes
   }
 
   // ---------------------------------------------------------------------------
@@ -843,6 +939,10 @@ class P4RuntimeService(
     private const val EXTERN_ENTRY_NOT_SUPPORTED = "ExternEntry is not supported"
     private const val ROLE_CONFIG_NOT_SUPPORTED =
       "Role.config is not supported; use @p4runtime_role annotations in p4info instead"
+
+    // Clone session ID for auto-installed punt-to-CPU clone. Chosen to avoid
+    // collision with user-installed sessions (which typically use small IDs).
+    internal const val PUNT_CLONE_SESSION_ID = 1023
 
     private const val OK_CODE = com.google.rpc.Code.OK_VALUE
 

--- a/p4runtime/SaiP4E2ETest.kt
+++ b/p4runtime/SaiP4E2ETest.kt
@@ -418,8 +418,8 @@ class SaiP4E2ETest {
     installRoutingChain()
     // ACL: trap packets to dst_ip=10.0.0.1 → copy to CPU + drop original.
     installAclEntry(findAction("acl_trap"))
-    // Clone infrastructure: marked_to_copy → clone session 255 → CPU port 510.
-    installCopyToCpuCloneSession()
+    // Clone infrastructure (ingress_clone_table + CloneSessionEntry) is auto-installed
+    // at pipeline load time — see P4RuntimeService.autoInstallCopyToCpuClone().
 
     // PacketOut with submit_to_ingress=1: enters ingress, gets trapped by ACL.
     harness.openStream().use { session ->
@@ -437,7 +437,6 @@ class SaiP4E2ETest {
     installRoutingChain()
     // ACL: copy packets to CPU without dropping (forward normally + clone to CPU).
     installAclEntry(findAction("acl_copy"))
-    installCopyToCpuCloneSession()
 
     // Via InjectPacket: verify both data-plane and CPU outputs exist.
     val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
@@ -470,7 +469,6 @@ class SaiP4E2ETest {
   fun `InjectPacket that egresses on CPU port produces PacketIn on StreamChannel`() {
     installRoutingChain()
     installAclEntry(findAction("acl_trap"))
-    installCopyToCpuCloneSession()
 
     // Open StreamChannel first so the PacketIn subscription is active.
     harness.openStream().use { session ->
@@ -490,7 +488,6 @@ class SaiP4E2ETest {
   fun `multiple streams each receive PacketIn (P4Runtime spec 16_1)`() {
     installRoutingChain()
     installAclEntry(findAction("acl_trap"))
-    installCopyToCpuCloneSession()
 
     // Two controllers with different election IDs — both should receive PacketIn per §16.1.
     harness.openStream().use { session1 ->
@@ -1203,9 +1200,13 @@ class SaiP4E2ETest {
       )
     )
 
-    val entities = harness.readRegularTableEntries(table.preamble.id)
-    assertEquals("expected one ingress_clone_table entry", 1, entities.size)
     val mirrorPortId = matchFieldId(table, "mirror_egress_port")
+    // Filter out the auto-installed punt-only entry (which has no mirror_egress_port match).
+    val entities =
+      harness.readRegularTableEntries(table.preamble.id).filter { entity ->
+        entity.tableEntry.matchList.any { it.fieldId == mirrorPortId && it.hasOptional() }
+      }
+    assertEquals("expected one mirror entry", 1, entities.size)
     assertEquals(
       "Ethernet0",
       entities[0]

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -631,13 +631,25 @@ class V1ModelArchitecture(
   private fun resolveCloneSession(ctx: PipelineContext, s: PipelineState, sessionId: Int): Long? {
     val session = ctx.tableStore.getCloneSession(sessionId)
     if (session != null) {
-      val egressPort = session.replicasList.first().egressPort
+      val egressPort = replicaPort(session.replicasList.first())
       s.packetCtx.addTraceEvent(cloneSessionLookupEvent(sessionId, egressPort))
       return egressPort.toLong()
     }
     s.packetCtx.addTraceEvent(cloneSessionMissEvent(sessionId))
     return null
   }
+
+  /**
+   * Reads the port from a Replica, supporting both the `port` (bytes) and deprecated `egress_port`
+   * (uint32) fields.
+   */
+  private fun replicaPort(replica: p4.v1.P4RuntimeOuterClass.Replica): Int =
+    @Suppress("DEPRECATION")
+    if (!replica.port.isEmpty) {
+      replica.port.toByteArray().fold(0) { acc, b -> (acc shl 8) or (b.toInt() and 0xFF) }
+    } else {
+      replica.egressPort
+    }
 
   private fun cloneSessionLookupEvent(sessionId: Int, egressPort: Int): TraceEvent =
     TraceEvent.newBuilder()


### PR DESCRIPTION
## Summary

Makes 4ward behave like real SAI hardware where punt-to-CPU is built in.

On v1model, SAI P4's `acl_copy`/`acl_trap` set `marked_to_copy = true`,
but the actual clone depends on `ingress_clone_table` entries + a
`CloneSessionEntry`. The table is `@unsupported` (not in P4Info), so
standard P4Runtime controllers can't install these entries. This gap
caused the sonic-pins DVaaS test (smolkaj/sonic-pins#4) to silently drop
packets on the control switch — `acl_trap` set `acl_drop = true` but
the clone never happened.

Three changes:
- **`P4RuntimeService.autoInstallCopyToCpuClone()`**: at pipeline load,
  detects `ingress_clone_table` in P4Info and installs a punt-only entry
  (`marked_to_copy=1, marked_to_mirror=0`) + `CloneSessionEntry` pointing
  at the CPU port.
- **`V1ModelArchitecture.replicaPort()`**: reads port from a `Replica`
  proto supporting both the newer `port` (bytes, P4Runtime v1.4+) and
  deprecated `egress_port` (uint32) fields.
- **`SaiP4E2ETest`**: removes manual `installCopyToCpuCloneSession()`
  calls from 4 tests that now rely on the auto-install.

## Test plan

- [x] `bazel test //p4runtime/... //simulator/...` — 31/31 pass
- [x] `./tools/format.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)