### PR TITLE
Fix empty list display in error messages

### DIFF
--- a/p4runtime/golden_errors/unknown-counter-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-counter-id.golden.txt
@@ -1,1 +1,1 @@
-NOT_FOUND: unknown counter ID: 99999 (valid counter IDs: )
+NOT_FOUND: unknown counter ID: 99999 (valid counter IDs: none)

--- a/p4runtime/golden_errors/unknown-meter-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-meter-id.golden.txt
@@ -1,1 +1,1 @@
-NOT_FOUND: unknown meter ID: 99999 (valid meter IDs: )
+NOT_FOUND: unknown meter ID: 99999 (valid meter IDs: none)

--- a/p4runtime/golden_errors/unknown-register-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-register-id.golden.txt
@@ -1,1 +1,1 @@
-NOT_FOUND: unknown register ID: 99999 (valid registers: )
+NOT_FOUND: unknown register ID: 99999 (valid registers: none)

--- a/p4runtime/golden_errors/unknown-value-set-id.golden.txt
+++ b/p4runtime/golden_errors/unknown-value-set-id.golden.txt
@@ -1,1 +1,1 @@
-NOT_FOUND: unknown value_set ID: 99999 (valid value_sets: )
+NOT_FOUND: unknown value_set ID: 99999 (valid value_sets: none)

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -1438,8 +1438,11 @@ class TableStore : TableDataReader {
   }
 
   private fun formatOptions(options: List<String>): String =
-    if (options.size <= 10) options.joinToString(", ")
-    else options.take(10).joinToString(", ") + " ... and ${options.size - 10} more"
+    when {
+      options.isEmpty() -> "none"
+      options.size <= 10 -> options.joinToString(", ")
+      else -> options.take(10).joinToString(", ") + " ... and ${options.size - 10} more"
+    }
 
   private fun resolveActionName(actionId: Int): String =
     actionNameById[actionId]


### PR DESCRIPTION
`(valid registers: )` → `(valid registers: none)`

One-line fix in TableStore's `formatOptions` to handle empty lists, matching WriteValidator's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)