### PR TITLE
Add issue templates and enable GitHub Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Ideally, provide a minimal P4 program and STF test (or CLI/gRPC
+        commands) that trigger the issue.
+      placeholder: |
+        1. Compile `example.p4` with `4ward compile example.p4`
+        2. Run `4ward sim ...`
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: >
+        Output of `4ward --version`, or the commit SHA you're building from.
+    validations:
+      required: false
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: P4 architecture
+      options:
+        - v1model
+        - PNA
+        - Other / N/A
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/smolkaj/4ward/discussions/categories/q-a
+    about: Ask questions and get help in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like?
+      description: A clear description of the feature or improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why?
+      description: >
+        What problem does this solve? What use case does it enable?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >
+        Any workarounds or alternative approaches you've thought about.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Gives the project proper community infrastructure so people know how to engage:

- **Bug report template** — structured form with reproduction steps, P4 architecture selector, and version field.
- **Feature request template** — motivation-first structure.
- **Questions redirect to Discussions** — blank issues disabled; questions route to the new Q&A discussion category.
- **GitHub Discussions enabled** on the repo.

## Test plan

- [ ] Visit https://github.com/smolkaj/4ward/issues/new/choose and verify the three options appear.
- [ ] Verify blank issues are disabled.
- [ ] Verify the "Question" link points to Discussions Q&A.
- [ ] Visit https://github.com/smolkaj/4ward/discussions and verify it's live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)