### PR TITLE
Structured P4RT error details, CLI file check, error message tests

### DIFF
--- a/cli/Compile.kt
+++ b/cli/Compile.kt
@@ -15,6 +15,10 @@ import java.nio.file.Path
  * runfiles when available. Returns an exit code (does not call `exitProcess`).
  */
 fun compile(p4Source: Path, outputPath: Path?, includeDirs: List<Path>): Int {
+  if (!Files.exists(p4Source)) {
+    System.err.println("error: file not found: $p4Source")
+    return ExitCode.USAGE_ERROR
+  }
   val p4c = findP4c4ward()
   if (p4c == null) {
     System.err.println(
@@ -35,7 +39,7 @@ fun compile(p4Source: Path, outputPath: Path?, includeDirs: List<Path>): Int {
   process.inputStream.copyTo(System.out)
   val exitCode = process.waitFor()
   if (exitCode != 0) {
-    System.err.println("error: p4c-4ward exited with code $exitCode")
+    System.err.println("error: p4c-4ward exited with code $exitCode (see compiler output above)")
     return ExitCode.COMPILE_ERROR
   }
   return ExitCode.SUCCESS

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -349,13 +349,21 @@ class P4RuntimeService(
     for (rawUpdate in updates) {
       try {
         processUpdate(rawUpdate, state, roleName)
-        errors.add(P4RuntimeOuterClass.Error.newBuilder().setCanonicalCode(OK_CODE).build())
+        errors.add(
+          P4RuntimeOuterClass.Error.newBuilder()
+            .setCanonicalCode(OK_CODE)
+            .setSpace(P4RT_ERROR_SPACE)
+            .setCode(OK_CODE)
+            .build()
+        )
       } catch (e: StatusException) {
         hasError = true
         errors.add(
           P4RuntimeOuterClass.Error.newBuilder()
             .setCanonicalCode(e.status.code.value())
             .setMessage(e.status.description ?: "")
+            .setSpace(P4RT_ERROR_SPACE)
+            .setCode(e.status.code.value())
             .build()
         )
       }
@@ -1001,6 +1009,9 @@ class P4RuntimeService(
       "Role.config is not supported; use @p4runtime_role annotations in p4info instead"
 
     private const val OK_CODE = com.google.rpc.Code.OK_VALUE
+
+    // P4Runtime spec §12.3: the error space for P4Runtime-specific errors.
+    private const val P4RT_ERROR_SPACE = "p4.v1"
 
     private fun isZeroElectionId(id: Uint128): Boolean = id.high == 0L && id.low == 0L
 

--- a/p4runtime/P4RuntimeWriteErrorTest.kt
+++ b/p4runtime/P4RuntimeWriteErrorTest.kt
@@ -215,6 +215,78 @@ class P4RuntimeWriteErrorTest {
     assertGrpcError(Status.Code.INVALID_ARGUMENT, "missing") { harness.installEntry(entity) }
   }
 
+  // P4Runtime spec §9.1.2: param_id must exist in the action's p4info schema.
+  @Test
+  fun `insert with unknown param ID returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entity =
+      buildInvalidEntry(config) { b ->
+        b.tableEntryBuilder.actionBuilder.actionBuilder.getParamsBuilder(0).setParamId(99999)
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "unknown") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §9.1.1: match field IDs must correspond to p4info fields.
+  @Test
+  fun `insert with unknown match field ID returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entity =
+      buildInvalidEntry(config) { b -> b.tableEntryBuilder.getMatchBuilder(0).setFieldId(99999) }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "unknown") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §9.1: each match field may appear at most once.
+  @Test
+  fun `insert with duplicate match field returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entity =
+      buildInvalidEntry(config) { b ->
+        // Add a second copy of the first match field.
+        b.tableEntryBuilder.addMatch(b.tableEntryBuilder.getMatch(0))
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "duplicate") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §9.1.1: a match field with no value set must be rejected.
+  @Test
+  fun `insert with match field missing value returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val matchField = config.p4Info.tablesList.first().matchFieldsList.first()
+    val entity =
+      buildInvalidEntry(config) { b ->
+        // Clear the exact value, leaving field_id set but no oneof variant.
+        b.tableEntryBuilder.getMatchBuilder(0).clearExact().setFieldId(matchField.id)
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "no value set") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §9.1.1: exact-only tables must have priority == 0.
+  @Test
+  fun `insert with priority must be 0 message on exact table`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entity = buildInvalidEntry(config) { b -> b.tableEntryBuilder.setPriority(5) }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "priority") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §12.3: per-update errors must include space and code fields.
+  @Test
+  fun `batch error details include space and code fields`() {
+    harness.loadPipeline(loadBasicTableConfig())
+    val request = harness.buildBatchRequest(Update.Type.INSERT, listOf(badTableEntity()))
+    val errors = assertBatchError { harness.writeRaw(request) }
+    assert(errors.size == 1)
+    assert(errors[0].space == "p4.v1") { "error space should be 'p4.v1', got '${errors[0].space}'" }
+    assert(errors[0].code == errors[0].canonicalCode) {
+      "error code should match canonical_code, got code=${errors[0].code} " +
+        "canonical_code=${errors[0].canonicalCode}"
+    }
+  }
+
   // =========================================================================
   // Unimplemented feature guards
   // =========================================================================


### PR DESCRIPTION
## Summary

Follow-up to #404. Three improvements to take error quality to the next level:

**1. Structured P4Runtime error details (spec §12.3)**
Per-update errors now include `space` (`"p4.v1"`) and `code` fields. Controllers that parse `grpc-status-details-bin` get complete diagnostics.

**2. CLI error improvement**
`4ward compile` now checks file existence before invoking p4c, and points users to compiler output on failure instead of a generic exit code message.

**3. Error message regression tests (+6)**
Every previously untested error path now has a test verifying message content:
- Unknown param ID, unknown match field ID, duplicate match field
- Match field missing value, priority must be 0
- Structured error fields (space + code)

## Test plan

- [x] 35/35 tests pass (p4runtime + simulator)
- [x] 6 new error message tests
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)