### PR TITLE
Make Interpreter long-lived with lightweight Execution inner class

### DIFF
--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -90,7 +90,7 @@ internal fun bindStageParams(
 
 /** Runs a parser stage, recording trace events and routing parser errors to [onParserError]. */
 internal fun runParserStage(
-  interpreter: Interpreter,
+  interpreter: Interpreter.Execution,
   ctx: PacketContext,
   env: Environment,
   stage: PipelineStage,
@@ -108,7 +108,7 @@ internal fun runParserStage(
 
 /** Runs a control stage, recording trace events. An `exit` statement terminates only the stage. */
 internal fun runControlStage(
-  interpreter: Interpreter,
+  interpreter: Interpreter.Execution,
   ctx: PacketContext,
   env: Environment,
   stage: PipelineStage,

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -25,9 +25,11 @@ import fourward.sim.SimulatorProto.TraceEvent
 import java.math.BigInteger
 
 /**
- * The core P4 interpreter.
+ * Long-lived P4 interpreter engine, built once per pipeline config.
  *
- * Walks the proto IR tree for a single packet traversal. Variable scopes live in [Environment];
+ * Holds config-derived maps (parsers, controls, actions, tables, types) that never change between
+ * packets. Call [execution] for each pipeline run — the [Execution] inner class walks the IR tree
+ * and is cheap to construct (just field assignments). Variable scopes live in [Environment];
  * packet-level state (input buffer, output buffer, trace) lives in [PacketContext]; program-global
  * state (table entries, extern instances) lives in [TableStore].
  *
@@ -35,22 +37,7 @@ import java.math.BigInteger
  * to focused methods. There is no bytecode compilation or optimisation — correctness and
  * readability are the goals.
  */
-class Interpreter(
-  private val config: BehavioralConfig,
-  private val tableStore: TableStore,
-  private val packetCtx: PacketContext? = null,
-  private val selectorOverrides: Map<String, Int> = emptyMap(),
-  private val externHandler: ExternHandler? = null,
-  /**
-   * Cached table lookup results from a prior execution, keyed by table name. When non-null, table
-   * lookups use the cache instead of scanning [tableStore] — avoiding O(n) scans for tables whose
-   * key values haven't changed since the cache was populated (i.e., tables before a fork point).
-   *
-   * The cache is disabled once a table from [selectorOverrides] is hit, since tables after the fork
-   * point may produce different key values due to different selector member actions.
-   */
-  private val tableLookupCache: Map<String, TableStore.LookupResult>? = null,
-) {
+class Interpreter internal constructor(config: BehavioralConfig) {
   private val parsers: Map<String, ParserDecl> = config.parsersList.associateBy { it.name }
 
   private val controls: Map<String, ControlDecl> = config.controlsList.associateBy { it.name }
@@ -77,1190 +64,1254 @@ class Interpreter(
 
   private val tables: Map<String, TableBehavior> = config.tablesList.associateBy { it.name }
 
-  /** Non-null packet context; throws a clear error if packet I/O is attempted without one. */
-  private val packet: PacketContext
-    get() = packetCtx ?: error("packet I/O requires a PacketContext")
-
-  private val types = config.typesList.associateBy { it.name }
-
-  /** Table lookup results recorded during this execution, for caching in fork re-executions. */
-  private val recordedLookups = mutableMapOf<String, TableStore.LookupResult>()
-
-  /** Set to true once a [selectorOverrides] table is hit, disabling the [tableLookupCache]. */
-  private var pastForkPoint = false
-
-  /** Context from the most recent table miss, for PNA's `add_entry` extern. */
-  private var lastTableMissCtx: TableMissContext? = null
-
-  /** Source info of the statement currently being executed, for trace events. */
-  private var currentSourceInfo: SourceInfo? = null
-
-  /** Name of the control block currently being executed, for BranchEvent. */
-  private var currentControlName: String? = null
-
-  /** Builds a TraceEvent with source info attached, if available. */
-  private fun traceEventBuilder(sourceInfo: SourceInfo? = currentSourceInfo): TraceEvent.Builder {
-    val b = TraceEvent.newBuilder()
-    sourceInfo?.let { b.sourceInfo = it }
-    return b
-  }
-
-  // -------------------------------------------------------------------------
-  // Parser
-  // -------------------------------------------------------------------------
-
-  fun runParser(parserName: String, env: Environment) {
-    val parser = parsers[parserName] ?: error("unknown parser: $parserName")
-    withLocalScope(parser.localVarsList, env) { runParserState(parser, "start", env) }
-  }
-
-  private fun runParserState(parser: ParserDecl, startState: String, env: Environment) {
-    // Index states by name for O(1) lookup during traversal.
-    val statesByName = parser.statesList.associateBy { it.name }
-
-    var stateName = startState
-    while (stateName != "accept" && stateName != "reject") {
-      val state =
-        statesByName[stateName] ?: error("unknown parser state: $stateName in ${parser.name}")
-
-      for (stmt in state.stmtsList) execStmt(stmt, env)
-
-      val (nextState, selectValue, selectExpr) =
-        when {
-          state.transition.hasSelect() -> evalSelectWithValue(state.transition.select, env)
-          else -> Triple(state.transition.nextState, "", "")
-        }
-
-      packetCtx?.addTraceEvent(
-        traceEventBuilder(if (state.hasSourceInfo()) state.sourceInfo else null)
-          .setParserTransition(
-            ParserTransitionEvent.newBuilder()
-              .setParserName(parser.name)
-              .setFromState(stateName)
-              .setToState(nextState)
-              .also {
-                if (selectValue.isNotEmpty()) it.setSelectValue(selectValue)
-                if (selectExpr.isNotEmpty()) it.setSelectExpression(selectExpr)
-              }
-          )
-          .build()
-      )
-
-      stateName = nextState
-    }
-  }
-
-  /** Evaluates a select expression, returning (nextState, formattedValue, formattedExpression). */
-  private fun evalSelectWithValue(
-    select: fourward.ir.SelectTransition,
-    env: Environment,
-  ): Triple<String, String, String> {
-    val keyValues = select.keysList.map { evalExpr(it, env) }
-    val formatted =
-      keyValues.joinToString(", ") {
-        when (it) {
-          is BitVal -> "0x${it.bits.value.toString(16).uppercase()}"
-          is IntVal -> "0x${it.bits.value.toString(16).uppercase()}"
-          is BoolVal -> it.value.toString()
-          else -> it.toString()
-        }
-      }
-    val expression = select.keysList.joinToString(", ") { formatExpr(it) }
-    // Keyset expressions in parser select are always compile-time constants; a single
-    // empty environment is correct for all of them.
-    val constEnv = Environment()
-    for (case in select.casesList) {
-      // P4 spec §12.14: a value_set replaces the entire keyset tuple for a case —
-      // it cannot be mixed with non-value_set keysets. Checking only the first keyset
-      // is sufficient to distinguish value_set cases from normal keyset cases.
-      val firstKeyset = case.keysetsList.firstOrNull()
-      if (firstKeyset != null && firstKeyset.hasValueSet()) {
-        val members = tableStore.getValueSetMembers(firstKeyset.valueSet)
-        if (members.any { member -> matchesValueSetMember(keyValues, member) }) {
-          return Triple(case.nextState, formatted, expression)
-        }
-      } else if (keyValues.zip(case.keysetsList).all { (v, k) -> matchesKeyset(v, k, constEnv) }) {
-        return Triple(case.nextState, formatted, expression)
-      }
-    }
-    // P4 spec §12.6: if no case matches and there is no default, reject.
-    return Triple(select.defaultState.ifEmpty { "reject" }, formatted, expression)
-  }
-
-  /** Human-readable rendering of an IR expression (best-effort, for trace display). */
-  private fun formatExpr(expr: fourward.ir.Expr): String =
-    when {
-      expr.hasNameRef() -> expr.nameRef.name
-      expr.hasFieldAccess() -> "${formatExpr(expr.fieldAccess.expr)}.${expr.fieldAccess.fieldName}"
-      expr.hasArrayIndex() ->
-        "${formatExpr(expr.arrayIndex.expr)}[${formatExpr(expr.arrayIndex.index)}]"
-      expr.hasSlice() -> "${formatExpr(expr.slice.expr)}[${expr.slice.hi}:${expr.slice.lo}]"
-      expr.hasLiteral() -> {
-        val lit = expr.literal
-        when {
-          lit.hasInteger() -> "0x${lit.integer.toString(16).uppercase()}"
-          lit.hasBoolean() -> lit.boolean.toString()
-          else -> lit.toString().trim()
-        }
-      }
-      else -> "?"
-    }
-
-  private fun matchesKeyset(
-    value: Value,
-    keyset: fourward.ir.KeysetExpr,
-    constEnv: Environment,
-  ): Boolean =
-    when {
-      keyset.hasDefaultCase() -> true
-      keyset.hasExact() -> value == evalExpr(keyset.exact, constEnv)
-      keyset.hasMask() -> {
-        val v = (value as BitVal).bits
-        val mask = (evalExpr(keyset.mask.mask, constEnv) as BitVal).bits
-        val want = (evalExpr(keyset.mask.value, constEnv) as BitVal).bits
-        (v and mask) == (want and mask)
-      }
-      keyset.hasRange() -> {
-        val v = (value as BitVal).bits
-        val lo = (evalExpr(keyset.range.lo, constEnv) as BitVal).bits
-        val hi = (evalExpr(keyset.range.hi, constEnv) as BitVal).bits
-        v >= lo && v <= hi
-      }
-      else -> error("unhandled keyset kind: $keyset")
-    }
-
-  /**
-   * Matches a list of select key values against a single [ValueSetMember]'s field matches.
-   *
-   * Each member has one [FieldMatch] per key, in the same order as the select keys. An unset
-   * FieldMatch acts as a wildcard (matches any value).
-   */
-  private fun matchesValueSetMember(
-    keyValues: List<Value>,
-    member: p4.v1.P4RuntimeOuterClass.ValueSetMember,
-  ): Boolean {
-    if (member.matchCount != keyValues.size) return false
-    return keyValues.zip(member.matchList).all { (value, fieldMatch) ->
-      matchFieldMatch(value, fieldMatch)
-    }
-  }
-
-  /** Matches a single runtime value against a P4Runtime [FieldMatch]. */
-  private fun matchFieldMatch(
-    value: Value,
-    fieldMatch: p4.v1.P4RuntimeOuterClass.FieldMatch,
-  ): Boolean {
-    val bits =
-      when (value) {
-        is BitVal -> value.bits
-        is BoolVal -> if (value.value) BOOL_TRUE_BITS else BOOL_FALSE_BITS
-        else -> return false
-      }
-    return matchesFieldMatch(bits, fieldMatch)
-  }
-
-  // -------------------------------------------------------------------------
-  // Control
-  // -------------------------------------------------------------------------
-
-  fun runControl(controlName: String, env: Environment) {
-    val control = controls[controlName] ?: error("unknown control: $controlName")
-    currentControlName = controlName
-    withLocalScope(control.localVarsList, env) { execBlock(control.applyBodyList, env) }
-  }
-
-  /** Pushes a scope, defines [localVars], runs [body], then pops the scope. */
-  private inline fun withLocalScope(
-    localVars: List<fourward.ir.VarDecl>,
-    env: Environment,
-    body: () -> Unit,
-  ) {
-    env.pushScope()
-    try {
-      for (varDecl in localVars) {
-        val init =
-          if (varDecl.hasInitializer()) evalExpr(varDecl.initializer, env)
-          else defaultValue(varDecl.type, types)
-        env.define(varDecl.name, init)
-      }
-      body()
-    } finally {
-      env.popScope()
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Statements
-  // -------------------------------------------------------------------------
-
-  private fun execBlock(stmts: List<Stmt>, env: Environment) {
-    for (stmt in stmts) execStmt(stmt, env)
-  }
-
-  private fun execStmt(stmt: Stmt, env: Environment) {
-    if (stmt.hasSourceInfo()) currentSourceInfo = stmt.sourceInfo else currentSourceInfo = null
-    when {
-      stmt.hasAssignment() ->
-        setLValue(stmt.assignment.lhs, evalExpr(stmt.assignment.rhs, env), env)
-      stmt.hasMethodCall() -> evalExpr(stmt.methodCall.call, env) // result discarded
-      stmt.hasIfStmt() -> execIf(stmt.ifStmt, env)
-      stmt.hasSwitchStmt() -> execSwitch(stmt.switchStmt, env)
-      stmt.hasBlock() -> execBlock(stmt.block.stmtsList, env)
-      stmt.hasExit() -> throw ExitException()
-      stmt.hasReturnStmt() -> throw ReturnException(evalExpr(stmt.returnStmt.value, env))
-      else -> error("unhandled statement kind: $stmt")
-    }
-  }
-
-  private fun execIf(ifStmt: fourward.ir.IfStmt, env: Environment) {
-    val condition = (evalExpr(ifStmt.condition, env) as BoolVal).value
-
-    packetCtx?.addTraceEvent(
-      traceEventBuilder()
-        .setBranch(
-          BranchEvent.newBuilder().setControlName(currentControlName ?: "").setTaken(condition)
-        )
-        .build()
-    )
-
-    if (condition) {
-      execBlock(ifStmt.thenBlock.stmtsList, env)
-    } else {
-      execBlock(ifStmt.elseBlock.stmtsList, env)
-    }
-  }
-
-  private fun execSwitch(switchStmt: fourward.ir.SwitchStmt, env: Environment) {
-    val tableResult = applyTable(switchStmt.subject.tableApply.tableName, env)
-    val matchedCase = switchStmt.casesList.find { it.actionName == tableResult.actionName }
-    if (matchedCase != null) {
-      execBlock(matchedCase.block.stmtsList, env)
-    } else {
-      execBlock(switchStmt.defaultBlock.stmtsList, env)
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Expressions
-  // -------------------------------------------------------------------------
-
-  fun evalExpr(expr: Expr, env: Environment): Value =
-    when {
-      expr.hasLiteral() -> evalLiteral(expr.literal, expr.type)
-      expr.hasNameRef() ->
-        env.lookup(expr.nameRef.name) ?: error("undefined variable: ${expr.nameRef.name}")
-      expr.hasFieldAccess() -> evalFieldAccess(expr.fieldAccess, env)
-      expr.hasArrayIndex() -> evalArrayIndex(expr.arrayIndex, env)
-      expr.hasSlice() -> evalSlice(expr.slice, env)
-      expr.hasConcat() -> evalConcat(expr.concat, env)
-      expr.hasCast() -> evalCast(expr.cast, env)
-      expr.hasBinaryOp() -> evalBinaryOp(expr.binaryOp, env)
-      expr.hasUnaryOp() -> evalUnaryOp(expr.unaryOp, env)
-      expr.hasMethodCall() -> evalMethodCall(expr.methodCall, expr.type, env)
-      expr.hasMux() -> evalMux(expr.mux, env)
-      expr.hasStructExpr() -> evalStructExpr(expr.structExpr, expr.type, env)
-      expr.hasTableApply() -> {
-        val result = applyTable(expr.tableApply.tableName, env)
-        when (expr.tableApply.accessKind) {
-          TableApplyExpr.AccessKind.HIT -> BoolVal(result.hit)
-          TableApplyExpr.AccessKind.MISS -> BoolVal(!result.hit)
-          else -> UnitVal // RESULT / default: switch context
-        }
-      }
-      else -> error("unhandled expression kind: $expr")
-    }
-
-  private fun evalLiteral(lit: Literal, type: fourward.ir.Type): Value =
-    when {
-      lit.hasBoolean() -> BoolVal(lit.boolean)
-      lit.hasErrorMember() -> ErrorVal(lit.errorMember)
-      lit.hasEnumMember() -> EnumVal(lit.enumMember)
-      lit.hasStringLiteral() -> StringVal(lit.stringLiteral)
-      lit.hasInteger() -> {
-        val v = BigInteger.valueOf(lit.integer.toLong())
-        when {
-          type.hasBit() -> BitVal(BitVector(v, type.bit.width))
-          type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
-          else -> InfIntVal(v) // compile-time constant integer (P4 spec §8.1)
-        }
-      }
-      lit.hasBigInteger() -> {
-        val v = BigInteger(1, lit.bigInteger.toByteArray())
-        when {
-          type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
-          type.hasBit() -> BitVal(BitVector(v, type.bit.width))
-          else -> error("big integer literal with unexpected type: $type")
-        }
-      }
-      else -> error("unhandled literal kind: $lit")
-    }
-
-  private fun evalFieldAccess(fa: fourward.ir.FieldAccess, env: Environment): Value {
-    // Special case: table.apply().hit / .miss — the p4c midend may restructure
-    // the apply call such that the backend emits FieldAccess{TableApplyExpr, "hit"}
-    // rather than TableApplyExpr{access_kind=HIT}.
-    if (fa.expr.hasTableApply()) {
-      val result = applyTable(fa.expr.tableApply.tableName, env)
-      return when (fa.fieldName) {
-        "hit" -> BoolVal(result.hit)
-        "miss" -> BoolVal(!result.hit)
-        else -> error("unknown field '${fa.fieldName}' on table apply result")
-      }
-    }
-    val target = evalExpr(fa.expr, env)
-    return when (target) {
-      is HeaderVal ->
-        target.fields[fa.fieldName]
-          ?: error("field ${fa.fieldName} not found in header ${target.typeName}")
-      is StructVal ->
-        target.fields[fa.fieldName]
-          ?: error("field ${fa.fieldName} not found in struct ${target.typeName}")
-      is HeaderStackVal -> evalHeaderStackProperty(target, fa.fieldName)
-      else -> error("field access on non-aggregate value: $target")
-    }
-  }
-
-  /** P4 spec §8.18: header stack built-in properties. */
-  private fun evalHeaderStackProperty(stack: HeaderStackVal, name: String): Value =
-    when (name) {
-      // P4 spec §8.18: accessing .next when the stack is full is an error that
-      // transitions the parser to the reject state with error.StackOutOfBounds.
-      "next" -> {
-        if (stack.nextIndex >= stack.headers.size) {
-          throw ParserErrorException(
-            "StackOutOfBounds",
-            "header stack overflow: nextIndex=${stack.nextIndex}, size=${stack.headers.size}",
-          )
-        }
-        stack.headers[stack.nextIndex].also { stack.nextIndex++ }
-      }
-      "last" -> stack.headers[(stack.nextIndex - 1).coerceAtLeast(0)]
-      "lastIndex" -> BitVal(stack.headers.size.toLong() - 1, STACK_PROPERTY_BITS)
-      "size" -> BitVal(stack.headers.size.toLong(), STACK_PROPERTY_BITS)
-      else -> error("unknown header stack property: $name")
-    }
-
-  // P4 spec §8.18: out-of-bounds reads return an invalid header with default values.
-  private fun evalArrayIndex(ai: fourward.ir.ArrayIndex, env: Environment): Value {
-    val stack = evalExpr(ai.expr, env) as? HeaderStackVal ?: error("array index on non-stack value")
-    val index = intValue(evalExpr(ai.index, env))
-    if (index !in 0 until stack.size) return defaultValue(stack.elementTypeName, types)
-    return stack.headers[index]
-  }
-
-  private fun evalSlice(slice: fourward.ir.Slice, env: Environment): Value {
-    val bits = (evalExpr(slice.expr, env) as BitVal).bits
-    return BitVal(bits.slice(slice.hi, slice.lo))
-  }
-
-  private fun evalConcat(concat: fourward.ir.Concat, env: Environment): Value {
-    val left = (evalExpr(concat.left, env) as BitVal).bits
-    val right = (evalExpr(concat.right, env) as BitVal).bits
-    return BitVal(left.concat(right))
-  }
-
-  private fun evalCast(cast: fourward.ir.Cast, env: Environment): Value {
-    val inner = evalExpr(cast.expr, env)
-    return when {
-      cast.targetType.hasBit() -> {
-        val targetWidth = cast.targetType.bit.width
-        val sourceBits =
-          when (inner) {
-            is BitVal -> inner.bits.value
-            is InfIntVal -> inner.value
-            is IntVal -> inner.bits.toUnsigned().value
-            is BoolVal -> if (inner.value) BigInteger.ONE else BigInteger.ZERO
-            else -> error("cannot cast $inner to bit<$targetWidth>")
-          }
-        BitVal(BitVector(sourceBits.mod(BigInteger.TWO.pow(targetWidth)), targetWidth))
-      }
-      cast.targetType.hasSignedInt() -> {
-        val targetWidth = cast.targetType.signedInt.width
-        when (inner) {
-          // int<N> → int<M>: preserve the signed value (sign-extends or truncates).
-          // int<N> → int<M>: sign-extend if widening, truncate if narrowing.
-          is IntVal ->
-            if (targetWidth >= inner.bits.width) {
-              IntVal(SignedBitVector(inner.bits.value, targetWidth))
-            } else {
-              IntVal(
-                SignedBitVector.fromUnsignedBits(
-                  inner.bits.value.mod(java.math.BigInteger.TWO.pow(targetWidth)),
-                  targetWidth,
-                )
-              )
-            }
-          else -> {
-            val sourceBits =
-              when (inner) {
-                is BitVal -> inner.bits.value
-                is InfIntVal -> inner.value
-                else -> error("cannot cast $inner to int<$targetWidth>")
-              }
-            IntVal(SignedBitVector.fromUnsignedBits(sourceBits, targetWidth))
-          }
-        }
-      }
-      cast.targetType.boolean -> {
-        val v =
-          when (inner) {
-            is BitVal -> inner.bits.value
-            is InfIntVal -> inner.value
-            else -> error("cannot cast $inner to bool")
-          }
-        BoolVal(v != BigInteger.ZERO)
-      }
-      else -> error("unsupported cast target type: ${cast.targetType}")
-    }
-  }
-
-  @Suppress("CyclomaticComplexMethod")
-  private fun evalBinaryOp(op: fourward.ir.BinaryOp, env: Environment): Value {
-    // P4 spec §8.1: compile-time integers adopt the width of the other operand.
-    val (left, right) = coerceInfInts(evalExpr(op.left, env), evalExpr(op.right, env))
-
-    // P4 spec §8.5: shift amount is always unsigned, so left may be IntVal while right is BitVal.
-    // SHR on int<N> is arithmetic (sign-extending); SHL is logical.
-    if (left is IntVal && (op.op == BinaryOperator.SHL || op.op == BinaryOperator.SHR)) {
-      val amount = intValue(right)
-      return if (op.op == BinaryOperator.SHL) {
-        IntVal(left.bits.toUnsigned().shl(amount).toSigned())
-      } else {
-        // Arithmetic right shift: shift the signed value, then re-wrap.
-        val shifted = left.bits.value.shiftRight(amount)
-        IntVal(SignedBitVector(shifted, left.bits.width))
-      }
-    }
-
-    return when (op.op) {
-      // Arithmetic and bitwise ops work on unsigned bits; liftBitwise rewraps as
-      // the original signedness (BitVal or IntVal).
-      BinaryOperator.ADD -> liftBitwise(left, right) { a, b -> a + b }
-      BinaryOperator.SUB -> liftBitwise(left, right) { a, b -> a - b }
-      BinaryOperator.MUL -> liftBitwise(left, right) { a, b -> a * b }
-      BinaryOperator.BIT_AND -> liftBitwise(left, right) { a, b -> a and b }
-      BinaryOperator.BIT_OR -> liftBitwise(left, right) { a, b -> a or b }
-      BinaryOperator.BIT_XOR -> liftBitwise(left, right) { a, b -> a xor b }
-      // bit<N>-only: division/modulo are unsigned-only in P4.
-      BinaryOperator.DIV -> BitVal((left as BitVal).bits / (right as BitVal).bits)
-      BinaryOperator.MOD -> BitVal((left as BitVal).bits % (right as BitVal).bits)
-      // Saturating ops can't use liftBitwise: signed/unsigned have different clamp bounds.
-      BinaryOperator.ADD_SAT ->
-        when (left) {
-          is BitVal -> BitVal(left.bits.addSat((right as BitVal).bits))
-          is IntVal -> IntVal(left.bits.addSat((right as IntVal).bits))
-          else -> error("ADD_SAT on non-fixed-width: $left")
-        }
-      BinaryOperator.SUB_SAT ->
-        when (left) {
-          is BitVal -> BitVal(left.bits.subSat((right as BitVal).bits))
-          is IntVal -> IntVal(left.bits.subSat((right as IntVal).bits))
-          else -> error("SUB_SAT on non-fixed-width: $left")
-        }
-      BinaryOperator.SHL -> BitVal((left as BitVal).bits.shl(intValue(right)))
-      BinaryOperator.SHR -> BitVal((left as BitVal).bits.shr(intValue(right)))
-      // Equality uses data-class structural equality (works for both bit<N> and int<N>).
-      BinaryOperator.EQ -> BoolVal(left == right)
-      BinaryOperator.NEQ -> BoolVal(left != right)
-      // P4 spec §8.5: relational operators use signed comparison for int<N>.
-      BinaryOperator.LT -> liftCompare(left, right) { it < 0 }
-      BinaryOperator.GT -> liftCompare(left, right) { it > 0 }
-      BinaryOperator.LE -> liftCompare(left, right) { it <= 0 }
-      BinaryOperator.GE -> liftCompare(left, right) { it >= 0 }
-      BinaryOperator.AND -> BoolVal((left as BoolVal).value && (right as BoolVal).value)
-      BinaryOperator.OR -> BoolVal((left as BoolVal).value || (right as BoolVal).value)
-      else -> error("unhandled binary operator: ${op.op}")
-    }
-  }
-
-  /** Apply a [BitVector] operation to two fixed-width values, preserving signedness. */
-  private inline fun liftBitwise(
-    left: Value,
-    right: Value,
-    f: (BitVector, BitVector) -> BitVector,
-  ): Value =
-    when (left) {
-      is BitVal -> BitVal(f(left.bits, (right as BitVal).bits))
-      is IntVal -> IntVal(f(left.bits.toUnsigned(), (right as IntVal).bits.toUnsigned()).toSigned())
-      else -> error("expected fixed-width integer operands, got: $left, $right")
-    }
-
-  /** Compare two fixed-width values, dispatching to signed or unsigned comparison. */
-  private inline fun liftCompare(left: Value, right: Value, pred: (Int) -> Boolean): BoolVal =
-    when (left) {
-      is BitVal -> BoolVal(pred(left.bits.compareTo((right as BitVal).bits)))
-      is IntVal -> BoolVal(pred(left.bits.value.compareTo((right as IntVal).bits.value)))
-      else -> error("expected fixed-width integer operands for comparison")
-    }
-
-  /** Extract a small integer from a [BitVal], [IntVal], or [InfIntVal]. */
-  private fun intValue(v: Value): Int =
-    when (v) {
-      is BitVal -> v.bits.value.toInt()
-      is IntVal -> v.bits.value.toInt()
-      is InfIntVal -> v.value.toInt()
-      else -> error("expected integer value: $v")
-    }
-
-  /** P4 spec §8.1: InfInt adopts the width of the fixed-width operand. */
-  private fun coerceInfInts(left: Value, right: Value): Pair<Value, Value> =
-    when {
-      left is InfIntVal && right is BitVal -> left.toBitVal(right.bits.width) to right
-      right is InfIntVal && left is BitVal -> left to right.toBitVal(left.bits.width)
-      left is InfIntVal && right is IntVal -> left.toIntVal(right.bits.width) to right
-      right is InfIntVal && left is IntVal -> left to right.toIntVal(left.bits.width)
-      else -> left to right
-    }
-
-  private fun evalUnaryOp(op: fourward.ir.UnaryOp, env: Environment): Value {
-    val inner = evalExpr(op.expr, env)
-    return when (op.op) {
-      // Two's-complement negation: (2^N - x) mod 2^N = (0 - x) using wrapping subtraction.
-      // BitVector.ofInt(-1, width) would violate the non-negative value invariant.
-      UnaryOperator.NEG ->
-        when (inner) {
-          is InfIntVal -> InfIntVal(inner.value.negate())
-          is BitVal -> BitVal(BitVector.ofInt(0, inner.bits.width) - inner.bits)
-          else -> error("NEG on non-numeric: $inner")
-        }
-      UnaryOperator.BIT_NOT -> BitVal((inner as BitVal).bits.inv())
-      UnaryOperator.NOT -> BoolVal(!(inner as BoolVal).value)
-      else -> error("unhandled unary operator: ${op.op}")
-    }
-  }
-
-  private fun evalMux(mux: fourward.ir.MuxExpr, env: Environment): Value =
-    if ((evalExpr(mux.condition, env) as BoolVal).value) evalExpr(mux.thenExpr, env)
-    else evalExpr(mux.elseExpr, env)
-
-  private fun evalStructExpr(
-    se: fourward.ir.StructExpr,
-    type: fourward.ir.Type,
-    env: Environment,
-  ): Value {
-    require(type.hasNamed()) { "StructExpr must have a named type, got: $type" }
-    val typeName = type.named
-    val fields = se.fieldsList.associateTo(mutableMapOf()) { f -> f.name to evalExpr(f.value, env) }
-    return StructVal(typeName, fields)
-  }
-
-  @Suppress("CyclomaticComplexMethod")
-  private fun evalMethodCall(call: MethodCall, returnType: Type, env: Environment): Value {
-    return when (call.method) {
-      // Header validity methods: target is the header instance.
-      "isValid" -> {
-        when (val target = evalExpr(call.target, env)) {
-          is HeaderVal -> BoolVal(target.valid)
-          is StructVal -> BoolVal(target.isUnionValid())
-          else -> error("isValid on non-header: $target")
-        }
-      }
-      "setValid" -> {
-        val target = evalExpr(call.target, env) as HeaderVal
-        invalidateUnionSiblings(call.target, target, env)
-        target.valid = true
-        UnitVal
-      }
-      "setInvalid" -> {
-        when (val target = evalExpr(call.target, env)) {
-          is HeaderVal -> target.setInvalid()
-          is StructVal -> target.invalidateUnion()
-          else -> error("setInvalid on non-header: $target")
-        }
-        UnitVal
-      }
-      // P4 spec §8.18: header stack push_front/pop_front.
-      "push_front" -> {
-        val stack = evalExpr(call.target, env) as HeaderStackVal
-        val count = intValue(evalExpr(call.argsList[0], env)).coerceAtMost(stack.size)
-        // Shift elements toward higher indices; first `count` become invalid.
-        for (i in (stack.size - 1) downTo count) {
-          stack.headers[i] = stack.headers[i - count]
-        }
-        for (i in 0 until count) {
-          stack.headers[i] = defaultValue(stack.elementTypeName, types)
-        }
-        stack.nextIndex = (stack.nextIndex + count).coerceAtMost(stack.size)
-        UnitVal
-      }
-      "pop_front" -> {
-        val stack = evalExpr(call.target, env) as HeaderStackVal
-        val count = intValue(evalExpr(call.argsList[0], env)).coerceAtMost(stack.size)
-        // Shift elements toward lower indices; last `count` become invalid.
-        for (i in 0 until stack.size - count) {
-          stack.headers[i] = stack.headers[i + count]
-        }
-        for (i in stack.size - count until stack.size) {
-          stack.headers[i] = defaultValue(stack.elementTypeName, types)
-        }
-        stack.nextIndex = (stack.nextIndex - count).coerceAtLeast(0)
-        UnitVal
-      }
-      // packet_in.extract(hdr) / packet_out.emit(hdr): target is the extern object
-      // (not in env); the header is the first argument.
-      "extract" -> execExtract(call, env)
-      "lookahead" -> execLookahead(returnType)
-      "advance" -> {
-        val bits = intValue(evalExpr(call.argsList[0], env))
-        packet.advanceBits(bits)
-        UnitVal
-      }
-      "emit" -> execEmit(call, env)
-      // "__call__" is used for free functions and direct action calls. Check actions first;
-      // fall back to extern handling (mark_to_drop, etc.) for unrecognised names.
-      "__call__" -> {
-        val funcName = call.target.nameRef.name
-        if (funcName in actions) execInlineActionCall(funcName, call.argsList, env)
-        else execExternCall(call, env)
-      }
-      // Extern object methods (register.read/write, counter.count, meter.execute_meter, etc.)
-      // are architecture-specific — delegate to the handler.
-      else -> {
-        val handler = externHandler
-        if (handler != null && call.target.hasNameRef()) {
-          val externCall =
-            ExternCall.Method(call.target.type.named, call.target.nameRef.name, call.method)
-          handler.handle(externCall, createExternEvaluator(call, env, returnType))
-        } else {
-          error("unhandled method call: ${call.method} on ${call.target}")
-        }
-      }
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Table application
-  // -------------------------------------------------------------------------
+  private val types: Map<String, fourward.ir.TypeDecl> = config.typesList.associateBy { it.name }
 
   private data class TableResult(val hit: Boolean, val actionName: String)
 
-  private fun applyTable(tableName: String, env: Environment): TableResult {
-    val tableBehavior = tables[tableName] ?: error("unknown table: $tableName")
-    val keyValues = tableBehavior.keysList.map { key -> key.fieldName to evalExpr(key.expr, env) }
+  /** Creates a lightweight per-execution context. */
+  fun execution(
+    tableStore: TableStore,
+    packetCtx: PacketContext? = null,
+    selectorOverrides: Map<String, Int> = emptyMap(),
+    externHandler: ExternHandler? = null,
+    tableLookupCache: Map<String, TableStore.LookupResult>? = null,
+  ) = Execution(tableStore, packetCtx, selectorOverrides, externHandler, tableLookupCache)
 
-    // On fork re-executions, use cached results for tables before the fork point.
-    val cached =
-      if (!pastForkPoint && tableLookupCache != null) tableLookupCache[tableName] else null
-    val result = cached ?: tableStore.lookup(tableName, keyValues)
-    if (!pastForkPoint) recordedLookups.putIfAbsent(tableName, result)
-
-    // Record table miss context so PNA's add_entry extern knows which table to insert into.
-    if (!result.hit) lastTableMissCtx = TableMissContext(tableName, keyValues)
-
-    // P4Runtime spec §9.3: direct counters are incremented on every table hit.
-    if (result.hit && result.entry != null && packetCtx != null) {
-      tableStore.directCounterIncrement(tableName, result.entry, packetCtx.payloadSize)
-    }
-
-    packetCtx?.addTraceEvent(
-      traceEventBuilder()
-        .setTableLookup(
-          TableLookupEvent.newBuilder()
-            .setTableName(tableStore.tableDisplayName(tableName))
-            .setHit(result.hit)
-            .setActionName(tableStore.actionDisplayName(result.actionName))
-            .also { if (result.entry != null) it.setMatchedEntry(result.entry) }
-        )
-        .build()
-    )
-
-    if (result.members != null) {
-      val forced = selectorOverrides[tableName]
-      if (forced != null) {
-        // Re-execution with a forced member. Disable cache: tables after the fork may
-        // see different key values per branch.
-        pastForkPoint = true
-        val member =
-          result.members.find { it.memberId == forced }
-            ?: error("forced member $forced not found in table $tableName")
-        val resolvedMember =
-          tableBehavior.actionOverridesMap[member.actionName] ?: member.actionName
-        execAction(resolvedMember, member.params, env)
-        return TableResult(result.hit, member.actionName)
-      }
-      // First encounter: throw to let the architecture build the trace tree.
-      throw ActionSelectorFork(
-        tableName,
-        result.members,
-        packetCtx!!.getEvents(),
-        recordedLookups.toMap(),
-      )
-    }
-
-    // Resolve per-table action specialization: the p4info uses original names,
-    // but the midend may have created per-table copies with distinct bodies.
-    val resolvedName = tableBehavior.actionOverridesMap[result.actionName] ?: result.actionName
-    val params = result.entry?.action?.action?.paramsList ?: result.actionParams
-    execAction(resolvedName, params, env)
-    return TableResult(result.hit, result.actionName)
-  }
-
-  private fun execAction(
-    actionName: String,
-    paramProtos: List<p4.v1.P4RuntimeOuterClass.Action.Param>,
-    env: Environment,
+  /**
+   * Per-execution interpreter state. Cheap to create (5 field assignments). Accesses the outer
+   * [Interpreter]'s config-derived maps directly via the inner class relationship.
+   */
+  inner class Execution(
+    private val tableStore: TableStore,
+    private val packetCtx: PacketContext? = null,
+    private val selectorOverrides: Map<String, Int> = emptyMap(),
+    private val externHandler: ExternHandler? = null,
+    /**
+     * Cached table lookup results from a prior execution, keyed by table name. When non-null, table
+     * lookups use the cache instead of scanning [tableStore] — avoiding O(n) scans for tables whose
+     * key values haven't changed since the cache was populated (i.e., tables before a fork point).
+     *
+     * The cache is disabled once a table from [selectorOverrides] is hit, since tables after the
+     * fork point may produce different key values due to different selector member actions.
+     */
+    private val tableLookupCache: Map<String, TableStore.LookupResult>? = null,
   ) {
-    // NoAction is a P4 built-in no-op (P4 spec §12.7) that is implicitly available in
-    // every table. It may appear in const entries without being listed in the actions block,
-    // so it might not have been compiled into the IR. Handle it directly rather than
-    // requiring the backend to emit an explicit empty ActionDecl for it.
-    if (actionName == "NoAction") {
-      packetCtx?.addTraceEvent(
-        traceEventBuilder()
-          .setActionExecution(ActionExecutionEvent.newBuilder().setActionName(actionName))
-          .build()
-      )
-      return
+
+    /** Non-null packet context; throws a clear error if packet I/O is attempted without one. */
+    private val packet: PacketContext
+      get() = packetCtx ?: error("packet I/O requires a PacketContext")
+
+    /** Table lookup results recorded during this execution, for caching in fork re-executions. */
+    private val recordedLookups = mutableMapOf<String, TableStore.LookupResult>()
+
+    /** Set to true once a [selectorOverrides] table is hit, disabling the [tableLookupCache]. */
+    private var pastForkPoint = false
+
+    /** Context from the most recent table miss, for PNA's `add_entry` extern. */
+    private var lastTableMissCtx: TableMissContext? = null
+
+    /** Source info of the statement currently being executed, for trace events. */
+    private var currentSourceInfo: SourceInfo? = null
+
+    /** Name of the control block currently being executed, for BranchEvent. */
+    private var currentControlName: String? = null
+
+    /** Builds a TraceEvent with source info attached, if available. */
+    private fun traceEventBuilder(sourceInfo: SourceInfo? = currentSourceInfo): TraceEvent.Builder {
+      val b = TraceEvent.newBuilder()
+      sourceInfo?.let { b.sourceInfo = it }
+      return b
     }
 
-    val actionDecl = actions[actionName] ?: error("unknown action: $actionName")
+    // -------------------------------------------------------------------------
+    // Parser
+    // -------------------------------------------------------------------------
 
-    val paramMap = mutableMapOf<String, com.google.protobuf.ByteString>()
-
-    env.pushScope()
-    try {
-      actionDecl.paramsList.forEachIndexed { i, paramDecl ->
-        val paramProto = paramProtos.getOrNull(i)
-        val value: Value =
-          if (paramProto != null) {
-            val width = paramDecl.type.bit.width
-            paramMap[paramDecl.name] = paramProto.value
-            BitVal(BitVector.ofBytes(paramProto.value.toByteArray(), width))
-          } else {
-            UnitVal
-          }
-        env.define(paramDecl.name, value)
-      }
-
-      // Use the p4info alias (short source-level name) for trace display. The behavioral
-      // IR name may be mangled by the midend (e.g. "acl_pre_ingress_ctrl_set_vrf").
-      val displayName = tableStore.actionDisplayName(actionName)
-      packetCtx?.addTraceEvent(
-        traceEventBuilder()
-          .setActionExecution(
-            ActionExecutionEvent.newBuilder()
-              .setActionName(displayName)
-              .putAllParams(paramMap.mapValues { it.value })
-          )
-          .build()
-      )
-
-      execBlock(actionDecl.bodyList, env)
-    } finally {
-      env.popScope()
-    }
-  }
-
-  /**
-   * Executes a direct (non-table-mediated) action call such as `do_thing(h.h.b)`.
-   *
-   * Binds argument values to the action's parameter names, runs the body, then writes back any
-   * `inout`/`out` parameters to the corresponding call-site lvalues (call-by-value-result
-   * semantics, as required by the P4 spec).
-   */
-  private fun execInlineActionCall(actionName: String, args: List<Expr>, env: Environment): Value {
-    val actionDecl = actions[actionName]!!
-    val argValues = args.map { evalExpr(it, env) }
-
-    env.pushScope()
-    try {
-      actionDecl.paramsList.forEachIndexed { i, param ->
-        env.define(param.name, argValues.getOrElse(i) { UnitVal })
-      }
-      try {
-        execBlock(actionDecl.bodyList, env)
-      } catch (_: ReturnException) {
-        // P4 action return exits the body without a value; fall through to writeback.
-      }
-      // Write back inout/out parameters before the scope is popped.
-      actionDecl.paramsList.forEachIndexed { i, param ->
-        if (
-          (param.direction == Direction.INOUT || param.direction == Direction.OUT) && i < args.size
-        ) {
-          setLValue(args[i], env.lookup(param.name)!!, env)
-        }
-      }
-    } finally {
-      env.popScope()
-    }
-    return UnitVal
-  }
-
-  // -------------------------------------------------------------------------
-  // Extern dispatch
-  // -------------------------------------------------------------------------
-
-  /** Creates an [ExternEvaluator] bound to [call]'s arguments and the current interpreter state. */
-  private fun createExternEvaluator(
-    call: MethodCall,
-    env: Environment,
-    returnType: Type = Type.getDefaultInstance(),
-  ): ExternEvaluator =
-    object : ExternEvaluator {
-      override fun returnType(): Type = returnType
-
-      override fun argCount(): Int = call.argsList.size
-
-      override fun evalArg(index: Int): Value = evalExpr(call.argsList[index], env)
-
-      override fun argType(index: Int): Type = call.argsList[index].type
-
-      override fun writeOutArg(index: Int, value: Value) =
-        setLValue(call.argsList[index], value, env)
-
-      override fun defaultValue(type: Type): Value = defaultValue(type, types)
-
-      override fun traceEventBuilder(): TraceEvent.Builder = this@Interpreter.traceEventBuilder()
-
-      override fun addTraceEvent(event: TraceEvent) {
-        packetCtx?.addTraceEvent(event)
-      }
-
-      override fun peekRemainingInput(): ByteArray = packet.peekRemainingInput()
-
-      override fun lastTableMiss(): TableMissContext? = lastTableMissCtx
+    fun runParser(parserName: String, env: Environment) {
+      val parser = parsers[parserName] ?: error("unknown parser: $parserName")
+      withLocalScope(parser.localVarsList, env) { runParserState(parser, "start", env) }
     }
 
-  private fun execExternCall(call: MethodCall, env: Environment): Value {
-    val funcName = call.target.nameRef.name
+    private fun runParserState(parser: ParserDecl, startState: String, env: Environment) {
+      // Index states by name for O(1) lookup during traversal.
+      val statesByName = parser.statesList.associateBy { it.name }
 
-    // verify() is a P4 core language construct (spec §12.8), not an architecture extern.
-    if (funcName == "verify") {
-      val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
-      if (!condition) {
-        val err = (evalExpr(call.argsList[1], env) as ErrorVal).member
-        throw ParserErrorException(err, "verify failed: $err")
-      }
-      return UnitVal
-    }
+      var stateName = startState
+      while (stateName != "accept" && stateName != "reject") {
+        val state =
+          statesByName[stateName] ?: error("unknown parser state: $stateName in ${parser.name}")
 
-    // assert(condition) / assume(condition): P4 spec §12.9.
-    // At runtime, assume behaves identically to assert — the distinction is for
-    // static analysis tools. On failure, emit a trace event and abort processing.
-    if (funcName == "assert" || funcName == "assume") {
-      val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
-      packetCtx?.addTraceEvent(
-        traceEventBuilder().setAssertion(AssertionEvent.newBuilder().setPassed(condition)).build()
-      )
-      if (!condition) throw AssertionFailureException("$funcName failed")
-      return UnitVal
-    }
+        for (stmt in state.stmtsList) execStmt(stmt, env)
 
-    // All other externs are architecture-specific — delegate to the handler.
-    val handler = externHandler ?: error("no extern handler for: $funcName")
-    return handler.handle(ExternCall.FreeFunction(funcName), createExternEvaluator(call, env))
-  }
-
-  /** Whether [expr] is a field access into a header union. */
-  private fun isUnionFieldAccess(expr: Expr): Boolean =
-    expr.hasFieldAccess() &&
-      expr.fieldAccess.expr.type.let { t ->
-        t.hasNamed() && types[t.named]?.hasHeaderUnion() == true
-      }
-
-  /** If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20). */
-  private fun invalidateUnionSiblings(expr: Expr, target: HeaderVal, env: Environment) {
-    if (!isUnionFieldAccess(expr)) return
-    val parent = evalExpr(expr.fieldAccess.expr, env) as StructVal
-    parent.invalidateUnionExcept(target)
-  }
-
-  // -------------------------------------------------------------------------
-  // Packet extract / emit
-  // -------------------------------------------------------------------------
-
-  private fun execExtract(call: MethodCall, env: Environment): Value {
-    // packet_in.extract(hdr.field): the header to extract into is args[0], not the target.
-    // P4's don't-care extract `p.extract<T>(_)` compiles to extract(arg) where
-    // `arg` is an undeclared temporary. Create a throw-away header to consume bytes.
-    val arg = call.argsList[0]
-    // When the arg is a field access into a union (e.g. hdr.u.next.byte), resolve the
-    // union parent once and invalidate siblings inline. This avoids re-evaluating
-    // side-effecting expressions like `.next` on header stacks.
-    var unionHandled = false
-    val header =
-      if (arg.hasNameRef() && env.lookup(arg.nameRef.name) == null && arg.type.hasNamed()) {
-        defaultValue(arg.type.named, types) as? HeaderVal
-          ?: error("type not found for don't-care extract: ${arg.type.named}")
-      } else if (isUnionFieldAccess(arg)) {
-        // Parent is a header union — resolve it once, invalidate siblings (P4 §8.20).
-        val parent = evalExpr(arg.fieldAccess.expr, env) as StructVal
-        val member = parent.fields[arg.fieldAccess.fieldName] as HeaderVal
-        parent.invalidateUnionExcept(member)
-        unionHandled = true
-        member
-      } else {
-        evalExpr(arg, env) as HeaderVal
-      }
-    val headerDecl = (types[header.typeName] ?: error("type not found: ${header.typeName}")).header
-
-    // The 2-argument form b.extract(hdr, varbitBits) is used when the header contains a varbit
-    // field. The second argument gives the varbit field's runtime length in bits.
-    val varbitBits: Int = if (call.argsCount > 1) intValue(evalExpr(call.argsList[1], env)) else 0
-
-    // P4 spec §12.8.1: validate varbit extract constraints.
-    if (varbitBits > 0) {
-      if (varbitBits % 8 != 0) {
-        throw ParserErrorException(
-          "ParserInvalidArgument",
-          "varbit extract length $varbitBits is not a multiple of 8",
-        )
-      }
-      val varbitField = headerDecl.fieldsList.find { it.type.hasVarbit() }
-      if (varbitField != null && varbitBits > varbitField.type.varbit.maxWidth) {
-        throw ParserErrorException(
-          "HeaderTooShort",
-          "varbit extract length $varbitBits exceeds max width ${varbitField.type.varbit.maxWidth}",
-        )
-      }
-    }
-
-    val widths = headerDecl.fieldsList.map { fieldWireWidth(it.type, varbitBits) }
-    val totalBits = widths.sum()
-    val allBits = BigInteger(1, packet.extractBytes((totalBits + 7) / 8))
-    val newFields = unpackFields(headerDecl.fieldsList, widths, allBits, totalBits)
-    if (!unionHandled) invalidateUnionSiblings(call.argsList[0], header, env)
-    header.setValid(newFields)
-    return UnitVal
-  }
-
-  /** P4 spec §12.8.2: peek at packet bits and construct a value of type T without consuming. */
-  private fun execLookahead(returnType: Type): Value {
-    // Primitive bit<N> lookahead: peek N bits and return a BitVal.
-    if (returnType.hasBit()) {
-      val width = returnType.bit.width
-      val raw = BigInteger(1, packet.peekBytes((width + 7) / 8))
-      // Mask to exactly N bits (peekBytes may return extra high bits from byte alignment).
-      val mask = BigInteger.ONE.shiftLeft(width).subtract(BigInteger.ONE)
-      return BitVal(BitVector(raw.and(mask), width))
-    }
-
-    val typeName = returnType.named
-    val typeDecl = types[typeName] ?: error("type not found for lookahead: $typeName")
-    val fields =
-      when {
-        typeDecl.hasHeader() -> typeDecl.header.fieldsList
-        typeDecl.hasStruct() -> typeDecl.struct.fieldsList
-        else -> error("lookahead type must be a header or struct: $typeName")
-      }
-    val widths = fields.map { fieldWireWidth(it.type) }
-    val totalBits = widths.sum()
-    val allBits = BigInteger(1, packet.peekBytes((totalBits + 7) / 8))
-    val newFields = unpackFields(fields, widths, allBits, totalBits)
-    return if (typeDecl.hasHeader()) {
-      HeaderVal(typeName, newFields, valid = true)
-    } else {
-      StructVal(typeName, newFields)
-    }
-  }
-
-  /**
-   * Unpacks a BigInteger of raw packet bits into named field values.
-   *
-   * Handles sub-byte fields (e.g. IPv4's bit<4> version and ihl) that share a byte by shift+mask
-   * from a single MSB-first BigInteger. Used by both extract and lookahead.
-   */
-  private fun unpackFields(
-    fields: List<FieldDecl>,
-    widths: List<Int>,
-    allBits: BigInteger,
-    totalBits: Int,
-  ): MutableMap<String, Value> {
-    val result = mutableMapOf<String, Value>()
-    var bitOffset = 0
-    for ((field, width) in fields.zip(widths)) {
-      if (width == 0) {
-        // Zero-width varbit fields still need a map entry so checksum StructExprs
-        // can reference them (e.g. hdr.ipv4.options when IHL=5).
-        if (field.type.hasVarbit()) result[field.name] = BitVal(BitVector(BigInteger.ZERO, 0))
-        continue
-      }
-      val mask = BigInteger.ONE.shiftLeft(width) - BigInteger.ONE
-      val raw = (allBits shr (totalBits - bitOffset - width)) and mask
-      result[field.name] = bitsToValue(field.type, raw, width)
-      bitOffset += width
-    }
-    return result
-  }
-
-  /**
-   * Returns the on-wire bit-width of a header field type.
-   *
-   * P4 spec §8.9.2: bool in a header occupies exactly 1 bit on the wire. int<N> and bit<N> occupy N
-   * bits. varbit<N> occupies [varbitBits] bits (caller must supply the runtime value). Serializable
-   * enums are looked up by name and use their declared underlying width.
-   */
-  private fun fieldWireWidth(type: Type, varbitBits: Int = 0): Int =
-    when {
-      type.hasBit() -> type.bit.width
-      type.hasSignedInt() -> type.signedInt.width
-      type.hasBoolean() -> 1
-      type.hasVarbit() -> varbitBits
-      type.hasNamed() -> {
-        val decl = types[type.named]
-        when {
-          decl != null && decl.hasEnum() -> decl.enum.width
-          else -> 0
-        }
-      }
-      else -> 0
-    }
-
-  /**
-   * Converts raw extracted bits to the appropriate [Value] for a header field.
-   *
-   * bit<N> → [BitVal], bool → [BoolVal], int<N> → [IntVal], varbit / enum → [BitVal].
-   */
-  private fun bitsToValue(type: Type, raw: BigInteger, width: Int): Value =
-    when {
-      type.hasBoolean() -> BoolVal(raw != BigInteger.ZERO)
-      type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(raw, width))
-      else -> BitVal(BitVector(raw, width))
-    }
-
-  private fun execEmit(call: MethodCall, env: Environment): Value {
-    emitValue(evalExpr(call.argsList[0], env))
-    return UnitVal
-  }
-
-  /**
-   * Recursively emits a value to the packet output buffer.
-   * - [HeaderVal]: packs all fields into bytes (MSB-first) and appends if valid.
-   * - [StructVal]: iterates fields in declaration order (looking up the TypeDecl) and emits each.
-   * - Other types: no-op (non-emittable values such as BoolVal in metadata structs).
-   *
-   * This handles both `pkt.emit(hdr.ethernet)` (single header) and `pkt.emit(hdr)` where `hdr` is a
-   * struct containing multiple headers, as required by the P4 deparser model.
-   */
-  private fun emitValue(value: Value) {
-    when (value) {
-      is HeaderVal -> emitHeader(value)
-      is StructVal -> {
-        // Emit in the declaration order from the TypeDecl; fall back to map order if unknown.
-        val typeDecl = types[value.typeName]
-        val fieldDecls =
+        val (nextState, selectValue, selectExpr) =
           when {
-            typeDecl != null && typeDecl.hasStruct() -> typeDecl.struct.fieldsList
-            typeDecl != null && typeDecl.hasHeaderUnion() -> typeDecl.headerUnion.fieldsList
-            else -> null
+            state.transition.hasSelect() -> evalSelectWithValue(state.transition.select, env)
+            else -> Triple(state.transition.nextState, "", "")
           }
-        if (fieldDecls != null) {
-          for (field in fieldDecls) {
-            emitValue(value.fields[field.name] ?: continue)
-          }
-        } else {
-          for (fieldVal in value.fields.values) emitValue(fieldVal)
-        }
-      }
-      is HeaderStackVal -> {
-        for (header in value.headers) emitValue(header)
-      }
-      else -> {} // BoolVal, BitVal outside a header, UnitVal — not emittable
-    }
-  }
 
-  /** Packs a valid header's fields into bytes (MSB-first) and appends to the output buffer. */
-  private fun emitHeader(header: HeaderVal) {
-    if (!header.valid) return
-    val headerDecl = (types[header.typeName] ?: error("type not found: ${header.typeName}")).header
-    // Compute total wire bits from field declarations; varbit fields use their stored BitVal
-    // width since we don't have the runtime length separately at emit time.
-    val totalBits =
-      headerDecl.fieldsList.sumOf { field ->
-        when (val v = header.fields[field.name]) {
-          is BitVal -> v.bits.width
-          is BoolVal -> 1
-          is IntVal -> v.bits.width
-          else -> 0
-        }
+        packetCtx?.addTraceEvent(
+          traceEventBuilder(if (state.hasSourceInfo()) state.sourceInfo else null)
+            .setParserTransition(
+              ParserTransitionEvent.newBuilder()
+                .setParserName(parser.name)
+                .setFromState(stateName)
+                .setToState(nextState)
+                .also {
+                  if (selectValue.isNotEmpty()) it.setSelectValue(selectValue)
+                  if (selectExpr.isNotEmpty()) it.setSelectExpression(selectExpr)
+                }
+            )
+            .build()
+        )
+
+        stateName = nextState
       }
-    var packedBits = BigInteger.ZERO
-    var bitOffset = 0
-    for (field in headerDecl.fieldsList) {
-      val fieldBits: BigInteger
-      val width: Int
-      when (val fieldVal = header.fields[field.name]) {
-        is BitVal -> {
-          fieldBits = fieldVal.bits.value
-          width = fieldVal.bits.width
-        }
-        is BoolVal -> {
-          // P4 spec §8.9.2: bool occupies 1 bit on the wire.
-          fieldBits = if (fieldVal.value) BigInteger.ONE else BigInteger.ZERO
-          width = 1
-        }
-        is IntVal -> {
-          fieldBits = fieldVal.bits.toUnsigned().value
-          width = fieldVal.bits.width
-        }
-        else -> continue // UnitVal (e.g. varbit placeholder) — skip
-      }
-      if (totalBits > 0 && width > 0) {
-        val shift = totalBits - bitOffset - width
-        packedBits = packedBits or fieldBits.shiftLeft(shift)
-      }
-      bitOffset += width
     }
-    if (totalBits > 0) {
-      val bytes = BitVector(packedBits, totalBits).toByteArray()
-      packet.emitBytes(bytes)
+
+    /**
+     * Evaluates a select expression, returning (nextState, formattedValue, formattedExpression).
+     */
+    private fun evalSelectWithValue(
+      select: fourward.ir.SelectTransition,
+      env: Environment,
+    ): Triple<String, String, String> {
+      val keyValues = select.keysList.map { evalExpr(it, env) }
+      val formatted =
+        keyValues.joinToString(", ") {
+          when (it) {
+            is BitVal -> "0x${it.bits.value.toString(16).uppercase()}"
+            is IntVal -> "0x${it.bits.value.toString(16).uppercase()}"
+            is BoolVal -> it.value.toString()
+            else -> it.toString()
+          }
+        }
+      val expression = select.keysList.joinToString(", ") { formatExpr(it) }
+      // Keyset expressions in parser select are always compile-time constants; a single
+      // empty environment is correct for all of them.
+      val constEnv = Environment()
+      for (case in select.casesList) {
+        // P4 spec §12.14: a value_set replaces the entire keyset tuple for a case —
+        // it cannot be mixed with non-value_set keysets. Checking only the first keyset
+        // is sufficient to distinguish value_set cases from normal keyset cases.
+        val firstKeyset = case.keysetsList.firstOrNull()
+        if (firstKeyset != null && firstKeyset.hasValueSet()) {
+          val members = tableStore.getValueSetMembers(firstKeyset.valueSet)
+          if (members.any { member -> matchesValueSetMember(keyValues, member) }) {
+            return Triple(case.nextState, formatted, expression)
+          }
+        } else if (
+          keyValues.zip(case.keysetsList).all { (v, k) -> matchesKeyset(v, k, constEnv) }
+        ) {
+          return Triple(case.nextState, formatted, expression)
+        }
+      }
+      // P4 spec §12.6: if no case matches and there is no default, reject.
+      return Triple(select.defaultState.ifEmpty { "reject" }, formatted, expression)
+    }
+
+    /** Human-readable rendering of an IR expression (best-effort, for trace display). */
+    private fun formatExpr(expr: fourward.ir.Expr): String =
+      when {
+        expr.hasNameRef() -> expr.nameRef.name
+        expr.hasFieldAccess() ->
+          "${formatExpr(expr.fieldAccess.expr)}.${expr.fieldAccess.fieldName}"
+        expr.hasArrayIndex() ->
+          "${formatExpr(expr.arrayIndex.expr)}[${formatExpr(expr.arrayIndex.index)}]"
+        expr.hasSlice() -> "${formatExpr(expr.slice.expr)}[${expr.slice.hi}:${expr.slice.lo}]"
+        expr.hasLiteral() -> {
+          val lit = expr.literal
+          when {
+            lit.hasInteger() -> "0x${lit.integer.toString(16).uppercase()}"
+            lit.hasBoolean() -> lit.boolean.toString()
+            else -> lit.toString().trim()
+          }
+        }
+        else -> "?"
+      }
+
+    private fun matchesKeyset(
+      value: Value,
+      keyset: fourward.ir.KeysetExpr,
+      constEnv: Environment,
+    ): Boolean =
+      when {
+        keyset.hasDefaultCase() -> true
+        keyset.hasExact() -> value == evalExpr(keyset.exact, constEnv)
+        keyset.hasMask() -> {
+          val v = (value as BitVal).bits
+          val mask = (evalExpr(keyset.mask.mask, constEnv) as BitVal).bits
+          val want = (evalExpr(keyset.mask.value, constEnv) as BitVal).bits
+          (v and mask) == (want and mask)
+        }
+        keyset.hasRange() -> {
+          val v = (value as BitVal).bits
+          val lo = (evalExpr(keyset.range.lo, constEnv) as BitVal).bits
+          val hi = (evalExpr(keyset.range.hi, constEnv) as BitVal).bits
+          v >= lo && v <= hi
+        }
+        else -> error("unhandled keyset kind: $keyset")
+      }
+
+    /**
+     * Matches a list of select key values against a single [ValueSetMember]'s field matches.
+     *
+     * Each member has one [FieldMatch] per key, in the same order as the select keys. An unset
+     * FieldMatch acts as a wildcard (matches any value).
+     */
+    private fun matchesValueSetMember(
+      keyValues: List<Value>,
+      member: p4.v1.P4RuntimeOuterClass.ValueSetMember,
+    ): Boolean {
+      if (member.matchCount != keyValues.size) return false
+      return keyValues.zip(member.matchList).all { (value, fieldMatch) ->
+        matchFieldMatch(value, fieldMatch)
+      }
+    }
+
+    /** Matches a single runtime value against a P4Runtime [FieldMatch]. */
+    private fun matchFieldMatch(
+      value: Value,
+      fieldMatch: p4.v1.P4RuntimeOuterClass.FieldMatch,
+    ): Boolean {
+      val bits =
+        when (value) {
+          is BitVal -> value.bits
+          is BoolVal -> if (value.value) BOOL_TRUE_BITS else BOOL_FALSE_BITS
+          else -> return false
+        }
+      return matchesFieldMatch(bits, fieldMatch)
+    }
+
+    // -------------------------------------------------------------------------
+    // Control
+    // -------------------------------------------------------------------------
+
+    fun runControl(controlName: String, env: Environment) {
+      val control = controls[controlName] ?: error("unknown control: $controlName")
+      currentControlName = controlName
+      withLocalScope(control.localVarsList, env) { execBlock(control.applyBodyList, env) }
+    }
+
+    /** Pushes a scope, defines [localVars], runs [body], then pops the scope. */
+    private inline fun withLocalScope(
+      localVars: List<fourward.ir.VarDecl>,
+      env: Environment,
+      body: () -> Unit,
+    ) {
+      env.pushScope()
+      try {
+        for (varDecl in localVars) {
+          val init =
+            if (varDecl.hasInitializer()) evalExpr(varDecl.initializer, env)
+            else defaultValue(varDecl.type, types)
+          env.define(varDecl.name, init)
+        }
+        body()
+      } finally {
+        env.popScope()
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // Statements
+    // -------------------------------------------------------------------------
+
+    private fun execBlock(stmts: List<Stmt>, env: Environment) {
+      for (stmt in stmts) execStmt(stmt, env)
+    }
+
+    private fun execStmt(stmt: Stmt, env: Environment) {
+      if (stmt.hasSourceInfo()) currentSourceInfo = stmt.sourceInfo else currentSourceInfo = null
+      when {
+        stmt.hasAssignment() ->
+          setLValue(stmt.assignment.lhs, evalExpr(stmt.assignment.rhs, env), env)
+        stmt.hasMethodCall() -> evalExpr(stmt.methodCall.call, env) // result discarded
+        stmt.hasIfStmt() -> execIf(stmt.ifStmt, env)
+        stmt.hasSwitchStmt() -> execSwitch(stmt.switchStmt, env)
+        stmt.hasBlock() -> execBlock(stmt.block.stmtsList, env)
+        stmt.hasExit() -> throw ExitException()
+        stmt.hasReturnStmt() -> throw ReturnException(evalExpr(stmt.returnStmt.value, env))
+        else -> error("unhandled statement kind: $stmt")
+      }
+    }
+
+    private fun execIf(ifStmt: fourward.ir.IfStmt, env: Environment) {
+      val condition = (evalExpr(ifStmt.condition, env) as BoolVal).value
+
       packetCtx?.addTraceEvent(
-        TraceEvent.newBuilder()
-          .setDeparserEmit(
-            DeparserEmitEvent.newBuilder().setHeaderType(header.typeName).setByteLength(bytes.size)
+        traceEventBuilder()
+          .setBranch(
+            BranchEvent.newBuilder().setControlName(currentControlName ?: "").setTaken(condition)
           )
           .build()
       )
+
+      if (condition) {
+        execBlock(ifStmt.thenBlock.stmtsList, env)
+      } else {
+        execBlock(ifStmt.elseBlock.stmtsList, env)
+      }
     }
-  }
 
-  // -------------------------------------------------------------------------
-  // LValue assignment
-  // -------------------------------------------------------------------------
+    private fun execSwitch(switchStmt: fourward.ir.SwitchStmt, env: Environment) {
+      val tableResult = applyTable(switchStmt.subject.tableApply.tableName, env)
+      val matchedCase = switchStmt.casesList.find { it.actionName == tableResult.actionName }
+      if (matchedCase != null) {
+        execBlock(matchedCase.block.stmtsList, env)
+      } else {
+        execBlock(switchStmt.defaultBlock.stmtsList, env)
+      }
+    }
 
-  private fun setLValue(lhs: Expr, value: Value, env: Environment) {
-    // P4 assignment is copy-by-value. Headers and structs carry mutable fields maps,
-    // so we copy them to prevent aliasing (e.g. `x = h.h; x.a = 2` must not modify `h.h.a`).
-    val copy =
-      when (value) {
-        is HeaderVal -> value.copy()
-        is StructVal -> value.copy()
-        else -> value
+    // -------------------------------------------------------------------------
+    // Expressions
+    // -------------------------------------------------------------------------
+
+    fun evalExpr(expr: Expr, env: Environment): Value =
+      when {
+        expr.hasLiteral() -> evalLiteral(expr.literal, expr.type)
+        expr.hasNameRef() ->
+          env.lookup(expr.nameRef.name) ?: error("undefined variable: ${expr.nameRef.name}")
+        expr.hasFieldAccess() -> evalFieldAccess(expr.fieldAccess, env)
+        expr.hasArrayIndex() -> evalArrayIndex(expr.arrayIndex, env)
+        expr.hasSlice() -> evalSlice(expr.slice, env)
+        expr.hasConcat() -> evalConcat(expr.concat, env)
+        expr.hasCast() -> evalCast(expr.cast, env)
+        expr.hasBinaryOp() -> evalBinaryOp(expr.binaryOp, env)
+        expr.hasUnaryOp() -> evalUnaryOp(expr.unaryOp, env)
+        expr.hasMethodCall() -> evalMethodCall(expr.methodCall, expr.type, env)
+        expr.hasMux() -> evalMux(expr.mux, env)
+        expr.hasStructExpr() -> evalStructExpr(expr.structExpr, expr.type, env)
+        expr.hasTableApply() -> {
+          val result = applyTable(expr.tableApply.tableName, env)
+          when (expr.tableApply.accessKind) {
+            TableApplyExpr.AccessKind.HIT -> BoolVal(result.hit)
+            TableApplyExpr.AccessKind.MISS -> BoolVal(!result.hit)
+            else -> UnitVal // RESULT / default: switch context
+          }
+        }
+        else -> error("unhandled expression kind: $expr")
       }
-    when {
-      lhs.hasNameRef() -> {
-        env.update(lhs.nameRef.name, copy)
+
+    private fun evalLiteral(lit: Literal, type: fourward.ir.Type): Value =
+      when {
+        lit.hasBoolean() -> BoolVal(lit.boolean)
+        lit.hasErrorMember() -> ErrorVal(lit.errorMember)
+        lit.hasEnumMember() -> EnumVal(lit.enumMember)
+        lit.hasStringLiteral() -> StringVal(lit.stringLiteral)
+        lit.hasInteger() -> {
+          val v = BigInteger.valueOf(lit.integer.toLong())
+          when {
+            type.hasBit() -> BitVal(BitVector(v, type.bit.width))
+            type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
+            else -> InfIntVal(v) // compile-time constant integer (P4 spec §8.1)
+          }
+        }
+        lit.hasBigInteger() -> {
+          val v = BigInteger(1, lit.bigInteger.toByteArray())
+          when {
+            type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
+            type.hasBit() -> BitVal(BitVector(v, type.bit.width))
+            else -> error("big integer literal with unexpected type: $type")
+          }
+        }
+        else -> error("unhandled literal kind: $lit")
       }
-      lhs.hasFieldAccess() -> {
-        val target = evalExpr(lhs.fieldAccess.expr, env)
-        when (target) {
-          is HeaderVal -> target.fields[lhs.fieldAccess.fieldName] = copy
-          is StructVal -> target.fields[lhs.fieldAccess.fieldName] = copy
-          else -> error("field assignment on non-aggregate: $target")
+
+    private fun evalFieldAccess(fa: fourward.ir.FieldAccess, env: Environment): Value {
+      // Special case: table.apply().hit / .miss — the p4c midend may restructure
+      // the apply call such that the backend emits FieldAccess{TableApplyExpr, "hit"}
+      // rather than TableApplyExpr{access_kind=HIT}.
+      if (fa.expr.hasTableApply()) {
+        val result = applyTable(fa.expr.tableApply.tableName, env)
+        return when (fa.fieldName) {
+          "hit" -> BoolVal(result.hit)
+          "miss" -> BoolVal(!result.hit)
+          else -> error("unknown field '${fa.fieldName}' on table apply result")
         }
       }
-      // P4 spec §8.18: out-of-bounds writes are no-ops.
-      lhs.hasArrayIndex() -> {
-        val stack = evalExpr(lhs.arrayIndex.expr, env) as HeaderStackVal
-        val index = intValue(evalExpr(lhs.arrayIndex.index, env))
-        if (index in 0 until stack.size) stack.headers[index] = copy
+      val target = evalExpr(fa.expr, env)
+      return when (target) {
+        is HeaderVal ->
+          target.fields[fa.fieldName]
+            ?: error("field ${fa.fieldName} not found in header ${target.typeName}")
+        is StructVal ->
+          target.fields[fa.fieldName]
+            ?: error("field ${fa.fieldName} not found in struct ${target.typeName}")
+        is HeaderStackVal -> evalHeaderStackProperty(target, fa.fieldName)
+        else -> error("field access on non-aggregate value: $target")
       }
-      lhs.hasSlice() -> {
-        // Slice assignment: update [hi:lo] bits of the target.
-        val target = evalExpr(lhs.slice.expr, env) as BitVal
-        val src = value as BitVal
-        val hi = lhs.slice.hi
-        val lo = lhs.slice.lo
-        val mask =
-          BitVector(
-            BigInteger.TWO.pow(hi - lo + 1).minus(BigInteger.ONE).shiftLeft(lo),
-            target.bits.width,
+    }
+
+    /** P4 spec §8.18: header stack built-in properties. */
+    private fun evalHeaderStackProperty(stack: HeaderStackVal, name: String): Value =
+      when (name) {
+        // P4 spec §8.18: accessing .next when the stack is full is an error that
+        // transitions the parser to the reject state with error.StackOutOfBounds.
+        "next" -> {
+          if (stack.nextIndex >= stack.headers.size) {
+            throw ParserErrorException(
+              "StackOutOfBounds",
+              "header stack overflow: nextIndex=${stack.nextIndex}, size=${stack.headers.size}",
+            )
+          }
+          stack.headers[stack.nextIndex].also { stack.nextIndex++ }
+        }
+        "last" -> stack.headers[(stack.nextIndex - 1).coerceAtLeast(0)]
+        "lastIndex" -> BitVal(stack.headers.size.toLong() - 1, STACK_PROPERTY_BITS)
+        "size" -> BitVal(stack.headers.size.toLong(), STACK_PROPERTY_BITS)
+        else -> error("unknown header stack property: $name")
+      }
+
+    // P4 spec §8.18: out-of-bounds reads return an invalid header with default values.
+    private fun evalArrayIndex(ai: fourward.ir.ArrayIndex, env: Environment): Value {
+      val stack =
+        evalExpr(ai.expr, env) as? HeaderStackVal ?: error("array index on non-stack value")
+      val index = intValue(evalExpr(ai.index, env))
+      if (index !in 0 until stack.size) return defaultValue(stack.elementTypeName, types)
+      return stack.headers[index]
+    }
+
+    private fun evalSlice(slice: fourward.ir.Slice, env: Environment): Value {
+      val bits = (evalExpr(slice.expr, env) as BitVal).bits
+      return BitVal(bits.slice(slice.hi, slice.lo))
+    }
+
+    private fun evalConcat(concat: fourward.ir.Concat, env: Environment): Value {
+      val left = (evalExpr(concat.left, env) as BitVal).bits
+      val right = (evalExpr(concat.right, env) as BitVal).bits
+      return BitVal(left.concat(right))
+    }
+
+    private fun evalCast(cast: fourward.ir.Cast, env: Environment): Value {
+      val inner = evalExpr(cast.expr, env)
+      return when {
+        cast.targetType.hasBit() -> {
+          val targetWidth = cast.targetType.bit.width
+          val sourceBits =
+            when (inner) {
+              is BitVal -> inner.bits.value
+              is InfIntVal -> inner.value
+              is IntVal -> inner.bits.toUnsigned().value
+              is BoolVal -> if (inner.value) BigInteger.ONE else BigInteger.ZERO
+              else -> error("cannot cast $inner to bit<$targetWidth>")
+            }
+          BitVal(BitVector(sourceBits.mod(BigInteger.TWO.pow(targetWidth)), targetWidth))
+        }
+        cast.targetType.hasSignedInt() -> {
+          val targetWidth = cast.targetType.signedInt.width
+          when (inner) {
+            // int<N> → int<M>: preserve the signed value (sign-extends or truncates).
+            // int<N> → int<M>: sign-extend if widening, truncate if narrowing.
+            is IntVal ->
+              if (targetWidth >= inner.bits.width) {
+                IntVal(SignedBitVector(inner.bits.value, targetWidth))
+              } else {
+                IntVal(
+                  SignedBitVector.fromUnsignedBits(
+                    inner.bits.value.mod(java.math.BigInteger.TWO.pow(targetWidth)),
+                    targetWidth,
+                  )
+                )
+              }
+            else -> {
+              val sourceBits =
+                when (inner) {
+                  is BitVal -> inner.bits.value
+                  is InfIntVal -> inner.value
+                  else -> error("cannot cast $inner to int<$targetWidth>")
+                }
+              IntVal(SignedBitVector.fromUnsignedBits(sourceBits, targetWidth))
+            }
+          }
+        }
+        cast.targetType.boolean -> {
+          val v =
+            when (inner) {
+              is BitVal -> inner.bits.value
+              is InfIntVal -> inner.value
+              else -> error("cannot cast $inner to bool")
+            }
+          BoolVal(v != BigInteger.ZERO)
+        }
+        else -> error("unsupported cast target type: ${cast.targetType}")
+      }
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun evalBinaryOp(op: fourward.ir.BinaryOp, env: Environment): Value {
+      // P4 spec §8.1: compile-time integers adopt the width of the other operand.
+      val (left, right) = coerceInfInts(evalExpr(op.left, env), evalExpr(op.right, env))
+
+      // P4 spec §8.5: shift amount is always unsigned, so left may be IntVal while right is BitVal.
+      // SHR on int<N> is arithmetic (sign-extending); SHL is logical.
+      if (left is IntVal && (op.op == BinaryOperator.SHL || op.op == BinaryOperator.SHR)) {
+        val amount = intValue(right)
+        return if (op.op == BinaryOperator.SHL) {
+          IntVal(left.bits.toUnsigned().shl(amount).toSigned())
+        } else {
+          // Arithmetic right shift: shift the signed value, then re-wrap.
+          val shifted = left.bits.value.shiftRight(amount)
+          IntVal(SignedBitVector(shifted, left.bits.width))
+        }
+      }
+
+      return when (op.op) {
+        // Arithmetic and bitwise ops work on unsigned bits; liftBitwise rewraps as
+        // the original signedness (BitVal or IntVal).
+        BinaryOperator.ADD -> liftBitwise(left, right) { a, b -> a + b }
+        BinaryOperator.SUB -> liftBitwise(left, right) { a, b -> a - b }
+        BinaryOperator.MUL -> liftBitwise(left, right) { a, b -> a * b }
+        BinaryOperator.BIT_AND -> liftBitwise(left, right) { a, b -> a and b }
+        BinaryOperator.BIT_OR -> liftBitwise(left, right) { a, b -> a or b }
+        BinaryOperator.BIT_XOR -> liftBitwise(left, right) { a, b -> a xor b }
+        // bit<N>-only: division/modulo are unsigned-only in P4.
+        BinaryOperator.DIV -> BitVal((left as BitVal).bits / (right as BitVal).bits)
+        BinaryOperator.MOD -> BitVal((left as BitVal).bits % (right as BitVal).bits)
+        // Saturating ops can't use liftBitwise: signed/unsigned have different clamp bounds.
+        BinaryOperator.ADD_SAT ->
+          when (left) {
+            is BitVal -> BitVal(left.bits.addSat((right as BitVal).bits))
+            is IntVal -> IntVal(left.bits.addSat((right as IntVal).bits))
+            else -> error("ADD_SAT on non-fixed-width: $left")
+          }
+        BinaryOperator.SUB_SAT ->
+          when (left) {
+            is BitVal -> BitVal(left.bits.subSat((right as BitVal).bits))
+            is IntVal -> IntVal(left.bits.subSat((right as IntVal).bits))
+            else -> error("SUB_SAT on non-fixed-width: $left")
+          }
+        BinaryOperator.SHL -> BitVal((left as BitVal).bits.shl(intValue(right)))
+        BinaryOperator.SHR -> BitVal((left as BitVal).bits.shr(intValue(right)))
+        // Equality uses data-class structural equality (works for both bit<N> and int<N>).
+        BinaryOperator.EQ -> BoolVal(left == right)
+        BinaryOperator.NEQ -> BoolVal(left != right)
+        // P4 spec §8.5: relational operators use signed comparison for int<N>.
+        BinaryOperator.LT -> liftCompare(left, right) { it < 0 }
+        BinaryOperator.GT -> liftCompare(left, right) { it > 0 }
+        BinaryOperator.LE -> liftCompare(left, right) { it <= 0 }
+        BinaryOperator.GE -> liftCompare(left, right) { it >= 0 }
+        BinaryOperator.AND -> BoolVal((left as BoolVal).value && (right as BoolVal).value)
+        BinaryOperator.OR -> BoolVal((left as BoolVal).value || (right as BoolVal).value)
+        else -> error("unhandled binary operator: ${op.op}")
+      }
+    }
+
+    /** Apply a [BitVector] operation to two fixed-width values, preserving signedness. */
+    private inline fun liftBitwise(
+      left: Value,
+      right: Value,
+      f: (BitVector, BitVector) -> BitVector,
+    ): Value =
+      when (left) {
+        is BitVal -> BitVal(f(left.bits, (right as BitVal).bits))
+        is IntVal ->
+          IntVal(f(left.bits.toUnsigned(), (right as IntVal).bits.toUnsigned()).toSigned())
+        else -> error("expected fixed-width integer operands, got: $left, $right")
+      }
+
+    /** Compare two fixed-width values, dispatching to signed or unsigned comparison. */
+    private inline fun liftCompare(left: Value, right: Value, pred: (Int) -> Boolean): BoolVal =
+      when (left) {
+        is BitVal -> BoolVal(pred(left.bits.compareTo((right as BitVal).bits)))
+        is IntVal -> BoolVal(pred(left.bits.value.compareTo((right as IntVal).bits.value)))
+        else -> error("expected fixed-width integer operands for comparison")
+      }
+
+    /** Extract a small integer from a [BitVal], [IntVal], or [InfIntVal]. */
+    private fun intValue(v: Value): Int =
+      when (v) {
+        is BitVal -> v.bits.value.toInt()
+        is IntVal -> v.bits.value.toInt()
+        is InfIntVal -> v.value.toInt()
+        else -> error("expected integer value: $v")
+      }
+
+    /** P4 spec §8.1: InfInt adopts the width of the fixed-width operand. */
+    private fun coerceInfInts(left: Value, right: Value): Pair<Value, Value> =
+      when {
+        left is InfIntVal && right is BitVal -> left.toBitVal(right.bits.width) to right
+        right is InfIntVal && left is BitVal -> left to right.toBitVal(left.bits.width)
+        left is InfIntVal && right is IntVal -> left.toIntVal(right.bits.width) to right
+        right is InfIntVal && left is IntVal -> left to right.toIntVal(left.bits.width)
+        else -> left to right
+      }
+
+    private fun evalUnaryOp(op: fourward.ir.UnaryOp, env: Environment): Value {
+      val inner = evalExpr(op.expr, env)
+      return when (op.op) {
+        // Two's-complement negation: (2^N - x) mod 2^N = (0 - x) using wrapping subtraction.
+        // BitVector.ofInt(-1, width) would violate the non-negative value invariant.
+        UnaryOperator.NEG ->
+          when (inner) {
+            is InfIntVal -> InfIntVal(inner.value.negate())
+            is BitVal -> BitVal(BitVector.ofInt(0, inner.bits.width) - inner.bits)
+            else -> error("NEG on non-numeric: $inner")
+          }
+        UnaryOperator.BIT_NOT -> BitVal((inner as BitVal).bits.inv())
+        UnaryOperator.NOT -> BoolVal(!(inner as BoolVal).value)
+        else -> error("unhandled unary operator: ${op.op}")
+      }
+    }
+
+    private fun evalMux(mux: fourward.ir.MuxExpr, env: Environment): Value =
+      if ((evalExpr(mux.condition, env) as BoolVal).value) evalExpr(mux.thenExpr, env)
+      else evalExpr(mux.elseExpr, env)
+
+    private fun evalStructExpr(
+      se: fourward.ir.StructExpr,
+      type: fourward.ir.Type,
+      env: Environment,
+    ): Value {
+      require(type.hasNamed()) { "StructExpr must have a named type, got: $type" }
+      val typeName = type.named
+      val fields =
+        se.fieldsList.associateTo(mutableMapOf()) { f -> f.name to evalExpr(f.value, env) }
+      return StructVal(typeName, fields)
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun evalMethodCall(call: MethodCall, returnType: Type, env: Environment): Value {
+      return when (call.method) {
+        // Header validity methods: target is the header instance.
+        "isValid" -> {
+          when (val target = evalExpr(call.target, env)) {
+            is HeaderVal -> BoolVal(target.valid)
+            is StructVal -> BoolVal(target.isUnionValid())
+            else -> error("isValid on non-header: $target")
+          }
+        }
+        "setValid" -> {
+          val target = evalExpr(call.target, env) as HeaderVal
+          invalidateUnionSiblings(call.target, target, env)
+          target.valid = true
+          UnitVal
+        }
+        "setInvalid" -> {
+          when (val target = evalExpr(call.target, env)) {
+            is HeaderVal -> target.setInvalid()
+            is StructVal -> target.invalidateUnion()
+            else -> error("setInvalid on non-header: $target")
+          }
+          UnitVal
+        }
+        // P4 spec §8.18: header stack push_front/pop_front.
+        "push_front" -> {
+          val stack = evalExpr(call.target, env) as HeaderStackVal
+          val count = intValue(evalExpr(call.argsList[0], env)).coerceAtMost(stack.size)
+          // Shift elements toward higher indices; first `count` become invalid.
+          for (i in (stack.size - 1) downTo count) {
+            stack.headers[i] = stack.headers[i - count]
+          }
+          for (i in 0 until count) {
+            stack.headers[i] = defaultValue(stack.elementTypeName, types)
+          }
+          stack.nextIndex = (stack.nextIndex + count).coerceAtMost(stack.size)
+          UnitVal
+        }
+        "pop_front" -> {
+          val stack = evalExpr(call.target, env) as HeaderStackVal
+          val count = intValue(evalExpr(call.argsList[0], env)).coerceAtMost(stack.size)
+          // Shift elements toward lower indices; last `count` become invalid.
+          for (i in 0 until stack.size - count) {
+            stack.headers[i] = stack.headers[i + count]
+          }
+          for (i in stack.size - count until stack.size) {
+            stack.headers[i] = defaultValue(stack.elementTypeName, types)
+          }
+          stack.nextIndex = (stack.nextIndex - count).coerceAtLeast(0)
+          UnitVal
+        }
+        // packet_in.extract(hdr) / packet_out.emit(hdr): target is the extern object
+        // (not in env); the header is the first argument.
+        "extract" -> execExtract(call, env)
+        "lookahead" -> execLookahead(returnType)
+        "advance" -> {
+          val bits = intValue(evalExpr(call.argsList[0], env))
+          packet.advanceBits(bits)
+          UnitVal
+        }
+        "emit" -> execEmit(call, env)
+        // "__call__" is used for free functions and direct action calls. Check actions first;
+        // fall back to extern handling (mark_to_drop, etc.) for unrecognised names.
+        "__call__" -> {
+          val funcName = call.target.nameRef.name
+          if (funcName in actions) execInlineActionCall(funcName, call.argsList, env)
+          else execExternCall(call, env)
+        }
+        // Extern object methods (register.read/write, counter.count, meter.execute_meter, etc.)
+        // are architecture-specific — delegate to the handler.
+        else -> {
+          val handler = externHandler
+          if (handler != null && call.target.hasNameRef()) {
+            val externCall =
+              ExternCall.Method(call.target.type.named, call.target.nameRef.name, call.method)
+            handler.handle(externCall, createExternEvaluator(call, env, returnType))
+          } else {
+            error("unhandled method call: ${call.method} on ${call.target}")
+          }
+        }
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // Table application
+    // -------------------------------------------------------------------------
+
+    private fun applyTable(tableName: String, env: Environment): TableResult {
+      val tableBehavior = tables[tableName] ?: error("unknown table: $tableName")
+      val keyValues = tableBehavior.keysList.map { key -> key.fieldName to evalExpr(key.expr, env) }
+
+      // On fork re-executions, use cached results for tables before the fork point.
+      val cached =
+        if (!pastForkPoint && tableLookupCache != null) tableLookupCache[tableName] else null
+      val result = cached ?: tableStore.lookup(tableName, keyValues)
+      if (!pastForkPoint) recordedLookups.putIfAbsent(tableName, result)
+
+      // Record table miss context so PNA's add_entry extern knows which table to insert into.
+      if (!result.hit) lastTableMissCtx = TableMissContext(tableName, keyValues)
+
+      // P4Runtime spec §9.3: direct counters are incremented on every table hit.
+      if (result.hit && result.entry != null && packetCtx != null) {
+        tableStore.directCounterIncrement(tableName, result.entry, packetCtx.payloadSize)
+      }
+
+      packetCtx?.addTraceEvent(
+        traceEventBuilder()
+          .setTableLookup(
+            TableLookupEvent.newBuilder()
+              .setTableName(tableStore.tableDisplayName(tableName))
+              .setHit(result.hit)
+              .setActionName(tableStore.actionDisplayName(result.actionName))
+              .also { if (result.entry != null) it.setMatchedEntry(result.entry) }
           )
-        val shifted = BitVector(src.bits.value.shiftLeft(lo), target.bits.width)
-        val result = (target.bits and mask.inv()) or (shifted and mask)
-        setLValue(lhs.slice.expr, BitVal(result), env)
+          .build()
+      )
+
+      if (result.members != null) {
+        val forced = selectorOverrides[tableName]
+        if (forced != null) {
+          // Re-execution with a forced member. Disable cache: tables after the fork may
+          // see different key values per branch.
+          pastForkPoint = true
+          val member =
+            result.members.find { it.memberId == forced }
+              ?: error("forced member $forced not found in table $tableName")
+          val resolvedMember =
+            tableBehavior.actionOverridesMap[member.actionName] ?: member.actionName
+          execAction(resolvedMember, member.params, env)
+          return TableResult(result.hit, member.actionName)
+        }
+        // First encounter: throw to let the architecture build the trace tree.
+        throw ActionSelectorFork(
+          tableName,
+          result.members,
+          packetCtx!!.getEvents(),
+          recordedLookups.toMap(),
+        )
       }
-      else -> error("unhandled lvalue kind: $lhs")
+
+      // Resolve per-table action specialization: the p4info uses original names,
+      // but the midend may have created per-table copies with distinct bodies.
+      val resolvedName = tableBehavior.actionOverridesMap[result.actionName] ?: result.actionName
+      val params = result.entry?.action?.action?.paramsList ?: result.actionParams
+      execAction(resolvedName, params, env)
+      return TableResult(result.hit, result.actionName)
+    }
+
+    private fun execAction(
+      actionName: String,
+      paramProtos: List<p4.v1.P4RuntimeOuterClass.Action.Param>,
+      env: Environment,
+    ) {
+      // NoAction is a P4 built-in no-op (P4 spec §12.7) that is implicitly available in
+      // every table. It may appear in const entries without being listed in the actions block,
+      // so it might not have been compiled into the IR. Handle it directly rather than
+      // requiring the backend to emit an explicit empty ActionDecl for it.
+      if (actionName == "NoAction") {
+        packetCtx?.addTraceEvent(
+          traceEventBuilder()
+            .setActionExecution(ActionExecutionEvent.newBuilder().setActionName(actionName))
+            .build()
+        )
+        return
+      }
+
+      val actionDecl = actions[actionName] ?: error("unknown action: $actionName")
+
+      val paramMap = mutableMapOf<String, com.google.protobuf.ByteString>()
+
+      env.pushScope()
+      try {
+        actionDecl.paramsList.forEachIndexed { i, paramDecl ->
+          val paramProto = paramProtos.getOrNull(i)
+          val value: Value =
+            if (paramProto != null) {
+              val width = paramDecl.type.bit.width
+              paramMap[paramDecl.name] = paramProto.value
+              BitVal(BitVector.ofBytes(paramProto.value.toByteArray(), width))
+            } else {
+              UnitVal
+            }
+          env.define(paramDecl.name, value)
+        }
+
+        // Use the p4info alias (short source-level name) for trace display. The behavioral
+        // IR name may be mangled by the midend (e.g. "acl_pre_ingress_ctrl_set_vrf").
+        val displayName = tableStore.actionDisplayName(actionName)
+        packetCtx?.addTraceEvent(
+          traceEventBuilder()
+            .setActionExecution(
+              ActionExecutionEvent.newBuilder()
+                .setActionName(displayName)
+                .putAllParams(paramMap.mapValues { it.value })
+            )
+            .build()
+        )
+
+        execBlock(actionDecl.bodyList, env)
+      } finally {
+        env.popScope()
+      }
+    }
+
+    /**
+     * Executes a direct (non-table-mediated) action call such as `do_thing(h.h.b)`.
+     *
+     * Binds argument values to the action's parameter names, runs the body, then writes back any
+     * `inout`/`out` parameters to the corresponding call-site lvalues (call-by-value-result
+     * semantics, as required by the P4 spec).
+     */
+    private fun execInlineActionCall(
+      actionName: String,
+      args: List<Expr>,
+      env: Environment,
+    ): Value {
+      val actionDecl = actions[actionName]!!
+      val argValues = args.map { evalExpr(it, env) }
+
+      env.pushScope()
+      try {
+        actionDecl.paramsList.forEachIndexed { i, param ->
+          env.define(param.name, argValues.getOrElse(i) { UnitVal })
+        }
+        try {
+          execBlock(actionDecl.bodyList, env)
+        } catch (_: ReturnException) {
+          // P4 action return exits the body without a value; fall through to writeback.
+        }
+        // Write back inout/out parameters before the scope is popped.
+        actionDecl.paramsList.forEachIndexed { i, param ->
+          if (
+            (param.direction == Direction.INOUT || param.direction == Direction.OUT) &&
+              i < args.size
+          ) {
+            setLValue(args[i], env.lookup(param.name)!!, env)
+          }
+        }
+      } finally {
+        env.popScope()
+      }
+      return UnitVal
+    }
+
+    // -------------------------------------------------------------------------
+    // Extern dispatch
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates an [ExternEvaluator] bound to [call]'s arguments and the current interpreter state.
+     */
+    private fun createExternEvaluator(
+      call: MethodCall,
+      env: Environment,
+      returnType: Type = Type.getDefaultInstance(),
+    ): ExternEvaluator =
+      object : ExternEvaluator {
+        override fun returnType(): Type = returnType
+
+        override fun argCount(): Int = call.argsList.size
+
+        override fun evalArg(index: Int): Value = evalExpr(call.argsList[index], env)
+
+        override fun argType(index: Int): Type = call.argsList[index].type
+
+        override fun writeOutArg(index: Int, value: Value) =
+          setLValue(call.argsList[index], value, env)
+
+        override fun defaultValue(type: Type): Value = defaultValue(type, types)
+
+        override fun traceEventBuilder(): TraceEvent.Builder = this@Execution.traceEventBuilder()
+
+        override fun addTraceEvent(event: TraceEvent) {
+          packetCtx?.addTraceEvent(event)
+        }
+
+        override fun peekRemainingInput(): ByteArray = packet.peekRemainingInput()
+
+        override fun lastTableMiss(): TableMissContext? = lastTableMissCtx
+      }
+
+    private fun execExternCall(call: MethodCall, env: Environment): Value {
+      val funcName = call.target.nameRef.name
+
+      // verify() is a P4 core language construct (spec §12.8), not an architecture extern.
+      if (funcName == "verify") {
+        val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
+        if (!condition) {
+          val err = (evalExpr(call.argsList[1], env) as ErrorVal).member
+          throw ParserErrorException(err, "verify failed: $err")
+        }
+        return UnitVal
+      }
+
+      // assert(condition) / assume(condition): P4 spec §12.9.
+      // At runtime, assume behaves identically to assert — the distinction is for
+      // static analysis tools. On failure, emit a trace event and abort processing.
+      if (funcName == "assert" || funcName == "assume") {
+        val condition = (evalExpr(call.argsList[0], env) as BoolVal).value
+        packetCtx?.addTraceEvent(
+          traceEventBuilder().setAssertion(AssertionEvent.newBuilder().setPassed(condition)).build()
+        )
+        if (!condition) throw AssertionFailureException("$funcName failed")
+        return UnitVal
+      }
+
+      // All other externs are architecture-specific — delegate to the handler.
+      val handler = externHandler ?: error("no extern handler for: $funcName")
+      return handler.handle(ExternCall.FreeFunction(funcName), createExternEvaluator(call, env))
+    }
+
+    /** Whether [expr] is a field access into a header union. */
+    private fun isUnionFieldAccess(expr: Expr): Boolean =
+      expr.hasFieldAccess() &&
+        expr.fieldAccess.expr.type.let { t ->
+          t.hasNamed() && types[t.named]?.hasHeaderUnion() == true
+        }
+
+    /** If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20). */
+    private fun invalidateUnionSiblings(expr: Expr, target: HeaderVal, env: Environment) {
+      if (!isUnionFieldAccess(expr)) return
+      val parent = evalExpr(expr.fieldAccess.expr, env) as StructVal
+      parent.invalidateUnionExcept(target)
+    }
+
+    // -------------------------------------------------------------------------
+    // Packet extract / emit
+    // -------------------------------------------------------------------------
+
+    private fun execExtract(call: MethodCall, env: Environment): Value {
+      // packet_in.extract(hdr.field): the header to extract into is args[0], not the target.
+      // P4's don't-care extract `p.extract<T>(_)` compiles to extract(arg) where
+      // `arg` is an undeclared temporary. Create a throw-away header to consume bytes.
+      val arg = call.argsList[0]
+      // When the arg is a field access into a union (e.g. hdr.u.next.byte), resolve the
+      // union parent once and invalidate siblings inline. This avoids re-evaluating
+      // side-effecting expressions like `.next` on header stacks.
+      var unionHandled = false
+      val header =
+        if (arg.hasNameRef() && env.lookup(arg.nameRef.name) == null && arg.type.hasNamed()) {
+          defaultValue(arg.type.named, types) as? HeaderVal
+            ?: error("type not found for don't-care extract: ${arg.type.named}")
+        } else if (isUnionFieldAccess(arg)) {
+          // Parent is a header union — resolve it once, invalidate siblings (P4 §8.20).
+          val parent = evalExpr(arg.fieldAccess.expr, env) as StructVal
+          val member = parent.fields[arg.fieldAccess.fieldName] as HeaderVal
+          parent.invalidateUnionExcept(member)
+          unionHandled = true
+          member
+        } else {
+          evalExpr(arg, env) as HeaderVal
+        }
+      val headerDecl =
+        (types[header.typeName] ?: error("type not found: ${header.typeName}")).header
+
+      // The 2-argument form b.extract(hdr, varbitBits) is used when the header contains a varbit
+      // field. The second argument gives the varbit field's runtime length in bits.
+      val varbitBits: Int = if (call.argsCount > 1) intValue(evalExpr(call.argsList[1], env)) else 0
+
+      // P4 spec §12.8.1: validate varbit extract constraints.
+      if (varbitBits > 0) {
+        if (varbitBits % 8 != 0) {
+          throw ParserErrorException(
+            "ParserInvalidArgument",
+            "varbit extract length $varbitBits is not a multiple of 8",
+          )
+        }
+        val varbitField = headerDecl.fieldsList.find { it.type.hasVarbit() }
+        if (varbitField != null && varbitBits > varbitField.type.varbit.maxWidth) {
+          throw ParserErrorException(
+            "HeaderTooShort",
+            "varbit extract length $varbitBits exceeds max width " +
+              "${varbitField.type.varbit.maxWidth}",
+          )
+        }
+      }
+
+      val widths = headerDecl.fieldsList.map { fieldWireWidth(it.type, varbitBits) }
+      val totalBits = widths.sum()
+      val allBits = BigInteger(1, packet.extractBytes((totalBits + 7) / 8))
+      val newFields = unpackFields(headerDecl.fieldsList, widths, allBits, totalBits)
+      if (!unionHandled) invalidateUnionSiblings(call.argsList[0], header, env)
+      header.setValid(newFields)
+      return UnitVal
+    }
+
+    /** P4 spec §12.8.2: peek at packet bits and construct a value of type T without consuming. */
+    private fun execLookahead(returnType: Type): Value {
+      // Primitive bit<N> lookahead: peek N bits and return a BitVal.
+      if (returnType.hasBit()) {
+        val width = returnType.bit.width
+        val raw = BigInteger(1, packet.peekBytes((width + 7) / 8))
+        // Mask to exactly N bits (peekBytes may return extra high bits from byte alignment).
+        val mask = BigInteger.ONE.shiftLeft(width).subtract(BigInteger.ONE)
+        return BitVal(BitVector(raw.and(mask), width))
+      }
+
+      val typeName = returnType.named
+      val typeDecl = types[typeName] ?: error("type not found for lookahead: $typeName")
+      val fields =
+        when {
+          typeDecl.hasHeader() -> typeDecl.header.fieldsList
+          typeDecl.hasStruct() -> typeDecl.struct.fieldsList
+          else -> error("lookahead type must be a header or struct: $typeName")
+        }
+      val widths = fields.map { fieldWireWidth(it.type) }
+      val totalBits = widths.sum()
+      val allBits = BigInteger(1, packet.peekBytes((totalBits + 7) / 8))
+      val newFields = unpackFields(fields, widths, allBits, totalBits)
+      return if (typeDecl.hasHeader()) {
+        HeaderVal(typeName, newFields, valid = true)
+      } else {
+        StructVal(typeName, newFields)
+      }
+    }
+
+    /**
+     * Unpacks a BigInteger of raw packet bits into named field values.
+     *
+     * Handles sub-byte fields (e.g. IPv4's bit<4> version and ihl) that share a byte by shift+mask
+     * from a single MSB-first BigInteger. Used by both extract and lookahead.
+     */
+    private fun unpackFields(
+      fields: List<FieldDecl>,
+      widths: List<Int>,
+      allBits: BigInteger,
+      totalBits: Int,
+    ): MutableMap<String, Value> {
+      val result = mutableMapOf<String, Value>()
+      var bitOffset = 0
+      for ((field, width) in fields.zip(widths)) {
+        if (width == 0) {
+          // Zero-width varbit fields still need a map entry so checksum StructExprs
+          // can reference them (e.g. hdr.ipv4.options when IHL=5).
+          if (field.type.hasVarbit()) result[field.name] = BitVal(BitVector(BigInteger.ZERO, 0))
+          continue
+        }
+        val mask = BigInteger.ONE.shiftLeft(width) - BigInteger.ONE
+        val raw = (allBits shr (totalBits - bitOffset - width)) and mask
+        result[field.name] = bitsToValue(field.type, raw, width)
+        bitOffset += width
+      }
+      return result
+    }
+
+    /**
+     * Returns the on-wire bit-width of a header field type.
+     *
+     * P4 spec §8.9.2: bool in a header occupies exactly 1 bit on the wire. int<N> and bit<N> occupy
+     * N bits. varbit<N> occupies [varbitBits] bits (caller must supply the runtime value).
+     * Serializable enums are looked up by name and use their declared underlying width.
+     */
+    private fun fieldWireWidth(type: Type, varbitBits: Int = 0): Int =
+      when {
+        type.hasBit() -> type.bit.width
+        type.hasSignedInt() -> type.signedInt.width
+        type.hasBoolean() -> 1
+        type.hasVarbit() -> varbitBits
+        type.hasNamed() -> {
+          val decl = types[type.named]
+          when {
+            decl != null && decl.hasEnum() -> decl.enum.width
+            else -> 0
+          }
+        }
+        else -> 0
+      }
+
+    /**
+     * Converts raw extracted bits to the appropriate [Value] for a header field.
+     *
+     * bit<N> → [BitVal], bool → [BoolVal], int<N> → [IntVal], varbit / enum → [BitVal].
+     */
+    private fun bitsToValue(type: Type, raw: BigInteger, width: Int): Value =
+      when {
+        type.hasBoolean() -> BoolVal(raw != BigInteger.ZERO)
+        type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(raw, width))
+        else -> BitVal(BitVector(raw, width))
+      }
+
+    private fun execEmit(call: MethodCall, env: Environment): Value {
+      emitValue(evalExpr(call.argsList[0], env))
+      return UnitVal
+    }
+
+    /**
+     * Recursively emits a value to the packet output buffer.
+     * - [HeaderVal]: packs all fields into bytes (MSB-first) and appends if valid.
+     * - [StructVal]: iterates fields in declaration order (looking up the TypeDecl) and emits each.
+     * - Other types: no-op (non-emittable values such as BoolVal in metadata structs).
+     *
+     * This handles both `pkt.emit(hdr.ethernet)` (single header) and `pkt.emit(hdr)` where `hdr` is
+     * a struct containing multiple headers, as required by the P4 deparser model.
+     */
+    private fun emitValue(value: Value) {
+      when (value) {
+        is HeaderVal -> emitHeader(value)
+        is StructVal -> {
+          // Emit in the declaration order from the TypeDecl; fall back to map order if unknown.
+          val typeDecl = types[value.typeName]
+          val fieldDecls =
+            when {
+              typeDecl != null && typeDecl.hasStruct() -> typeDecl.struct.fieldsList
+              typeDecl != null && typeDecl.hasHeaderUnion() -> typeDecl.headerUnion.fieldsList
+              else -> null
+            }
+          if (fieldDecls != null) {
+            for (field in fieldDecls) {
+              emitValue(value.fields[field.name] ?: continue)
+            }
+          } else {
+            for (fieldVal in value.fields.values) emitValue(fieldVal)
+          }
+        }
+        is HeaderStackVal -> {
+          for (header in value.headers) emitValue(header)
+        }
+        else -> {} // BoolVal, BitVal outside a header, UnitVal — not emittable
+      }
+    }
+
+    /** Packs a valid header's fields into bytes (MSB-first) and appends to the output buffer. */
+    private fun emitHeader(header: HeaderVal) {
+      if (!header.valid) return
+      val headerDecl =
+        (types[header.typeName] ?: error("type not found: ${header.typeName}")).header
+      // Compute total wire bits from field declarations; varbit fields use their stored BitVal
+      // width since we don't have the runtime length separately at emit time.
+      val totalBits =
+        headerDecl.fieldsList.sumOf { field ->
+          when (val v = header.fields[field.name]) {
+            is BitVal -> v.bits.width
+            is BoolVal -> 1
+            is IntVal -> v.bits.width
+            else -> 0
+          }
+        }
+      var packedBits = BigInteger.ZERO
+      var bitOffset = 0
+      for (field in headerDecl.fieldsList) {
+        val fieldBits: BigInteger
+        val width: Int
+        when (val fieldVal = header.fields[field.name]) {
+          is BitVal -> {
+            fieldBits = fieldVal.bits.value
+            width = fieldVal.bits.width
+          }
+          is BoolVal -> {
+            // P4 spec §8.9.2: bool occupies 1 bit on the wire.
+            fieldBits = if (fieldVal.value) BigInteger.ONE else BigInteger.ZERO
+            width = 1
+          }
+          is IntVal -> {
+            fieldBits = fieldVal.bits.toUnsigned().value
+            width = fieldVal.bits.width
+          }
+          else -> continue // UnitVal (e.g. varbit placeholder) — skip
+        }
+        if (totalBits > 0 && width > 0) {
+          val shift = totalBits - bitOffset - width
+          packedBits = packedBits or fieldBits.shiftLeft(shift)
+        }
+        bitOffset += width
+      }
+      if (totalBits > 0) {
+        val bytes = BitVector(packedBits, totalBits).toByteArray()
+        packet.emitBytes(bytes)
+        packetCtx?.addTraceEvent(
+          TraceEvent.newBuilder()
+            .setDeparserEmit(
+              DeparserEmitEvent.newBuilder()
+                .setHeaderType(header.typeName)
+                .setByteLength(bytes.size)
+            )
+            .build()
+        )
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // LValue assignment
+    // -------------------------------------------------------------------------
+
+    private fun setLValue(lhs: Expr, value: Value, env: Environment) {
+      // P4 assignment is copy-by-value. Headers and structs carry mutable fields maps,
+      // so we copy them to prevent aliasing (e.g. `x = h.h; x.a = 2` must not modify `h.h.a`).
+      val copy =
+        when (value) {
+          is HeaderVal -> value.copy()
+          is StructVal -> value.copy()
+          else -> value
+        }
+      when {
+        lhs.hasNameRef() -> {
+          env.update(lhs.nameRef.name, copy)
+        }
+        lhs.hasFieldAccess() -> {
+          val target = evalExpr(lhs.fieldAccess.expr, env)
+          when (target) {
+            is HeaderVal -> target.fields[lhs.fieldAccess.fieldName] = copy
+            is StructVal -> target.fields[lhs.fieldAccess.fieldName] = copy
+            else -> error("field assignment on non-aggregate: $target")
+          }
+        }
+        // P4 spec §8.18: out-of-bounds writes are no-ops.
+        lhs.hasArrayIndex() -> {
+          val stack = evalExpr(lhs.arrayIndex.expr, env) as HeaderStackVal
+          val index = intValue(evalExpr(lhs.arrayIndex.index, env))
+          if (index in 0 until stack.size) stack.headers[index] = copy
+        }
+        lhs.hasSlice() -> {
+          // Slice assignment: update [hi:lo] bits of the target.
+          val target = evalExpr(lhs.slice.expr, env) as BitVal
+          val src = value as BitVal
+          val hi = lhs.slice.hi
+          val lo = lhs.slice.lo
+          val mask =
+            BitVector(
+              BigInteger.TWO.pow(hi - lo + 1).minus(BigInteger.ONE).shiftLeft(lo),
+              target.bits.width,
+            )
+          val shifted = BitVector(src.bits.value.shiftLeft(lo), target.bits.width)
+          val result = (target.bits and mask.inv()) or (shifted and mask)
+          setLValue(lhs.slice.expr, BitVal(result), env)
+        }
+        else -> error("unhandled lvalue kind: $lhs")
+      }
+    }
+  } // end Execution
+
+  /** Holds one [Interpreter] per [BehavioralConfig], rebuilding only when the config changes. */
+  class Cache {
+    private var cached: Interpreter? = null
+    private var cachedConfig: BehavioralConfig? = null
+
+    fun get(config: BehavioralConfig): Interpreter {
+      if (config === cachedConfig) return cached!!
+      return Interpreter(config).also {
+        cached = it
+        cachedConfig = config
+      }
     }
   }
 
@@ -1271,6 +1322,18 @@ class Interpreter(
     private val BOOL_FALSE_BITS = BitVector.ofInt(0, 1)
   }
 }
+
+/** Creates a one-shot [Interpreter.Execution] — convenience for tests. */
+fun interpreterExecution(
+  config: BehavioralConfig,
+  tableStore: TableStore,
+  packetCtx: PacketContext? = null,
+  selectorOverrides: Map<String, Int> = emptyMap(),
+  externHandler: ExternHandler? = null,
+  tableLookupCache: Map<String, TableStore.LookupResult>? = null,
+): Interpreter.Execution =
+  Interpreter(config)
+    .execution(tableStore, packetCtx, selectorOverrides, externHandler, tableLookupCache)
 
 /**
  * Thrown by an `exit` statement; unwinds the call stack to the top of the current pipeline stage.

--- a/simulator/InterpreterControlTest.kt
+++ b/simulator/InterpreterControlTest.kt
@@ -92,7 +92,7 @@ class InterpreterControlTest {
   }
 
   private fun interp(config: BehavioralConfig, tableStore: TableStore = TableStore()) =
-    Interpreter(config, tableStore, externHandler = testExternHandler(tableStore))
+    interpreterExecution(config, tableStore, externHandler = testExternHandler(tableStore))
 
   /** Builds a `switch (tableName.apply().action_run)` statement. */
   private fun switchOn(
@@ -561,7 +561,7 @@ class InterpreterControlTest {
   fun `free-function extern without handler throws`() {
     val stmt = externCall("unknown_extern", bit(0, 8))
     val config = controlConfig(stmt)
-    val noHandler = Interpreter(config, TableStore())
+    val noHandler = interpreterExecution(config, TableStore())
     val e =
       assertThrows(IllegalStateException::class.java) {
         noHandler.runControl("MyControl", emptyEnv)
@@ -573,7 +573,7 @@ class InterpreterControlTest {
   fun `extern method without handler throws`() {
     val stmt = methodCallStmt("obj", "some_method", bit(0, 8), targetType = namedType("my_extern"))
     val config = controlConfig(stmt)
-    val noHandler = Interpreter(config, TableStore())
+    val noHandler = interpreterExecution(config, TableStore())
     val e =
       assertThrows(IllegalStateException::class.java) {
         noHandler.runControl("MyControl", emptyEnv)
@@ -611,7 +611,7 @@ class InterpreterControlTest {
     val stmt = externCall("capture_input")
     val config = controlConfig(stmt)
     val pktCtx = PacketContext(payload)
-    Interpreter(config, TableStore(), pktCtx, externHandler = handler)
+    interpreterExecution(config, TableStore(), pktCtx, externHandler = handler)
       .runControl("MyControl", emptyEnv)
     assertEquals(payload.toList(), captured?.toList())
   }

--- a/simulator/InterpreterExprTest.kt
+++ b/simulator/InterpreterExprTest.kt
@@ -39,11 +39,11 @@ class InterpreterExprTest {
   private val emptyEnv
     get() = Environment()
 
-  private fun interp() = Interpreter(emptyConfig, TableStore())
+  private fun interp() = interpreterExecution(emptyConfig, TableStore())
 
   /** Interpreter with v1model hash extern handler, for hash tests. */
   private fun interpWithHash() =
-    Interpreter(
+    interpreterExecution(
       emptyConfig,
       TableStore(),
       externHandler =
@@ -635,7 +635,7 @@ class InterpreterExprTest {
             .setHeaderUnion(fourward.ir.HeaderUnionDecl.getDefaultInstance())
         )
         .build()
-    Interpreter(config, TableStore()).evalExpr(expr, env)
+    interpreterExecution(config, TableStore()).evalExpr(expr, env)
 
     assertTrue(memberB.valid)
     assertFalse(memberA.valid)
@@ -851,7 +851,7 @@ class InterpreterExprTest {
       )
       .build()
 
-  private fun stackInterp() = Interpreter(stackTestConfig, TableStore())
+  private fun stackInterp() = interpreterExecution(stackTestConfig, TableStore())
 
   private fun makeStack(vararg validFields: Int?): HeaderStackVal {
     val headers =

--- a/simulator/InterpreterInlineActionTest.kt
+++ b/simulator/InterpreterInlineActionTest.kt
@@ -45,10 +45,10 @@ class InterpreterInlineActionTest {
       )
       .build()
 
-  private fun interp(vararg actions: ActionDecl): Interpreter {
+  private fun interp(vararg actions: ActionDecl): Interpreter.Execution {
     val config =
       BehavioralConfig.newBuilder().also { cfg -> actions.forEach { cfg.addActions(it) } }.build()
-    return Interpreter(config, TableStore())
+    return interpreterExecution(config, TableStore())
   }
 
   @Test

--- a/simulator/InterpreterPacketTest.kt
+++ b/simulator/InterpreterPacketTest.kt
@@ -71,10 +71,10 @@ class InterpreterPacketTest {
       )
       .build()
 
-  private fun interp(packetCtx: PacketContext, vararg types: TypeDecl): Interpreter {
+  private fun interp(packetCtx: PacketContext, vararg types: TypeDecl): Interpreter.Execution {
     val config =
       BehavioralConfig.newBuilder().also { cfg -> types.forEach { cfg.addTypes(it) } }.build()
-    return Interpreter(config, TableStore(), packetCtx)
+    return interpreterExecution(config, TableStore(), packetCtx)
   }
 
   // ---------------------------------------------------------------------------
@@ -85,7 +85,7 @@ class InterpreterPacketTest {
   fun `extract without PacketContext gives a descriptive error`() {
     val type = headerType("h_t", "f" to 8)
     val config = BehavioralConfig.newBuilder().also { cfg -> cfg.addTypes(type) }.build()
-    val interp = Interpreter(config, TableStore()) // no PacketContext
+    val interp = interpreterExecution(config, TableStore()) // no PacketContext
     val env = Environment()
     env.define("hdr", HeaderVal(typeName = "h_t", valid = false))
 

--- a/simulator/InterpreterParserTest.kt
+++ b/simulator/InterpreterParserTest.kt
@@ -48,14 +48,17 @@ class InterpreterParserTest {
     vararg states: ParserState,
     tableStore: TableStore = TableStore(),
     valueSets: List<ValueSetDecl> = emptyList(),
-  ): Interpreter {
+  ): Interpreter.Execution {
     val parser =
       ParserDecl.newBuilder()
         .setName("MyParser")
         .addAllStates(states.toList())
         .addAllValueSets(valueSets)
         .build()
-    return Interpreter(BehavioralConfig.newBuilder().addParsers(parser).build(), tableStore)
+    return interpreterExecution(
+      BehavioralConfig.newBuilder().addParsers(parser).build(),
+      tableStore,
+    )
   }
 
   @Test

--- a/simulator/InterpreterTraceEventTest.kt
+++ b/simulator/InterpreterTraceEventTest.kt
@@ -97,7 +97,7 @@ class InterpreterTraceEventTest {
     val config = controlConfig("MyIngress", markToDropStmt())
     val env = standardMetadataEnv()
     val pktCtx = PacketContext(byteArrayOf())
-    Interpreter(config, TableStore(), pktCtx, externHandler = markToDropHandler)
+    interpreterExecution(config, TableStore(), pktCtx, externHandler = markToDropHandler)
       .runControl("MyIngress", env)
 
     val markToDropEvents = pktCtx.getEvents().filter { it.hasMarkToDrop() }
@@ -114,7 +114,7 @@ class InterpreterTraceEventTest {
     val config = controlConfig("MyIngress", ifStmt(boolLit(true)))
     val env = Environment()
     val pktCtx = PacketContext(byteArrayOf())
-    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", env)
+    interpreterExecution(config, TableStore(), pktCtx).runControl("MyIngress", env)
 
     val branchEvents = pktCtx.getEvents().filter { it.hasBranch() }
     assertEquals(1, branchEvents.size)
@@ -137,7 +137,7 @@ class InterpreterTraceEventTest {
     val config = controlConfig("MyIngress", ifStmt(boolLit(true), sourceInfo = si))
     val env = Environment()
     val pktCtx = PacketContext(byteArrayOf())
-    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", env)
+    interpreterExecution(config, TableStore(), pktCtx).runControl("MyIngress", env)
 
     val branchEvents = pktCtx.getEvents().filter { it.hasBranch() }
     assertEquals(1, branchEvents.size)
@@ -157,7 +157,7 @@ class InterpreterTraceEventTest {
     val config = controlConfig("MyIngress", ifStmt(boolLit(true)))
     val env = Environment()
     val pktCtx = PacketContext(byteArrayOf())
-    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", env)
+    interpreterExecution(config, TableStore(), pktCtx).runControl("MyIngress", env)
 
     val branchEvents = pktCtx.getEvents().filter { it.hasBranch() }
     assertEquals(1, branchEvents.size)
@@ -175,7 +175,7 @@ class InterpreterTraceEventTest {
       ParserDecl.newBuilder().setName("P").addStates(parserState("start", "accept", si)).build()
     val config = BehavioralConfig.newBuilder().addParsers(parser).build()
     val pktCtx = PacketContext(byteArrayOf())
-    Interpreter(config, TableStore(), pktCtx).runParser("P", Environment())
+    interpreterExecution(config, TableStore(), pktCtx).runParser("P", Environment())
 
     val transitions = pktCtx.getEvents().filter { it.hasParserTransition() }
     assertEquals(1, transitions.size)
@@ -201,7 +201,7 @@ class InterpreterTraceEventTest {
         .build()
     val config = BehavioralConfig.newBuilder().addParsers(parser).build()
     val pktCtx = PacketContext(byteArrayOf())
-    Interpreter(config, TableStore(), pktCtx).runParser("P", Environment())
+    interpreterExecution(config, TableStore(), pktCtx).runParser("P", Environment())
 
     val transitions = pktCtx.getEvents().filter { it.hasParserTransition() }
     assertEquals(2, transitions.size)
@@ -223,7 +223,7 @@ class InterpreterTraceEventTest {
       controlConfig("MyIngress", ifStmt(boolLit(true), sourceInfo = si1), markToDropStmt(si2))
     val env = standardMetadataEnv()
     val pktCtx = PacketContext(byteArrayOf())
-    Interpreter(config, TableStore(), pktCtx, externHandler = markToDropHandler)
+    interpreterExecution(config, TableStore(), pktCtx, externHandler = markToDropHandler)
       .runControl("MyIngress", env)
 
     val events = pktCtx.getEvents()
@@ -243,7 +243,7 @@ class InterpreterTraceEventTest {
   fun `assert true emits passing AssertionEvent`() {
     val config = controlConfig("MyIngress", externCall("assert", boolLit(true)))
     val pktCtx = PacketContext(byteArrayOf())
-    Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
+    interpreterExecution(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
 
     val events = pktCtx.getEvents().filter { it.hasAssertion() }
     assertEquals(1, events.size)
@@ -259,7 +259,7 @@ class InterpreterTraceEventTest {
     val config = controlConfig("MyIngress", externCall("assert", boolLit(false)))
     val pktCtx = PacketContext(byteArrayOf())
     assertThrows(AssertionFailureException::class.java) {
-      Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
+      interpreterExecution(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
     }
 
     val events = pktCtx.getEvents().filter { it.hasAssertion() }
@@ -276,7 +276,7 @@ class InterpreterTraceEventTest {
     val config = controlConfig("MyIngress", externCall("assume", boolLit(false)))
     val pktCtx = PacketContext(byteArrayOf())
     assertThrows(AssertionFailureException::class.java) {
-      Interpreter(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
+      interpreterExecution(config, TableStore(), pktCtx).runControl("MyIngress", Environment())
     }
   }
 }

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -30,7 +30,9 @@ import java.math.BigInteger
  */
 class PNAArchitecture : Architecture {
 
-  /** Pipeline-invariant state derived from the [BehavioralConfig]. Computed once per packet. */
+  private val interpreterCache = Interpreter.Cache()
+
+  /** Pipeline-invariant state derived from the [BehavioralConfig]. */
   @Suppress("LongParameterList")
   private class PipelineConfig(
     val config: BehavioralConfig,
@@ -38,6 +40,7 @@ class PNAArchitecture : Architecture {
     val blockParams: Map<String, List<BlockParam>>,
     val typesByName: Map<String, TypeDecl>,
     val externInstances: Map<String, ExternInstanceDecl>,
+    val interpreter: Interpreter,
     val mainParser: PipelineStage,
     val preControl: PipelineStage,
     val mainControl: PipelineStage,
@@ -78,6 +81,7 @@ class PNAArchitecture : Architecture {
         blockParams = buildBlockParamsMap(config),
         typesByName = config.typesList.associateBy { it.name },
         externInstances = buildExternInstancesMap(config),
+        interpreter = interpreterCache.get(config),
         mainParser = stage("main_parser"),
         preControl = stage("pre_control"),
         mainControl = stage("main_control"),
@@ -124,8 +128,7 @@ class PNAArchitecture : Architecture {
 
     val checksumState = mutableMapOf<String, BigInteger>()
     val interpreter =
-      Interpreter(
-        pipeline.config,
+      pipeline.interpreter.execution(
         pipeline.tableStore,
         ctx,
         selectorMembers,

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -34,7 +34,9 @@ import java.math.BigInteger
  */
 class PSAArchitecture : Architecture {
 
-  /** Pipeline-invariant state derived from the [BehavioralConfig]. Computed once per packet. */
+  private val interpreterCache = Interpreter.Cache()
+
+  /** Pipeline-invariant state derived from the [BehavioralConfig]. */
   @Suppress("LongParameterList")
   private class PipelineConfig(
     val config: BehavioralConfig,
@@ -42,6 +44,7 @@ class PSAArchitecture : Architecture {
     val blockParams: Map<String, List<BlockParam>>,
     val typesByName: Map<String, TypeDecl>,
     val externInstances: Map<String, ExternInstanceDecl>,
+    val interpreter: Interpreter,
     // Pre-resolved PSA pipeline stages (fail fast on misconfigured pipelines).
     val ingressParser: PipelineStage,
     val ingress: PipelineStage,
@@ -69,6 +72,7 @@ class PSAArchitecture : Architecture {
         blockParams = buildBlockParamsMap(config),
         typesByName = config.typesList.associateBy { it.name },
         externInstances = buildExternInstancesMap(config),
+        interpreter = interpreterCache.get(config),
         ingressParser = stage("ingress_parser"),
         ingress = stage("ingress"),
         ingressDeparser = stage("ingress_deparser"),
@@ -213,8 +217,7 @@ class PSAArchitecture : Architecture {
     val output = values["psa_ingress_output_metadata_t"] as? StructVal
 
     val interpreter =
-      Interpreter(
-        pipeline.config,
+      pipeline.interpreter.execution(
         pipeline.tableStore,
         ctx,
         selectorMembers,
@@ -411,7 +414,7 @@ class PSAArchitecture : Architecture {
     val egressOutput = egressValues["psa_egress_output_metadata_t"] as? StructVal
 
     val egressInterpreter =
-      Interpreter(p.config, p.tableStore, egressCtx, selectorMembers, createPsaExternHandler(p))
+      p.interpreter.execution(p.tableStore, egressCtx, selectorMembers, createPsaExternHandler(p))
 
     // --- Egress Parser ---
     bindStageParams(egressEnv, p.egressParser.blockName, p.blockParams, egressValues)

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -77,6 +77,7 @@ class V1ModelArchitecture(
    * start of each [processPacket] to prevent stale state across packets.
    */
   private var postParserSnapshot: PostParserSnapshot? = null
+  private val interpreterCache = Interpreter.Cache()
 
   /** Invariant inputs to the pipeline, shared across fork re-executions. */
   private data class PipelineContext(
@@ -84,6 +85,7 @@ class V1ModelArchitecture(
     val payload: ByteArray,
     val config: BehavioralConfig,
     val tableStore: TableStore,
+    val interpreter: Interpreter,
   )
 
   /** Per-execution state created fresh for each pipeline run. */
@@ -91,7 +93,7 @@ class V1ModelArchitecture(
   private class PipelineState(
     val packetCtx: PacketContext,
     val pendingOps: V1ModelPendingOps,
-    val interpreter: Interpreter,
+    val interpreter: Interpreter.Execution,
     val env: Environment,
     val standardMetadata: StructVal,
     val metaParamName: String,
@@ -120,7 +122,8 @@ class V1ModelArchitecture(
     tableStore: TableStore,
   ): PipelineResult {
     postParserSnapshot = null
-    val ctx = PipelineContext(ingressPort, payload, config, tableStore)
+    val ctx =
+      PipelineContext(ingressPort, payload, config, tableStore, interpreterCache.get(config))
     return buildTraceTree(ctx, V1ModelDecisions(), prefixLength = 0)
   }
 
@@ -386,8 +389,7 @@ class V1ModelArchitecture(
 
     val pendingOps = V1ModelPendingOps()
     val interpreter =
-      Interpreter(
-        ctx.config,
+      ctx.interpreter.execution(
         ctx.tableStore,
         packetCtx,
         decisions.selectorMembers,


### PR DESCRIPTION
## Summary

Split the Interpreter into a **long-lived engine** (config-derived maps, built once per pipeline load) and a **lightweight Execution** inner class (per-run state, 5 field assignments).

Previously, every pipeline execution constructed a new Interpreter, rebuilding 5 maps from config protos — 32× per packet on wcmp×16+mirr. Now the maps are built once and all three architectures (V1Model, PSA, PNA) cache the Interpreter per pipeline config.

### Design

- `Interpreter(config)` — long-lived, holds 5 immutable config-derived maps
- `Interpreter.Execution(tableStore, packetCtx, ...)` — cheap per-run context, accesses outer maps directly
- `interpreterExecution(config, tableStore, ...)` — one-shot factory for tests
- All architectures cache one `Interpreter` per `BehavioralConfig` identity

### Review fixes

- Merged stale KDoc (old "single packet traversal" + new "long-lived engine")
- Renamed `Interpreter(...)` factory → `interpreterExecution(...)` (was confusing — looked like constructor but returned Execution)
- Added Interpreter caching to PSA and PNA (were rebuilding maps every packet, defeating the purpose)

## Test plan

- [x] `bazel test //...` — all 58 tests pass
- [x] `./tools/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)