### PR TITLE
Add Track 11: error quality to roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -594,6 +594,48 @@ Deeper changes, only if Phase 2 doesn't reach the 1k pps target:
 - **Read-optimized concurrency** (read-heavy workload: many packets, rare
   table writes).
 
+### Track 11: error quality
+
+**Priority: next | Parallelizable: yes**
+
+Every error 4ward produces — whether from the simulator, the P4Runtime
+server, or the CLI — should be clear, actionable, and specific. Today,
+many errors surface as opaque gRPC `UNKNOWN` with no detail about what
+went wrong or how to fix it. A user hitting a table size limit,
+a malformed packet, or an unsupported feature should get a message that
+tells them exactly what happened and what to do about it.
+
+This isn't about P4Runtime spec compliance (Track 9 covers that). It's
+about the overall developer experience: when something goes wrong, the
+error message is the product.
+
+#### Phase 1: audit and classify
+
+Survey all error paths across the stack:
+- **Simulator**: `error()`, `require()`, `check()` calls in
+  `Interpreter.kt`, `TableStore.kt`, architecture implementations.
+- **gRPC server**: `StatusException` throws in `P4RuntimeService`,
+  `DataplaneService`. Which ones surface as `UNKNOWN` vs a proper
+  status code with detail?
+- **CLI**: error output from `4ward compile`, `4ward sim`, `4ward run`.
+
+For each error, classify: (1) already clear and actionable,
+(2) has the right info but poor formatting, (3) swallowed or opaque.
+
+#### Phase 2: fix the worst offenders
+
+Start with errors that users actually hit:
+- Simulator exceptions that surface as gRPC `UNKNOWN` — catch at the
+  service layer and translate to proper gRPC status codes with the
+  original message.
+- Table write failures — include the table name, the constraint that
+  was violated, and the entry that caused it.
+- Pipeline load failures — include the P4 program name and the
+  specific IR validation error.
+
+**Done when:** no error path produces a bare `UNKNOWN` or
+`INTERNAL` without an actionable message.
+
 ## Sequencing
 
 ```
@@ -620,6 +662,9 @@ Deeper changes, only if Phase 2 doesn't reach the 1k pps target:
               │                           │    │          │    │          │
   Track 10    │                           │    │ bench +  │    │ optimize │
               │                           │    │ profile  │    │          │
+              │                           │    │          │    │          │
+  Track 11    │                           │    │ error    │    │          │
+              │                           │    │ quality  │    │          │
               └───────────────────────────┘    └──────────┘    └──────────┘
 ```
 
@@ -635,3 +680,5 @@ Deeper changes, only if Phase 2 doesn't reach the 1k pps target:
   (adversarial testing) is next.
 - Track 10 (performance) has no blockers — SAI P4 already works E2E. Phase 1
   (benchmark + profile) informs all subsequent optimization work.
+- Track 11 (error quality) has no blockers. Complements Track 9 (P4Runtime
+  hardening) but covers the full stack, not just P4Runtime compliance.


### PR DESCRIPTION
## Summary

Adds **Track 11: error quality** — every error 4ward produces should be clear, actionable, and specific.

Motivated by the Track 10 benchmarking work, where table size limits and write failures surfaced as opaque gRPC `UNKNOWN` with no detail. The problem is broader than P4Runtime compliance (Track 9): simulator `error()`/`require()` exceptions propagate up as `UNKNOWN` because the gRPC service layer doesn't catch and translate them.

Two phases:
1. **Audit** all error paths (simulator, gRPC server, CLI) and classify as clear / poor format / opaque
2. **Fix** the worst offenders — no bare `UNKNOWN` or `INTERNAL` without an actionable message

## Test plan

- [ ] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)