### PR TITLE
Add PNA p4testgen test targets

### DIFF
--- a/e2e_tests/p4testgen/BUILD.bazel
+++ b/e2e_tests/p4testgen/BUILD.bazel
@@ -261,3 +261,41 @@ p4_testgen_test(
     max_tests = 500,
     src_p4 = "//e2e_tests/sai_p4:instantiations/google/middleblock.p4",
 )
+
+# PNA p4testgen tests. p4testgen's PNA model does not account for drop-by-default:
+# it expects packets forwarded even when send_to_port() is never called (parser
+# failure, non-matching etherType, etc.). Tests where all generated cases trigger
+# this mismatch are excluded. Programs that generate at least some valid forwarding
+# paths are included — the subset of cases that fail due to the drop-by-default
+# issue will show as test failures until p4testgen's PNA model is fixed upstream.
+p4_testgen_test(
+    name = "pna-dpdk-small_sample",
+    arch = "pna",
+    max_tests = 10,
+    tags = ["manual"],
+    target = "dpdk",
+)
+
+p4_testgen_test(
+    name = "pna-direction",
+    arch = "pna",
+    max_tests = 10,
+    tags = ["manual"],
+    target = "dpdk",
+)
+
+p4_testgen_test(
+    name = "pna-example-SelectByDirection",
+    arch = "pna",
+    max_tests = 10,
+    tags = ["manual"],
+    target = "dpdk",
+)
+
+p4_testgen_test(
+    name = "pna-example-tunnel",
+    arch = "pna",
+    max_tests = 10,
+    tags = ["manual"],
+    target = "dpdk",
+)


### PR DESCRIPTION
## Summary

Wires up p4testgen symbolic test generation for PNA programs using the
new `target`/`arch` parameters added in #381. Four programs generate
~33 test cases via Z3 constraint solving.

**Key finding:** p4testgen's PNA model has a systematic mismatch with the
PNA spec — it doesn't account for **drop-by-default**. When
`send_to_port()` is never called (parser failure on short packets,
non-matching etherType skipping the table), p4testgen expects packets
forwarded while the simulator correctly drops them. This affects 26/33
generated tests. The 7 passing tests are cases where `send_to_port()`
is actually called.

Tests are marked `manual` until the p4testgen model is fixed upstream.
All 26 failures are confirmed correct simulator behavior, not simulator
bugs — they validate that our drop-by-default implementation is right.

## Test plan

- [x] 7/33 p4testgen tests pass (correct forwarding paths)
- [x] 26/33 fail due to p4testgen drop-by-default model mismatch (confirmed correct drops)
- [x] 16/16 simulator unit tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)