### PR TITLE
Clean up nondeterminism model: remove compat shims, exhaustive forkModeOf

### DIFF
--- a/cli/Simulate.kt
+++ b/cli/Simulate.kt
@@ -7,6 +7,7 @@ import fourward.e2e.StfFile
 import fourward.e2e.installStfEntries
 import fourward.e2e.loadPipelineConfig
 import fourward.e2e.matchOutputAgainstExpects
+import fourward.simulator.MAX_POSSIBLE_OUTCOMES
 import fourward.simulator.Simulator
 import java.io.FileNotFoundException
 import java.nio.file.NoSuchFileException
@@ -78,14 +79,16 @@ fun simulate(pipelinePath: Path, stfPath: Path, format: OutputFormat, dropPort: 
     // Each packet may have multiple possible outcomes (alternative forks, e.g. action selectors).
     // Expand the Cartesian product of outcomes across packets.
     possibleWorlds =
-      possibleWorlds.flatMap { world ->
-        result.possibleOutcomes.map { outcome ->
-          world +
-            outcome.map { pkt ->
-              ReceivedPacket(pkt.dataplaneEgressPort, pkt.payload.toByteArray())
-            }
+      possibleWorlds
+        .flatMap { world ->
+          result.possibleOutcomes.map { outcome ->
+            world +
+              outcome.map { pkt ->
+                ReceivedPacket(pkt.dataplaneEgressPort, pkt.payload.toByteArray())
+              }
+          }
         }
-      }
+        .let { if (it.size > MAX_POSSIBLE_OUTCOMES) it.take(MAX_POSSIBLE_OUTCOMES) else it }
   }
 
   // Find the first world that satisfies all expects, or report the best failure.

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -3,6 +3,7 @@ package fourward.e2e
 import com.google.protobuf.ByteString
 import com.google.protobuf.TextFormat
 import fourward.ir.PipelineConfig
+import fourward.simulator.MAX_POSSIBLE_OUTCOMES
 import fourward.simulator.Simulator
 import fourward.simulator.WriteResult
 import java.math.BigInteger
@@ -70,14 +71,16 @@ class StfRunner(private val pipelineConfigPath: Path, private val dropPortOverri
         println("--- End trace tree ---")
       }
       possibleWorlds =
-        possibleWorlds.flatMap { world ->
-          result.possibleOutcomes.map { outcome ->
-            world +
-              outcome.map { pkt ->
-                ReceivedPacket(pkt.dataplaneEgressPort, pkt.payload.toByteArray())
-              }
+        possibleWorlds
+          .flatMap { world ->
+            result.possibleOutcomes.map { outcome ->
+              world +
+                outcome.map { pkt ->
+                  ReceivedPacket(pkt.dataplaneEgressPort, pkt.payload.toByteArray())
+                }
+            }
           }
-        }
+          .let { if (it.size > MAX_POSSIBLE_OUTCOMES) it.take(MAX_POSSIBLE_OUTCOMES) else it }
     }
 
     // Find the first world that satisfies all expects, or report the best failure.

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -8,7 +8,6 @@ import fourward.sim.SimulatorProto.PacketOutcome
 import fourward.sim.SimulatorProto.TraceTree
 import fourward.simulator.ProcessPacketResult
 import fourward.simulator.Simulator
-import fourward.simulator.collectPossibleOutcomes
 import java.nio.file.Paths
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -21,8 +20,8 @@ import org.junit.runners.Parameterized.Parameters
  * Verifies that output packets from [ProcessPacketResult] are consistent with the leaf outcomes in
  * the trace tree.
  *
- * The possible outcomes (from [collectPossibleOutcomes]) should be consistent with the trace tree's
- * leaf outcomes, whether the trace forks (multicast, clone, action selectors) or not.
+ * The possible outcomes should be consistent with the trace tree's leaf outcomes, whether the trace
+ * forks (multicast, clone, action selectors) or not.
  */
 @RunWith(Parameterized::class)
 class TraceTreeConsistencyTest(private val testName: String) {

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -77,7 +77,6 @@ events {
 }
 fork_outcome {
   reason: ACTION_SELECTOR
-  mode: FORK_MODE_ALTERNATIVE
   branches {
     label: "member_0"
     subtree {

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -77,7 +77,6 @@ events {
 }
 fork_outcome {
   reason: ACTION_SELECTOR
-  mode: FORK_MODE_ALTERNATIVE
   branches {
     label: "member_0"
     subtree {
@@ -123,7 +122,6 @@ fork_outcome {
       }
       fork_outcome {
         reason: ACTION_SELECTOR
-        mode: FORK_MODE_ALTERNATIVE
         branches {
           label: "member_0"
           subtree {
@@ -334,7 +332,6 @@ fork_outcome {
       }
       fork_outcome {
         reason: ACTION_SELECTOR
-        mode: FORK_MODE_ALTERNATIVE
         branches {
           label: "member_0"
           subtree {

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -77,13 +77,11 @@ events {
 }
 fork_outcome {
   reason: CLONE
-  mode: FORK_MODE_PARALLEL
   branches {
     label: "original"
     subtree {
       fork_outcome {
         reason: MULTICAST
-        mode: FORK_MODE_PARALLEL
         branches {
           label: "replica_0_port_1"
           subtree {

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -77,7 +77,6 @@ events {
 }
 fork_outcome {
   reason: CLONE
-  mode: FORK_MODE_PARALLEL
   branches {
     label: "original"
     subtree {

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -88,7 +88,6 @@ events {
 }
 fork_outcome {
   reason: CLONE
-  mode: FORK_MODE_PARALLEL
   branches {
     label: "original"
     subtree {

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -88,7 +88,6 @@ events {
 }
 fork_outcome {
   reason: ACTION_SELECTOR
-  mode: FORK_MODE_ALTERNATIVE
   branches {
     label: "member_0"
     subtree {
@@ -123,7 +122,6 @@ fork_outcome {
       }
       fork_outcome {
         reason: CLONE
-        mode: FORK_MODE_PARALLEL
         branches {
           label: "original"
           subtree {
@@ -272,7 +270,6 @@ fork_outcome {
       }
       fork_outcome {
         reason: CLONE
-        mode: FORK_MODE_PARALLEL
         branches {
           label: "original"
           subtree {

--- a/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
@@ -77,7 +77,6 @@ events {
 }
 fork_outcome {
   reason: CLONE
-  mode: FORK_MODE_PARALLEL
   branches {
     label: "original"
     subtree {

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -77,7 +77,6 @@ events {
 }
 fork_outcome {
   reason: CLONE
-  mode: FORK_MODE_PARALLEL
   branches {
     label: "original"
     subtree {

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -59,7 +59,6 @@ events {
 }
 fork_outcome {
   reason: MULTICAST
-  mode: FORK_MODE_PARALLEL
   branches {
     label: "replica_0_port_1"
     subtree {

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -59,7 +59,6 @@ events {
 }
 fork_outcome {
   reason: MULTICAST
-  mode: FORK_MODE_PARALLEL
   branches {
     label: "replica_0_port_1"
     subtree {

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -59,7 +59,6 @@ events {
 }
 fork_outcome {
   reason: MULTICAST
-  mode: FORK_MODE_PARALLEL
   branches {
     label: "replica_0_port_1"
     subtree {
@@ -97,7 +96,6 @@ fork_outcome {
       }
       fork_outcome {
         reason: ACTION_SELECTOR
-        mode: FORK_MODE_ALTERNATIVE
         branches {
           label: "member_0"
           subtree {
@@ -264,7 +262,6 @@ fork_outcome {
       }
       fork_outcome {
         reason: ACTION_SELECTOR
-        mode: FORK_MODE_ALTERNATIVE
         branches {
           label: "member_0"
           subtree {

--- a/e2e_tests/trace_tree/selector_exit.golden.txtpb
+++ b/e2e_tests/trace_tree/selector_exit.golden.txtpb
@@ -77,7 +77,6 @@ events {
 }
 fork_outcome {
   reason: ACTION_SELECTOR
-  mode: FORK_MODE_ALTERNATIVE
   branches {
     label: "member_0"
     subtree {

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -1,6 +1,7 @@
 package fourward.simulator
 
 import fourward.ir.BehavioralConfig
+import fourward.sim.SimulatorProto.OutputPacket
 import fourward.sim.SimulatorProto.TraceTree
 
 /**
@@ -42,4 +43,7 @@ interface Architecture {
  * The [trace] tree carries the complete execution trace. Leaf nodes contain [PacketOutcome]s
  * (output packets or drops); fork nodes represent non-deterministic choice points.
  */
-data class PipelineResult(val trace: TraceTree)
+data class PipelineResult(val trace: TraceTree) {
+  /** All possible outcome sets, derived from the trace tree's fork structure. */
+  val possibleOutcomes: List<List<OutputPacket>> by lazy { collectPossibleOutcomes(trace) }
+}

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -217,9 +217,7 @@ class PNAArchitecture : Architecture {
       val reason = if (mirrorBranches.isNotEmpty()) ForkReason.CLONE else ForkReason.RECIRCULATE
       return TraceTree.newBuilder()
         .addAllEvents(ctx.getEvents())
-        .setForkOutcome(
-          Fork.newBuilder().setReason(reason).setMode(forkModeOf(reason)).addAllBranches(branches)
-        )
+        .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
         .build()
     }
 

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -265,7 +265,7 @@ class PNAArchitectureTest {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(5)))
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val result = PNAArchitecture().processPacket(0u, payload, config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
@@ -287,7 +287,7 @@ class PNAArchitectureTest {
     // drop_packet then send_to_port — last writer wins, packet forwards.
     val config = pnaConfig(mainControlStmts = listOf(dropPacket(), sendToPort(5)))
     val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
@@ -341,7 +341,7 @@ class PNAArchitectureTest {
     val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
 
     // Packet should forward (register write doesn't affect drop).
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
 
     // Verify the register was actually written to the store.
@@ -388,7 +388,7 @@ class PNAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 5))
 
     val result = PNAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, store)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
     assertTrue(outputs.any { it.dataplaneEgressPort == 2 })
@@ -403,7 +403,7 @@ class PNAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 7))
 
     val result = PNAArchitecture().processPacket(0u, byteArrayOf(0xBB.toByte()), config, store)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(7, outputs[0].dataplaneEgressPort)
@@ -427,7 +427,7 @@ class PNAArchitectureTest {
   fun `mirror_packet with unknown session silently ignores mirror`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(2), mirrorPacket(0, 999)))
     val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(2, outputs[0].dataplaneEgressPort)
@@ -440,7 +440,7 @@ class PNAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 5, 1 to 6, 2 to 7))
 
     val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // Original + 3 mirror replicas = 4 outputs.
     assertEquals(4, outputs.size)

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -300,12 +300,7 @@ class PSAArchitecture : Architecture {
           .build()
       }
     return TraceTree.newBuilder()
-      .setForkOutcome(
-        Fork.newBuilder()
-          .setReason(ForkReason.MULTICAST)
-          .setMode(forkModeOf(ForkReason.MULTICAST))
-          .addAllBranches(branches)
-      )
+      .setForkOutcome(Fork.newBuilder().setReason(ForkReason.MULTICAST).addAllBranches(branches))
       .build()
   }
 
@@ -384,7 +379,6 @@ class PSAArchitecture : Architecture {
           .setForkOutcome(
             Fork.newBuilder()
               .setReason(ForkReason.RECIRCULATE)
-              .setMode(forkModeOf(ForkReason.RECIRCULATE))
               .addBranches(ForkBranch.newBuilder().setLabel("recirculate").setSubtree(recircTree))
           )
           .build()

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -356,7 +356,7 @@ class PSAArchitectureTest {
     val config = psaConfig(ingressStmts = listOf(sendToPort(5)))
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val result = PSAArchitecture().processPacket(0u, payload, config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
@@ -417,7 +417,7 @@ class PSAArchitectureTest {
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
 
     // Packet should forward (register write doesn't affect drop).
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
 
     // Verify the register was actually written to the store.
@@ -444,7 +444,7 @@ class PSAArchitectureTest {
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
     // Should not crash — the read returns a default zero value.
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -456,7 +456,7 @@ class PSAArchitectureTest {
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val result = PSAArchitecture().processPacket(0u, payload, config, tableStore)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(3, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
@@ -578,7 +578,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -593,8 +593,8 @@ class PSAArchitectureTest {
     // Run twice — should get the same result (deterministic hash).
     val result1 = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
     val result2 = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val out1 = collectPossibleOutcomes(result1.trace).single()
-    val out2 = collectPossibleOutcomes(result2.trace).single()
+    val out1 = result1.possibleOutcomes.single()
+    val out2 = result2.possibleOutcomes.single()
     assertEquals(out1[0].payload, out2[0].payload)
   }
 
@@ -694,7 +694,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -709,7 +709,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(hashInstance("h_0", "IDENTITY")),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -722,7 +722,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -736,7 +736,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(randomInstance("rng_0", 0, 100)),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -750,7 +750,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(digestInstance("digest_0")),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -763,7 +763,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(meterInstance("meter0")),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -831,7 +831,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(checksumInstance("ck_0")),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 
@@ -894,7 +894,7 @@ class PSAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 5))
 
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, store)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
     // Original on port 2, clone on port 5.
@@ -910,7 +910,7 @@ class PSAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 7))
 
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0xBB.toByte()), config, store)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // Original dropped, clone emitted.
     assertEquals(1, outputs.size)
@@ -938,7 +938,7 @@ class PSAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 5, 1 to 6, 2 to 7))
 
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // Original + 3 clones = 4 outputs.
     assertEquals(4, outputs.size)
@@ -955,7 +955,7 @@ class PSAArchitectureTest {
     writeCloneSession(store, 200, listOf(0 to 8))
 
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0xCC.toByte()), config, store)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
     assertTrue(outputs.any { it.dataplaneEgressPort == 2 })
@@ -991,7 +991,7 @@ class PSAArchitectureTest {
   fun `E2E clone with unknown session silently drops clone`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(2)), egressStmts = cloneStmts(999))
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // No clone session 999 → clone silently ignored, original output normally.
     assertEquals(1, outputs.size)
@@ -1019,7 +1019,7 @@ class PSAArchitectureTest {
   fun `I2E clone with unknown session silently drops clone`() {
     val config = psaConfig(ingressStmts = cloneStmts(999) + listOf(sendToPort(2)))
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // No clone session 999 → clone silently ignored, original output normally.
     assertEquals(1, outputs.size)
@@ -1075,7 +1075,7 @@ class PSAArchitectureTest {
       )
     val result =
       PSAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // Packet recirculates once, then forwards on port 5.
     assertEquals(1, outputs.size)
@@ -1114,7 +1114,7 @@ class PSAArchitectureTest {
     val config =
       psaConfig(ingressStmts = listOf(assignField("ostd", "clone", boolLit(true)), sendToPort(2)))
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // No clone session 0 → clone silently ignored, original output normally.
     assertEquals(1, outputs.size)
@@ -1146,7 +1146,7 @@ class PSAArchitectureTest {
       )
     val result =
       PSAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(7, outputs[0].dataplaneEgressPort)
@@ -1173,7 +1173,7 @@ class PSAArchitectureTest {
       )
     val result =
       PSAArchitecture().processPacket(0u, byteArrayOf(0xBB.toByte()), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // Resubmitted packet exits on port 1 with original bytes.
     assertEquals(1, outputs.size)
@@ -1210,7 +1210,7 @@ class PSAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 9))
 
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     // Resubmit wins: packet loops back, then exits on port 5. No clone on port 9.
     assertEquals(1, outputs.size)
@@ -1446,7 +1446,7 @@ class PSAArchitectureTest {
     assertEquals("member_1", result.trace.forkOutcome.branchesList[1].label)
 
     // Alternative fork: 2 possible worlds, each with 1 output (send_to_port(1) post-table).
-    val outcomes = collectPossibleOutcomes(result.trace)
+    val outcomes = result.possibleOutcomes
     assertEquals(2, outcomes.size)
     assertTrue(outcomes.all { world -> world.size == 1 && world[0].dataplaneEgressPort == 1 })
   }
@@ -1481,7 +1481,7 @@ class PSAArchitectureTest {
     assertEquals("member_0", result.trace.forkOutcome.branchesList[0].label)
 
     // Alternative fork: 1 possible world with 1 output.
-    val outcomes = collectPossibleOutcomes(result.trace)
+    val outcomes = result.possibleOutcomes
     assertEquals(1, outcomes.size)
     assertEquals(1, outcomes[0].size)
   }
@@ -1507,7 +1507,7 @@ class PSAArchitectureTest {
     assertEquals("member_1", result.trace.forkOutcome.branchesList[1].label)
 
     // Alternative fork: 2 possible worlds, each with 1 output.
-    val outcomes = collectPossibleOutcomes(result.trace)
+    val outcomes = result.possibleOutcomes
     assertEquals(2, outcomes.size)
     assertTrue(outcomes.all { world -> world.size == 1 && world[0].dataplaneEgressPort == 1 })
   }
@@ -1544,7 +1544,7 @@ class PSAArchitectureTest {
 
     // Parallel clone × alternative selector: 2 members × 2 members = 4 possible worlds,
     // each with 2 outputs (one from original, one from clone).
-    val outcomes = collectPossibleOutcomes(result.trace)
+    val outcomes = result.possibleOutcomes
     assertEquals(4, outcomes.size)
     assertTrue(outcomes.all { it.size == 2 })
   }
@@ -1566,7 +1566,7 @@ class PSAArchitectureTest {
         ingressExterns = listOf(checksumInstance("ck_0")),
       )
     val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
 }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -1,7 +1,6 @@
 package fourward.simulator
 
 import fourward.ir.PipelineConfig
-import fourward.sim.SimulatorProto.ForkMode
 import fourward.sim.SimulatorProto.OutputPacket
 import fourward.sim.SimulatorProto.TraceTree
 
@@ -200,6 +199,12 @@ class Simulator(
 }
 
 /**
+ * Maximum number of possible worlds before truncation. Guards against exponential blowup when
+ * alternative forks are nested inside parallel forks (e.g. 10 packets × 16-member selector each).
+ */
+const val MAX_POSSIBLE_OUTCOMES = 1024
+
+/**
  * Collects all possible outcome sets from a trace tree, respecting fork semantics.
  * - **Parallel forks** (clone, multicast, resubmit, recirculate): outputs from all branches are
  *   combined within each possible world (Cartesian product of branch outcomes).
@@ -209,7 +214,7 @@ class Simulator(
  * - **Leaf (drop):** one possible world with no packets.
  *
  * Returns a non-empty list. Each inner list is one complete set of output packets that could result
- * from a single real execution.
+ * from a single real execution. Capped at [MAX_POSSIBLE_OUTCOMES] worlds to prevent blowup.
  */
 fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
   if (!tree.hasForkOutcome()) {
@@ -222,14 +227,18 @@ fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
   val fork = tree.forkOutcome
   val branchOutcomes = fork.branchesList.map { collectPossibleOutcomes(it.subtree) }
   if (branchOutcomes.isEmpty()) return listOf(emptyList())
-  return when (fork.mode) {
-    // Alternative: each branch adds its worlds to the result.
-    ForkMode.FORK_MODE_ALTERNATIVE -> branchOutcomes.flatten()
-    // Parallel (and unspecified, for forward compatibility): Cartesian product across
-    // branches — for each combination of one world per branch, concatenate the packets.
-    else ->
-      branchOutcomes.reduce { acc, next ->
-        acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
-      }
-  }
+  val outcomes =
+    when (forkModeOf(fork.reason)) {
+      // Alternative: each branch adds its worlds to the result.
+      ForkMode.ALTERNATIVE -> branchOutcomes.flatten()
+      // Parallel: Cartesian product across branches — for each combination of one world per
+      // branch, concatenate the packets.
+      ForkMode.PARALLEL ->
+        branchOutcomes.reduce { acc, next ->
+          val product = acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
+          if (product.size > MAX_POSSIBLE_OUTCOMES) product.take(MAX_POSSIBLE_OUTCOMES) else product
+        }
+    }
+  return if (outcomes.size > MAX_POSSIBLE_OUTCOMES) outcomes.take(MAX_POSSIBLE_OUTCOMES)
+  else outcomes
 }

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -277,7 +277,7 @@ class SimulatorTest {
     sim.loadPipeline(config)
 
     val result = sim.processPacket(ingressPort = 0, payload = byteArrayOf(0x01))
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(V1ModelArchitecture.DEFAULT_DROP_PORT, outputs[0].dataplaneEgressPort)
   }
@@ -309,19 +309,14 @@ class CollectPossibleOutcomesTest {
       )
       .build()
 
-  private fun parallelFork(
+  private fun fork(
     reason: fourward.sim.SimulatorProto.ForkReason,
     vararg branches: Pair<String, fourward.sim.SimulatorProto.TraceTree>,
-  ): fourward.sim.SimulatorProto.TraceTree {
-    val mode =
-      if (reason == fourward.sim.SimulatorProto.ForkReason.ACTION_SELECTOR)
-        fourward.sim.SimulatorProto.ForkMode.FORK_MODE_ALTERNATIVE
-      else fourward.sim.SimulatorProto.ForkMode.FORK_MODE_PARALLEL
-    return fourward.sim.SimulatorProto.TraceTree.newBuilder()
+  ): fourward.sim.SimulatorProto.TraceTree =
+    fourward.sim.SimulatorProto.TraceTree.newBuilder()
       .setForkOutcome(
         fourward.sim.SimulatorProto.Fork.newBuilder()
           .setReason(reason)
-          .setMode(mode)
           .addAllBranches(
             branches.map {
               fourward.sim.SimulatorProto.ForkBranch.newBuilder()
@@ -332,12 +327,11 @@ class CollectPossibleOutcomesTest {
           )
       )
       .build()
-  }
 
   private fun alternativeFork(
     vararg branches: Pair<String, fourward.sim.SimulatorProto.TraceTree>
   ): fourward.sim.SimulatorProto.TraceTree =
-    parallelFork(fourward.sim.SimulatorProto.ForkReason.ACTION_SELECTOR, *branches)
+    fork(fourward.sim.SimulatorProto.ForkReason.ACTION_SELECTOR, *branches)
 
   @Test
   fun `linear trace produces one world with one output`() {
@@ -355,7 +349,7 @@ class CollectPossibleOutcomesTest {
   @Test
   fun `parallel fork combines outputs within each world`() {
     val tree =
-      parallelFork(
+      fork(
         fourward.sim.SimulatorProto.ForkReason.CLONE,
         "original" to output(1),
         "clone" to output(2),
@@ -382,7 +376,7 @@ class CollectPossibleOutcomesTest {
   fun `alternative inside parallel produces Cartesian product`() {
     // Clone (parallel) with 2 branches, each containing a 2-member selector (alternative).
     val tree =
-      parallelFork(
+      fork(
         fourward.sim.SimulatorProto.ForkReason.CLONE,
         "original" to alternativeFork("m0" to output(1), "m1" to output(2)),
         "clone" to alternativeFork("m0" to output(3), "m1" to output(4)),
@@ -408,7 +402,7 @@ class CollectPossibleOutcomesTest {
   @Test
   fun `multicast fork is parallel`() {
     val tree =
-      parallelFork(
+      fork(
         fourward.sim.SimulatorProto.ForkReason.MULTICAST,
         "r0" to output(1),
         "r1" to output(2),

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -5,13 +5,40 @@ import fourward.sim.SimulatorProto.Drop
 import fourward.sim.SimulatorProto.DropReason
 import fourward.sim.SimulatorProto.Fork
 import fourward.sim.SimulatorProto.ForkBranch
-import fourward.sim.SimulatorProto.ForkMode
 import fourward.sim.SimulatorProto.ForkReason
 import fourward.sim.SimulatorProto.PacketIngressEvent
 import fourward.sim.SimulatorProto.PacketOutcome
 import fourward.sim.SimulatorProto.PipelineStageEvent
 import fourward.sim.SimulatorProto.TraceEvent
 import fourward.sim.SimulatorProto.TraceTree
+
+/**
+ * Whether a fork's branches all happen (parallel) or only one happens (alternative).
+ * - **Parallel** (clone, multicast, resubmit, recirculate): all branches execute simultaneously.
+ *   Output packets are the union of all branch outputs.
+ * - **Alternative** (action selector): exactly one branch executes at runtime. Each branch is a
+ *   "possible world" — a distinct possible outcome set.
+ */
+enum class ForkMode {
+  PARALLEL,
+  ALTERNATIVE,
+}
+
+/**
+ * Maps a [ForkReason] to its [ForkMode].
+ *
+ * Exhaustive — adding a new [ForkReason] without updating this function is a compile error.
+ */
+fun forkModeOf(reason: ForkReason): ForkMode =
+  when (reason) {
+    ForkReason.ACTION_SELECTOR -> ForkMode.ALTERNATIVE
+    ForkReason.CLONE,
+    ForkReason.MULTICAST,
+    ForkReason.RESUBMIT,
+    ForkReason.RECIRCULATE -> ForkMode.PARALLEL
+    ForkReason.FORK_REASON_UNSPECIFIED,
+    ForkReason.UNRECOGNIZED -> error("unexpected fork reason: $reason")
+  }
 
 /** Builds a [TraceTree] representing a dropped packet with the given trace events and reason. */
 internal fun buildDropTrace(
@@ -50,15 +77,6 @@ internal fun stageEvent(stage: PipelineStage, direction: PipelineStageEvent.Dire
     )
     .build()
 
-/**
- * Maps a [ForkReason] to its [ForkMode]: alternative for action selectors, parallel for all else.
- */
-internal fun forkModeOf(reason: ForkReason): ForkMode =
-  when (reason) {
-    ForkReason.ACTION_SELECTOR -> ForkMode.FORK_MODE_ALTERNATIVE
-    else -> ForkMode.FORK_MODE_PARALLEL
-  }
-
 /** Builds a [TraceTree] with a fork outcome from accumulated events and branches. */
 internal fun buildForkTree(
   events: List<TraceEvent>,
@@ -67,7 +85,5 @@ internal fun buildForkTree(
 ): TraceTree =
   TraceTree.newBuilder()
     .addAllEvents(events)
-    .setForkOutcome(
-      Fork.newBuilder().setReason(reason).setMode(forkModeOf(reason)).addAllBranches(branches)
-    )
+    .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
     .build()

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -160,9 +160,7 @@ class V1ModelArchitecture(
       val tree =
         TraceTree.newBuilder()
           .addAllEvents(levelEvents)
-          .setForkOutcome(
-            Fork.newBuilder().setReason(reason).setMode(forkModeOf(reason)).addAllBranches(branches)
-          )
+          .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
           .build()
       return PipelineResult(tree)
     }

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -300,7 +300,7 @@ class V1ModelArchitectureTest {
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
     val result = V1ModelArchitecture().processPacket(0u, payload, config, tableStore)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
     assertEquals(2, outputs[0].dataplaneEgressPort)
@@ -316,7 +316,7 @@ class V1ModelArchitectureTest {
       v1modelConfig(assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS))
     val payload = byteArrayOf(0x01, 0x02, 0x03)
     val result = V1ModelArchitecture().processPacket(0u, payload, config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
@@ -384,7 +384,7 @@ class V1ModelArchitectureTest {
           ),
       )
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
@@ -424,7 +424,7 @@ class V1ModelArchitectureTest {
     assertEquals("original", branches[0].label)
     assertEquals("clone", branches[1].label)
 
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     // Original branch uses egress_spec set by ingress.
     assertEquals(2, outputs[0].dataplaneEgressPort)
@@ -444,7 +444,7 @@ class V1ModelArchitectureTest {
 
     val result =
       V1ModelArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, tableStore)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
     assertEquals(2, outputs[0].dataplaneEgressPort)
@@ -464,7 +464,7 @@ class V1ModelArchitectureTest {
 
     val result =
       V1ModelArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, tableStore)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
     assertEquals(510, outputs[1].dataplaneEgressPort)
@@ -482,7 +482,7 @@ class V1ModelArchitectureTest {
     )
 
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
@@ -510,7 +510,7 @@ class V1ModelArchitectureTest {
     assertEquals("original", branches[0].label)
     assertEquals("clone", branches[1].label)
 
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
     assertEquals(8, outputs[1].dataplaneEgressPort)
@@ -570,7 +570,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
     assertFalse(result.trace.hasForkOutcome())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(2, outputs[0].dataplaneEgressPort)
   }
@@ -588,7 +588,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
     assertFalse(result.trace.hasForkOutcome())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
   }
@@ -605,7 +605,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
     // No fork — falls through to unicast path.
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
   }
@@ -629,7 +629,7 @@ class V1ModelArchitectureTest {
 
     val result =
       V1ModelArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, tableStore)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
     assertEquals(2, outputs[0].dataplaneEgressPort)
@@ -647,7 +647,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     // Original is dropped (mark_to_drop set egress_spec to drop port).
     // Clone survives on port 7.
     assertEquals(1, outputs.size)
@@ -681,7 +681,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     // Original is dropped (egress mark_to_drop). Clone survives on port 8.
     assertEquals(1, outputs.size)
     assertEquals(8, outputs[0].dataplaneEgressPort)
@@ -799,7 +799,7 @@ class V1ModelArchitectureTest {
     val largePort = 1000L // beyond bit<9> range
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", largePort, portBits))
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(largePort.toInt(), outputs[0].dataplaneEgressPort)
@@ -822,7 +822,7 @@ class V1ModelArchitectureTest {
     val portBits = 16
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", 511, portBits))
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(511, outputs[0].dataplaneEgressPort)
@@ -848,7 +848,7 @@ class V1ModelArchitectureTest {
     val largePort = 100_000L
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", largePort, portBits))
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(largePort.toInt(), outputs[0].dataplaneEgressPort)
@@ -905,7 +905,7 @@ class V1ModelArchitectureTest {
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     // Both original and clone produce output (metadata was preserved, so no drop).
     assertEquals(2, outputs.size)
     assertEquals(2, outputs[0].dataplaneEgressPort)
@@ -951,7 +951,7 @@ class V1ModelArchitectureTest {
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
     assertEquals(8, outputs[1].dataplaneEgressPort)
@@ -992,7 +992,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
 
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
   }
 
@@ -1039,7 +1039,7 @@ class V1ModelArchitectureTest {
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     // Resubmit branch outputs (metadata was preserved, so no drop).
     assertEquals(1, outputs.size)
     assertEquals(1, outputs[0].dataplaneEgressPort)
@@ -1092,7 +1092,7 @@ class V1ModelArchitectureTest {
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     // Recirculate branch outputs (metadata was preserved, so no drop).
     assertEquals(1, outputs.size)
     assertEquals(1, outputs[0].dataplaneEgressPort)
@@ -1136,7 +1136,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     // Clone should NOT drop: not_preserved was reset to 0, so 0x1234 check is false.
     assertEquals(2, outputs.size)
   }
@@ -1153,7 +1153,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     assertEquals(1, outputs[0].dataplaneEgressPort)
@@ -1195,7 +1195,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     val logEvents = result.trace.eventsList.filter { it.hasLogMessage() }
@@ -1211,7 +1211,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
     val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
     val logEvents = result.trace.eventsList.filter { it.hasLogMessage() }
@@ -1260,7 +1260,7 @@ class V1ModelArchitectureTest {
       V1ModelArchitecture(dropPortOverride = 42)
         .processPacket(0u, byteArrayOf(0x01), config, TableStore())
 
-    val outputs = collectPossibleOutcomes(result.trace).single()
+    val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(DEFAULT_DROP_PORT, outputs[0].dataplaneEgressPort)
   }

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -76,9 +76,6 @@ message TraceTree {
 message Fork {
   ForkReason reason = 1;
   repeated ForkBranch branches = 2;
-  // How to interpret the branches.  Derived from `reason` but explicit so
-  // consumers don't need their own reason→mode mapping.
-  ForkMode mode = 3;
 }
 
 // One branch of a fork.  The label describes this particular outcome (e.g. the
@@ -88,19 +85,8 @@ message ForkBranch {
   TraceTree subtree = 2;
 }
 
-// Whether a fork's branches all happen (parallel) or only one happens
-// (alternative).  See the Fork message for details.
-enum ForkMode {
-  FORK_MODE_UNSPECIFIED = 0;
-  // All branches execute simultaneously in a single real execution.
-  // Output packets are the union of all branch outputs.
-  FORK_MODE_PARALLEL = 1;
-  // Exactly one branch executes; each is an alternative possible outcome.
-  // The simulator explores all alternatives so consumers can reason about
-  // every possible forwarding decision.
-  FORK_MODE_ALTERNATIVE = 2;
-}
-
+// Whether a fork's branches all happen or only one happens is determined by
+// the ForkReason.  See ForkMode in the simulator Kotlin code.
 enum ForkReason {
   FORK_REASON_UNSPECIFIED = 0;
   ACTION_SELECTOR = 1;  // Alternative: one member is selected by hash.


### PR DESCRIPTION
## Summary

Follow-up to #433 — aggressive cleanup of the parallel vs alternative nondeterminism model.

- **Remove `output_packets` from `dataplane.proto`** — `possible_outcomes` (repeated `PacketSet`) is now the sole output representation. No backwards-compatibility shim.
- **Remove `collectAllOutputsFromTrace`** — the flat-list helper that ignored fork semantics. All callers use `collectPossibleOutcomes` or `result.possibleOutcomes`.
- **Remove `ForkMode` enum and `mode` field from `simulator.proto`** — the reason→mode mapping lives exclusively in `forkModeOf()` in Kotlin, eliminating a second source of truth that could get out of sync.
- **Make `forkModeOf` exhaustive** — enumerates all `ForkReason` values explicitly. Adding a new reason without updating the mapping is a compile error, not a silent default to PARALLEL.
- **Add `possibleOutcomes` on `PipelineResult`** — lazy property that eliminates 62+ `collectPossibleOutcomes(result.trace)` calls. Architecture tests now read `result.possibleOutcomes.single()`.
- **Cap Cartesian product at 1024 worlds** — guards against exponential blowup when alternative forks nest inside parallel forks across multiple packets.

## Test plan

- [x] All 60 non-heavy tests pass
- [x] Format and lint clean
- [ ] CI (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)