### PR TITLE
Extract shared architecture helpers, add PNA e2e tests

### DIFF
--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -359,6 +359,20 @@ corpus_test_suite(
     ],
 )
 
+corpus_test_suite(
+    name = "pna_stf_corpus_test",
+    stf_overrides = {
+        "pna-dpdk-direct-counter": "//e2e_tests/corpus:pna-dpdk-direct-counter.stf",
+        "pna-dpdk-small_sample": "//e2e_tests/corpus:pna-dpdk-small_sample.stf",
+        "pna-example-template": "//e2e_tests/corpus:pna-example-template.stf",
+    },
+    tests = [
+        "pna-dpdk-direct-counter",
+        "pna-dpdk-small_sample",
+        "pna-example-template",
+    ],
+)
+
 # Tests that take excessively long to compile with p4c-4ward.
 corpus_test_suite(
     name = "slow_compile_stf_corpus_test",

--- a/e2e_tests/corpus/pna-dpdk-direct-counter.stf
+++ b/e2e_tests/corpus/pna-dpdk-direct-counter.stf
@@ -1,0 +1,8 @@
+# PNA direct counter: tables with direct counters, no send_to_port.
+# Tests: PNA pipeline, direct counter externs, drop-by-default.
+
+# IPv4 packet -> tables apply but no send_to_port -> drop
+packet 0 001122334455 00aabbccddee 0800 4500001400000000400600000A0000010A000002
+
+# Non-IPv4 packet -> drop
+packet 0 001122334455 00aabbccddee 0806 0001080006040001

--- a/e2e_tests/corpus/pna-dpdk-small_sample.stf
+++ b/e2e_tests/corpus/pna-dpdk-small_sample.stf
@@ -1,0 +1,12 @@
+# PNA small_sample: IPv4 table with default next_hop(1) action.
+# Tests: PNA pipeline, send_to_port, drop-by-default for non-IPv4.
+
+# IPv4 packet -> table ipv4_da hits default action next_hop(1) -> port 1
+# Ethernet: dst=00:11:22:33:44:55 src=00:aa:bb:cc:dd:ee etherType=0x0800
+# IPv4: ver=4 ihl=5 tos=0 len=20 id=0 flags=0 ttl=64 proto=6 cksum=0
+#       src=10.0.0.1 dst=10.0.0.2
+packet 0 001122334455 00aabbccddee 0800 4500001400000000400600000A0000010A000002
+expect 1 001122334455 00aabbccddee 0800 4500001400000000400600000A0000010A000002$
+
+# Non-IPv4 packet -> hdr.ipv4 not valid -> no send_to_port -> drop
+packet 0 001122334455 00aabbccddee 0806 0001080006040001

--- a/e2e_tests/corpus/pna-example-template.stf
+++ b/e2e_tests/corpus/pna-example-template.stf
@@ -1,0 +1,22 @@
+# PNA template: LPM routing with next_hop/drop actions.
+# Tests: PNA pipeline with runtime table entries, LPM match, send_to_port, drop_packet.
+
+add ipv4_da_lpm hdr.ipv4.dstAddr:10.0.0.0/8 next_hop(vport:1)
+add ipv4_da_lpm hdr.ipv4.dstAddr:10.1.0.0/16 next_hop(vport:2)
+
+# 10.2.3.4 matches 10.0.0.0/8 -> port 1
+# Ethernet: dst=ff:ff:ff:ff:ff:ff src=00:00:00:00:00:01 etherType=0x0800
+# IPv4: ver=4 ihl=5 tos=0 len=20 id=0 flags=0 ttl=64 proto=0 cksum=0
+#       src=10.0.0.1 dst=10.2.3.4
+packet 0 FFFFFFFFFFFF 000000000001 0800 4500001400000000400000000A0000010A020304
+expect 1 FFFFFFFFFFFF 000000000001 0800 4500001400000000400000000A0000010A020304$
+
+# 10.1.2.3 matches 10.1.0.0/16 (longest prefix) -> port 2
+packet 0 FFFFFFFFFFFF 000000000001 0800 4500001400000000400000000A0000010A010203
+expect 2 FFFFFFFFFFFF 000000000001 0800 4500001400000000400000000A0000010A010203$
+
+# 192.168.1.1 matches nothing -> default drop
+packet 0 FFFFFFFFFFFF 000000000001 0800 4500001400000000400000000A000001C0A80101
+
+# Non-IPv4 -> hdr.ipv4 not valid -> table not applied -> drop
+packet 0 FFFFFFFFFFFF 000000000001 0806 0001080006040001

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -1,0 +1,159 @@
+package fourward.simulator
+
+import fourward.ir.BehavioralConfig
+import fourward.ir.ExternInstanceDecl
+import fourward.ir.PipelineStage
+import fourward.ir.TypeDecl
+import fourward.sim.SimulatorProto.PipelineStageEvent
+import fourward.sim.SimulatorProto.TraceTree
+
+/** Simplified parameter descriptor: just name and type. */
+internal data class BlockParam(val name: String, val typeName: String)
+
+/** Architecture-level packet I/O types that are not user-visible parameters. */
+internal val IO_TYPES = setOf("packet_in", "packet_out")
+
+/** Guard against infinite recirculation loops. */
+internal const val MAX_RECIRCULATIONS = 16
+
+/** Builds a map from block name to parameter list across all parsers and controls. */
+internal fun buildBlockParamsMap(config: BehavioralConfig): Map<String, List<BlockParam>> {
+  val result = mutableMapOf<String, List<BlockParam>>()
+  for (parser in config.parsersList) {
+    result[parser.name] =
+      parser.paramsList
+        .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
+        .map { BlockParam(it.name, it.type.named) }
+  }
+  for (control in config.controlsList) {
+    result[control.name] =
+      control.paramsList
+        .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
+        .map { BlockParam(it.name, it.type.named) }
+  }
+  return result
+}
+
+/**
+ * Creates default values for all named types referenced by parser/control parameters.
+ *
+ * Returns a mutable map keyed by type name. The same value instance is shared across all parameters
+ * of that type (e.g., `headers` is shared between parser `parsed_hdr` and control `hdr`), so
+ * mutations in one stage are visible to subsequent stages.
+ */
+internal fun createDefaultValues(
+  config: BehavioralConfig,
+  typesByName: Map<String, TypeDecl>,
+): MutableMap<String, Value> {
+  val values = mutableMapOf<String, Value>()
+  for (parser in config.parsersList) {
+    for (param in parser.paramsList) {
+      if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
+        values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
+      }
+    }
+  }
+  for (control in config.controlsList) {
+    for (param in control.paramsList) {
+      if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
+        values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
+      }
+    }
+  }
+  return values
+}
+
+/** Builds a flat map from extern instance name to declaration across all parsers and controls. */
+internal fun buildExternInstancesMap(config: BehavioralConfig): Map<String, ExternInstanceDecl> =
+  (config.parsersList.flatMap { it.externInstancesList } +
+      config.controlsList.flatMap { it.externInstancesList })
+    .associateBy { it.name }
+
+/**
+ * Binds a stage's parameters in the environment, mapping each param name to the shared value for
+ * its type.
+ *
+ * PSA/PNA stages reuse parameter names (e.g. `istd`) with different types, so parameters must be
+ * re-bound before each stage.
+ */
+internal fun bindStageParams(
+  env: Environment,
+  blockName: String,
+  blockParams: Map<String, List<BlockParam>>,
+  valueByType: Map<String, Value>,
+) {
+  for (param in blockParams[blockName] ?: emptyList()) {
+    valueByType[param.typeName]?.let { env.define(param.name, it) }
+  }
+}
+
+/** Runs a parser stage, recording trace events and routing parser errors to [onParserError]. */
+internal fun runParserStage(
+  interpreter: Interpreter,
+  ctx: PacketContext,
+  env: Environment,
+  stage: PipelineStage,
+  onParserError: (ParserErrorException) -> Unit,
+) {
+  ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
+  try {
+    interpreter.runParser(stage.blockName, env)
+  } catch (e: ParserErrorException) {
+    onParserError(e)
+  } finally {
+    ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
+  }
+}
+
+/** Runs a control stage, recording trace events. An `exit` statement terminates only the stage. */
+internal fun runControlStage(
+  interpreter: Interpreter,
+  ctx: PacketContext,
+  env: Environment,
+  stage: PipelineStage,
+) {
+  ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
+  try {
+    interpreter.runControl(stage.blockName, env)
+  } catch (_: ExitException) {
+    // exit terminates the current control, but the pipeline continues.
+  } finally {
+    ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
+  }
+}
+
+/**
+ * Handles an [ActionSelectorFork] by re-executing the pipeline segment for each group member.
+ *
+ * On the first encounter with an action selector group hit, the [Interpreter] throws
+ * [ActionSelectorFork] with the list of group members and the trace events accumulated before the
+ * fork. This method builds a fork [TraceTree] with one branch per member, re-executing via
+ * [reExecute] with the forced member selection added to [currentSelectors].
+ *
+ * The re-execution produces identical events up to the fork point (deterministic replay), so the
+ * prefix is safely stripped from each branch's trace.
+ */
+internal fun handleActionSelectorFork(
+  fork: ActionSelectorFork,
+  currentSelectors: Map<String, Int>,
+  reExecute: (Map<String, Int>) -> TraceTree,
+): TraceTree {
+  val prefixLength = fork.eventsBeforeFork.size
+  val branches =
+    fork.members.map { member ->
+      val newSelectors = currentSelectors + (fork.tableName to member.memberId)
+      val subtree = reExecute(newSelectors)
+      val stripped = TraceTree.newBuilder().addAllEvents(subtree.eventsList.drop(prefixLength))
+      if (subtree.hasPacketOutcome()) stripped.setPacketOutcome(subtree.packetOutcome)
+      if (subtree.hasForkOutcome()) stripped.setForkOutcome(subtree.forkOutcome)
+      fourward.sim.SimulatorProto.ForkBranch.newBuilder()
+        .setLabel("member_${member.memberId}")
+        .setSubtree(stripped.build())
+        .build()
+    }
+  return buildForkTree(
+    fork.eventsBeforeFork,
+    fourward.sim.SimulatorProto.ForkReason.ACTION_SELECTOR,
+    branches,
+  )
+}

--- a/simulator/Hash.kt
+++ b/simulator/Hash.kt
@@ -1,5 +1,6 @@
 package fourward.simulator
 
+import fourward.ir.ExternInstanceDecl
 import java.math.BigInteger
 import java.util.zip.CRC32
 
@@ -134,3 +135,56 @@ fun computeHashWithPayload(algorithm: String, data: StructVal, payload: ByteArra
       }
     }
   }
+
+/**
+ * Coerces a hash data argument to [StructVal]. The p4c midend usually wraps hash inputs in a
+ * StructExpression, but single-field inputs (e.g. `get_hash(hdr.ethernet.srcAddr)`) arrive as bare
+ * [BitVal]. Headers arrive as [HeaderVal].
+ */
+internal fun hashDataArg(value: Value): StructVal =
+  when (value) {
+    is BitVal -> StructVal("", mutableMapOf("_0" to value))
+    else -> value.asStructVal()
+  }
+
+/**
+ * Sums all 16-bit words in [data]'s concatenated fields. Returns the raw sum (not complemented).
+ */
+internal fun sumWords(data: StructVal): BigInteger =
+  concatFields(data)?.let { sumBitWords(it) } ?: BigInteger.ZERO
+
+/**
+ * Evaluates Hash.get_hash (1-arg or 3-arg form). [algorithmMap] maps architecture-specific enum
+ * members to the internal algorithm names used by [computeHash].
+ */
+internal fun evalGetHash(
+  call: ExternCall.Method,
+  eval: ExternEvaluator,
+  externInstances: Map<String, ExternInstanceDecl>,
+  algorithmMap: Map<String, String>,
+): Value {
+  val instance =
+    externInstances[call.instanceName] ?: error("unknown Hash instance: ${call.instanceName}")
+  val archAlgorithm =
+    instance.constructorArgsList.firstOrNull()?.literal?.enumMember
+      ?: error("Hash instance ${call.instanceName} missing algorithm constructor arg")
+  val algorithm = algorithmMap[archAlgorithm] ?: error("unsupported hash algorithm: $archAlgorithm")
+  val resultWidth = eval.returnType().bit.width
+
+  val resultMask = BigInteger.TWO.pow(resultWidth) - BigInteger.ONE
+
+  return if (eval.argCount() == 1) {
+    // 1-arg form: get_hash(data) -> hash(data) truncated to result width
+    val data = hashDataArg(eval.evalArg(0))
+    val hash = computeHash(algorithm, data).and(resultMask)
+    BitVal(BitVector(hash, resultWidth))
+  } else {
+    // 3-arg form: get_hash(base, data, max) -> (base + hash(data)) mod max
+    val base = (eval.evalArg(0) as BitVal).bits.value
+    val data = hashDataArg(eval.evalArg(1))
+    val max = (eval.evalArg(2) as BitVal).bits.value
+    val hash = computeHash(algorithm, data)
+    val result = if (max > BigInteger.ZERO) (base + hash.mod(max)).and(resultMask) else base
+    BitVal(BitVector(result, resultWidth))
+  }
+}

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -8,8 +8,6 @@ import fourward.sim.SimulatorProto.DropReason
 import fourward.sim.SimulatorProto.Fork
 import fourward.sim.SimulatorProto.ForkBranch
 import fourward.sim.SimulatorProto.ForkReason
-import fourward.sim.SimulatorProto.PipelineStageEvent
-import fourward.sim.SimulatorProto.TraceEvent
 import fourward.sim.SimulatorProto.TraceTree
 import java.math.BigInteger
 
@@ -239,120 +237,9 @@ class PNAArchitecture : Architecture {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Stage execution helpers
-  // ---------------------------------------------------------------------------
-
-  private fun runParserStage(
-    interpreter: Interpreter,
-    ctx: PacketContext,
-    env: Environment,
-    stage: PipelineStage,
-    onParserError: (ParserErrorException) -> Unit,
-  ) {
-    ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
-    try {
-      interpreter.runParser(stage.blockName, env)
-    } catch (e: ParserErrorException) {
-      onParserError(e)
-    } finally {
-      ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
-    }
-  }
-
-  private fun runControlStage(
-    interpreter: Interpreter,
-    ctx: PacketContext,
-    env: Environment,
-    stage: PipelineStage,
-  ) {
-    ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
-    try {
-      interpreter.runControl(stage.blockName, env)
-    } catch (_: ExitException) {
-      // PNA: exit terminates the current control, but the pipeline continues.
-    } finally {
-      ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Parameter binding
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Binds a stage's parameters in the environment, mapping each param name to the shared value for
-   * its type.
-   *
-   * PNA stages reuse parameter names (e.g. `istd`) with different types, so parameters must be
-   * re-bound before each stage.
-   */
-  private fun bindStageParams(
-    env: Environment,
-    blockName: String,
-    blockParams: Map<String, List<BlockParam>>,
-    valueByType: Map<String, Value>,
-  ) {
-    for (param in blockParams[blockName] ?: emptyList()) {
-      valueByType[param.typeName]?.let { env.define(param.name, it) }
-    }
-  }
-
-  /** Simplified parameter descriptor: just name and type. */
-  private data class BlockParam(val name: String, val typeName: String)
-
-  /** Builds a map from block name to parameter list across all parsers and controls. */
-  private fun buildBlockParamsMap(config: BehavioralConfig): Map<String, List<BlockParam>> {
-    val result = mutableMapOf<String, List<BlockParam>>()
-    for (parser in config.parsersList) {
-      result[parser.name] =
-        parser.paramsList
-          .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
-          .map { BlockParam(it.name, it.type.named) }
-    }
-    for (control in config.controlsList) {
-      result[control.name] =
-        control.paramsList
-          .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
-          .map { BlockParam(it.name, it.type.named) }
-    }
-    return result
-  }
-
-  /**
-   * Creates default values for all named types referenced by parser/control parameters.
-   *
-   * Returns a mutable map keyed by type name. The same value instance is shared across all
-   * parameters of that type (e.g., `headers` is shared between parser `parsed_hdr` and control
-   * `hdr`), so mutations in one stage are visible to subsequent stages.
-   */
-  private fun createDefaultValues(
-    config: BehavioralConfig,
-    typesByName: Map<String, TypeDecl>,
-  ): MutableMap<String, Value> {
-    val values = mutableMapOf<String, Value>()
-    for (parser in config.parsersList) {
-      for (param in parser.paramsList) {
-        if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
-          values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
-        }
-      }
-    }
-    for (control in config.controlsList) {
-      for (param in control.paramsList) {
-        if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
-          values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
-        }
-      }
-    }
-    return values
-  }
-
-  /** Builds a flat map from extern instance name → declaration across all parsers and controls. */
-  private fun buildExternInstancesMap(config: BehavioralConfig): Map<String, ExternInstanceDecl> =
-    (config.parsersList.flatMap { it.externInstancesList } +
-        config.controlsList.flatMap { it.externInstancesList })
-      .associateBy { it.name }
+  // Stage execution helpers (bindStageParams, runParserStage, runControlStage,
+  // createDefaultValues, buildBlockParamsMap, buildExternInstancesMap) live in
+  // ArchitectureHelpers.kt.
 
   // ---------------------------------------------------------------------------
   // PNA extern handler
@@ -448,7 +335,7 @@ class PNAArchitecture : Architecture {
       }
       "count" -> UnitVal
       // Hash.get_hash: 1-arg or 3-arg form. Algorithm from constructor args.
-      "get_hash" -> evalGetHash(call, eval, pipeline.externInstances)
+      "get_hash" -> evalGetHash(call, eval, pipeline.externInstances, PNA_HASH_ALGORITHMS)
       // Meter.execute(index): returns PNA_MeterColor_t. Always GREEN — no real
       // packet rates in simulator.
       "execute" -> EnumVal("GREEN")
@@ -500,108 +387,9 @@ class PNAArchitecture : Architecture {
         )
     }
 
-  /** Evaluates PNA Hash.get_hash (1-arg or 3-arg form). */
-  private fun evalGetHash(
-    call: ExternCall.Method,
-    eval: ExternEvaluator,
-    externInstances: Map<String, ExternInstanceDecl>,
-  ): Value {
-    val instance =
-      externInstances[call.instanceName] ?: error("unknown Hash instance: ${call.instanceName}")
-    val pnaAlgorithm =
-      instance.constructorArgsList.firstOrNull()?.literal?.enumMember
-        ?: error("Hash instance ${call.instanceName} missing algorithm constructor arg")
-    val algorithm =
-      PNA_HASH_ALGORITHMS[pnaAlgorithm] ?: error("unsupported PNA hash algorithm: $pnaAlgorithm")
-    val resultWidth = eval.returnType().bit.width
-
-    val resultMask = BigInteger.TWO.pow(resultWidth) - BigInteger.ONE
-
-    return if (eval.argCount() == 1) {
-      // 1-arg form: get_hash(data) → hash(data) truncated to result width
-      val data = hashDataArg(eval.evalArg(0))
-      val hash = computeHash(algorithm, data).and(resultMask)
-      BitVal(BitVector(hash, resultWidth))
-    } else {
-      // 3-arg form: get_hash(base, data, max) → (base + hash(data)) mod max
-      val base = (eval.evalArg(0) as BitVal).bits.value
-      val data = hashDataArg(eval.evalArg(1))
-      val max = (eval.evalArg(2) as BitVal).bits.value
-      val hash = computeHash(algorithm, data)
-      val result = if (max > BigInteger.ZERO) (base + hash.mod(max)).and(resultMask) else base
-      BitVal(BitVector(result, resultWidth))
-    }
-  }
-
-  /**
-   * Coerces a hash data argument to [StructVal]. The p4c midend usually wraps hash inputs in a
-   * StructExpression, but single-field inputs (e.g. `get_hash(hdr.ethernet.srcAddr)`) arrive as
-   * bare [BitVal]. Headers arrive as [HeaderVal].
-   */
-  private fun hashDataArg(value: Value): StructVal =
-    when (value) {
-      is BitVal -> StructVal("", mutableMapOf("_0" to value))
-      else -> value.asStructVal()
-    }
-
-  /**
-   * Sums all 16-bit words in [data]'s concatenated fields. Returns the raw sum (not complemented).
-   */
-  private fun sumWords(data: StructVal): BigInteger =
-    concatFields(data)?.let { sumBitWords(it) } ?: BigInteger.ZERO
-
-  // ---------------------------------------------------------------------------
-  // Action selector fork handling
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Handles an [ActionSelectorFork] by re-executing the pipeline segment for each group member.
-   *
-   * On the first encounter with an action selector group hit, the [Interpreter] throws
-   * [ActionSelectorFork] with the list of group members and the trace events accumulated before the
-   * fork. This method builds a fork [TraceTree] with one branch per member, re-executing via
-   * [reExecute] with the forced member selection added to [currentSelectors].
-   *
-   * The re-execution produces identical events up to the fork point (deterministic replay), so the
-   * prefix is safely stripped from each branch's trace.
-   */
-  private fun handleActionSelectorFork(
-    fork: ActionSelectorFork,
-    currentSelectors: Map<String, Int>,
-    reExecute: (Map<String, Int>) -> TraceTree,
-  ): TraceTree {
-    val prefixLength = fork.eventsBeforeFork.size
-    val branches =
-      fork.members.map { member ->
-        val newSelectors = currentSelectors + (fork.tableName to member.memberId)
-        val subtree = reExecute(newSelectors)
-        val stripped = TraceTree.newBuilder().addAllEvents(subtree.eventsList.drop(prefixLength))
-        if (subtree.hasPacketOutcome()) stripped.setPacketOutcome(subtree.packetOutcome)
-        if (subtree.hasForkOutcome()) stripped.setForkOutcome(subtree.forkOutcome)
-        ForkBranch.newBuilder()
-          .setLabel("member_${member.memberId}")
-          .setSubtree(stripped.build())
-          .build()
-      }
-    return buildForkTree(fork.eventsBeforeFork, ForkReason.ACTION_SELECTOR, branches)
-  }
-
-  // ---------------------------------------------------------------------------
-  // Trace helpers
-  // ---------------------------------------------------------------------------
-
-  private fun buildForkTree(
-    events: List<TraceEvent>,
-    reason: ForkReason,
-    branches: List<ForkBranch>,
-  ): TraceTree =
-    TraceTree.newBuilder()
-      .addAllEvents(events)
-      .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
-      .build()
-
-  // Shared trace helpers (buildDropTrace, buildOutputTrace, packetIngressEvent, stageEvent)
-  // live in TraceHelpers.kt.
+  // Hash helpers (evalGetHash, hashDataArg, sumWords) live in Hash.kt.
+  // Action selector fork handling (handleActionSelectorFork) and trace helpers
+  // (buildForkTree) live in ArchitectureHelpers.kt and TraceHelpers.kt.
 
   private companion object {
     // PNA_Direction_t enum values (pna.p4).
@@ -610,9 +398,6 @@ class PNAArchitecture : Architecture {
     // PNA_PacketPath_t enum values (pna.p4).
     const val PACKET_PATH_FROM_NET_PORT = "FROM_NET_PORT"
     const val PACKET_PATH_FROM_NET_RECIRCULATED = "FROM_NET_RECIRCULATED"
-
-    /** Architecture-level packet I/O types that are not user-visible parameters. */
-    val IO_TYPES = setOf("packet_in", "packet_out")
 
     /**
      * Maps PNA_HashAlgorithm_t enum members to the internal algorithm names used by Hash.kt.
@@ -628,8 +413,5 @@ class PNAArchitecture : Architecture {
         "ONES_COMPLEMENT16" to "csum16",
         "TARGET_DEFAULT" to "identity",
       )
-
-    /** Guard against infinite recirculation loops. */
-    const val MAX_RECIRCULATIONS = 16
   }
 }

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -8,7 +8,6 @@ import fourward.sim.SimulatorProto.DropReason
 import fourward.sim.SimulatorProto.Fork
 import fourward.sim.SimulatorProto.ForkBranch
 import fourward.sim.SimulatorProto.ForkReason
-import fourward.sim.SimulatorProto.PipelineStageEvent
 import fourward.sim.SimulatorProto.TraceEvent
 import fourward.sim.SimulatorProto.TraceTree
 import java.math.BigInteger
@@ -617,114 +616,9 @@ class PSAArchitecture : Architecture {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Stage execution helpers
-  // ---------------------------------------------------------------------------
-
-  private fun runParserStage(
-    interpreter: Interpreter,
-    ctx: PacketContext,
-    env: Environment,
-    stage: PipelineStage,
-    onParserError: (ParserErrorException) -> Unit,
-  ) {
-    ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
-    try {
-      interpreter.runParser(stage.blockName, env)
-    } catch (e: ParserErrorException) {
-      onParserError(e)
-    } finally {
-      ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
-    }
-  }
-
-  private fun runControlStage(
-    interpreter: Interpreter,
-    ctx: PacketContext,
-    env: Environment,
-    stage: PipelineStage,
-  ) {
-    ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
-    try {
-      interpreter.runControl(stage.blockName, env)
-    } catch (_: ExitException) {
-      // PSA: exit terminates the current control, but the pipeline continues.
-    } finally {
-      ctx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Parameter binding
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Binds a stage's parameters in the environment, mapping each param name to the shared value for
-   * its type.
-   *
-   * PSA stages reuse parameter names (e.g. `istd`) with different types, so parameters must be
-   * re-bound before each stage — unlike v1model where all params can be bound once upfront.
-   */
-  private fun bindStageParams(
-    env: Environment,
-    blockName: String,
-    blockParams: Map<String, List<BlockParam>>,
-    valueByType: Map<String, Value>,
-  ) {
-    for (param in blockParams[blockName] ?: emptyList()) {
-      valueByType[param.typeName]?.let { env.define(param.name, it) }
-    }
-  }
-
-  /** Simplified parameter descriptor: just name and type. */
-  private data class BlockParam(val name: String, val typeName: String)
-
-  /** Builds a map from block name to parameter list across all parsers and controls. */
-  private fun buildBlockParamsMap(config: BehavioralConfig): Map<String, List<BlockParam>> {
-    val result = mutableMapOf<String, List<BlockParam>>()
-    for (parser in config.parsersList) {
-      result[parser.name] =
-        parser.paramsList
-          .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
-          .map { BlockParam(it.name, it.type.named) }
-    }
-    for (control in config.controlsList) {
-      result[control.name] =
-        control.paramsList
-          .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
-          .map { BlockParam(it.name, it.type.named) }
-    }
-    return result
-  }
-
-  /**
-   * Creates default values for all named types referenced by parser/control parameters.
-   *
-   * Returns a mutable map keyed by type name. The same value instance is shared across all
-   * parameters of that type (e.g., `headers` is shared between parser `parsed_hdr` and control
-   * `hdr`), so mutations in one stage are visible to subsequent stages.
-   */
-  private fun createDefaultValues(
-    config: BehavioralConfig,
-    typesByName: Map<String, TypeDecl>,
-  ): MutableMap<String, Value> {
-    val values = mutableMapOf<String, Value>()
-    for (parser in config.parsersList) {
-      for (param in parser.paramsList) {
-        if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
-          values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
-        }
-      }
-    }
-    for (control in config.controlsList) {
-      for (param in control.paramsList) {
-        if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
-          values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
-        }
-      }
-    }
-    return values
-  }
+  // Stage execution helpers (bindStageParams, runParserStage, runControlStage,
+  // createDefaultValues, buildBlockParamsMap, buildExternInstancesMap) live in
+  // ArchitectureHelpers.kt.
 
   // ---------------------------------------------------------------------------
   // PSA extern handler
@@ -793,7 +687,7 @@ class PSAArchitecture : Architecture {
             "count" -> UnitVal
             // PSA Hash.get_hash: 1-arg form returns hash(data), 3-arg form returns
             // (base + hash(data)) mod max. Algorithm comes from constructor args.
-            "get_hash" -> evalGetHash(call, eval, pipeline.externInstances)
+            "get_hash" -> evalGetHash(call, eval, pipeline.externInstances, PSA_HASH_ALGORITHMS)
             // PSA Meter.execute(index): returns PSA_MeterColor_t. Always GREEN — no real
             // packet rates in simulator (same as v1model).
             "execute" -> EnumVal("GREEN")
@@ -842,114 +736,9 @@ class PSAArchitecture : Architecture {
     }
   }
 
-  /** Evaluates PSA Hash.get_hash (1-arg or 3-arg form). */
-  private fun evalGetHash(
-    call: ExternCall.Method,
-    eval: ExternEvaluator,
-    externInstances: Map<String, ExternInstanceDecl>,
-  ): Value {
-    val instance =
-      externInstances[call.instanceName] ?: error("unknown Hash instance: ${call.instanceName}")
-    val psaAlgorithm =
-      instance.constructorArgsList.firstOrNull()?.literal?.enumMember
-        ?: error("Hash instance ${call.instanceName} missing algorithm constructor arg")
-    val algorithm =
-      PSA_HASH_ALGORITHMS[psaAlgorithm] ?: error("unsupported PSA hash algorithm: $psaAlgorithm")
-    val resultWidth = eval.returnType().bit.width
-
-    val resultMask = BigInteger.TWO.pow(resultWidth) - BigInteger.ONE
-
-    return if (eval.argCount() == 1) {
-      // 1-arg form: get_hash(data) → hash(data) truncated to result width
-      val data = hashDataArg(eval.evalArg(0))
-      val hash = computeHash(algorithm, data).and(resultMask)
-      BitVal(BitVector(hash, resultWidth))
-    } else {
-      // 3-arg form: get_hash(base, data, max) → (base + hash(data)) mod max
-      val base = (eval.evalArg(0) as BitVal).bits.value
-      val data = hashDataArg(eval.evalArg(1))
-      val max = (eval.evalArg(2) as BitVal).bits.value
-      val hash = computeHash(algorithm, data)
-      val result = if (max > BigInteger.ZERO) (base + hash.mod(max)).and(resultMask) else base
-      BitVal(BitVector(result, resultWidth))
-    }
-  }
-
-  /**
-   * Coerces a hash data argument to [StructVal]. The p4c midend usually wraps hash inputs in a
-   * StructExpression, but single-field inputs (e.g. `get_hash(hdr.ethernet.srcAddr)`) arrive as
-   * bare [BitVal]. Headers arrive as [HeaderVal].
-   */
-  private fun hashDataArg(value: Value): StructVal =
-    when (value) {
-      is BitVal -> StructVal("", mutableMapOf("_0" to value))
-      else -> value.asStructVal()
-    }
-
-  /**
-   * Sums all 16-bit words in [data]'s concatenated fields. Returns the raw sum (not complemented).
-   */
-  private fun sumWords(data: StructVal): BigInteger =
-    concatFields(data)?.let { sumBitWords(it) } ?: BigInteger.ZERO
-
-  /** Builds a flat map from extern instance name → declaration across all parsers and controls. */
-  private fun buildExternInstancesMap(config: BehavioralConfig): Map<String, ExternInstanceDecl> =
-    (config.parsersList.flatMap { it.externInstancesList } +
-        config.controlsList.flatMap { it.externInstancesList })
-      .associateBy { it.name }
-
-  // ---------------------------------------------------------------------------
-  // Action selector fork handling
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Handles an [ActionSelectorFork] by re-executing the pipeline segment for each group member.
-   *
-   * On the first encounter with an action selector group hit, the [Interpreter] throws
-   * [ActionSelectorFork] with the list of group members and the trace events accumulated before the
-   * fork. This method builds a fork [TraceTree] with one branch per member, re-executing via
-   * [reExecute] with the forced member selection added to [currentSelectors].
-   *
-   * The re-execution produces identical events up to the fork point (deterministic replay), so the
-   * prefix is safely stripped from each branch's trace.
-   */
-  private fun handleActionSelectorFork(
-    fork: ActionSelectorFork,
-    currentSelectors: Map<String, Int>,
-    reExecute: (Map<String, Int>) -> TraceTree,
-  ): TraceTree {
-    val prefixLength = fork.eventsBeforeFork.size
-    val branches =
-      fork.members.map { member ->
-        val newSelectors = currentSelectors + (fork.tableName to member.memberId)
-        val subtree = reExecute(newSelectors)
-        val stripped = TraceTree.newBuilder().addAllEvents(subtree.eventsList.drop(prefixLength))
-        if (subtree.hasPacketOutcome()) stripped.setPacketOutcome(subtree.packetOutcome)
-        if (subtree.hasForkOutcome()) stripped.setForkOutcome(subtree.forkOutcome)
-        ForkBranch.newBuilder()
-          .setLabel("member_${member.memberId}")
-          .setSubtree(stripped.build())
-          .build()
-      }
-    return buildForkTree(fork.eventsBeforeFork, ForkReason.ACTION_SELECTOR, branches)
-  }
-
-  // ---------------------------------------------------------------------------
-  // Trace helpers
-  // ---------------------------------------------------------------------------
-
-  private fun buildForkTree(
-    events: List<TraceEvent>,
-    reason: ForkReason,
-    branches: List<ForkBranch>,
-  ): TraceTree =
-    TraceTree.newBuilder()
-      .addAllEvents(events)
-      .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
-      .build()
-
-  // Shared trace helpers (buildDropTrace, buildOutputTrace, packetIngressEvent, stageEvent)
-  // live in TraceHelpers.kt.
+  // Hash helpers (evalGetHash, hashDataArg, sumWords) live in Hash.kt.
+  // Action selector fork handling (handleActionSelectorFork) and trace helpers
+  // (buildForkTree) live in ArchitectureHelpers.kt and TraceHelpers.kt.
 
   private companion object {
     // PSA_PacketPath_t enum values (PSA spec §6.1).
@@ -960,9 +749,6 @@ class PSAArchitecture : Architecture {
     const val PACKET_PATH_CLONE_E2E = "CLONE_E2E"
     const val PACKET_PATH_RESUBMIT = "RESUBMIT"
     const val PACKET_PATH_RECIRCULATE = "RECIRCULATE"
-
-    /** Architecture-level packet I/O types that are not user-visible parameters. */
-    val IO_TYPES = setOf("packet_in", "packet_out")
 
     /** Maps PSA_HashAlgorithm_t enum members to the internal algorithm names used by Hash.kt. */
     val PSA_HASH_ALGORITHMS =
@@ -976,8 +762,5 @@ class PSAArchitecture : Architecture {
     /** PSA_PORT_RECIRCULATE (psa.p4: `const PortId_t PSA_PORT_RECIRCULATE = 32w0xfffffffa`). */
     const val PSA_PORT_RECIRCULATE_LONG = 0xFFFFFFFAL
     val PSA_PORT_RECIRCULATE_UINT = PSA_PORT_RECIRCULATE_LONG.toUInt()
-
-    /** Guard against infinite recirculation loops (BMv2 psa_switch uses a similar limit). */
-    const val MAX_RECIRCULATIONS = 16
   }
 }

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -3,6 +3,9 @@ package fourward.simulator
 import fourward.ir.PipelineStage
 import fourward.sim.SimulatorProto.Drop
 import fourward.sim.SimulatorProto.DropReason
+import fourward.sim.SimulatorProto.Fork
+import fourward.sim.SimulatorProto.ForkBranch
+import fourward.sim.SimulatorProto.ForkReason
 import fourward.sim.SimulatorProto.PacketIngressEvent
 import fourward.sim.SimulatorProto.PacketOutcome
 import fourward.sim.SimulatorProto.PipelineStageEvent
@@ -44,4 +47,15 @@ internal fun stageEvent(stage: PipelineStage, direction: PipelineStageEvent.Dire
         .setStageKind(stage.kind)
         .setDirection(direction)
     )
+    .build()
+
+/** Builds a [TraceTree] with a fork outcome from accumulated events and branches. */
+internal fun buildForkTree(
+  events: List<TraceEvent>,
+  reason: ForkReason,
+  branches: List<ForkBranch>,
+): TraceTree =
+  TraceTree.newBuilder()
+    .addAllEvents(events)
+    .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
     .build()


### PR DESCRIPTION
## Summary

Follow-up to #378 (PNA support). Two improvements:

**1. Extract shared architecture helpers (-152 net lines)**

PSA and PNA duplicated ~350 lines of architecture-agnostic code. Now shared in three files:
- `ArchitectureHelpers.kt`: pipeline infrastructure (stage runners, param binding, default values, action selector forks, `BlockParam`, `IO_TYPES`, `MAX_RECIRCULATIONS`)
- `TraceHelpers.kt`: `buildForkTree`
- `Hash.kt`: `evalGetHash` (parameterized on algorithm map), `hashDataArg`, `sumWords`

Adding a fourth architecture (TNA) now requires even less boilerplate.

**2. First PNA corpus STF tests (3 tests)**

Hand-crafted STF tests for PNA programs from the p4c corpus:
- `pna-dpdk-small_sample`: forwarding via const default action + drop-by-default
- `pna-example-template`: LPM routing with runtime table entries + explicit `drop_packet()`
- `pna-dpdk-direct-counter`: direct counter externs + drop-by-default

## Test plan

- [x] 16/16 simulator unit tests pass
- [x] 3/3 PNA corpus STF tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)