### PR TITLE
Fix 4 exception handling bugs, expand golden error tests to 30

### DIFF
--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -1,6 +1,9 @@
 package fourward.p4runtime
 
 import com.google.protobuf.ByteString
+import fourward.ir.Architecture
+import fourward.ir.BehavioralConfig
+import fourward.ir.DeviceConfig
 import fourward.ir.PipelineConfig
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildExactEntry
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.extractBatchErrors
@@ -97,6 +100,19 @@ class GoldenErrorTest(private val testName: String) {
       "digest-not-supported" -> triggerDigestNotSupported()
       "extern-entry-not-supported" -> triggerExternEntryNotSupported()
       "unrecognized-atomicity" -> triggerUnrecognizedAtomicity()
+      "idle-timeout-not-supported" -> triggerIdleTimeoutNotSupported()
+      "default-entry-wrong-type" -> triggerDefaultEntryWrongType()
+      "default-entry-with-match" -> triggerDefaultEntryWithMatch()
+      "unknown-param-id" -> triggerUnknownParamId()
+      "unknown-match-field-id" -> triggerUnknownMatchFieldId()
+      "match-field-no-value" -> triggerMatchFieldNoValue()
+      "priority-must-be-zero" -> triggerPriorityMustBeZero()
+      "table-entry-already-exists" -> triggerTableEntryAlreadyExists()
+      "table-entry-not-found" -> triggerTableEntryNotFound()
+      "commit-without-save" -> triggerCommitWithoutSave()
+      "unrecognized-pipeline-action" -> triggerUnrecognizedPipelineAction()
+      "simulator-rejected-pipeline" -> triggerSimulatorRejectedPipeline()
+      "register-insert-not-supported" -> triggerRegisterInsertNotSupported()
       else -> error("unknown test: $name")
     }
   }
@@ -306,6 +322,169 @@ class GoldenErrorTest(private val testName: String) {
     harness.writeRaw(request)
   }
 
+  @Suppress("MagicNumber")
+  private fun triggerIdleTimeoutNotSupported() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    val entity = valid.toBuilder().apply { tableEntryBuilder.setIdleTimeoutNs(1000) }.build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerDefaultEntryWrongType() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val tableId = config.p4Info.tablesList.first().preamble.id
+    val entity =
+      Entity.newBuilder()
+        .setTableEntry(TableEntry.newBuilder().setTableId(tableId).setIsDefaultAction(true))
+        .build()
+    // INSERT a default entry (should be MODIFY).
+    harness.installEntry(entity)
+  }
+
+  private fun triggerDefaultEntryWithMatch() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    // MODIFY a default entry that still has match fields set.
+    val entity = valid.toBuilder().apply { tableEntryBuilder.setIsDefaultAction(true) }.build()
+    harness.modifyEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerUnknownParamId() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    // Replace the param with one that has the correct count but wrong ID.
+    val entity =
+      valid
+        .toBuilder()
+        .apply {
+          tableEntryBuilder.actionBuilder.actionBuilder.setParams(
+            0,
+            valid.tableEntry.action.action.getParams(0).toBuilder().setParamId(99999),
+          )
+        }
+        .build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerUnknownMatchFieldId() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    val entity =
+      valid.toBuilder().apply { tableEntryBuilder.getMatchBuilder(0).setFieldId(99999) }.build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerMatchFieldNoValue() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val matchField = config.p4Info.tablesList.first().matchFieldsList.first()
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    // Set a FieldMatch with only field_id — no exact/ternary/lpm/etc.
+    val entity =
+      valid
+        .toBuilder()
+        .apply {
+          tableEntryBuilder.setMatch(
+            0,
+            P4RuntimeOuterClass.FieldMatch.newBuilder().setFieldId(matchField.id),
+          )
+        }
+        .build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerPriorityMustBeZero() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    // Exact-match table: priority must be zero.
+    val entity = valid.toBuilder().apply { tableEntryBuilder.setPriority(42) }.build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerTableEntryAlreadyExists() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(entry)
+    // INSERT the same entry again.
+    harness.installEntry(entry)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerTableEntryNotFound() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    // DELETE an entry that was never inserted.
+    harness.deleteEntry(entry)
+  }
+
+  private fun triggerCommitWithoutSave() = runBlocking {
+    harness.stub.setForwardingPipelineConfig(
+      SetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setAction(SetForwardingPipelineConfigRequest.Action.COMMIT)
+        .build()
+    )
+  }
+
+  private fun triggerUnrecognizedPipelineAction() = runBlocking {
+    harness.stub.setForwardingPipelineConfig(
+      SetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setAction(SetForwardingPipelineConfigRequest.Action.UNSPECIFIED)
+        .build()
+    )
+  }
+
+  private fun triggerSimulatorRejectedPipeline() {
+    // Build a DeviceConfig with an unsupported architecture name. The proto parses fine
+    // but the simulator rejects it at loadPipeline time.
+    val deviceConfig =
+      DeviceConfig.newBuilder()
+        .setBehavioral(
+          BehavioralConfig.newBuilder()
+            .setArchitecture(Architecture.newBuilder().setName("bogus_arch"))
+        )
+        .build()
+    val fwdConfig =
+      ForwardingPipelineConfig.newBuilder()
+        .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
+        .setP4DeviceConfig(deviceConfig.toByteString())
+        .build()
+    runBlocking {
+      harness.stub.setForwardingPipelineConfig(
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+          .setConfig(fwdConfig)
+          .build()
+      )
+    }
+  }
+
+  private fun triggerRegisterInsertNotSupported() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    // INSERT a register entry — registers only support MODIFY.
+    val entity =
+      Entity.newBuilder()
+        .setRegisterEntry(P4RuntimeOuterClass.RegisterEntry.newBuilder().setRegisterId(1))
+        .build()
+    harness.installEntry(entity)
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
@@ -364,6 +543,19 @@ class GoldenErrorTest(private val testName: String) {
         "digest-not-supported",
         "extern-entry-not-supported",
         "unrecognized-atomicity",
+        "idle-timeout-not-supported",
+        "default-entry-wrong-type",
+        "default-entry-with-match",
+        "unknown-param-id",
+        "unknown-match-field-id",
+        "match-field-no-value",
+        "priority-must-be-zero",
+        "table-entry-already-exists",
+        "table-entry-not-found",
+        "commit-without-save",
+        "unrecognized-pipeline-action",
+        "simulator-rejected-pipeline",
+        "register-insert-not-supported",
       )
 
     private fun goldenDir(): java.nio.file.Path {

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -198,7 +198,15 @@ class P4RuntimeService(
       writeValidator = WriteValidator(pipelineConfig.p4Info),
       referenceValidator = ReferenceValidator.create(fwdConfig.p4Info),
       constraintValidator =
-        constraintValidatorBinary?.let { ConstraintValidator.create(fwdConfig.p4Info, it) },
+        constraintValidatorBinary?.let {
+          try {
+            ConstraintValidator.create(fwdConfig.p4Info, it)
+          } catch (e: ConstraintValidatorException) {
+            throw Status.INTERNAL.withDescription("constraint validation failed: ${e.message}")
+              .withCause(e)
+              .asException()
+          }
+        },
       packetHeaderCodec =
         when (cpuPortConfig) {
           is CpuPortConfig.Disabled -> null
@@ -404,7 +412,14 @@ class P4RuntimeService(
     // are checked at canonical widths (P4Runtime spec §8.3, §9.1).
     state.writeValidator.validate(rawUpdate)
     val translator = state.typeTranslator?.takeIf { it.hasTranslations }
-    val update = translator?.translateForWrite(rawUpdate) ?: rawUpdate
+    val update =
+      try {
+        translator?.translateForWrite(rawUpdate) ?: rawUpdate
+      } catch (e: TranslationException) {
+        throw Status.INVALID_ARGUMENT.withDescription("type translation failed: ${e.message}")
+          .withCause(e)
+          .asException()
+      }
 
     // Validate @refers_to referential integrity after translation so values
     // are in dataplane form (matching what's stored in the simulator).
@@ -514,10 +529,16 @@ class P4RuntimeService(
             // For specific (non-wildcard) entities, check access upfront so the controller
             // gets a clear PERMISSION_DENIED. For wildcards, results are filtered post-read.
             requireEntityAccess(entity, state.roleMap, roleName)
-            if (entity.hasTableEntry()) {
-              state.entityReader.readTableEntities(entity.tableEntry, simulator)
-            } else {
-              simulator.readEntries(listOf(entity))
+            try {
+              if (entity.hasTableEntry()) {
+                state.entityReader.readTableEntities(entity.tableEntry, simulator)
+              } else {
+                simulator.readEntries(listOf(entity))
+              }
+            } catch (e: IllegalStateException) {
+              throw Status.INTERNAL.withDescription("read failed: ${e.message}")
+                .withCause(e)
+                .asException()
             }
           }
         // Filter results by role for named-role controllers. This handles wildcard reads
@@ -626,7 +647,13 @@ class P4RuntimeService(
         extractIngressPort(packetOut.metadataList) to packetOut.payload.toByteArray()
       }
 
-    broker.processPacket(ingressPort, payload)
+    try {
+      broker.processPacket(ingressPort, payload)
+    } catch (e: IllegalStateException) {
+      throw Status.INTERNAL.withDescription("PacketOut processing failed: ${e.message}")
+        .withCause(e)
+        .asException()
+    }
   }
 
   /**

--- a/p4runtime/golden_errors/commit-without-save.golden.txt
+++ b/p4runtime/golden_errors/commit-without-save.golden.txt
@@ -1,0 +1,1 @@
+FAILED_PRECONDITION: COMMIT requires a previously saved pipeline (VERIFY_AND_SAVE)

--- a/p4runtime/golden_errors/default-entry-with-match.golden.txt
+++ b/p4runtime/golden_errors/default-entry-with-match.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: default entry for table 'port_table' must not have match fields

--- a/p4runtime/golden_errors/default-entry-wrong-type.golden.txt
+++ b/p4runtime/golden_errors/default-entry-wrong-type.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: default entry for table 'port_table' only supports MODIFY, got INSERT

--- a/p4runtime/golden_errors/idle-timeout-not-supported.golden.txt
+++ b/p4runtime/golden_errors/idle-timeout-not-supported.golden.txt
@@ -1,0 +1,1 @@
+UNIMPLEMENTED: idle_timeout_ns is not supported on table 'port_table'

--- a/p4runtime/golden_errors/match-field-no-value.golden.txt
+++ b/p4runtime/golden_errors/match-field-no-value.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: match field 'hdr.ethernet.etherType' has no value set

--- a/p4runtime/golden_errors/priority-must-be-zero.golden.txt
+++ b/p4runtime/golden_errors/priority-must-be-zero.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: table 'port_table' must have priority == 0 (exact/LPM match only)

--- a/p4runtime/golden_errors/register-insert-not-supported.golden.txt
+++ b/p4runtime/golden_errors/register-insert-not-supported.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: registers only support MODIFY, not INSERT

--- a/p4runtime/golden_errors/simulator-rejected-pipeline.golden.txt
+++ b/p4runtime/golden_errors/simulator-rejected-pipeline.golden.txt
@@ -1,0 +1,1 @@
+INTERNAL: Simulator rejected pipeline: unsupported architecture: bogus_arch

--- a/p4runtime/golden_errors/table-entry-already-exists.golden.txt
+++ b/p4runtime/golden_errors/table-entry-already-exists.golden.txt
@@ -1,0 +1,1 @@
+ALREADY_EXISTS: table 'port_table' already contains an entry with the same match key

--- a/p4runtime/golden_errors/table-entry-not-found.golden.txt
+++ b/p4runtime/golden_errors/table-entry-not-found.golden.txt
@@ -1,0 +1,1 @@
+NOT_FOUND: table 'port_table' has no entry with the given match key

--- a/p4runtime/golden_errors/unknown-match-field-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-match-field-id.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: unknown match field ID 99999 in table 'port_table'

--- a/p4runtime/golden_errors/unknown-param-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-param-id.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: unknown param ID 99999 for action 'MyIngress.forward'

--- a/p4runtime/golden_errors/unrecognized-pipeline-action.golden.txt
+++ b/p4runtime/golden_errors/unrecognized-pipeline-action.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: unrecognized SetForwardingPipelineConfig action


### PR DESCRIPTION
## Summary

Two improvements:

### 4 exception handling bugs fixed

Uncaught exceptions in P4RuntimeService.kt that surfaced as opaque gRPC `UNKNOWN`:

| Bug | Exception | Now |
|---|---|---|
| Type translation failure on write | `TranslationException` | `INVALID_ARGUMENT` |
| Constraint validator failure at pipeline load | `ConstraintValidatorException` | `INTERNAL` |
| Simulator crash during PacketOut | `IllegalStateException` | `INTERNAL` |
| Unsupported entity type on read | `IllegalStateException` | `INTERNAL` |

### 13 new golden error tests (30 total)

| Category | New tests |
|---|---|
| Write validation | idle-timeout, default-entry-wrong-type, default-entry-with-match, unknown-param-id, unknown-match-field-id, match-field-no-value, priority-must-be-zero |
| Table write results | table-entry-already-exists, table-entry-not-found |
| Pipeline lifecycle | commit-without-save, unrecognized-pipeline-action, simulator-rejected-pipeline |
| Other entities | register-insert-not-supported |

## Test plan

- [x] 36/36 tests pass (p4runtime + simulator)
- [x] 30/30 golden error tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)