### PR TITLE
Include P4 source location in simulator errors, improve extern messages

### DIFF
--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -116,6 +116,17 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     /** Name of the control block currently being executed, for BranchEvent. */
     private var currentControlName: String? = null
 
+    /** Formats current P4 source location for inclusion in error messages. */
+    private fun sourceContext(): String {
+      val src = currentSourceInfo ?: return ""
+      val loc = buildString {
+        if (src.file.isNotEmpty()) append(src.file)
+        if (src.line > 0) append(":${src.line}")
+        if (src.column > 0) append(":${src.column}")
+      }
+      return if (loc.isNotEmpty()) " (at $loc)" else ""
+    }
+
     /** Builds a TraceEvent with source info attached, if available. */
     private fun traceEventBuilder(sourceInfo: SourceInfo? = currentSourceInfo): TraceEvent.Builder {
       val b = TraceEvent.newBuilder()
@@ -249,7 +260,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           val hi = (evalExpr(keyset.range.hi, constEnv) as BitVal).bits
           v >= lo && v <= hi
         }
-        else -> error("unhandled keyset kind: $keyset")
+        else -> error("unhandled keyset kind: $keyset${sourceContext()}")
       }
 
     /**
@@ -331,7 +342,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         stmt.hasBlock() -> execBlock(stmt.block.stmtsList, env)
         stmt.hasExit() -> throw ExitException()
         stmt.hasReturnStmt() -> throw ReturnException(evalExpr(stmt.returnStmt.value, env))
-        else -> error("unhandled statement kind: $stmt")
+        else -> error("unhandled statement kind: $stmt${sourceContext()}")
       }
     }
 
@@ -371,7 +382,8 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       when {
         expr.hasLiteral() -> evalLiteral(expr.literal, expr.type)
         expr.hasNameRef() ->
-          env.lookup(expr.nameRef.name) ?: error("undefined variable: ${expr.nameRef.name}")
+          env.lookup(expr.nameRef.name)
+            ?: error("undefined variable: ${expr.nameRef.name}${sourceContext()}")
         expr.hasFieldAccess() -> evalFieldAccess(expr.fieldAccess, env)
         expr.hasArrayIndex() -> evalArrayIndex(expr.arrayIndex, env)
         expr.hasSlice() -> evalSlice(expr.slice, env)
@@ -390,7 +402,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             else -> UnitVal // RESULT / default: switch context
           }
         }
-        else -> error("unhandled expression kind: $expr")
+        else -> error("unhandled expression kind: $expr${sourceContext()}")
       }
 
     private fun evalLiteral(lit: Literal, type: fourward.ir.Type): Value =
@@ -412,10 +424,10 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when {
             type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
             type.hasBit() -> BitVal(BitVector(v, type.bit.width))
-            else -> error("big integer literal with unexpected type: $type")
+            else -> error("big integer literal with unexpected type: $type${sourceContext()}")
           }
         }
-        else -> error("unhandled literal kind: $lit")
+        else -> error("unhandled literal kind: $lit${sourceContext()}")
       }
 
     private fun evalFieldAccess(fa: fourward.ir.FieldAccess, env: Environment): Value {
@@ -427,19 +439,23 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         return when (fa.fieldName) {
           "hit" -> BoolVal(result.hit)
           "miss" -> BoolVal(!result.hit)
-          else -> error("unknown field '${fa.fieldName}' on table apply result")
+          else -> error("unknown field '${fa.fieldName}' on table apply result${sourceContext()}")
         }
       }
       val target = evalExpr(fa.expr, env)
       return when (target) {
         is HeaderVal ->
           target.fields[fa.fieldName]
-            ?: error("field ${fa.fieldName} not found in header ${target.typeName}")
+            ?: error(
+              "field ${fa.fieldName} not found in header ${target.typeName}${sourceContext()}"
+            )
         is StructVal ->
           target.fields[fa.fieldName]
-            ?: error("field ${fa.fieldName} not found in struct ${target.typeName}")
+            ?: error(
+              "field ${fa.fieldName} not found in struct ${target.typeName}${sourceContext()}"
+            )
         is HeaderStackVal -> evalHeaderStackProperty(target, fa.fieldName)
-        else -> error("field access on non-aggregate value: $target")
+        else -> error("field access on non-aggregate value: $target${sourceContext()}")
       }
     }
 
@@ -460,13 +476,14 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         "last" -> stack.headers[(stack.nextIndex - 1).coerceAtLeast(0)]
         "lastIndex" -> BitVal(stack.headers.size.toLong() - 1, STACK_PROPERTY_BITS)
         "size" -> BitVal(stack.headers.size.toLong(), STACK_PROPERTY_BITS)
-        else -> error("unknown header stack property: $name")
+        else -> error("unknown header stack property: $name${sourceContext()}")
       }
 
     // P4 spec §8.18: out-of-bounds reads return an invalid header with default values.
     private fun evalArrayIndex(ai: fourward.ir.ArrayIndex, env: Environment): Value {
       val stack =
-        evalExpr(ai.expr, env) as? HeaderStackVal ?: error("array index on non-stack value")
+        evalExpr(ai.expr, env) as? HeaderStackVal
+          ?: error("array index on non-stack value${sourceContext()}")
       val index = intValue(evalExpr(ai.index, env))
       if (index !in 0 until stack.size) return defaultValue(stack.elementTypeName, types)
       return stack.headers[index]
@@ -494,7 +511,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
               is InfIntVal -> inner.value
               is IntVal -> inner.bits.toUnsigned().value
               is BoolVal -> if (inner.value) BigInteger.ONE else BigInteger.ZERO
-              else -> error("cannot cast $inner to bit<$targetWidth>")
+              else -> error("cannot cast $inner to bit<$targetWidth>${sourceContext()}")
             }
           BitVal(BitVector(sourceBits.mod(BigInteger.TWO.pow(targetWidth)), targetWidth))
         }
@@ -519,7 +536,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
                 when (inner) {
                   is BitVal -> inner.bits.value
                   is InfIntVal -> inner.value
-                  else -> error("cannot cast $inner to int<$targetWidth>")
+                  else -> error("cannot cast $inner to int<$targetWidth>${sourceContext()}")
                 }
               IntVal(SignedBitVector.fromUnsignedBits(sourceBits, targetWidth))
             }
@@ -530,11 +547,11 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             when (inner) {
               is BitVal -> inner.bits.value
               is InfIntVal -> inner.value
-              else -> error("cannot cast $inner to bool")
+              else -> error("cannot cast $inner to bool${sourceContext()}")
             }
           BoolVal(v != BigInteger.ZERO)
         }
-        else -> error("unsupported cast target type: ${cast.targetType}")
+        else -> error("unsupported cast target type: ${cast.targetType}${sourceContext()}")
       }
     }
 
@@ -573,13 +590,13 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when (left) {
             is BitVal -> BitVal(left.bits.addSat((right as BitVal).bits))
             is IntVal -> IntVal(left.bits.addSat((right as IntVal).bits))
-            else -> error("ADD_SAT on non-fixed-width: $left")
+            else -> error("ADD_SAT on non-fixed-width: $left${sourceContext()}")
           }
         BinaryOperator.SUB_SAT ->
           when (left) {
             is BitVal -> BitVal(left.bits.subSat((right as BitVal).bits))
             is IntVal -> IntVal(left.bits.subSat((right as IntVal).bits))
-            else -> error("SUB_SAT on non-fixed-width: $left")
+            else -> error("SUB_SAT on non-fixed-width: $left${sourceContext()}")
           }
         BinaryOperator.SHL -> BitVal((left as BitVal).bits.shl(intValue(right)))
         BinaryOperator.SHR -> BitVal((left as BitVal).bits.shr(intValue(right)))
@@ -593,7 +610,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         BinaryOperator.GE -> liftCompare(left, right) { it >= 0 }
         BinaryOperator.AND -> BoolVal((left as BoolVal).value && (right as BoolVal).value)
         BinaryOperator.OR -> BoolVal((left as BoolVal).value || (right as BoolVal).value)
-        else -> error("unhandled binary operator: ${op.op}")
+        else -> error("unhandled binary operator: ${op.op}${sourceContext()}")
       }
     }
 
@@ -607,7 +624,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         is BitVal -> BitVal(f(left.bits, (right as BitVal).bits))
         is IntVal ->
           IntVal(f(left.bits.toUnsigned(), (right as IntVal).bits.toUnsigned()).toSigned())
-        else -> error("expected fixed-width integer operands, got: $left, $right")
+        else -> error("expected fixed-width integer operands, got: $left, $right${sourceContext()}")
       }
 
     /** Compare two fixed-width values, dispatching to signed or unsigned comparison. */
@@ -615,7 +632,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       when (left) {
         is BitVal -> BoolVal(pred(left.bits.compareTo((right as BitVal).bits)))
         is IntVal -> BoolVal(pred(left.bits.value.compareTo((right as IntVal).bits.value)))
-        else -> error("expected fixed-width integer operands for comparison")
+        else -> error("expected fixed-width integer operands for comparison${sourceContext()}")
       }
 
     /** Extract a small integer from a [BitVal], [IntVal], or [InfIntVal]. */
@@ -624,7 +641,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         is BitVal -> v.bits.value.toInt()
         is IntVal -> v.bits.value.toInt()
         is InfIntVal -> v.value.toInt()
-        else -> error("expected integer value: $v")
+        else -> error("expected integer value: $v${sourceContext()}")
       }
 
     /** P4 spec §8.1: InfInt adopts the width of the fixed-width operand. */
@@ -646,11 +663,11 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when (inner) {
             is InfIntVal -> InfIntVal(inner.value.negate())
             is BitVal -> BitVal(BitVector.ofInt(0, inner.bits.width) - inner.bits)
-            else -> error("NEG on non-numeric: $inner")
+            else -> error("NEG on non-numeric: $inner${sourceContext()}")
           }
         UnaryOperator.BIT_NOT -> BitVal((inner as BitVal).bits.inv())
         UnaryOperator.NOT -> BoolVal(!(inner as BoolVal).value)
-        else -> error("unhandled unary operator: ${op.op}")
+        else -> error("unhandled unary operator: ${op.op}${sourceContext()}")
       }
     }
 
@@ -678,7 +695,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when (val target = evalExpr(call.target, env)) {
             is HeaderVal -> BoolVal(target.valid)
             is StructVal -> BoolVal(target.isUnionValid())
-            else -> error("isValid on non-header: $target")
+            else -> error("isValid on non-header: $target${sourceContext()}")
           }
         }
         "setValid" -> {
@@ -691,7 +708,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when (val target = evalExpr(call.target, env)) {
             is HeaderVal -> target.setInvalid()
             is StructVal -> target.invalidateUnion()
-            else -> error("setInvalid on non-header: $target")
+            else -> error("setInvalid on non-header: $target${sourceContext()}")
           }
           UnitVal
         }
@@ -748,7 +765,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
               ExternCall.Method(call.target.type.named, call.target.nameRef.name, call.method)
             handler.handle(externCall, createExternEvaluator(call, env, returnType))
           } else {
-            error("unhandled method call: ${call.method} on ${call.target}")
+            error("unhandled method call: ${call.method} on ${call.target}${sourceContext()}")
           }
         }
       }
@@ -1272,7 +1289,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when (target) {
             is HeaderVal -> target.fields[lhs.fieldAccess.fieldName] = copy
             is StructVal -> target.fields[lhs.fieldAccess.fieldName] = copy
-            else -> error("field assignment on non-aggregate: $target")
+            else -> error("field assignment on non-aggregate: $target${sourceContext()}")
           }
         }
         // P4 spec §8.18: out-of-bounds writes are no-ops.
@@ -1296,7 +1313,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           val result = (target.bits and mask.inv()) or (shifted and mask)
           setLValue(lhs.slice.expr, BitVal(result), env)
         }
-        else -> error("unhandled lvalue kind: $lhs")
+        else -> error("unhandled lvalue kind: $lhs${sourceContext()}")
       }
     }
   } // end Execution

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -117,7 +117,9 @@ class PNAArchitecture : Architecture {
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): TraceTree {
-    check(depth < MAX_RECIRCULATIONS) { "PNA recirculation depth exceeded ($MAX_RECIRCULATIONS)" }
+    check(depth < MAX_RECIRCULATIONS) {
+      "PNA recirculation depth exceeded ($MAX_RECIRCULATIONS) — possible infinite recirculate loop"
+    }
 
     val ctx = PacketContext(payload)
     val env = Environment()
@@ -338,7 +340,7 @@ class PNAArchitecture : Architecture {
       // No-op: the simulator has no real timers, so expiration is not modeled.
       "set_entry_expire_time" -> UnitVal
       "restart_expire_timer" -> UnitVal
-      else -> error("unhandled PNA extern: ${call.name}")
+      else -> error("PNA extern '${call.name}' is not implemented")
     }
 
   /**
@@ -392,8 +394,8 @@ class PNAArchitecture : Architecture {
       PNA_HASH_ALGORITHMS,
     )
       ?: error(
-        "unhandled PNA extern method: ${call.externType}.${call.method}" +
-          " on ${call.instanceName}"
+        "PNA extern method '${call.externType}.${call.method}' is not implemented" +
+          " (on ${call.instanceName})"
       )
 
   // ---------------------------------------------------------------------------

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -100,7 +100,9 @@ class PSAArchitecture : Architecture {
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): TraceTree {
-    check(depth < MAX_RECIRCULATIONS) { "PSA recirculation depth exceeded ($MAX_RECIRCULATIONS)" }
+    check(depth < MAX_RECIRCULATIONS) {
+      "PSA recirculation depth exceeded ($MAX_RECIRCULATIONS) — possible infinite recirculate loop"
+    }
 
     // === Ingress pipeline ===
     val ingress: IngressResult
@@ -660,7 +662,7 @@ class PSAArchitecture : Architecture {
               ostd.fields["drop"] = BoolVal(true)
               UnitVal
             }
-            else -> error("unhandled PSA extern: ${call.name}")
+            else -> error("PSA extern '${call.name}' is not implemented")
           }
         is ExternCall.Method ->
           handleCommonExternMethod(
@@ -672,8 +674,8 @@ class PSAArchitecture : Architecture {
             PSA_HASH_ALGORITHMS,
           )
             ?: error(
-              "unhandled PSA extern method: ${call.externType}.${call.method}" +
-                " on ${call.instanceName}"
+              "PSA extern method '${call.externType}.${call.method}' is not implemented" +
+                " (on ${call.instanceName})"
             )
       }
     }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -282,7 +282,9 @@ class V1ModelArchitecture(
    * stages. Stage topology (ingress/egress split) is derived by [PipelineState] itself.
    */
   private fun initPipelineState(ctx: PipelineContext, decisions: V1ModelDecisions): PipelineState {
-    require(decisions.pipelineDepth <= MAX_PIPELINE_DEPTH) { "max pipeline depth exceeded" }
+    require(decisions.pipelineDepth <= MAX_PIPELINE_DEPTH) {
+      "max pipeline depth exceeded ($MAX_PIPELINE_DEPTH) — possible infinite resubmit/recirculate loop"
+    }
     val config = ctx.config
     val typesByName = config.typesList.associateBy { it.name }
 
@@ -390,7 +392,9 @@ class V1ModelArchitecture(
   /** Executes the full v1model pipeline once, returning a flat trace tree with a leaf outcome. */
   @Suppress("CyclomaticComplexMethod", "ThrowsCount")
   private fun runPipeline(ctx: PipelineContext, decisions: V1ModelDecisions): TraceTree {
-    require(decisions.pipelineDepth <= MAX_PIPELINE_DEPTH) { "max pipeline depth exceeded" }
+    require(decisions.pipelineDepth <= MAX_PIPELINE_DEPTH) {
+      "max pipeline depth exceeded ($MAX_PIPELINE_DEPTH) — possible infinite resubmit/recirculate loop"
+    }
     val snapshot = decisions.postParserSnapshot
 
     // --- Init + Parser ---
@@ -864,7 +868,7 @@ class V1ModelArchitecture(
         )
         UnitVal
       }
-      else -> error("unhandled v1model extern: $name")
+      else -> error("v1model extern '$name' is not implemented")
     }
 
   // -------------------------------------------------------------------------
@@ -898,14 +902,20 @@ class V1ModelArchitecture(
             tableStore.registerWrite(call.instanceName, index, eval.evalArg(1))
             UnitVal
           }
-          else -> error("unhandled register method: ${call.method} on ${call.instanceName}")
+          else ->
+            error(
+              "v1model register method '${call.method}' is not implemented (on ${call.instanceName})"
+            )
         }
       "counter",
       "direct_counter" ->
         when (call.method) {
           // fire-and-forget side-effect, invisible to data plane.
           "count" -> UnitVal
-          else -> error("unhandled counter method: ${call.method} on ${call.instanceName}")
+          else ->
+            error(
+              "v1model counter method '${call.method}' is not implemented (on ${call.instanceName})"
+            )
         }
       "meter" ->
         when (call.method) {
@@ -914,7 +924,10 @@ class V1ModelArchitecture(
             eval.writeOutArg(1, eval.defaultValue(eval.argType(1)))
             UnitVal
           }
-          else -> error("unhandled meter method: ${call.method} on ${call.instanceName}")
+          else ->
+            error(
+              "v1model meter method '${call.method}' is not implemented (on ${call.instanceName})"
+            )
         }
       "direct_meter" ->
         when (call.method) {
@@ -923,12 +936,15 @@ class V1ModelArchitecture(
             eval.writeOutArg(0, eval.defaultValue(eval.argType(0)))
             UnitVal
           }
-          else -> error("unhandled direct_meter method: ${call.method} on ${call.instanceName}")
+          else ->
+            error(
+              "v1model direct_meter method '${call.method}' is not implemented (on ${call.instanceName})"
+            )
         }
       else ->
         error(
-          "unhandled v1model extern method: ${call.externType}.${call.method}" +
-            " on ${call.instanceName}"
+          "v1model extern method '${call.externType}.${call.method}' is not implemented" +
+            " (on ${call.instanceName})"
         )
     }
 

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -10,6 +10,8 @@ import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.Executors
+import java.util.logging.Level
+import java.util.logging.Logger
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -38,6 +40,7 @@ class WebServer(
   private val staticDir: Path? = null,
 ) {
 
+  private val logger = Logger.getLogger(WebServer::class.java.name)
   private val server = HttpServer.create(InetSocketAddress(httpPort), 0)
   private val jsonPrinter: JsonFormat.Printer =
     JsonFormat.printer().preservingProtoFieldNames().alwaysPrintFieldsWithNoPresence()
@@ -82,6 +85,11 @@ class WebServer(
     } catch (e: io.grpc.StatusException) {
       sendJson(exchange, HTTP_BAD_REQUEST, errorJson(e.status.description ?: e.status.code.name))
     } catch (e: Exception) {
+      logger.log(
+        Level.SEVERE,
+        "Unhandled exception in ${exchange.requestMethod} ${exchange.requestURI}",
+        e,
+      )
       sendJson(exchange, HTTP_INTERNAL_ERROR, errorJson(e.message ?: "Internal server error"))
     }
   }


### PR DESCRIPTION
## Summary

The deepest error quality improvement: simulator errors now tell you *where in the P4 source* the problem is.

**Before:**
```
INTERNAL: undefined variable: x
```

**After:**
```
INTERNAL: undefined variable: x (at my_program.p4:42:3)
```

### Changes

**1. P4 source location in ~30 interpreter errors**
Added `sourceContext()` helper that formats `currentSourceInfo` (file:line:column) and appended it to every user-facing `error()` call in the interpreter — undefined variables, type mismatches, unhandled operators, etc.

**2. "Unhandled extern" → "not implemented" (8 sites)**
Changed across v1model, PSA, and PNA architectures. Makes it clear the feature is missing, not buggy.

**3. Pipeline depth errors hint at the cause**
"max pipeline depth exceeded (10) — possible infinite resubmit/recirculate loop"

**4. WebServer logs stack traces**
Generic exception handler now logs at SEVERE before returning error JSON.

## Test plan

- [x] 38/38 tests pass (simulator + p4runtime + web)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)