### PR TITLE
Fix spec version links, improve type translation framing

### DIFF
--- a/userdocs/concepts/architectures.md
+++ b/userdocs/concepts/architectures.md
@@ -76,7 +76,7 @@ Multiple calls use last-writer-wins. All produce
 
 The Portable Switch Architecture — a more modern design with a cleaner
 separation between ingress and egress. Defined in
-[psa.p4](https://github.com/p4lang/p4-spec/blob/main/p4-16/psa/psa.p4);
+[psa.p4](https://github.com/p4lang/p4-spec/blob/psa-v1.2/p4-16/psa/psa.p4);
 see the [PSA specification](https://p4lang.github.io/p4-spec/docs/PSA.pdf)
 for the canonical behavioral spec.
 

--- a/userdocs/concepts/type-translation.md
+++ b/userdocs/concepts/type-translation.md
@@ -1,11 +1,13 @@
 # Type Translation
 
-P4 programs use
-[`@p4runtime_translation`](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html#sec-user-defined-types)
-to decouple controller-facing values from data-plane values — but the
-[P4Runtime spec](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html)
-leaves the actual mapping mechanism unspecified. Every deployment rolls its
-own. 4ward ships a built-in translation engine that handles this automatically.
+Type translation is a
+[P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.5.0/P4Runtime-Spec.html)
+mechanism that decouples controller-facing values from data-plane values. P4
+programs declare translated types with the
+[`@p4runtime_translation`](https://p4lang.github.io/p4runtime/spec/v1.5.0/P4Runtime-Spec.html#sec-user-defined-types)
+annotation — but the P4Runtime spec leaves the actual mapping mechanism
+unspecified. Every deployment rolls its own. 4ward ships a built-in
+translation engine that handles this automatically.
 
 ## The problem
 

--- a/userdocs/getting-started/grpc.md
+++ b/userdocs/getting-started/grpc.md
@@ -3,7 +3,7 @@
 The gRPC API is how test infrastructure (DVaaS, sonic-pins) integrates with
 4ward programmatically. Two services are exposed on the same port:
 
-- **[P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html)** — the standard P4Runtime gRPC API for
+- **[P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.5.0/P4Runtime-Spec.html)** — the standard P4Runtime gRPC API for
   pipeline management, table entries, and PacketIO.
 - **DataplaneService** — 4ward-specific API for packet injection with trace
   trees.

--- a/userdocs/index.md
+++ b/userdocs/index.md
@@ -32,7 +32,7 @@ all possible outcomes in a single pass.
 - **v1model and PSA** — two P4 architectures fully implemented, with support
   for architecture modifications like translated port types.
   [Learn more](concepts/architectures.md).
-- **[P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html) server** — spec-compliant gRPC server
+- **[P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.5.0/P4Runtime-Spec.html) server** — spec-compliant gRPC server
   with full arbitration, table management, PacketIO, and clone/multicast
   support.
 - **Type translation** — `@p4runtime_translation` types (string port names,

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -17,7 +17,7 @@ bazel run //p4runtime:p4runtime_server -- [flags]
 
 ## P4Runtime service
 
-Standard [P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.4.0/P4Runtime-Spec.html) gRPC API (reports version
+Standard [P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.5.0/P4Runtime-Spec.html) gRPC API (reports version
 **1.5.0**). All six RPCs are implemented:
 
 | RPC | Description |

--- a/userdocs/stylesheets/extra.css
+++ b/userdocs/stylesheets/extra.css
@@ -1,5 +1,11 @@
 /* Make sidebar section headers visually distinct from page links. */
 .md-nav__item--section > .md-nav__link {
   font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--md-default-fg-color) !important;
+  margin-top: 0.6rem;
+  padding-bottom: 0.1rem;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
 }


### PR DESCRIPTION
- psa.p4: tagged psa-v1.2 instead of main
- P4Runtime spec: v1.5.0 (matches Capabilities RPC)
- Type translation: opens by framing it as a P4Runtime mechanism

All 17 external links verified.