### PR TITLE
Add cache correctness tests for selector fork optimizations

### DIFF
--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -17,7 +17,7 @@ exports_files([
 # unimplemented features are tagged "manual".
 # =============================================================================
 
-_P4_PROGRAMS = [
+_GOLDEN = [
     "no_fork",
     "action_selector_3",
     "action_selector_miss",
@@ -34,7 +34,15 @@ _P4_PROGRAMS = [
     "selector_exit",
 ]
 
-_PASSING = _P4_PROGRAMS
+# Programs without golden files — tested via STF expect directives only.
+_STF_ONLY = [
+    "selector_multi_packet",
+    "selector_post_fork_table",
+]
+
+_P4_PROGRAMS = _GOLDEN + _STF_ONLY
+
+_PASSING = _GOLDEN
 
 _MANUAL = []
 
@@ -79,8 +87,8 @@ kt_jvm_test(
 kt_jvm_test(
     name = "trace_tree_consistency_test",
     srcs = ["TraceTreeConsistencyTest.kt"],
-    data = ["%s.stf" % n for n in _PASSING] +
-           [":%s_pb" % n for n in _PASSING],
+    data = ["%s.stf" % n for n in _P4_PROGRAMS] +
+           [":%s_pb" % n for n in _P4_PROGRAMS],
     test_class = "fourward.e2e.tracetree.TraceTreeConsistencyTest",
     deps = _TEST_DEPS,
 )

--- a/e2e_tests/trace_tree/selector_multi_packet.p4
+++ b/e2e_tests/trace_tree/selector_multi_packet.p4
@@ -1,0 +1,62 @@
+/* selector_multi_packet.p4 — two packets through the same selector pipeline.
+ *
+ * Tests that selector fork caches (table lookups, parser snapshots) are
+ * correctly invalidated between packets.  Packet 1 matches table entry A
+ * (dstAddr=0x01...01), packet 2 matches table entry B (dstAddr=0x02...02).
+ * Each has a different ECMP group pointing to different ports.  If caches
+ * leaked across packets, packet 2 would incorrectly use packet 1's results.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    action set_port(bit<9> port) { smeta.egress_spec = port; }
+    action drop() { mark_to_drop(smeta); }
+
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) ecmp;
+
+    table routing {
+        key = {
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { set_port; drop; }
+        implementation = ecmp;
+        default_action = drop();
+    }
+
+    apply { routing.apply(); }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/selector_multi_packet.stf
+++ b/e2e_tests/trace_tree/selector_multi_packet.stf
@@ -1,0 +1,25 @@
+# selector_multi_packet.stf — two packets through different ECMP groups.
+# Tests that fork caches are correctly invalidated between packets.
+
+# Group 1: members point to ports 1, 2
+member ecmp 0 set_port port=0x0001
+member ecmp 1 set_port port=0x0002
+group ecmp 1 0 1
+
+# Group 2: members point to ports 3, 4
+member ecmp 2 set_port port=0x0003
+member ecmp 3 set_port port=0x0004
+group ecmp 2 2 3
+
+add routing hdr.ethernet.dstAddr:0x010101010101 group=1
+add routing hdr.ethernet.dstAddr:0x020202020202 group=2
+
+# Packet 1: dst=01:01:01:01:01:01 → group 1 → ports 1, 2
+packet 0 010101010101 AABBCCDDEEFF 0800
+expect 1 010101010101 AABBCCDDEEFF 0800
+expect 2 010101010101 AABBCCDDEEFF 0800
+
+# Packet 2: dst=02:02:02:02:02:02 → group 2 → ports 3, 4
+packet 0 020202020202 AABBCCDDEEFF 0800
+expect 3 020202020202 AABBCCDDEEFF 0800
+expect 4 020202020202 AABBCCDDEEFF 0800

--- a/e2e_tests/trace_tree/selector_post_fork_table.p4
+++ b/e2e_tests/trace_tree/selector_post_fork_table.p4
@@ -1,0 +1,79 @@
+/* selector_post_fork_table.p4 — selector fork followed by a dependent table.
+ *
+ * Tests that the table lookup cache is correctly invalidated after a selector
+ * fork. The selector sets meta.tag to different values per member, and a
+ * post-fork table matches on meta.tag.  If the cache were incorrectly
+ * applied to the post-fork table, all branches would see the same result.
+ *
+ * Expected trace tree:
+ *   fork(selector, 2 members) {
+ *     member_0: tag=1 → port=1 (post_table hit)
+ *     member_1: tag=2 → port=2 (post_table hit)
+ *   }
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t { bit<8> tag; }
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    action set_tag(bit<8> tag) { meta.tag = tag; }
+    action set_port(bit<9> port) { smeta.egress_spec = port; }
+    action drop() { mark_to_drop(smeta); }
+
+    action_selector(HashAlgorithm.crc16, 32w1024, 32w14) my_selector;
+
+    // Selector table: each member sets a different tag.
+    table selector_table {
+        key = {
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : selector;
+        }
+        actions = { set_tag; drop; }
+        implementation = my_selector;
+        default_action = drop();
+    }
+
+    // Post-fork table: matches on meta.tag (which differs per selector member).
+    table post_table {
+        key = { meta.tag : exact; }
+        actions = { set_port; drop; }
+        default_action = drop();
+    }
+
+    apply {
+        selector_table.apply();
+        post_table.apply();
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/selector_post_fork_table.stf
+++ b/e2e_tests/trace_tree/selector_post_fork_table.stf
@@ -1,0 +1,17 @@
+# selector_post_fork_table.stf — selector members set different tags,
+# post-fork table routes based on tag. Tests cache invalidation.
+
+member my_selector 0 set_tag tag=0x01
+member my_selector 1 set_tag tag=0x02
+group my_selector 1 0 1
+add selector_table hdr.ethernet.dstAddr:0xFFFFFFFFFFFF group=1
+
+# Post-fork table: tag=1 → port 1, tag=2 → port 2.
+add post_table meta.tag:0x01 set_port(1)
+add post_table meta.tag:0x02 set_port(2)
+
+packet 0 FFFFFFFFFFFF 000000000001 0800
+# Member 0: tag=1 → post_table hit → port 1
+expect 1 FFFFFFFFFFFF 000000000001 0800
+# Member 1: tag=2 → post_table hit → port 2
+expect 2 FFFFFFFFFFFF 000000000001 0800


### PR DESCRIPTION
## Summary

Two new P4 test programs that specifically exercise the cache invalidation boundaries introduced by the table lookup cache (PR #382) and parser snapshot (PR #390):

1. **`selector_post_fork_table`** — Selector members set different `meta.tag` values. A post-fork table matches on `meta.tag`, producing different output ports per branch. If the table lookup cache incorrectly served cached results past the fork point, all branches would exit on the same port.

2. **`selector_multi_packet`** — Two packets with different destinations through the same pipeline, each hitting a different ECMP group with different member ports. If caches (table lookups or parser snapshots) leaked across packets, the second packet would incorrectly use the first packet's results.

Both tests use STF `expect` directives to verify exact output packets per port, and run as part of the `trace_tree_consistency_test` (which validates that output packets match trace tree leaves).

## Test plan

- [x] `bazel test //e2e_tests/trace_tree/...` — 16 consistency tests pass (14 existing + 2 new), 14 golden tests pass
- [x] `bazel test //...` — all 58 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)