### PR TITLE
Fix docs CI: clone gh-pages instead of worktree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,21 @@ jobs:
       - name: Deploy to GitHub Pages
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          git fetch --depth=1 origin gh-pages || true
-          git worktree add /tmp/gh-pages gh-pages
-          # Sync docs output to gh-pages root, preserving coverage directories.
-          rsync -a --delete --exclude='main/' --exclude='pr/' site/ /tmp/gh-pages/
-          git -C /tmp/gh-pages config user.name "github-actions[bot]"
-          git -C /tmp/gh-pages config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git -C /tmp/gh-pages add -A
-          git -C /tmp/gh-pages diff --cached --quiet || git -C /tmp/gh-pages commit -m "Docs for $SHORT_SHA"
-          git -C /tmp/gh-pages push origin gh-pages || (git -C /tmp/gh-pages pull --rebase origin gh-pages && git -C /tmp/gh-pages push origin gh-pages)
+          # Clone gh-pages into a standalone repo (avoids worktree issues with
+          # actions/checkout's git config).
+          git clone --depth=1 --branch=gh-pages \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" \
+            /tmp/gh-pages
+          # Sync docs output, preserving coverage directories.
+          rsync -a --delete --exclude='.git/' --exclude='main/' --exclude='pr/' site/ /tmp/gh-pages/
+          cd /tmp/gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "Docs for $SHORT_SHA"
+          git push || (git pull --rebase && git push)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     if: github.event.action != 'closed'  # skip on PR close; only cancel job runs


### PR DESCRIPTION
## Summary

The docs deploy step fails on main with `fatal: not in a git directory`
because `actions/checkout@v6` modifies the git config in ways that break
worktree resolution (even with `git -C`).

Fix: replace `git worktree add` with a standalone shallow clone of the
`gh-pages` branch. The clone is self-contained and unaffected by the main
repo's config. This matches how many other GitHub Actions deploy workflows
handle gh-pages.

## Test plan

- [x] The `git clone` approach is standard for gh-pages deploys
- [x] `rsync --exclude='.git/'` prevents overwriting the clone's `.git`
- [x] Coverage directories preserved via `--exclude='main/' --exclude='pr/'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)