### PR TITLE
Fix docs CI deploy + README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,11 @@ jobs:
           git worktree add /tmp/gh-pages gh-pages
           # Sync docs output to gh-pages root, preserving coverage directories.
           rsync -a --delete --exclude='main/' --exclude='pr/' site/ /tmp/gh-pages/
-          cd /tmp/gh-pages
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --cached --quiet || git commit -m "Docs for $SHORT_SHA"
-          git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)
+          git -C /tmp/gh-pages config user.name "github-actions[bot]"
+          git -C /tmp/gh-pages config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C /tmp/gh-pages add -A
+          git -C /tmp/gh-pages diff --cached --quiet || git -C /tmp/gh-pages commit -m "Docs for $SHORT_SHA"
+          git -C /tmp/gh-pages push origin gh-pages || (git -C /tmp/gh-pages pull --rebase origin gh-pages && git -C /tmp/gh-pages push origin gh-pages)
 
   lint:
     if: github.event.action != 'closed'  # skip on PR close; only cancel job runs

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <br><br>
   <strong>Your P4 programs, finally explained.</strong>
   <br><br>
+  <a href="https://smolkaj.github.io/4ward/"><img src="https://img.shields.io/badge/docs-4ward-blue" alt="Docs"></a>
   <a href="https://github.com/smolkaj/4ward/actions/workflows/ci.yml"><img src="https://github.com/smolkaj/4ward/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://smolkaj.github.io/4ward/main/"><img src="https://img.shields.io/badge/coverage-report-blue" alt="Coverage"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
@@ -297,7 +298,8 @@ requirements.
 │   ├── bmv2_diff/          BMv2 differential testing
 │   ├── sai_p4/             SAI P4 test fixtures
 │   └── <feature>/          Hand-written feature tests (passthrough, lpm, …)
-├── docs/                   Project documentation
+├── userdocs/               User-facing documentation (MkDocs → smolkaj.github.io/4ward/)
+├── docs/                   Developer documentation (architecture, roadmap, testing)
 └── tools/                  Developer scripts (format, lint, coverage, …)
 ```
 


### PR DESCRIPTION
## Summary

Fixes the docs CI deploy failure on main (`fatal: not in a git directory`)
and updates the README.

- **CI fix**: `cd /tmp/gh-pages` broke git's worktree resolution after
  `actions/checkout@v6` modified the git config. Changed to `git -C
  /tmp/gh-pages` for all git commands in the deploy step.
- **README**: added docs badge linking to `smolkaj.github.io/4ward/`,
  updated project structure to mention `userdocs/`.

## Test plan

- [x] The `git -C` pattern is used by the existing coverage deploy steps
  in the same workflow (proven to work)
- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)