### PR TITLE
Fix site URL and sitemap for Google indexing

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: 4ward
 site_description: Glass-box P4 simulator — trace every decision your packet makes.
-site_url: https://smolkaj.github.io/4ward/
+site_url: https://smolka.st/4ward/
 repo_url: https://github.com/smolkaj/4ward
 repo_name: smolkaj/4ward
 edit_uri: edit/main/userdocs/


### PR DESCRIPTION
## Summary

The docs site wasn't being indexed by Google because:

1. **Wrong sitemap URLs** — MkDocs generated `smolkaj.github.io` URLs but the
   site is served at `smolka.st` (GitHub Pages custom domain redirect).
2. **Orphaned sitemap** — the root `robots.txt` at `smolka.st` didn't
   reference the 4ward sitemap.

Fixes:
- `mkdocs.yml`: `site_url` → `https://smolka.st/4ward/`
- `smolkaj.github.io` repo: added `Sitemap: https://smolka.st/4ward/sitemap.xml`
  to `robots.txt` (already committed directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)