### PR TITLE
Set up MkDocs for user-facing documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,28 @@ jobs:
           HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
 
 
+  docs:
+    if: github.event_name == 'push'  # deploy docs only on main pushes
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build docs
+        run: pip install 'mkdocs-material>=9,<10' && mkdocs build --strict
+
+      - name: Deploy to GitHub Pages
+        run: |
+          git fetch --depth=1 origin gh-pages || true
+          git worktree add /tmp/gh-pages gh-pages
+          # Sync docs output to gh-pages root, preserving coverage directories.
+          rsync -a --delete --exclude='main/' --exclude='pr/' site/ /tmp/gh-pages/
+          cd /tmp/gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "Docs for $(git -C "$GITHUB_WORKSPACE" rev-parse --short HEAD)"
+          git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
+
   lint:
     if: github.event.action != 'closed'  # skip on PR close; only cancel job runs
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ bazel-*
 *.pb.py
 coverage-report/
 coverage.lcov
+site/
 .claude
 .DS_STORE

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+site_name: 4ward
+site_description: Glass-box P4 simulator — trace every decision your packet makes.
+site_url: https://smolkaj.github.io/4ward/
+repo_url: https://github.com/smolkaj/4ward
+repo_name: smolkaj/4ward
+edit_uri: edit/main/userdocs/
+
+docs_dir: userdocs
+site_dir: site
+exclude_docs: README.md
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - search.highlight
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Web Playground:
+      - Getting Started: getting-started/playground.md
+      - Reference: reference/playground.md
+  - CLI:
+      - Getting Started: getting-started/cli.md
+      - Reference: reference/cli.md
+      - STF Test Format: reference/stf.md
+  - gRPC API:
+      - Getting Started: getting-started/grpc.md
+      - Reference: reference/grpc.md
+  - Concepts:
+      - Trace Trees: concepts/traces.md
+      - Type Translation: concepts/type-translation.md
+      - Architectures: concepts/architectures.md
+      - Architecture Modifications: concepts/architecture-modifications.md
+  - Examples: examples.md

--- a/userdocs/README.md
+++ b/userdocs/README.md
@@ -1,0 +1,15 @@
+# userdocs
+
+User-facing documentation for 4ward, built with
+[MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
+
+**Live site:** https://smolkaj.github.io/4ward/
+
+**Local preview:**
+
+```sh
+pip install mkdocs-material
+mkdocs serve        # http://localhost:8000
+```
+
+**Structure:** see [`mkdocs.yml`](../mkdocs.yml) for the full navigation tree.

--- a/userdocs/concepts/architecture-modifications.md
+++ b/userdocs/concepts/architecture-modifications.md
@@ -1,0 +1,3 @@
+# Architecture Modifications
+
+*Coming soon.*

--- a/userdocs/concepts/architectures.md
+++ b/userdocs/concepts/architectures.md
@@ -1,0 +1,3 @@
+# Architectures
+
+*Coming soon.*

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -1,0 +1,3 @@
+# Trace Trees
+
+*Coming soon.*

--- a/userdocs/concepts/type-translation.md
+++ b/userdocs/concepts/type-translation.md
@@ -1,0 +1,3 @@
+# Type Translation
+
+*Coming soon.*

--- a/userdocs/examples.md
+++ b/userdocs/examples.md
@@ -1,0 +1,3 @@
+# Examples
+
+*Coming soon.*

--- a/userdocs/getting-started/cli.md
+++ b/userdocs/getting-started/cli.md
@@ -1,0 +1,3 @@
+# CLI
+
+*Coming soon.*

--- a/userdocs/getting-started/grpc.md
+++ b/userdocs/getting-started/grpc.md
@@ -1,0 +1,3 @@
+# gRPC API
+
+*Coming soon.*

--- a/userdocs/getting-started/playground.md
+++ b/userdocs/getting-started/playground.md
@@ -1,0 +1,3 @@
+# Web Playground
+
+*Coming soon.*

--- a/userdocs/index.md
+++ b/userdocs/index.md
@@ -1,0 +1,41 @@
+# 4ward
+
+**A glass-box P4 simulator — trace every decision your packet makes.**
+
+4ward is a spec-compliant P4₁₆ reference simulator that produces **trace
+trees**: a complete record of every parser transition, table lookup, action
+execution, and branch decision a packet encounters. At non-deterministic
+choice points (action selectors, clone, multicast), the trace forks — showing
+all possible outcomes in a single pass.
+
+## Pick your entry point
+
+| | |
+|---|---|
+| **[Web Playground](getting-started/playground.md)** | Edit P4 in the browser, install table entries, send packets, step through traces visually. |
+| **[CLI](getting-started/cli.md)** | Compile a P4 program, run an STF test, read the trace — all from the terminal. |
+| **[gRPC API](getting-started/grpc.md)** | Load pipelines and inject packets programmatically via the DataplaneService and P4Runtime gRPC services. |
+
+## Who is this for?
+
+- **Network engineers** testing P4 programs — send a packet, see exactly what
+  happened and why.
+- **Platform teams** integrating a P4 simulator into test infrastructure
+  (DVaaS, sonic-pins) via the gRPC API.
+- **Students and researchers** learning P4 — the web playground lets you edit,
+  compile, and trace P4 programs in the browser.
+
+## Key features
+
+- **Trace trees** — every event recorded, every fork explored.
+  [Learn more](concepts/traces.md).
+- **v1model and PSA** — two P4 architectures fully implemented, with support
+  for architecture modifications like translated port types.
+  [Learn more](concepts/architectures.md).
+- **P4Runtime server** — spec-compliant gRPC server with full arbitration,
+  table management, PacketIO, and clone/multicast support.
+- **Type translation** — `@p4runtime_translation` types (string port names,
+  translated IDs) flow through the entire stack, including traces.
+  [Learn more](concepts/type-translation.md).
+- **Web playground** — visual pipeline diagrams, animated trace playback,
+  packet dissection.

--- a/userdocs/reference/cli.md
+++ b/userdocs/reference/cli.md
@@ -1,0 +1,3 @@
+# CLI
+
+*Coming soon.*

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -1,0 +1,3 @@
+# gRPC API
+
+*Coming soon.*

--- a/userdocs/reference/playground.md
+++ b/userdocs/reference/playground.md
@@ -1,0 +1,3 @@
+# Web Playground
+
+*Coming soon.*

--- a/userdocs/reference/stf.md
+++ b/userdocs/reference/stf.md
@@ -1,0 +1,3 @@
+# STF Test Format
+
+*Coming soon.*


### PR DESCRIPTION
## Summary

Establishes the user-facing documentation site at `smolkaj.github.io/4ward/`
using MkDocs with Material theme.

- **`userdocs/`** — new top-level directory for user docs, separate from the
  dev-facing `docs/`.
- **`mkdocs.yml`** — site config with Material theme, dark mode, code copy,
  search. Nav organized by entry point (Playground, CLI, gRPC) plus
  cross-cutting concepts.
- **CI deploys on main push** — `mkdocs build --strict` + rsync to `gh-pages`,
  coexisting with coverage reports.
- Content pages are stubs — the index page and site structure are real.

## Test plan

- [x] `mkdocs build --strict` succeeds locally
- [x] CI adds `docs` job with pinned `mkdocs-material>=9,<10`
- [x] rsync preserves coverage report directories (`main/`, `pr/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)