### PR TITLE
Fix broken docs link to ROADMAP.md

### DIFF
--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -199,7 +199,7 @@ Batch = `InjectPackets` (1000 packets streamed concurrently).
 - **16 cores** — `InjectPacket` parallelizes fork branches within each
   packet. `InjectPackets` adds cross-packet parallelism.
 
-Throughput scales with available cores. See [Track 10](../ROADMAP.md#track-10-dataplane-performance)
+Throughput scales with available cores. See [Track 10](https://github.com/smolkaj/4ward/blob/main/docs/ROADMAP.md#track-10-dataplane-performance)
 in the roadmap for methodology and optimization details.
 
 ## Error codes


### PR DESCRIPTION
Fixes the docs CI failure — `reference/grpc.md` linked to `../ROADMAP.md` which is outside the mkdocs `docs_dir` (`userdocs/`). Changed to absolute GitHub URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)