### PR TITLE
Array-indexed field lookup in table matching

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -512,8 +512,8 @@ entries and know where the time goes.
 
 **Current status: complete.** The 1k pps target is met across all
 workloads (sequential and concurrent). Benchmark, profiling, and five
-optimizations delivered **94× improvement** on the hardest workload
-(wcmp×16+mirr, batch on 16 cores) and **24× sequential single-core**.
+optimizations delivered **127× improvement** on the hardest workload
+(wcmp×16+mirr, batch on 16 cores) and **29× sequential single-core**.
 
 **Benchmark** (`bazel test //p4runtime:DataplaneBenchmark --test_output=streamed`).
 SAI P4 middleblock with 10k table entries + 500 ternary ACL entries.
@@ -525,10 +525,10 @@ sensitive workloads compared to typical server hardware.
 
 | Config       | Baseline | Sequential, 1 core | Sequential, 16 cores | Batch, 1 core | Batch, 16 cores |
 |--------------|----------|--------------------|----------------------|---------------|-----------------|
-| direct 10k   |    1,400 |              1,700 |                1,800 |         1,900 |          12,000 |
-| wcmp×4 10k   |      280 |              1,500 |                1,400 |               |                 |
-| wcmp×16 10k  |       83 |              1,200 |                1,300 |         1,000 |           6,100 |
-| wcmp×16+mirr |       41 |                800 |                  990 |           600 |           3,900 |
+| direct 10k   |    1,400 |              2,500 |                2,600 |         2,600 |          29,000 |
+| wcmp×4 10k   |      280 |              1,800 |                2,000 |               |                 |
+| wcmp×16 10k  |       83 |              1,400 |                1,700 |         1,200 |          10,000 |
+| wcmp×16+mirr |       41 |                970 |                1,200 |           710 |           5,200 |
 
 Sequential = `InjectPacket` (one packet at a time).
 Batch = `InjectPackets` (1000 packets streamed concurrently).
@@ -559,6 +559,9 @@ Batch = `InjectPackets` (1000 packets streamed concurrently).
    comparison. BigInteger cache for wide fields (IPv6).
 7. **Iterator elimination in table matching** (PR #429): indexed loops
    + HashMap replace iterator-heavy functional patterns in the hot loop.
+8. **Array-indexed field lookup** (PR #430): field ID array replaces
+   HashMap + String conversion in scoreEntry. Zero allocation per
+   match field.
 
 **What didn't help** (tried and reverted):
 - Caching `defaultValue()` templates — negligible.

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -1377,13 +1377,18 @@ class TableStore : TableDataReader {
     val default = defaultActions[tableName] ?: DefaultAction("NoAction")
 
     // Index key values by field ID for O(1) lookup in scoreEntry.
-    val keyMap = HashMap<String, Value>(keyValues.size * 2)
-    for ((name, value) in keyValues) keyMap[name] = value
+    // Field IDs are small positive integers; a sparse array avoids both
+    // iterator allocation (HashMap) and boxing (Int → Integer).
+    var maxId = 0
+    for ((name, _) in keyValues) maxId = maxOf(maxId, name.toInt())
+    val keyByFieldId = arrayOfNulls<Value>(maxId + 1)
+    for ((name, value) in keyValues) keyByFieldId[name.toInt()] = value
 
     var bestEntry: TableEntry? = null
     var bestScore = -1L
-    for (entry in entries) {
-      val score = scoreEntry(entry, keyMap) ?: continue
+    for (j in 0 until entries.size) {
+      val entry = entries[j]
+      val score = scoreEntry(entry, keyByFieldId) ?: continue
       if (score > bestScore) {
         bestScore = score
         bestEntry = entry
@@ -1491,10 +1496,14 @@ class TableStore : TableDataReader {
    * non-negative score where a higher value means a better match (used to implement LPM
    * longest-prefix and ternary priority semantics).
    */
-  private fun scoreEntry(entry: TableEntry, keyMap: Map<String, Value>): Long? {
+  private fun scoreEntry(entry: TableEntry, keyByFieldId: Array<Value?>): Long? {
     var score = 0L
-    for (match in entry.matchList) {
-      val value = keyMap[match.fieldId.toString()] ?: return null
+    val matchList = entry.matchList
+    for (i in 0 until matchList.size) {
+      val match = matchList[i]
+      val id = match.fieldId
+      val value = if (id in keyByFieldId.indices) keyByFieldId[id] else null
+      value ?: return null
 
       val bits =
         when (value) {

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -186,9 +186,9 @@ Representative numbers on SAI P4 middleblock with 10k table entries +
 
 | Workload | Sequential, 1 core | Sequential, 16 cores | Batch, 1 core | Batch, 16 cores |
 |----------|--------------------|----------------------|---------------|-----------------|
-| L3 forwarding | 1,700 | 1,800 | 1,900 | 12,000 |
-| WCMP ×16 members | 1,200 | 1,300 | 1,000 | 6,100 |
-| WCMP ×16 + mirror | 800 | 990 | 600 | 3,900 |
+| L3 forwarding | 2,500 | 2,600 | 2,600 | 29,000 |
+| WCMP ×16 members | 1,400 | 1,700 | 1,200 | 10,000 |
+| WCMP ×16 + mirror | 970 | 1,200 | 710 | 5,200 |
 
 Sequential = `InjectPacket` (one packet at a time).
 Batch = `InjectPackets` (1000 packets streamed concurrently).


### PR DESCRIPTION
## Summary

**+21-142% throughput** by replacing HashMap + String conversion with array-indexed field lookup in `scoreEntry`.

Field IDs in P4Runtime are small positive integers (1, 2, 3...). Instead of `keyMap[match.fieldId.toString()]` (HashMap lookup + Int→String allocation), use `keyByFieldId[match.fieldId]` (single array index, zero allocation).

### Results (500 ternary ACL entries, 10k routes, 16 cores)

| Config | Before | After | Improvement |
|--------|--------|-------|-------------|
| direct 10k sequential | 1,800 | **2,600** | **+44%** |
| wcmp×16+mirr sequential | 990 | **1,200** | **+21%** |
| direct 10k concurrent | 12,000 | **29,000** | **+142%** |
| wcmp×16+mirr concurrent | 3,900 | **5,200** | **+33%** |

### Cumulative from baseline

| Config | Baseline | Now | Total |
|--------|----------|-----|-------|
| wcmp×16+mirr concurrent | 41 pps | **5,200 pps** | **127×** |
| direct concurrent | 1,400 pps | **29,000 pps** | **21×** |

## Test plan

- [x] `bazel test //simulator/...` — 16 tests pass
- [x] Benchmark stable across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)