### PR TITLE
Document Dataplane RPCs, concurrent processing, and performance guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ packets, explore trace trees. No setup beyond Bazel.
 4ward is a **spec-compliant reference implementation** of the
 [P4₁₆ language](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/p4-16-working-draft.html)
 and [P4Runtime](https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.html),
-optimized for **correctness, observability, and extensibility** rather than
-performance. Think of it as a debugger that speaks P4, not a production data
-plane.
+optimized for **correctness, observability, and extensibility** — yet fast
+enough for production test workloads ([thousands of packets/sec](docs/ROADMAP.md#track-10-dataplane-performance)
+with full trace trees).
 
 | | BMv2 | 4ward goal | Status |
 |---|---|---|---|

--- a/userdocs/getting-started/grpc.md
+++ b/userdocs/getting-started/grpc.md
@@ -82,17 +82,37 @@ InjectPacketResponse {
 }
 ```
 
-### 4. Observe all results (optional)
+### 4. Inject many packets (bulk / DVaaS)
 
-`SubscribeResults` is a server-streaming RPC that delivers results from
-*all* packet sources (InjectPacket, PacketOut, etc.):
+For high throughput, use the streaming `InjectPackets` RPC with
+`SubscribeResults`:
+
+1. Open a `SubscribeResults` stream.
+2. Wait for the `active {}` confirmation — this guarantees the
+   subscription is registered and no results will be missed.
+3. Send all packets via `InjectPackets` (client-streaming).
+4. Collect results from the subscription.
+
+Packets process concurrently across available cores. This is the
+recommended pattern for DVaaS and any workload with many test packets.
 
 ```protobuf
-// First message confirms the subscription is active.
+// SubscribeResults delivers results from ALL sources.
 SubscribeResultsResponse { active {} }
-// Subsequent messages carry results.
 SubscribeResultsResponse { result { input_packet { ... } output_packets { ... } trace { ... } } }
 ```
+
+!!! tip
+    `InjectPacket` (singular) returns the result inline — simpler for
+    one-off debugging. `InjectPackets` (plural) processes concurrently
+    but results come via `SubscribeResults`.
+
+!!! note "Matching results to packets"
+    Each result includes the full input packet (port + payload). With
+    concurrent processing, results may arrive out of order — match by
+    payload content, not position. See the
+    [reference](../reference/grpc.md#matching-results-to-injected-packets)
+    for details on PacketIn interaction.
 
 ## Dual port encoding
 

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -80,10 +80,34 @@ message InjectPacketResponse {
 }
 ```
 
+### `InjectPackets`
+
+Client-streaming RPC for bulk packet injection. Packets are processed
+concurrently as they arrive from the stream. Results are **not** returned
+in the response — use [`SubscribeResults`](#subscriberesults) to collect them.
+
+```protobuf
+rpc InjectPackets(stream InjectPacketRequest) returns (InjectPacketsResponse);
+message InjectPacketsResponse {}  // empty — results via SubscribeResults
+```
+
+**Recommended pattern for DVaaS / bulk workloads:**
+
+1. Open a `SubscribeResults` stream.
+2. Wait for the `SubscriptionActive` message — this confirms the
+   subscription is registered and no results will be missed.
+3. Send all packets via `InjectPackets`.
+4. Collect results from the subscription (exactly one per injected
+   packet).
+
+Packets process concurrently across available cores, with trace tree fork
+branches (WCMP groups, multicast, clones) also parallelized within each
+packet.
+
 ### `SubscribeResults`
 
 Server-streaming RPC that delivers results from all packet sources
-(InjectPacket, PacketOut, etc.).
+(InjectPacket, InjectPackets, PacketOut, etc.).
 
 ```protobuf
 // First message confirms the subscription.
@@ -97,6 +121,47 @@ SubscribeResultsResponse {
   }
 }
 ```
+
+### Matching results to injected packets
+
+Each `ProcessPacketResult` in the `SubscribeResults` stream includes the
+full `InputPacket` (ingress port + payload). Match results to injected
+packets by comparing the payload bytes.
+
+!!! tip
+    For DVaaS workloads, embed a unique tag in each test packet (e.g., in
+    an unused header field or the payload body) to make matching
+    unambiguous.
+
+**Ordering:** With concurrent processing (`InjectPackets`), results may
+arrive in any order. Do not assume the result stream matches the
+injection order.
+
+**Completeness:** You will receive exactly one `ProcessPacketResult` per
+injected packet. Count results to know when you're done.
+
+**Relationship to P4Runtime PacketIn:** When a packet triggers
+copy-to-CPU (e.g., SAI P4's `acl_copy` or `acl_trap`), two things
+happen:
+
+- The CPU-bound clone appears as a **PacketIn** on the P4Runtime
+  `StreamChannel`.
+- The complete result (all outputs including the clone, plus the trace
+  tree) appears in **`SubscribeResults`**.
+
+`SubscribeResults` gives the full picture for every packet.
+`StreamChannel` PacketIn only carries the CPU-port copies — it's the
+standard P4Runtime mechanism for packets punted to the controller.
+
+!!! note "SubscribeResults vs PacketIn"
+    **`SubscribeResults`** delivers exactly N results for N injected
+    packets, so you always know when you're done.
+
+    **`PacketIn`** on `StreamChannel` is convenient because it carries
+    `@controller_header` metadata already parsed — but there's no
+    end-of-batch marker. To know when you've seen all PacketIns, count
+    CPU-port outputs in `SubscribeResults` — that tells you exactly how
+    many PacketIns to expect.
 
 ### Dual port encoding
 


### PR DESCRIPTION
## Summary

Updates user-facing docs with the new `InjectPackets` RPC and performance guidance.

### ARCHITECTURE.md
- Dataplane RPC table (InjectPacket, InjectPackets, SubscribeResults)
- Recommended usage pattern: subscribe first, then fire packets
- Updated lock description: ReadWriteMutex replaces Mutex
- Fixed stale simulator.proto reference

### ENTRY_POINTS.md
- InjectPackets in the P4Runtime server RPC table
- Performance tip for maximum throughput with link to benchmark data
- Bulk injection example in the test harness section

## Test plan

- [ ] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)