### PR TITLE
Fix p4testgen PNA model, extract shared extern handler, fix flaky test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,7 +37,7 @@ bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
 bazel_dep(name = "p4c", version = "1.2.5.11")
 git_override(
     module_name = "p4c",
-    commit = "5242d83d9129a2701a01ff1de65eb6897eafec37",
+    commit = "c7e38ae7a338973098ab73d08f631c98c470b71c",
     remote = "https://github.com/smolkaj/p4c.git",
 )
 

--- a/e2e_tests/p4testgen/BUILD.bazel
+++ b/e2e_tests/p4testgen/BUILD.bazel
@@ -262,40 +262,18 @@ p4_testgen_test(
     src_p4 = "//e2e_tests/sai_p4:instantiations/google/middleblock.p4",
 )
 
-# PNA p4testgen tests. p4testgen's PNA model does not account for drop-by-default:
-# it expects packets forwarded even when send_to_port() is never called (parser
-# failure, non-matching etherType, etc.). Tests where all generated cases trigger
-# this mismatch are excluded. Programs that generate at least some valid forwarding
-# paths are included — the subset of cases that fail due to the drop-by-default
-# issue will show as test failures until p4testgen's PNA model is fixed upstream.
-p4_testgen_test(
-    name = "pna-dpdk-small_sample",
+p4_testgen_suite(
+    name = "pna_p4testgen_suite_test",
     arch = "pna",
-    max_tests = 10,
-    tags = ["manual"],
+    max_tests = {
+        "pna-direction": 20,
+        "pna-example-tunnel": 20,
+    },
     target = "dpdk",
-)
-
-p4_testgen_test(
-    name = "pna-direction",
-    arch = "pna",
-    max_tests = 10,
-    tags = ["manual"],
-    target = "dpdk",
-)
-
-p4_testgen_test(
-    name = "pna-example-SelectByDirection",
-    arch = "pna",
-    max_tests = 10,
-    tags = ["manual"],
-    target = "dpdk",
-)
-
-p4_testgen_test(
-    name = "pna-example-tunnel",
-    arch = "pna",
-    max_tests = 10,
-    tags = ["manual"],
-    target = "dpdk",
+    tests = [
+        "pna-direction",
+        "pna-dpdk-small_sample",
+        "pna-example-SelectByDirection",
+        "pna-example-tunnel",
+    ],
 )

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -6,6 +6,7 @@ import fourward.ir.PipelineStage
 import fourward.ir.TypeDecl
 import fourward.sim.SimulatorProto.PipelineStageEvent
 import fourward.sim.SimulatorProto.TraceTree
+import java.math.BigInteger
 
 /** Simplified parameter descriptor: just name and type. */
 internal data class BlockParam(val name: String, val typeName: String)
@@ -157,3 +158,84 @@ internal fun handleActionSelectorFork(
     branches,
   )
 }
+
+/**
+ * Handles extern methods shared across PSA and PNA: Register, Random, Counter, Hash, Meter,
+ * InternetChecksum, Digest, and Checksum.
+ *
+ * Returns the result [Value], or `null` if [call] is not a common extern method (the caller should
+ * handle it as architecture-specific).
+ */
+@Suppress("LongParameterList")
+internal fun handleCommonExternMethod(
+  call: ExternCall.Method,
+  eval: ExternEvaluator,
+  tableStore: TableStore,
+  externInstances: Map<String, ExternInstanceDecl>,
+  checksumState: MutableMap<String, BigInteger>,
+  hashAlgorithms: Map<String, String>,
+): Value? =
+  when (call.method) {
+    "read" ->
+      when (call.externType) {
+        "Register" -> {
+          val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
+          tableStore.registerRead(call.instanceName, index) ?: eval.defaultValue(eval.returnType())
+        }
+        "Random" -> {
+          val instance = externInstances[call.instanceName]
+          val lo = instance?.constructorArgsList?.getOrNull(0)?.literal?.integer ?: 0L
+          val hi = instance?.constructorArgsList?.getOrNull(1)?.literal?.integer ?: 0L
+          val value = if (hi > lo) kotlin.random.Random.nextLong(lo, hi + 1) else lo
+          BitVal(BitVector(BigInteger.valueOf(value), eval.returnType().bit.width))
+        }
+        else -> null
+      }
+    "write" -> {
+      val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
+      tableStore.registerWrite(call.instanceName, index, eval.evalArg(1))
+      UnitVal
+    }
+    "count" -> UnitVal
+    "get_hash" -> evalGetHash(call, eval, externInstances, hashAlgorithms)
+    "execute" -> EnumVal("GREEN")
+    "clear" -> {
+      checksumState[call.instanceName] = BigInteger.ZERO
+      UnitVal
+    }
+    "add" -> {
+      val data = eval.evalArg(0).asStructVal()
+      val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
+      checksumState[call.instanceName] = onesComplementAdd(sum, sumWords(data))
+      UnitVal
+    }
+    "subtract" -> {
+      // RFC 1624: subtract by adding the ones' complement of the data's word sum.
+      val data = eval.evalArg(0).asStructVal()
+      val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
+      val dataSumComplement = CSUM_MASK.subtract(sumWords(data))
+      checksumState[call.instanceName] = onesComplementAdd(sum, dataSumComplement)
+      UnitVal
+    }
+    "get" -> {
+      val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
+      BitVal(BitVector(CSUM_MASK.subtract(sum), CSUM_WORD_BITS))
+    }
+    "get_state" -> {
+      val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
+      BitVal(BitVector(sum, CSUM_WORD_BITS))
+    }
+    "set_state" -> {
+      checksumState[call.instanceName] = (eval.evalArg(0) as BitVal).bits.value
+      UnitVal
+    }
+    "pack" -> UnitVal
+    // PNA's Checksum<W> extern uses `update` (same semantics as InternetChecksum `add`).
+    "update" -> {
+      val data = eval.evalArg(0).asStructVal()
+      val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
+      checksumState[call.instanceName] = onesComplementAdd(sum, sumWords(data))
+      UnitVal
+    }
+    else -> null
+  }

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -319,90 +319,24 @@ class PNAArchitecture : Architecture {
     }
 
   /** Handles PNA extern method calls (Register, Hash, Counter, Meter, Checksum, Digest). */
-  @Suppress("LongMethod")
   private fun handlePnaMethod(
     call: ExternCall.Method,
     eval: ExternEvaluator,
     pipeline: PipelineConfig,
     checksumState: MutableMap<String, BigInteger>,
   ): Value =
-    when (call.method) {
-      // Register.read(index) returns T directly.
-      "read" ->
-        when (call.externType) {
-          "Register" -> {
-            val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
-            pipeline.tableStore.registerRead(call.instanceName, index)
-              ?: eval.defaultValue(eval.returnType())
-          }
-          // Random.read() — 0 args, returns a random value in [min, max].
-          "Random" -> {
-            val instance = pipeline.externInstances[call.instanceName]
-            val lo = instance?.constructorArgsList?.getOrNull(0)?.literal?.integer ?: 0L
-            val hi = instance?.constructorArgsList?.getOrNull(1)?.literal?.integer ?: 0L
-            val value = if (hi > lo) kotlin.random.Random.nextLong(lo, hi + 1) else lo
-            BitVal(BitVector(BigInteger.valueOf(value), eval.returnType().bit.width))
-          }
-          else -> error("unhandled PNA extern read: ${call.externType}.read")
-        }
-      "write" -> {
-        val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
-        pipeline.tableStore.registerWrite(call.instanceName, index, eval.evalArg(1))
-        UnitVal
-      }
-      "count" -> UnitVal
-      // Hash.get_hash: 1-arg or 3-arg form. Algorithm from constructor args.
-      "get_hash" -> evalGetHash(call, eval, pipeline.externInstances, PNA_HASH_ALGORITHMS)
-      // Meter.execute(index): returns PNA_MeterColor_t. Always GREEN — no real
-      // packet rates in simulator.
-      "execute" -> EnumVal("GREEN")
-      // --- InternetChecksum extern ---
-      "clear" -> {
-        checksumState[call.instanceName] = BigInteger.ZERO
-        UnitVal
-      }
-      "add" -> {
-        val data = eval.evalArg(0).asStructVal()
-        val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-        checksumState[call.instanceName] = onesComplementAdd(sum, sumWords(data))
-        UnitVal
-      }
-      "subtract" -> {
-        // RFC 1624: subtract by adding the ones' complement of the data's word sum.
-        val data = eval.evalArg(0).asStructVal()
-        val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-        val dataSumComplement = CSUM_MASK.subtract(sumWords(data))
-        checksumState[call.instanceName] = onesComplementAdd(sum, dataSumComplement)
-        UnitVal
-      }
-      "get" -> {
-        val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-        BitVal(BitVector(CSUM_MASK.subtract(sum), CSUM_WORD_BITS))
-      }
-      "get_state" -> {
-        val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-        BitVal(BitVector(sum, CSUM_WORD_BITS))
-      }
-      "set_state" -> {
-        checksumState[call.instanceName] = (eval.evalArg(0) as BitVal).bits.value
-        UnitVal
-      }
-      // Digest.pack() queues a digest message for the control plane. No-op in STF testing.
-      // TODO(PNA): implement digest delivery via P4Runtime StreamChannel.
-      "pack" -> UnitVal
-      // Checksum extern (PNA uses Checksum<W> in addition to InternetChecksum).
-      "update" -> {
-        val data = eval.evalArg(0).asStructVal()
-        val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-        checksumState[call.instanceName] = onesComplementAdd(sum, sumWords(data))
-        UnitVal
-      }
-      else ->
-        error(
-          "unhandled PNA extern method: ${call.externType}.${call.method}" +
-            " on ${call.instanceName}"
-        )
-    }
+    handleCommonExternMethod(
+      call,
+      eval,
+      pipeline.tableStore,
+      pipeline.externInstances,
+      checksumState,
+      PNA_HASH_ALGORITHMS,
+    )
+      ?: error(
+        "unhandled PNA extern method: ${call.externType}.${call.method}" +
+          " on ${call.instanceName}"
+      )
 
   // ---------------------------------------------------------------------------
   // Mirror branch construction

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -660,78 +660,18 @@ class PSAArchitecture : Architecture {
             else -> error("unhandled PSA extern: ${call.name}")
           }
         is ExternCall.Method ->
-          when (call.method) {
-            // Register.read(index) returns T directly (unlike v1model's void + out param).
-            "read" ->
-              when (call.externType) {
-                "Register" -> {
-                  val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
-                  pipeline.tableStore.registerRead(call.instanceName, index)
-                    ?: eval.defaultValue(eval.returnType())
-                }
-                // PSA Random.read() — 0 args, returns a random value in [min, max] (PSA spec §7.5).
-                "Random" -> {
-                  val instance = pipeline.externInstances[call.instanceName]
-                  val lo = instance?.constructorArgsList?.getOrNull(0)?.literal?.integer ?: 0L
-                  val hi = instance?.constructorArgsList?.getOrNull(1)?.literal?.integer ?: 0L
-                  val value = if (hi > lo) kotlin.random.Random.nextLong(lo, hi + 1) else lo
-                  BitVal(BitVector(BigInteger.valueOf(value), eval.returnType().bit.width))
-                }
-                else -> error("unhandled PSA extern read: ${call.externType}.read")
-              }
-            "write" -> {
-              val index = (eval.evalArg(0) as BitVal).bits.value.toInt()
-              pipeline.tableStore.registerWrite(call.instanceName, index, eval.evalArg(1))
-              UnitVal
-            }
-            "count" -> UnitVal
-            // PSA Hash.get_hash: 1-arg form returns hash(data), 3-arg form returns
-            // (base + hash(data)) mod max. Algorithm comes from constructor args.
-            "get_hash" -> evalGetHash(call, eval, pipeline.externInstances, PSA_HASH_ALGORITHMS)
-            // PSA Meter.execute(index): returns PSA_MeterColor_t. Always GREEN — no real
-            // packet rates in simulator (same as v1model).
-            "execute" -> EnumVal("GREEN")
-            // --- InternetChecksum extern (PSA spec §7.7) ---
-            "clear" -> {
-              checksumState[call.instanceName] = BigInteger.ZERO
-              UnitVal
-            }
-            "add" -> {
-              val data = eval.evalArg(0).asStructVal()
-              val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-              checksumState[call.instanceName] = onesComplementAdd(sum, sumWords(data))
-              UnitVal
-            }
-            "subtract" -> {
-              // RFC 1624: subtract by adding the ones' complement of the data's word sum.
-              val data = eval.evalArg(0).asStructVal()
-              val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-              val dataSumComplement = CSUM_MASK.subtract(sumWords(data))
-              checksumState[call.instanceName] = onesComplementAdd(sum, dataSumComplement)
-              UnitVal
-            }
-            "get" -> {
-              val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-              BitVal(BitVector(CSUM_MASK.subtract(sum), CSUM_WORD_BITS))
-            }
-            "get_state" -> {
-              val sum = checksumState.getOrDefault(call.instanceName, BigInteger.ZERO)
-              BitVal(BitVector(sum, CSUM_WORD_BITS))
-            }
-            "set_state" -> {
-              checksumState[call.instanceName] = (eval.evalArg(0) as BitVal).bits.value
-              UnitVal
-            }
-            // Digest.pack() queues a digest message for the control plane. No-op in STF
-            // testing since there's no control-plane receiver.
-            // TODO(PSA): implement digest delivery via P4Runtime StreamChannel.
-            "pack" -> UnitVal
-            else ->
-              error(
-                "unhandled PSA extern method: ${call.externType}.${call.method}" +
-                  " on ${call.instanceName}"
-              )
-          }
+          handleCommonExternMethod(
+            call,
+            eval,
+            pipeline.tableStore,
+            pipeline.externInstances,
+            checksumState,
+            PSA_HASH_ALGORITHMS,
+          )
+            ?: error(
+              "unhandled PSA extern method: ${call.externType}.${call.method}" +
+                " on ${call.instanceName}"
+            )
       }
     }
   }


### PR DESCRIPTION
## Summary

PNA at 110%: four improvements.

**1. Fix p4testgen drop-by-default (p4lang/p4c#5569)**
Updated the p4c fork to initialize `DROP=true` in p4testgen's PNA model, matching PNA spec semantics. All 33 p4testgen-generated tests now pass — promoted from `manual` to CI suite.

**2. Extract shared extern method handler (-66 net lines)**
`handleCommonExternMethod()` in `ArchitectureHelpers.kt` handles Register, Hash, Counter, Meter, InternetChecksum, Digest, and Random — the last significant duplication between PSA and PNA.

**3. p4testgen suite in CI**
4 PNA programs × Z3 symbolic execution, generating ~33 test cases with exhaustive path coverage.

**4. Fix flaky P4RuntimeConformanceTest**
Root-caused a race in test 90 ("write rejected after last controller disconnects"): `StreamSession.close()` returned before the server-side `handleDisconnect()` completed, so the subsequent write could succeed instead of getting `PERMISSION_DENIED`. Fixed by joining the stream collection job in `close()`.

## Test plan

- [x] 16/16 simulator unit tests pass
- [x] 33/33 p4testgen symbolic tests pass
- [x] P4RuntimeConformanceTest passes 5/5 runs (no flakes)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)