### PR TITLE
Golden tests for match field validation, counter/meter errors (41 total)

### DIFF
--- a/e2e_tests/lpm_routing/BUILD.bazel
+++ b/e2e_tests/lpm_routing/BUILD.bazel
@@ -4,6 +4,7 @@ load("//e2e_tests:p4c.bzl", "p4c_compile")
 p4c_compile(
     name = "lpm_routing",
     src_p4 = "lpm_routing.p4",
+    visibility = ["//p4runtime:__pkg__"],
 )
 
 kt_jvm_test(

--- a/e2e_tests/ternary_acl/BUILD.bazel
+++ b/e2e_tests/ternary_acl/BUILD.bazel
@@ -4,6 +4,7 @@ load("//e2e_tests:p4c.bzl", "p4c_compile")
 p4c_compile(
     name = "ternary_acl",
     src_p4 = "ternary_acl.p4",
+    visibility = ["//p4runtime:__pkg__"],
 )
 
 kt_jvm_test(

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -190,6 +190,8 @@ kt_jvm_test(
     ],
     data = [
         "//e2e_tests/basic_table:basic_table_pb",
+        "//e2e_tests/lpm_routing:lpm_routing_pb",
+        "//e2e_tests/ternary_acl:ternary_acl_pb",
         "//e2e_tests/trace_tree:clone_with_egress_pb",
     ] + glob(["golden_errors/*.golden.txt"]),
     test_class = "fourward.p4runtime.GoldenErrorTest",

--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -114,6 +114,11 @@ class GoldenErrorTest(private val testName: String) {
       "unrecognized-pipeline-action" -> triggerUnrecognizedPipelineAction()
       "simulator-rejected-pipeline" -> triggerSimulatorRejectedPipeline()
       "param-width-mismatch" -> triggerParamWidthMismatch()
+      "priority-required" -> triggerPriorityRequired()
+      "ternary-masked-bits" -> triggerTernaryMaskedBits()
+      "lpm-trailing-bits" -> triggerLpmTrailingBits()
+      "counter-insert-not-supported" -> triggerCounterInsertNotSupported()
+      "meter-insert-not-supported" -> triggerMeterInsertNotSupported()
       "register-insert-not-supported" -> triggerRegisterInsertNotSupported()
       "pre-entry-missing-type" -> triggerPreEntryMissingType()
       "clone-session-already-exists" -> triggerCloneSessionAlreadyExists()
@@ -503,6 +508,159 @@ class GoldenErrorTest(private val testName: String) {
     }
   }
 
+  @Suppress("MagicNumber")
+  private fun triggerPriorityRequired() {
+    val config = loadTernaryAcl()
+    harness.loadPipeline(config)
+    val table = config.p4Info.tablesList.first()
+    val matchField = table.matchFieldsList.first()
+    val byteWidth = (matchField.bitwidth + 7) / 8
+    val forwardAction = config.p4Info.actionsList.find { it.preamble.name.contains("forward") }!!
+    val entity =
+      Entity.newBuilder()
+        .setTableEntry(
+          TableEntry.newBuilder()
+            .setTableId(table.preamble.id)
+            .setPriority(0)
+            .addMatch(
+              P4RuntimeOuterClass.FieldMatch.newBuilder()
+                .setFieldId(matchField.id)
+                .setTernary(
+                  P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
+                    .setValue(ByteString.copyFrom(longToBytes(0x06, byteWidth)))
+                    .setMask(ByteString.copyFrom(longToBytes(0xFF, byteWidth)))
+                )
+            )
+            .setAction(
+              P4RuntimeOuterClass.TableAction.newBuilder()
+                .setAction(
+                  P4RuntimeOuterClass.Action.newBuilder()
+                    .setActionId(forwardAction.preamble.id)
+                    .addParams(
+                      P4RuntimeOuterClass.Action.Param.newBuilder()
+                        .setParamId(forwardAction.paramsList.first().id)
+                        .setValue(
+                          ByteString.copyFrom(
+                            longToBytes(1, (forwardAction.paramsList.first().bitwidth + 7) / 8)
+                          )
+                        )
+                    )
+                )
+            )
+        )
+        .build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerTernaryMaskedBits() {
+    val config = loadTernaryAcl()
+    harness.loadPipeline(config)
+    val table = config.p4Info.tablesList.first()
+    val matchField = table.matchFieldsList.first()
+    val byteWidth = (matchField.bitwidth + 7) / 8
+    val forwardAction = config.p4Info.actionsList.find { it.preamble.name.contains("forward") }!!
+    // value=0xFF but mask=0x0F — high nibble has bits set where mask is 0.
+    val entity =
+      Entity.newBuilder()
+        .setTableEntry(
+          TableEntry.newBuilder()
+            .setTableId(table.preamble.id)
+            .setPriority(1)
+            .addMatch(
+              P4RuntimeOuterClass.FieldMatch.newBuilder()
+                .setFieldId(matchField.id)
+                .setTernary(
+                  P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
+                    .setValue(ByteString.copyFrom(longToBytes(0xFF, byteWidth)))
+                    .setMask(ByteString.copyFrom(longToBytes(0x0F, byteWidth)))
+                )
+            )
+            .setAction(
+              P4RuntimeOuterClass.TableAction.newBuilder()
+                .setAction(
+                  P4RuntimeOuterClass.Action.newBuilder()
+                    .setActionId(forwardAction.preamble.id)
+                    .addParams(
+                      P4RuntimeOuterClass.Action.Param.newBuilder()
+                        .setParamId(forwardAction.paramsList.first().id)
+                        .setValue(
+                          ByteString.copyFrom(
+                            longToBytes(1, (forwardAction.paramsList.first().bitwidth + 7) / 8)
+                          )
+                        )
+                    )
+                )
+            )
+        )
+        .build()
+    harness.installEntry(entity)
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerLpmTrailingBits() {
+    val config = loadLpmRouting()
+    harness.loadPipeline(config)
+    val table = config.p4Info.tablesList.first()
+    val matchField = table.matchFieldsList.first()
+    val byteWidth = (matchField.bitwidth + 7) / 8
+    val forwardAction = config.p4Info.actionsList.find { it.preamble.name.contains("forward") }!!
+    // 10.0.0.255/24 — the last byte (255) extends beyond the 24-bit prefix.
+    val entity =
+      Entity.newBuilder()
+        .setTableEntry(
+          TableEntry.newBuilder()
+            .setTableId(table.preamble.id)
+            .addMatch(
+              P4RuntimeOuterClass.FieldMatch.newBuilder()
+                .setFieldId(matchField.id)
+                .setLpm(
+                  P4RuntimeOuterClass.FieldMatch.LPM.newBuilder()
+                    .setValue(ByteString.copyFrom(longToBytes(0x0A0000FF, byteWidth)))
+                    .setPrefixLen(24)
+                )
+            )
+            .setAction(
+              P4RuntimeOuterClass.TableAction.newBuilder()
+                .setAction(
+                  P4RuntimeOuterClass.Action.newBuilder()
+                    .setActionId(forwardAction.preamble.id)
+                    .addParams(
+                      P4RuntimeOuterClass.Action.Param.newBuilder()
+                        .setParamId(forwardAction.paramsList.first().id)
+                        .setValue(
+                          ByteString.copyFrom(
+                            longToBytes(1, (forwardAction.paramsList.first().bitwidth + 7) / 8)
+                          )
+                        )
+                    )
+                )
+            )
+        )
+        .build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerCounterInsertNotSupported() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val entity =
+      Entity.newBuilder()
+        .setCounterEntry(P4RuntimeOuterClass.CounterEntry.newBuilder().setCounterId(1))
+        .build()
+    harness.installEntry(entity)
+  }
+
+  private fun triggerMeterInsertNotSupported() {
+    val config = loadBasicTable()
+    harness.loadPipeline(config)
+    val entity =
+      Entity.newBuilder()
+        .setMeterEntry(P4RuntimeOuterClass.MeterEntry.newBuilder().setMeterId(1))
+        .build()
+    harness.installEntry(entity)
+  }
+
   private fun triggerRegisterInsertNotSupported() {
     val config = loadBasicTable()
     harness.loadPipeline(config)
@@ -593,6 +751,12 @@ class GoldenErrorTest(private val testName: String) {
   private fun loadBasicTable(): PipelineConfig =
     loadConfig("e2e_tests/basic_table/basic_table.txtpb")
 
+  private fun loadTernaryAcl(): PipelineConfig =
+    loadConfig("e2e_tests/ternary_acl/ternary_acl.txtpb")
+
+  private fun loadLpmRouting(): PipelineConfig =
+    loadConfig("e2e_tests/lpm_routing/lpm_routing.txtpb")
+
   /**
    * Captures the error description from a gRPC call.
    *
@@ -657,6 +821,11 @@ class GoldenErrorTest(private val testName: String) {
         "unrecognized-pipeline-action",
         "simulator-rejected-pipeline",
         "param-width-mismatch",
+        "priority-required",
+        "ternary-masked-bits",
+        "lpm-trailing-bits",
+        "counter-insert-not-supported",
+        "meter-insert-not-supported",
         "register-insert-not-supported",
         "pre-entry-missing-type",
         "clone-session-already-exists",

--- a/p4runtime/golden_errors/counter-insert-not-supported.golden.txt
+++ b/p4runtime/golden_errors/counter-insert-not-supported.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: counters only support MODIFY, not INSERT

--- a/p4runtime/golden_errors/lpm-trailing-bits.golden.txt
+++ b/p4runtime/golden_errors/lpm-trailing-bits.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: match field 'hdr.ipv4.dstAddr' has non-zero bits beyond prefix length 24

--- a/p4runtime/golden_errors/meter-insert-not-supported.golden.txt
+++ b/p4runtime/golden_errors/meter-insert-not-supported.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: meters only support MODIFY, not INSERT

--- a/p4runtime/golden_errors/priority-required.golden.txt
+++ b/p4runtime/golden_errors/priority-required.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: table 'acl' requires priority > 0 (has ternary/range/optional match fields)

--- a/p4runtime/golden_errors/ternary-masked-bits.golden.txt
+++ b/p4runtime/golden_errors/ternary-masked-bits.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: match field 'hdr.ipv4.protocol' has masked-off bits set in value (value & ~mask != 0)


### PR DESCRIPTION
## Summary

5 new golden error tests exercising match field validation and stateful entity errors that previously had no test fixtures:

| Test | Error | Fixture |
|---|---|---|
| `priority-required` | ternary entry with priority=0 | ternary_acl |
| `ternary-masked-bits` | value bits set outside mask | ternary_acl |
| `lpm-trailing-bits` | non-zero bits beyond prefix length | lpm_routing |
| `counter-insert-not-supported` | INSERT on counter (MODIFY only) | basic_table |
| `meter-insert-not-supported` | INSERT on meter (MODIFY only) | basic_table |

**Total golden error tests: 41** — covering write validation, match field validation, pipeline lifecycle, arbitration, PRE entities, counter/meter/register writes, and batch errors.

## Test plan

- [x] 41/41 golden error tests pass
- [x] All p4runtime tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)