### PR TITLE
Normalize error messages, add 6 golden tests, improve STF/web errors

### DIFF
--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -695,12 +695,16 @@ fun allOnesMask(bitwidth: Int): String {
 fun findTable(name: String, p4info: P4InfoOuterClass.P4Info): P4InfoOuterClass.Table =
   p4info.tablesList.find { it.preamble.alias == name || it.preamble.name == name }
     ?: p4info.tablesList.find { it.preamble.name.endsWith(".$name") }
-    ?: error("unknown table: $name")
+    ?: error(
+      "unknown table: $name (available: ${p4info.tablesList.map { it.preamble.name }.sorted().joinToString(", ")})"
+    )
 
 fun findAction(name: String, p4info: P4InfoOuterClass.P4Info): P4InfoOuterClass.Action =
   p4info.actionsList.find { it.preamble.alias == name || it.preamble.name == name }
     ?: p4info.actionsList.find { it.preamble.name.endsWith(".$name") }
-    ?: error("unknown action: $name")
+    ?: error(
+      "unknown action: $name (available: ${p4info.actionsList.map { it.preamble.name }.sorted().joinToString(", ")})"
+    )
 
 fun findActionProfile(
   name: String,
@@ -708,7 +712,9 @@ fun findActionProfile(
 ): P4InfoOuterClass.ActionProfile =
   p4info.actionProfilesList.find { it.preamble.alias == name || it.preamble.name == name }
     ?: p4info.actionProfilesList.find { it.preamble.name.endsWith(".$name") }
-    ?: error("unknown action profile: $name")
+    ?: error(
+      "unknown action profile: $name (available: ${p4info.actionProfilesList.map { it.preamble.name }.sorted().joinToString(", ")})"
+    )
 
 private fun resolveStfMatchField(
   m: StfMatchField,
@@ -725,7 +731,9 @@ private fun resolveStfMatchField(
         val suffix = it.name.substringAfter(".")
         suffix == m.fieldName || suffix == stfNorm
       }
-      ?: error("unknown match field '${m.fieldName}' in table '$tableName'")
+      ?: error(
+        "unknown match field '${m.fieldName}' in table '$tableName' (available: ${table.matchFieldsList.map { it.name }.sorted().joinToString(", ")})"
+      )
   val fmBuilder = P4RuntimeOuterClass.FieldMatch.newBuilder().setFieldId(mf.id)
   val encodedValue = encodeValue(m.value, mf.bitwidth)
 

--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -81,6 +81,7 @@ class GoldenErrorTest(private val testName: String) {
   // Error triggers
   // ---------------------------------------------------------------------------
 
+  @Suppress("CyclomaticComplexMethod")
   private fun triggerError(name: String) {
     when (name) {
       "no-pipeline-loaded" -> triggerNoPipelineLoaded()
@@ -112,7 +113,13 @@ class GoldenErrorTest(private val testName: String) {
       "commit-without-save" -> triggerCommitWithoutSave()
       "unrecognized-pipeline-action" -> triggerUnrecognizedPipelineAction()
       "simulator-rejected-pipeline" -> triggerSimulatorRejectedPipeline()
+      "param-width-mismatch" -> triggerParamWidthMismatch()
       "register-insert-not-supported" -> triggerRegisterInsertNotSupported()
+      "pre-entry-missing-type" -> triggerPreEntryMissingType()
+      "clone-session-already-exists" -> triggerCloneSessionAlreadyExists()
+      "clone-session-not-found" -> triggerCloneSessionNotFound()
+      "multicast-group-already-exists" -> triggerMulticastGroupAlreadyExists()
+      "multicast-group-not-found" -> triggerMulticastGroupNotFound()
       else -> error("unknown test: $name")
     }
   }
@@ -372,6 +379,28 @@ class GoldenErrorTest(private val testName: String) {
   }
 
   @Suppress("MagicNumber")
+  private fun triggerParamWidthMismatch() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    // The 'port' param is 9-bit (2 bytes canonical); send 4 bytes instead.
+    val entity =
+      valid
+        .toBuilder()
+        .apply {
+          tableEntryBuilder.actionBuilder.actionBuilder.setParams(
+            0,
+            valid.tableEntry.action.action
+              .getParams(0)
+              .toBuilder()
+              .setValue(ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))),
+          )
+        }
+        .build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
   private fun triggerUnknownMatchFieldId() {
     val config = loadBasicTable()
     harness.loadPipeline(config)
@@ -485,6 +514,78 @@ class GoldenErrorTest(private val testName: String) {
     harness.installEntry(entity)
   }
 
+  private fun triggerPreEntryMissingType() {
+    harness.loadPipeline(loadBasicTable())
+    val entity =
+      Entity.newBuilder()
+        .setPacketReplicationEngineEntry(
+          P4RuntimeOuterClass.PacketReplicationEngineEntry.getDefaultInstance()
+        )
+        .build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerCloneSessionAlreadyExists() {
+    harness.loadPipeline(loadBasicTable())
+    val entity =
+      Entity.newBuilder()
+        .setPacketReplicationEngineEntry(
+          P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+            .setCloneSessionEntry(
+              P4RuntimeOuterClass.CloneSessionEntry.newBuilder().setSessionId(1)
+            )
+        )
+        .build()
+    harness.installEntry(entity)
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerCloneSessionNotFound() {
+    harness.loadPipeline(loadBasicTable())
+    val entity =
+      Entity.newBuilder()
+        .setPacketReplicationEngineEntry(
+          P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+            .setCloneSessionEntry(
+              P4RuntimeOuterClass.CloneSessionEntry.newBuilder().setSessionId(999)
+            )
+        )
+        .build()
+    harness.deleteEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerMulticastGroupAlreadyExists() {
+    harness.loadPipeline(loadBasicTable())
+    val entity =
+      Entity.newBuilder()
+        .setPacketReplicationEngineEntry(
+          P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+            .setMulticastGroupEntry(
+              P4RuntimeOuterClass.MulticastGroupEntry.newBuilder().setMulticastGroupId(42)
+            )
+        )
+        .build()
+    harness.installEntry(entity)
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerMulticastGroupNotFound() {
+    harness.loadPipeline(loadBasicTable())
+    val entity =
+      Entity.newBuilder()
+        .setPacketReplicationEngineEntry(
+          P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+            .setMulticastGroupEntry(
+              P4RuntimeOuterClass.MulticastGroupEntry.newBuilder().setMulticastGroupId(999)
+            )
+        )
+        .build()
+    harness.deleteEntry(entity)
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
@@ -555,7 +656,13 @@ class GoldenErrorTest(private val testName: String) {
         "commit-without-save",
         "unrecognized-pipeline-action",
         "simulator-rejected-pipeline",
+        "param-width-mismatch",
         "register-insert-not-supported",
+        "pre-entry-missing-type",
+        "clone-session-already-exists",
+        "clone-session-not-found",
+        "multicast-group-already-exists",
+        "multicast-group-not-found",
       )
 
     private fun goldenDir(): java.nio.file.Path {

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -304,7 +304,7 @@ class P4RuntimeService(
     try {
       load(state.config)
     } catch (e: IllegalArgumentException) {
-      throw Status.INTERNAL.withDescription("Simulator rejected pipeline: ${e.message}")
+      throw Status.INVALID_ARGUMENT.withDescription("simulator rejected pipeline: ${e.message}")
         .withCause(e)
         .asException()
     }
@@ -1028,7 +1028,7 @@ class P4RuntimeService(
     private const val P4RUNTIME_API_VERSION = "1.5.0"
 
     private const val NO_PIPELINE_MESSAGE =
-      "No pipeline loaded; call SetForwardingPipelineConfig first"
+      "no pipeline loaded; call SetForwardingPipelineConfig first"
 
     private const val DIGEST_NOT_SUPPORTED =
       "digest is not supported; the simulator does not implement digest extern generation"

--- a/p4runtime/WriteValidator.kt
+++ b/p4runtime/WriteValidator.kt
@@ -70,7 +70,7 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
   private fun validateTableEntry(update: P4RuntimeOuterClass.Update) {
     val entry = update.entity.tableEntry
     val tableInfo =
-      tableInfoById[entry.tableId] ?: throw notFound("unknown table ID: ${entry.tableId}")
+      tableInfoById[entry.tableId] ?: throw notFound("unknown table ID ${entry.tableId}")
 
     // §9.1: const tables are immutable — no writes allowed.
     if (entry.tableId in constTableIds) {

--- a/p4runtime/golden_errors/batch-write-failure.golden.txt
+++ b/p4runtime/golden_errors/batch-write-failure.golden.txt
@@ -1,1 +1,1 @@
-UNKNOWN: 1 of 2 updates failed: update #2: unknown table ID: 99999
+UNKNOWN: 1 of 2 updates failed: update #2: unknown table ID 99999

--- a/p4runtime/golden_errors/clone-session-already-exists.golden.txt
+++ b/p4runtime/golden_errors/clone-session-already-exists.golden.txt
@@ -1,0 +1,1 @@
+ALREADY_EXISTS: clone session 1 already exists

--- a/p4runtime/golden_errors/clone-session-not-found.golden.txt
+++ b/p4runtime/golden_errors/clone-session-not-found.golden.txt
@@ -1,0 +1,1 @@
+NOT_FOUND: clone session 999 not found

--- a/p4runtime/golden_errors/multicast-group-already-exists.golden.txt
+++ b/p4runtime/golden_errors/multicast-group-already-exists.golden.txt
@@ -1,0 +1,1 @@
+ALREADY_EXISTS: multicast group 42 already exists

--- a/p4runtime/golden_errors/multicast-group-not-found.golden.txt
+++ b/p4runtime/golden_errors/multicast-group-not-found.golden.txt
@@ -1,0 +1,1 @@
+NOT_FOUND: multicast group 999 not found

--- a/p4runtime/golden_errors/no-pipeline-loaded.golden.txt
+++ b/p4runtime/golden_errors/no-pipeline-loaded.golden.txt
@@ -1,1 +1,1 @@
-FAILED_PRECONDITION: No pipeline loaded; call SetForwardingPipelineConfig first
+FAILED_PRECONDITION: no pipeline loaded; call SetForwardingPipelineConfig first

--- a/p4runtime/golden_errors/param-width-mismatch.golden.txt
+++ b/p4runtime/golden_errors/param-width-mismatch.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: param 'port' expects 2 bytes, got 4

--- a/p4runtime/golden_errors/pre-entry-missing-type.golden.txt
+++ b/p4runtime/golden_errors/pre-entry-missing-type.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: PRE entry must have a clone session or multicast group

--- a/p4runtime/golden_errors/simulator-rejected-pipeline.golden.txt
+++ b/p4runtime/golden_errors/simulator-rejected-pipeline.golden.txt
@@ -1,1 +1,1 @@
-INTERNAL: Simulator rejected pipeline: unsupported architecture: bogus_arch
+INVALID_ARGUMENT: simulator rejected pipeline: unsupported architecture: bogus_arch

--- a/p4runtime/golden_errors/unknown-table-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-table-id.golden.txt
@@ -1,1 +1,1 @@
-NOT_FOUND: unknown table ID: 99999
+NOT_FOUND: unknown table ID 99999

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -821,7 +821,7 @@ class TableStore : TableDataReader {
       return WriteResult.InvalidArgument("${entityName}s only support MODIFY, not $type")
     val tableName =
       tableNameById[tableEntry.tableId]
-        ?: return WriteResult.NotFound("unknown table ID: ${tableEntry.tableId}")
+        ?: return WriteResult.NotFound("unknown table ID ${tableEntry.tableId}")
     if (tableName !in knownTables)
       return WriteResult.InvalidArgument("table '$tableName' has no $entityName")
     val entries =
@@ -973,7 +973,7 @@ class TableStore : TableDataReader {
     val entry = update.entity.tableEntry
     val tableName =
       tableNameById[entry.tableId]
-        ?: return WriteResult.NotFound("unknown table ID: ${entry.tableId}")
+        ?: return WriteResult.NotFound("unknown table ID ${entry.tableId}")
 
     // P4Runtime spec §9.1: default entries are stored separately and only support MODIFY.
     // The WriteValidator already rejects INSERT/DELETE for defaults.

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -81,7 +81,11 @@ class WebServer(
     try {
       handler(exchange)
     } catch (e: io.grpc.StatusException) {
-      sendJson(exchange, HTTP_BAD_REQUEST, errorJson(e.status.description ?: e.status.code.name))
+      sendJson(
+        exchange,
+        grpcToHttpStatus(e.status.code),
+        errorJson(e.status.description ?: e.status.code.name),
+      )
     } catch (e: Exception) {
       logger.log(
         Level.SEVERE,
@@ -344,6 +348,19 @@ class WebServer(
   // Helpers
   // ---------------------------------------------------------------------------
 
+  private fun grpcToHttpStatus(code: io.grpc.Status.Code): Int =
+    when (code) {
+      io.grpc.Status.Code.INVALID_ARGUMENT -> HTTP_BAD_REQUEST
+      io.grpc.Status.Code.PERMISSION_DENIED -> HTTP_FORBIDDEN
+      io.grpc.Status.Code.NOT_FOUND -> HTTP_NOT_FOUND
+      io.grpc.Status.Code.ALREADY_EXISTS -> HTTP_CONFLICT
+      io.grpc.Status.Code.FAILED_PRECONDITION -> HTTP_PRECONDITION_FAILED
+      io.grpc.Status.Code.RESOURCE_EXHAUSTED -> HTTP_TOO_MANY_REQUESTS
+      io.grpc.Status.Code.UNIMPLEMENTED -> HTTP_NOT_IMPLEMENTED
+      io.grpc.Status.Code.INTERNAL -> HTTP_INTERNAL_ERROR
+      else -> HTTP_BAD_REQUEST
+    }
+
   private fun sendJson(exchange: HttpExchange, statusCode: Int, json: String) {
     val bytes = json.toByteArray(Charsets.UTF_8)
     exchange.responseHeaders.add("Content-Type", "application/json; charset=utf-8")
@@ -368,8 +385,13 @@ class WebServer(
     private const val HTTP_OK = 200
     private const val HTTP_NO_CONTENT = 204
     private const val HTTP_BAD_REQUEST = 400
+    private const val HTTP_FORBIDDEN = 403
     private const val HTTP_NOT_FOUND = 404
+    private const val HTTP_CONFLICT = 409
+    private const val HTTP_PRECONDITION_FAILED = 412
+    private const val HTTP_TOO_MANY_REQUESTS = 429
     private const val HTTP_INTERNAL_ERROR = 500
+    private const val HTTP_NOT_IMPLEMENTED = 501
     private const val NO_BODY = -1L
 
     private fun contentType(path: String): String =


### PR DESCRIPTION
## Summary

Four categories of error quality improvements:

**1. Message consistency**
- Normalized "unknown table ID" formatting (dropped colon, matching other messages)
- Lowercased error messages per gRPC convention
- Fixed `simulator-rejected-pipeline` status: `INTERNAL` → `INVALID_ARGUMENT`

**2. 6 new golden tests (36 total)**
- PRE: clone-session-already-exists, clone-session-not-found, multicast-group-already-exists, multicast-group-not-found, pre-entry-missing-type
- Write validation: param-width-mismatch

**3. STF runner: "unknown X" errors list valid names**
Users writing STF tests with typos now see: `unknown table: foo (available: port_table, ipv4_da)`

**4. Web server: proper HTTP status codes**
gRPC status codes now map to correct HTTP codes instead of blanket 400.

## Test plan

- [x] 36/36 golden error tests pass
- [x] All p4runtime, simulator, web, and STF tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)