### PR TITLE
Add source links and proto headers to docs

### DIFF
--- a/userdocs/concepts/architecture-modifications.md
+++ b/userdocs/concepts/architecture-modifications.md
@@ -72,7 +72,8 @@ Adding a completely new P4 architecture (e.g., PNA, TNA) requires changes to
 4ward: a Kotlin class that implements the `Architecture` interface and handles
 the architecture's pipeline stages, externs, and non-deterministic operations.
 
-Use `V1ModelArchitecture.kt` as the reference implementation.
+Use [`V1ModelArchitecture.kt`](https://github.com/smolkaj/4ward/blob/main/simulator/V1ModelArchitecture.kt)
+as the reference implementation.
 
 ### Step 1: Implement `Architecture`
 
@@ -118,7 +119,7 @@ private fun createExternHandler(state: State): ExternHandler =
 
 ### Step 3: Register
 
-Add your architecture to the dispatcher in `Simulator.kt`:
+Add your architecture to the dispatcher in [`Simulator.kt`](https://github.com/smolkaj/4ward/blob/main/simulator/Simulator.kt):
 
 ```kotlin
 architecture = when (archName) {

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -1,7 +1,9 @@
 # Trace Trees
 
-Every packet 4ward processes produces a **trace tree** — a complete record of
-every decision the simulator made. Most packets take a single path through the
+Every packet 4ward processes produces a **trace tree**
+([`TraceTree`](https://github.com/smolkaj/4ward/blob/main/simulator/simulator.proto)
+in `simulator.proto`) — a complete record of every decision the simulator
+made. Most packets take a single path through the
 pipeline and produce a linear trace. At non-deterministic choice points (action
 selectors, clone, multicast), the trace **forks** into branches, one per
 possible outcome.

--- a/userdocs/concepts/type-translation.md
+++ b/userdocs/concepts/type-translation.md
@@ -70,6 +70,8 @@ most convenient approach — the mappings live with the type declaration.
 Alternatively, configure mappings in `SetForwardingPipelineConfig`:
 
 ```textproto
+# proto-file: @fourward//simulator/ir.proto
+# proto-message: fourward.ir.DeviceConfig
 translations {
   type_name: "port_id_t"
   auto_allocate: true

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -45,8 +45,8 @@ become primary for a role. The highest `election_id` wins.
 
 ## Dataplane service
 
-Defined in `p4runtime/dataplane.proto`. For packet injection and result
-observation — not part of the P4Runtime spec.
+Defined in [`dataplane.proto`](https://github.com/smolkaj/4ward/blob/main/p4runtime/dataplane.proto).
+For packet injection and result observation — not part of the P4Runtime spec.
 
 ### `InjectPacket`
 

--- a/userdocs/reference/stf.md
+++ b/userdocs/reference/stf.md
@@ -5,7 +5,9 @@ originally from the [p4c](https://github.com/p4lang/p4c) compiler test suite
 and widely used across the P4 ecosystem (p4c,
 [BMv2](https://github.com/p4lang/behavioral-model),
 [p4testgen](https://github.com/p4lang/p4c/tree/main/backends/p4tools/modules/testgen)).
-4ward uses the same format for compatibility.
+4ward uses the same format for compatibility. See the
+[`e2e_tests/`](https://github.com/smolkaj/4ward/tree/main/e2e_tests)
+directory for real-world examples.
 
 Lines starting with `#` are comments. Tokens are whitespace-separated.
 


### PR DESCRIPTION
Link to source files where the reader's next step is opening that file. Add proto-file/proto-message headers to all textproto blocks.