### PR TITLE
Fix broken links, use released spec versions, improve type translation

### DIFF
--- a/userdocs/concepts/architectures.md
+++ b/userdocs/concepts/architectures.md
@@ -76,7 +76,7 @@ Multiple calls use last-writer-wins. All produce
 
 The Portable Switch Architecture — a more modern design with a cleaner
 separation between ingress and egress. Defined in
-[psa.p4](https://github.com/p4lang/p4c/blob/main/p4include/psa.p4);
+[psa.p4](https://github.com/p4lang/p4-spec/blob/main/p4-16/psa/psa.p4);
 see the [PSA specification](https://p4lang.github.io/p4-spec/docs/PSA.pdf)
 for the canonical behavioral spec.
 

--- a/userdocs/concepts/type-translation.md
+++ b/userdocs/concepts/type-translation.md
@@ -1,38 +1,71 @@
 # Type Translation
 
-P4 programs can annotate types with
-[`@p4runtime_translation`](https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-translation-annotation)
-to give them two representations:
+P4 programs use
+[`@p4runtime_translation`](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html#sec-user-defined-types)
+to decouple controller-facing values from data-plane values — but the
+[P4Runtime spec](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html)
+leaves the actual mapping mechanism unspecified. Every deployment rolls its
+own. 4ward ships a built-in translation engine that handles this automatically.
 
-- **P4Runtime (controller-facing)** — what the controller sends and receives.
-  Can be a string (e.g. `"Ethernet0"`) or a fixed-width integer.
-- **Dataplane** — the compact value the P4 program processes internally
-  (e.g. a 9-bit port number).
+## The problem
 
-4ward translates between these automatically at the P4Runtime API boundary.
-
-## Example
-
-SAI P4 declares port IDs as translated strings:
+A P4 program might declare:
 
 ```p4
 @p4runtime_translation("", string)
 type bit<9> port_id_t;
 ```
 
-A controller installs a table entry with `port = "Ethernet1"`. The
-translator maps it to dataplane value `0x01`. When the entry is read back,
-the translator maps `0x01` back to `"Ethernet1"`.
+The controller sends `"Ethernet0"` (a string). The P4 program processes a
+9-bit integer. Something has to map between these — but the P4Runtime spec
+doesn't say how. Both `sdn_string` (like SAI P4's port names) and
+`sdn_bitwidth` (fixed-width integers in a wider SDN representation) are
+supported.
 
 ## Translation modes
 
-| Mode | Behavior |
-|------|----------|
-| **Auto-allocate** (default) | P4Runtime values are assigned sequential dataplane values on first use (0, 1, 2, ...) |
-| **Explicit** | Only pre-configured mappings accepted; unknown values rejected |
-| **Hybrid** | Explicit pins for known values, auto-allocate for the rest |
+4ward supports three modes:
 
-Configure via `DeviceConfig.translations` in `SetForwardingPipelineConfig`:
+- **Auto-allocate** (default) — 4ward assigns data-plane values on first use.
+  Zero config. The controller sends any value; 4ward maps it to 0, 1, 2, ...
+- **Explicit** — you provide the full mapping table upfront. Unknown values
+  are rejected.
+- **Hybrid** — pin the values that matter, auto-allocate the rest.
+
+```
+Hybrid mode example — pin special ports, auto-allocate the rest:
+
+  explicit:  "CpuPort"    → 510
+  explicit:  "DropPort"   → 511
+  auto:      "Ethernet0"  →   0  (assigned on first use)
+  auto:      "Ethernet1"  →   1
+  auto:      "Ethernet2"  →   2
+```
+
+## Configuring mappings
+
+There are two ways to provide explicit mappings.
+
+### In P4 source: `@p4runtime_translation_mappings`
+
+The P4 program itself can declare mappings inline:
+
+```p4
+@p4runtime_translation("", string)
+@p4runtime_translation_mappings({
+  {"CpuPort", 510},
+  {"DropPort", 511}
+})
+type bit<9> port_id_t;
+```
+
+The 4ward p4c backend extracts these at compile time and converts them to
+translation entries with auto-allocate enabled (hybrid mode). This is the
+most convenient approach — the mappings live with the type declaration.
+
+### At pipeline load: `DeviceConfig.translations`
+
+Alternatively, configure mappings in `SetForwardingPipelineConfig`:
 
 ```textproto
 translations {
@@ -43,7 +76,9 @@ translations {
 }
 ```
 
-Without explicit configuration, auto-allocation is used by default.
+This is useful when the controller, not the P4 program, owns the mapping.
+
+Without either source of configuration, auto-allocation is used by default.
 
 ## Where translation happens
 
@@ -66,7 +101,7 @@ multiple messages (`InjectPacketRequest.ingress_port`,
 `OutputPacket.egress_port`, `PacketIn`/`PacketOut` metadata, clone session
 replicas).
 
-4ward creates a `PortTranslator` when the architecture's port metadata field
+4ward creates a port translator when the architecture's port metadata field
 uses a `type` (not `typedef`) with `@p4runtime_translation`. Stock
 architectures use `typedef` — no port translation. Programs that need port
 translation use a [forked architecture](architecture-modifications.md).

--- a/userdocs/getting-started/grpc.md
+++ b/userdocs/getting-started/grpc.md
@@ -3,7 +3,7 @@
 The gRPC API is how test infrastructure (DVaaS, sonic-pins) integrates with
 4ward programmatically. Two services are exposed on the same port:
 
-- **[P4Runtime](https://p4.org/specs/)** — the standard P4Runtime gRPC API for
+- **[P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html)** — the standard P4Runtime gRPC API for
   pipeline management, table entries, and PacketIO.
 - **DataplaneService** — 4ward-specific API for packet injection with trace
   trees.

--- a/userdocs/index.md
+++ b/userdocs/index.md
@@ -2,7 +2,7 @@
 
 **A glass-box P4 simulator — trace every decision your packet makes.**
 
-4ward is a spec-compliant [P4₁₆](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html) reference simulator that produces **trace
+4ward is a spec-compliant [P4₁₆](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/P4-16-v1.2.4.html) reference simulator that produces **trace
 trees**: a complete record of every parser transition, table lookup, action
 execution, and branch decision a packet encounters. At non-deterministic
 choice points (action selectors, clone, multicast), the trace forks — showing
@@ -32,7 +32,7 @@ all possible outcomes in a single pass.
 - **v1model and PSA** — two P4 architectures fully implemented, with support
   for architecture modifications like translated port types.
   [Learn more](concepts/architectures.md).
-- **[P4Runtime](https://p4.org/specs/) server** — spec-compliant gRPC server
+- **[P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html) server** — spec-compliant gRPC server
   with full arbitration, table management, PacketIO, and clone/multicast
   support.
 - **Type translation** — `@p4runtime_translation` types (string port names,

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -17,7 +17,7 @@ bazel run //p4runtime:p4runtime_server -- [flags]
 
 ## P4Runtime service
 
-Standard [P4Runtime](https://p4.org/specs/) gRPC API (reports version
+Standard [P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html) gRPC API (reports version
 **1.5.0**). All six RPCs are implemented:
 
 | RPC | Description |


### PR DESCRIPTION
## Summary

- **3 broken links fixed**: psa.p4 (moved to p4-spec repo), p4.org/specs
  (removed), P4Runtime annotation anchor (changed).
- **Released spec versions**: P4-16 v1.2.4, P4Runtime v1.4.0 instead of
  brittle main/latest URLs.
- **Type translation rewrite**: leads with the problem (spec leaves mapping
  unspecified), adds the hybrid mode example from the README, documents
  `@p4runtime_translation_mappings` (P4 annotation for inline explicit
  mappings), and distinguishes P4-source vs pipeline-load configuration.

## Test plan

- [x] All external URLs verified with curl (zero 404s)
- [x] `mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)