### PR TITLE
v1model fork: golden diff test, CPU/drop port pins, upstream comments

### DIFF
--- a/e2e_tests/diff_test.bzl
+++ b/e2e_tests/diff_test.bzl
@@ -1,0 +1,124 @@
+# Golden file diff testing, adapted from sonic-pins (gutil/diff_test.bzl).
+#
+# diff_test: compares two files, succeeds if they match.
+# cmd_diff_test: runs a command, captures stdout, compares against expected.
+#
+# To update expected files: bazel run <target> -- --update
+
+def _diff_test_script(ctx, actual_file):
+    """Returns bash script to be executed by the diff_test target."""
+    return """
+if [[ "$1" == "--update" || "$1" == "--test" ]]; then
+    cp -f "{actual}" "${{BUILD_WORKSPACE_DIRECTORY}}/{expected}"
+fi
+diff -u "{expected}" "{actual}"
+if [[ $? = 0 ]]; then
+    if [[ "$1" == "--update" ]]; then
+        echo "Successfully updated: {expected}."
+    elif [[ "$1" == "--test" ]]; then
+        echo "Successfully updated: {expected}."
+        echo ""
+        cat {expected}
+    else
+        echo "PASSED"
+    fi
+    exit 0
+else
+    if [[ "$1" == "--update" ]]; then
+        echo "Failed to update: {expected}. Try updating manually."
+    else
+        cat << EOF
+Output not as expected. To update $(basename {expected}), run:
+  bazel run {target} -- --update
+EOF
+    fi
+    exit 1
+fi
+    """.format(
+        actual = actual_file,
+        expected = ctx.file.expected.short_path,
+        target = ctx.label,
+    )
+
+def _cmd_diff_test_script(ctx):
+    """Returns bash script to be executed by the cmd_diff_test target."""
+    actual_cmd = ctx.expand_location(
+        ctx.attr.actual_cmd,
+        targets = ctx.attr.tools + ctx.attr.data,
+    ).replace(ctx.var["BINDIR"] + "/", "")
+    pre_script = """\
+ACTUAL="${{TEST_UNDECLARED_OUTPUTS_DIR}}/actual_cmd.output"
+echo "$({actual_cmd})" > "$ACTUAL"
+""".format(actual_cmd = actual_cmd)
+    return "\n".join([
+        pre_script,
+        _diff_test_script(ctx, actual_file = '"${ACTUAL}"'),
+    ])
+
+def _diff_test_impl(ctx):
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        content = _diff_test_script(ctx, actual_file = ctx.file.actual.short_path),
+        is_executable = True,
+    )
+    return DefaultInfo(
+        runfiles = ctx.runfiles(files = [ctx.file.actual, ctx.file.expected]),
+    )
+
+diff_test = rule(
+    doc = """Compares two files, succeeding if they match.
+    To update the expected file: bazel run <target> -- --update
+    """,
+    implementation = _diff_test_impl,
+    test = True,
+    attrs = {
+        "actual": attr.label(
+            doc = "Actual file (typically generated).",
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "expected": attr.label(
+            doc = "Expected file (golden file, checked in).",
+            mandatory = True,
+            allow_single_file = True,
+        ),
+    },
+)
+
+def _cmd_diff_test_impl(ctx):
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        content = _cmd_diff_test_script(ctx),
+        is_executable = True,
+    )
+    return DefaultInfo(
+        runfiles = ctx.runfiles(ctx.files.tools + ctx.files.data + [ctx.file.expected]),
+    )
+
+cmd_diff_test = rule(
+    doc = """Runs a command to get "actual" output and diffs it against expected.
+    To update the expected file: bazel run <target> -- --update
+    """,
+    implementation = _cmd_diff_test_impl,
+    test = True,
+    attrs = {
+        "actual_cmd": attr.string(
+            doc = "Shell command whose stdout will be diffed against expected.",
+            mandatory = True,
+        ),
+        "expected": attr.label(
+            doc = "Expected file (golden file, checked in).",
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "tools": attr.label_list(
+            doc = "Executables used in actual_cmd.",
+            allow_files = True,
+            cfg = "target",
+        ),
+        "data": attr.label_list(
+            doc = "Non-executable files accessed by actual_cmd.",
+            allow_files = True,
+        ),
+    },
+)

--- a/e2e_tests/sai_p4/BUILD.bazel
+++ b/e2e_tests/sai_p4/BUILD.bazel
@@ -1,6 +1,8 @@
 # SAI P4 (middleblock instantiation) — vendored from sonic-net/sonic-pins.
 # Used for E2E testing of the P4Runtime server with @p4runtime_translation.
 
+load("//e2e_tests:diff_test.bzl", "cmd_diff_test")
+
 exports_files(
     glob([
         "fixed/*.p4",
@@ -64,4 +66,31 @@ genrule(
         "@p4c//p4include:core.p4",
     ],
     visibility = ["//visibility:public"],
+)
+
+# Extract stock v1model.p4 from p4c for diff testing.
+genrule(
+    name = "stock_v1model",
+    srcs = ["@p4c//p4include"],
+    outs = ["v1model.p4"],
+    cmd = "cp $$(dirname $(execpath @p4c//p4include:core.p4))/v1model.p4 $@",
+    tools = ["@p4c//p4include:core.p4"],
+)
+
+# Golden diff of v1model_sai.p4 vs stock v1model.p4 — tracks the size of
+# our fork. Update with: bazel run //e2e_tests/sai_p4:v1model_fork_diff_test -- --update
+cmd_diff_test(
+    name = "v1model_fork_diff_test",
+    actual_cmd = " ".join([
+        "diff -u",
+        "--label v1model.p4 --label v1model_sai.p4",
+        "$(location :stock_v1model)",
+        "$(location fixed/v1model_sai.p4)",
+        "|| true",
+    ]),
+    data = [
+        "fixed/v1model_sai.p4",
+        ":stock_v1model",
+    ],
+    expected = "v1model_fork.golden.diff",
 )

--- a/e2e_tests/sai_p4/fixed/v1model_sai.p4
+++ b/e2e_tests/sai_p4/fixed/v1model_sai.p4
@@ -70,6 +70,13 @@ const bit<32> __v1model_version = V1MODEL_VERSION;
 #ifndef PORT_BITWIDTH
 #error "PORT_BITWIDTH must be defined before including v1model_sai.p4"
 #endif
+// Pin well-known ports so they get deterministic P4RT names instead of
+// auto-allocated values. Values match SAI_P4_CPU_PORT / SAI_P4_DROP_PORT
+// in ids.h; raw literals used here to avoid an #include dependency.
+@p4runtime_translation_mappings({
+  {"CPU_PORT", 510},
+  {"DROP_PORT", 511},
+})
 @p4runtime_translation("", string)
 type bit<PORT_BITWIDTH> port_id_t;
 

--- a/e2e_tests/sai_p4/instantiations/google/acl_common_actions.p4
+++ b/e2e_tests/sai_p4/instantiations/google/acl_common_actions.p4
@@ -4,9 +4,20 @@
 #include "../../fixed/v1model_sai.p4"
 #include "ids.h"
 
+// This file lists ACL actions that may be used in multiple control blocks.
+
+// Drop the packet at the end of the current pipeline (ingress or egress). See
+// "mark_to_drop" in v1model.p4 for more information.
 @id(ACL_DROP_ACTION_ID)
 @sai_action(SAI_PACKET_ACTION_DROP)
 action acl_drop(inout local_metadata_t local_metadata) {
+  // It is necessary (and enough) to set acl_drop metadata at this point. The
+  // actual call to mark_to_drop (that affects standard_metadata) happens at the
+  // end of the current pipeline.
+  // This is done this way because we want to call mark_to_drop after
+  // determining the target_egress_port through the value assigned to
+  // standard_metadata.egress_spec (which happens in routing_resolution *after*
+  // ACL ingress) for punted packets.
   local_metadata.acl_drop = true;
 }
 

--- a/e2e_tests/sai_p4/v1model_fork.golden.diff
+++ b/e2e_tests/sai_p4/v1model_fork.golden.diff
@@ -1,0 +1,53 @@
+--- v1model.p4
++++ v1model_sai.p4
+@@ -1,3 +1,11 @@
++// Forked v1model for SAI P4.
++//
++// Changes from stock v1model:
++// - Port type uses `type` (newtype) instead of `typedef`, with
++//   @p4runtime_translation for string port names.
++// - Port width uses PORT_BITWIDTH (from bitwidths.p4) instead of
++//   hardcoded 9 bits.
++
+ /*
+ Copyright 2013-present Barefoot Networks, Inc.
+ 
+@@ -56,21 +64,27 @@
+ 
+ const bit<32> __v1model_version = V1MODEL_VERSION;
+ 
+-#if V1MODEL_VERSION >= 20200408
+-typedef bit<9>  PortId_t;       // should not be a constant size?
++// SAI P4 fork: port type is a newtype with @p4runtime_translation,
++// replacing the stock typedef. PORT_BITWIDTH must be defined before
++// including this file.
++#ifndef PORT_BITWIDTH
++#error "PORT_BITWIDTH must be defined before including v1model_sai.p4"
+ #endif
++// Pin well-known ports so they get deterministic P4RT names instead of
++// auto-allocated values. Values match SAI_P4_CPU_PORT / SAI_P4_DROP_PORT
++// in ids.h; raw literals used here to avoid an #include dependency.
++@p4runtime_translation_mappings({
++  {"CPU_PORT", 510},
++  {"DROP_PORT", 511},
++})
++@p4runtime_translation("", string)
++type bit<PORT_BITWIDTH> port_id_t;
+ 
+ @metadata @name("standard_metadata")
+ struct standard_metadata_t {
+-#if V1MODEL_VERSION >= 20200408
+-    PortId_t    ingress_port;
+-    PortId_t    egress_spec;
+-    PortId_t    egress_port;
+-#else
+-    bit<9>      ingress_port;
+-    bit<9>      egress_spec;
+-    bit<9>      egress_port;
+-#endif
++    port_id_t    ingress_port;
++    port_id_t    egress_spec;
++    port_id_t    egress_port;
+     bit<32>     instance_type;
+     bit<32>     packet_length;
+     //


### PR DESCRIPTION
## Summary

Three improvements to the v1model_sai.p4 fork and SAI P4 vendoring:

1. **Golden diff test** — `cmd_diff_test` (adapted from sonic-pins' `gutil/diff_test.bzl`) that diffs our v1model fork against stock v1model.p4. Gives a concrete handle on fork size (currently ~50 lines). If upstream v1model.p4 changes, the test surfaces it. Update with `bazel run //e2e_tests/sai_p4:v1model_fork_diff_test -- --update`.

2. **Pinned CPU/drop port translations** — `@p4runtime_translation_mappings` on `port_id_t` pins `CPU_PORT` (510) and `DROP_PORT` (511) to deterministic P4RT string names instead of auto-allocated values. The `PortTranslator` now maps 510 ↔ `"CPU_PORT"` and 511 ↔ `"DROP_PORT"` out of the box.

3. **Upstream comment cherry-pick** — `acl_drop` action documentation from sonic-net/sonic-pins explaining why `mark_to_drop` is deferred to the end of the pipeline.

Also rebased the `fourward-dvaas-integration` branch on smolkaj/sonic-pins onto the latest upstream main.

### Why we keep v1model_sai.p4

Upstream sonic-pins dropped their v1model fork in favor of stock v1model with a user-level `port_id_t` newtype. We intentionally keep ours: it gives `p4c-4ward` an authoritative `Architecture.port_type_name` in the compiled IR, so the `TypeTranslator` knows the port type without fragile heuristics.

## Test plan

- [x] All 56 tests pass locally (`bazel test //... --test_tag_filters=-heavy`)
- [x] Golden diff test: `bazel run ... -- --update` workflow works
- [x] SAI P4 E2E tests pass with `@p4runtime_translation_mappings`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)