### PR TITLE
Add golden tests for P4Runtime error messages

### DIFF
--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -183,6 +183,32 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "GoldenErrorTest",
+    srcs = [
+        "GoldenErrorTest.kt",
+        "P4RuntimeTestHarness.kt",
+    ],
+    data = [
+        "//e2e_tests/basic_table:basic_table_pb",
+        "//e2e_tests/trace_tree:clone_with_egress_pb",
+    ] + glob(["golden_errors/*.golden.txt"]),
+    test_class = "fourward.p4runtime.GoldenErrorTest",
+    deps = [
+        ":dataplane_kt_grpc",
+        ":p4runtime_java_proto",
+        ":p4runtime_lib",
+        "//simulator:ir_java_proto",
+        "//simulator:simulator_java_proto",
+        "@grpc-java//api",
+        "@grpc-java//inprocess",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_grpc_grpc_kotlin_stub",
+        "@maven//:junit_junit",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+    ],
+)
+
+kt_jvm_test(
     name = "WriteValidatorTest",
     srcs = ["WriteValidatorTest.kt"],
     test_class = "fourward.p4runtime.WriteValidatorTest",

--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -1,0 +1,374 @@
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import fourward.ir.PipelineConfig
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildExactEntry
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.extractBatchErrors
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.longToBytes
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.uint128
+import io.grpc.Status
+import io.grpc.StatusException
+import java.nio.file.Paths
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import p4.v1.P4RuntimeOuterClass
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.TableEntry
+import p4.v1.P4RuntimeOuterClass.Update
+import p4.v1.P4RuntimeOuterClass.WriteRequest
+
+/**
+ * Golden tests for P4Runtime error messages.
+ *
+ * Each test triggers a specific error path and compares the full gRPC error description against a
+ * golden file. This catches unintentional changes to user-facing error messages.
+ *
+ * Set `UPDATE_GOLDEN=1` to regenerate golden files from actual output.
+ */
+@RunWith(Parameterized::class)
+class GoldenErrorTest(private val testName: String) {
+
+  private lateinit var harness: P4RuntimeTestHarness
+
+  @Before
+  fun setUp() {
+    harness = P4RuntimeTestHarness()
+  }
+
+  @After
+  fun tearDown() {
+    harness.close()
+  }
+
+  @Test
+  fun test() {
+    val actual = captureError { triggerError(testName) }
+    val goldenPath = goldenDir().resolve("$testName.golden.txt")
+
+    if (System.getenv("UPDATE_GOLDEN") != null) {
+      goldenPath.toFile().parentFile.mkdirs()
+      goldenPath.toFile().writeText(actual + "\n")
+      // Also print to stdout so the message can be captured from test logs.
+      println("GOLDEN[$testName]: $actual")
+      return
+    }
+
+    val expected = goldenPath.toFile().readText().trim()
+    if (expected != actual) {
+      fail(
+        "Error message mismatch for '$testName'.\n\n" +
+          "Expected (golden):\n  $expected\n\n" +
+          "Actual:\n  $actual\n\n" +
+          "To update, run:\n" +
+          "  bazel test ${System.getenv("TEST_TARGET") ?: "<test target>"}" +
+          " --test_env=UPDATE_GOLDEN=1"
+      )
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error triggers
+  // ---------------------------------------------------------------------------
+
+  private fun triggerError(name: String) {
+    when (name) {
+      "no-pipeline-loaded" -> triggerNoPipelineLoaded()
+      "unknown-table-id" -> triggerUnknownTableId()
+      "unknown-action-id" -> triggerUnknownActionId()
+      "wrong-param-count" -> triggerWrongParamCount()
+      "wrong-match-width" -> triggerWrongMatchWidth()
+      "wrong-match-kind" -> triggerWrongMatchKind()
+      "missing-exact-field" -> triggerMissingExactField()
+      "duplicate-match-field" -> triggerDuplicateMatchField()
+      "const-table-write" -> triggerConstTableWrite()
+      "batch-write-failure" -> triggerBatchWriteFailure()
+      "invalid-device-config" -> triggerInvalidDeviceConfig()
+      "missing-pipeline-config" -> triggerMissingPipelineConfig()
+      "wrong-device-id" -> triggerWrongDeviceId()
+      "not-primary-controller" -> triggerNotPrimaryController()
+      "digest-not-supported" -> triggerDigestNotSupported()
+      "extern-entry-not-supported" -> triggerExternEntryNotSupported()
+      "unrecognized-atomicity" -> triggerUnrecognizedAtomicity()
+      else -> error("unknown test: $name")
+    }
+  }
+
+  private fun triggerNoPipelineLoaded() {
+    val entity = Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(1)).build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerUnknownTableId() {
+    harness.loadPipeline(loadBasicTable())
+    val entity =
+      Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(99999)).build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerUnknownActionId() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    val entity =
+      valid
+        .toBuilder()
+        .apply { tableEntryBuilder.actionBuilder.actionBuilder.setActionId(99999).clearParams() }
+        .build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerWrongParamCount() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    val entity =
+      valid
+        .toBuilder()
+        .apply { tableEntryBuilder.actionBuilder.actionBuilder.clearParams() }
+        .build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerWrongMatchWidth() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    // etherType is 16-bit (2 bytes); send 1 byte.
+    val entity =
+      valid
+        .toBuilder()
+        .apply {
+          tableEntryBuilder
+            .getMatchBuilder(0)
+            .exactBuilder
+            .setValue(ByteString.copyFrom(byteArrayOf(0x08)))
+        }
+        .build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerWrongMatchKind() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val matchField = config.p4Info.tablesList.first().matchFieldsList.first()
+    val byteWidth = (matchField.bitwidth + 7) / 8
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    val entity =
+      valid
+        .toBuilder()
+        .apply {
+          tableEntryBuilder.setPriority(1)
+          tableEntryBuilder
+            .getMatchBuilder(0)
+            .clearExact()
+            .setFieldId(matchField.id)
+            .ternaryBuilder
+            .setValue(ByteString.copyFrom(longToBytes(0x0800, byteWidth)))
+            .setMask(ByteString.copyFrom(longToBytes(0xFFFF, byteWidth)))
+        }
+        .build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerMissingExactField() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    val entity = valid.toBuilder().apply { tableEntryBuilder.clearMatch() }.build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerDuplicateMatchField() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    // Add the same match field a second time.
+    val entity =
+      valid.toBuilder().apply { tableEntryBuilder.addMatch(valid.tableEntry.getMatch(0)) }.build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerConstTableWrite() {
+    val config = loadConfig("e2e_tests/trace_tree/clone_with_egress.txtpb")
+    harness.loadPipeline(config)
+    val constTable = config.p4Info.tablesList.find { it.isConstTable }!!
+    val entity =
+      Entity.newBuilder()
+        .setTableEntry(TableEntry.newBuilder().setTableId(constTable.preamble.id))
+        .build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerBatchWriteFailure() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val good = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    val bad = Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(99999)).build()
+    val request = harness.buildBatchRequest(Update.Type.INSERT, listOf(good, bad))
+    harness.writeRaw(request)
+  }
+
+  private fun triggerInvalidDeviceConfig() = runBlocking {
+    harness.stub.setForwardingPipelineConfig(
+      SetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+        .setConfig(
+          ForwardingPipelineConfig.newBuilder()
+            .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
+            .setP4DeviceConfig(ByteString.copyFromUtf8("garbage"))
+        )
+        .build()
+    )
+  }
+
+  private fun triggerMissingPipelineConfig() = runBlocking {
+    harness.stub.setForwardingPipelineConfig(
+      SetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+        .setConfig(
+          ForwardingPipelineConfig.newBuilder()
+            .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
+        )
+        .build()
+    )
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerWrongDeviceId() {
+    harness.loadPipeline(loadBasicTable())
+    val request =
+      WriteRequest.newBuilder()
+        .setDeviceId(999)
+        .addUpdates(
+          Update.newBuilder()
+            .setType(Update.Type.INSERT)
+            .setEntity(
+              Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(1)).build()
+            )
+        )
+        .build()
+    harness.writeRaw(request)
+  }
+
+  private fun triggerNotPrimaryController() {
+    harness.loadPipeline(loadBasicTable())
+    // Establish a primary with election_id=5, then attempt a write with a lower election_id.
+    harness.openStream().use { stream -> stream.arbitrate(electionId = 5) }
+    val entry = buildExactEntry(loadBasicTable(), matchValue = 0x0800, port = 1)
+    harness.installEntry(entry, uint128(low = 3))
+  }
+
+  private fun triggerDigestNotSupported() {
+    harness.loadPipeline(loadBasicTable())
+    val entity =
+      Entity.newBuilder()
+        .setDigestEntry(P4RuntimeOuterClass.DigestEntry.newBuilder().setDigestId(1))
+        .build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerExternEntryNotSupported() {
+    harness.loadPipeline(loadBasicTable())
+    val entity =
+      Entity.newBuilder()
+        .setExternEntry(P4RuntimeOuterClass.ExternEntry.newBuilder().setExternTypeId(1))
+        .build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerUnrecognizedAtomicity() {
+    harness.loadPipeline(loadBasicTable())
+    val request =
+      WriteRequest.newBuilder()
+        .setDeviceId(1)
+        .setAtomicityValue(999)
+        .addUpdates(
+          Update.newBuilder()
+            .setType(Update.Type.INSERT)
+            .setEntity(
+              Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(1)).build()
+            )
+        )
+        .build()
+    harness.writeRaw(request)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private fun loadBasicTable(): PipelineConfig =
+    loadConfig("e2e_tests/basic_table/basic_table.txtpb")
+
+  /**
+   * Captures the error description from a gRPC call.
+   *
+   * For single-update batches that return UNKNOWN with per-update details, unwraps the batch error
+   * to get the underlying error message. For multi-update batches, captures the top-level message.
+   */
+  private fun captureError(block: () -> Unit): String {
+    try {
+      block()
+      fail("expected gRPC error but call succeeded")
+      error("unreachable")
+    } catch (e: StatusException) {
+      // For batch errors (UNKNOWN status), check if there's exactly one failing update.
+      if (e.status.code == Status.Code.UNKNOWN) {
+        val batchErrors = extractBatchErrors(e)
+        if (batchErrors != null && batchErrors.size == 1) {
+          // Single-update batch: return the per-update error message.
+          return "${statusCodeName(batchErrors[0].canonicalCode)}: ${batchErrors[0].message}"
+        }
+        // Multi-update batch: return the top-level UNKNOWN message.
+        return "${e.status.code}: ${e.status.description}"
+      }
+      return "${e.status.code}: ${e.status.description}"
+    }
+  }
+
+  private fun statusCodeName(canonicalCode: Int): String =
+    Status.Code.values().find { it.value() == canonicalCode }?.name ?: "CODE_$canonicalCode"
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "{0}")
+    fun testNames(): List<String> =
+      listOf(
+        "no-pipeline-loaded",
+        "unknown-table-id",
+        "unknown-action-id",
+        "wrong-param-count",
+        "wrong-match-width",
+        "wrong-match-kind",
+        "missing-exact-field",
+        "duplicate-match-field",
+        "const-table-write",
+        "batch-write-failure",
+        "invalid-device-config",
+        "missing-pipeline-config",
+        "wrong-device-id",
+        "not-primary-controller",
+        "digest-not-supported",
+        "extern-entry-not-supported",
+        "unrecognized-atomicity",
+      )
+
+    private fun goldenDir(): java.nio.file.Path {
+      val r = System.getenv("JAVA_RUNFILES") ?: "."
+      return Paths.get(r, "_main/p4runtime/golden_errors")
+    }
+  }
+}

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -968,9 +968,12 @@ class P4RuntimeService(
   private fun buildBatchError(errors: List<P4RuntimeOuterClass.Error>): StatusException {
     val failedCount = errors.count { it.canonicalCode != OK_CODE }
     val totalCount = errors.size
-    val message =
-      "$failedCount of $totalCount updates failed; " +
-        "see per-update status in grpc-status-details-bin trailer"
+    val failedDetails =
+      errors
+        .withIndex()
+        .filter { it.value.canonicalCode != OK_CODE }
+        .joinToString("; ") { (i, e) -> "update #${i + 1}: ${e.message}" }
+    val message = "$failedCount of $totalCount updates failed: $failedDetails"
     val rpcStatus =
       com.google.rpc.Status.newBuilder()
         .setCode(com.google.rpc.Code.UNKNOWN_VALUE)

--- a/p4runtime/golden_errors/batch-write-failure.golden.txt
+++ b/p4runtime/golden_errors/batch-write-failure.golden.txt
@@ -1,0 +1,1 @@
+UNKNOWN: 1 of 2 updates failed: update #2: unknown table ID: 99999

--- a/p4runtime/golden_errors/const-table-write.golden.txt
+++ b/p4runtime/golden_errors/const-table-write.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: table 'egress_classify' is const; writes are not allowed

--- a/p4runtime/golden_errors/digest-not-supported.golden.txt
+++ b/p4runtime/golden_errors/digest-not-supported.golden.txt
@@ -1,0 +1,1 @@
+UNIMPLEMENTED: digest is not supported; the simulator does not implement digest extern generation

--- a/p4runtime/golden_errors/duplicate-match-field.golden.txt
+++ b/p4runtime/golden_errors/duplicate-match-field.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: duplicate match field 'hdr.ethernet.etherType' (ID 1) in table 'port_table'

--- a/p4runtime/golden_errors/extern-entry-not-supported.golden.txt
+++ b/p4runtime/golden_errors/extern-entry-not-supported.golden.txt
@@ -1,0 +1,1 @@
+UNIMPLEMENTED: ExternEntry is not supported; use the dedicated entity types (TableEntry, CounterEntry, etc.) instead

--- a/p4runtime/golden_errors/invalid-device-config.golden.txt
+++ b/p4runtime/golden_errors/invalid-device-config.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: p4_device_config is not a valid DeviceConfig proto (expected serialized fourward.ir.DeviceConfig): Protocol message tag had invalid wire type.

--- a/p4runtime/golden_errors/missing-exact-field.golden.txt
+++ b/p4runtime/golden_errors/missing-exact-field.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: missing required exact match field 'hdr.ethernet.etherType' in table 'port_table'

--- a/p4runtime/golden_errors/missing-pipeline-config.golden.txt
+++ b/p4runtime/golden_errors/missing-pipeline-config.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: ForwardingPipelineConfig must include p4info and p4_device_config

--- a/p4runtime/golden_errors/no-pipeline-loaded.golden.txt
+++ b/p4runtime/golden_errors/no-pipeline-loaded.golden.txt
@@ -1,0 +1,1 @@
+FAILED_PRECONDITION: No pipeline loaded; call SetForwardingPipelineConfig first

--- a/p4runtime/golden_errors/not-primary-controller.golden.txt
+++ b/p4runtime/golden_errors/not-primary-controller.golden.txt
@@ -1,0 +1,1 @@
+PERMISSION_DENIED: only the primary controller for default role (election_id=none) may write

--- a/p4runtime/golden_errors/unknown-action-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-action-id.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: unknown action ID 99999 in table 'port_table'

--- a/p4runtime/golden_errors/unknown-table-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-table-id.golden.txt
@@ -1,0 +1,1 @@
+NOT_FOUND: unknown table ID: 99999

--- a/p4runtime/golden_errors/unrecognized-atomicity.golden.txt
+++ b/p4runtime/golden_errors/unrecognized-atomicity.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: unrecognized write atomicity; valid values: CONTINUE_ON_ERROR, ROLLBACK_ON_ERROR, DATAPLANE_ATOMIC

--- a/p4runtime/golden_errors/wrong-device-id.golden.txt
+++ b/p4runtime/golden_errors/wrong-device-id.golden.txt
@@ -1,0 +1,1 @@
+NOT_FOUND: unknown device_id 999 (this device is 1)

--- a/p4runtime/golden_errors/wrong-match-kind.golden.txt
+++ b/p4runtime/golden_errors/wrong-match-kind.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: match field 'hdr.ethernet.etherType' expects EXACT but got TERNARY

--- a/p4runtime/golden_errors/wrong-match-width.golden.txt
+++ b/p4runtime/golden_errors/wrong-match-width.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: match field 'hdr.ethernet.etherType' value expects 2 bytes, got 1

--- a/p4runtime/golden_errors/wrong-param-count.golden.txt
+++ b/p4runtime/golden_errors/wrong-param-count.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: action 'MyIngress.forward' expects 1 params, got 0


### PR DESCRIPTION
## Summary

10 golden tests that lock down the exact error message for each major P4Runtime error path. If anyone changes a message, the test fails and they review the diff.

Also inlines per-update failure details into batch error messages:

**Before:** `UNKNOWN: 1 of 2 updates failed; see per-update status in grpc-status-details-bin trailer`

**After:** `UNKNOWN: 1 of 2 updates failed: update #2: unknown table ID: 99999`

### Updating golden files

```bash
bazel test //p4runtime:GoldenErrorTest --test_env=UPDATE_GOLDEN=1
```

### Coverage

| Scenario | Golden message |
|---|---|
| Unknown table ID | `NOT_FOUND: unknown table ID: 99999` |
| Unknown action ID | `INVALID_ARGUMENT: unknown action ID 99999 in table 'port_table'` |
| Wrong param count | `INVALID_ARGUMENT: action 'MyIngress.forward' expects 1 params, got 0` |
| Wrong match width | `INVALID_ARGUMENT: match field 'hdr.ethernet.etherType' value expects 2 bytes, got 1` |
| Wrong match kind | `INVALID_ARGUMENT: match field 'hdr.ethernet.etherType' expects EXACT but got TERNARY` |
| Missing exact field | `INVALID_ARGUMENT: missing required exact match field 'hdr.ethernet.etherType' in table 'port_table'` |
| Duplicate match field | `INVALID_ARGUMENT: duplicate match field 'hdr.ethernet.etherType' (ID 1) in table 'port_table'` |
| Const table write | `INVALID_ARGUMENT: table 'egress_classify' is const; writes are not allowed` |
| No pipeline loaded | `FAILED_PRECONDITION: No pipeline loaded; call SetForwardingPipelineConfig first` |
| Batch write failure | `UNKNOWN: 1 of 2 updates failed: update #2: unknown table ID: 99999` |

## Test plan

- [x] 10/10 golden error tests pass
- [x] P4RuntimeWriteErrorTest passes
- [x] P4RuntimeConformanceTest passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)