### PR TITLE
Add JSON benchmark output and dev.sh benchmark command

### DIFF
--- a/p4runtime/DataplaneBenchmark.kt
+++ b/p4runtime/DataplaneBenchmark.kt
@@ -81,8 +81,11 @@ class DataplaneBenchmark {
         ),
       )
 
+    val cores = Runtime.getRuntime().availableProcessors()
+    val jsonResults = mutableListOf<String>()
+
     println()
-    println("${Runtime.getRuntime().availableProcessors()} cores available")
+    println("$cores cores available")
     println()
     println("Sequential (InjectPacket, one at a time):")
     println(HEADER)
@@ -101,6 +104,12 @@ class DataplaneBenchmark {
             result.meanMs,
             result.throughput,
           )
+      )
+      jsonResults.add(
+        """{"mode":"sequential","config":"${sp.label}","routes":${sp.routes},""" +
+          """"entries":${result.totalEntries},"p50_ms":%.3f,"p99_ms":%.3f,"""
+            .format(result.p50Ms, result.p99Ms) +
+          """"mean_ms":%.3f,"packets_per_sec":%.0f}""".format(result.meanMs, result.throughput)
       )
     }
 
@@ -137,10 +146,25 @@ class DataplaneBenchmark {
       println(
         "| %-12s | %6d | %10.0f | %10.1f |".format(sp.label, sp.routes, result.first, result.second)
       )
+      jsonResults.add(
+        """{"mode":"concurrent","config":"${sp.label}","routes":${sp.routes},""" +
+          """"packets_per_sec":%.0f,"elapsed_ms":%.1f}""".format(result.first, result.second)
+      )
     }
 
     println(CONCURRENT_SEPARATOR)
     println()
+
+    // Write JSON for machine consumption.
+    val jsonDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
+    if (jsonDir != null) {
+      val jsonFile = java.io.File(jsonDir, "benchmark.json")
+      jsonFile.writeText(
+        """{"cores":$cores,"packets":$BENCHMARK_PACKETS,"acl_entries":$ACL_ENTRIES,""" +
+          """"results":[${jsonResults.joinToString(",")}]}"""
+      )
+      println("JSON results written to ${jsonFile.absolutePath}")
+    }
   }
 
   // ===========================================================================

--- a/tools/dev.sh
+++ b/tools/dev.sh
@@ -16,6 +16,7 @@ Commands:
   lint            Run all linters
   coverage        Run tests with coverage, open report
   diff-coverage   Compute incremental coverage from a diff + LCOV file
+  benchmark       Run dataplane performance benchmark
   help            Show this help
 EOF
 }
@@ -45,6 +46,13 @@ cmd_diff_coverage() {
   exec "${REPO_ROOT}/tools/diff-coverage.sh" "$@"
 }
 
+cmd_benchmark() {
+  bazel test //p4runtime:DataplaneBenchmark \
+    --test_output=streamed \
+    --nocache_test_results \
+    "$@"
+}
+
 # Dispatch.
 case "${1:-help}" in
   build)        shift; cmd_build "$@" ;;
@@ -53,6 +61,7 @@ case "${1:-help}" in
   lint)         shift; cmd_lint "$@" ;;
   coverage|cov)  shift; cmd_coverage "$@" ;;
   diff-coverage) shift; cmd_diff_coverage "$@" ;;
+  benchmark|bench) shift; cmd_benchmark "$@" ;;
   help|--help|-h) cmd_help ;;
   *)
     echo "Unknown command: $1" >&2


### PR DESCRIPTION
## Summary

Makes the benchmark reproducible and trackable:

- **JSON output** — `benchmark.json` written alongside the test, containing all results in machine-readable format (cores, config, packets/sec, latencies). Useful for tracking performance over time.
- **`./tools/dev.sh benchmark`** — one-command entry point. Runs the benchmark with streamed output. Extra args passed through (e.g., `./tools/dev.sh benchmark --test_env=JAVA_TOOL_OPTIONS=...`).
- **Human-readable output unchanged** — the table prints to stdout as before.

## Test plan

- [x] `./tools/dev.sh benchmark` runs and produces both table and JSON
- [x] JSON is valid (verified with `python3 -m json.tool`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)