### PR TITLE
Replace exponential cross-packet world expansion with greedy per-packet selection

### DIFF
--- a/cli/Simulate.kt
+++ b/cli/Simulate.kt
@@ -4,10 +4,10 @@ import com.google.protobuf.TextFormat
 import com.google.protobuf.util.JsonFormat
 import fourward.e2e.ReceivedPacket
 import fourward.e2e.StfFile
+import fourward.e2e.appendBestOutcome
 import fourward.e2e.installStfEntries
 import fourward.e2e.loadPipelineConfig
 import fourward.e2e.matchOutputAgainstExpects
-import fourward.simulator.MAX_POSSIBLE_OUTCOMES
 import fourward.simulator.Simulator
 import java.io.FileNotFoundException
 import java.nio.file.NoSuchFileException
@@ -56,7 +56,7 @@ fun simulate(pipelinePath: Path, stfPath: Path, format: OutputFormat, dropPort: 
     return ExitCode.INTERNAL_ERROR
   }
 
-  var possibleWorlds: List<List<ReceivedPacket>> = listOf(emptyList())
+  val outputQueue = mutableListOf<ReceivedPacket>()
   val textProtoPrinter = TextFormat.printer()
   val jsonPrinter = JsonFormat.printer().preservingProtoFieldNames()
 
@@ -76,25 +76,10 @@ fun simulate(pipelinePath: Path, stfPath: Path, format: OutputFormat, dropPort: 
         println(jsonPrinter.print(result.trace))
       }
     }
-    // Each packet may have multiple possible outcomes (alternative forks, e.g. action selectors).
-    // Expand the Cartesian product of outcomes across packets.
-    possibleWorlds =
-      possibleWorlds
-        .flatMap { world ->
-          result.possibleOutcomes.map { outcome ->
-            world +
-              outcome.map { pkt ->
-                ReceivedPacket(pkt.dataplaneEgressPort, pkt.payload.toByteArray())
-              }
-          }
-        }
-        .let { if (it.size > MAX_POSSIBLE_OUTCOMES) it.take(MAX_POSSIBLE_OUTCOMES) else it }
+    appendBestOutcome(result.possibleOutcomes, stf.expects, outputQueue)
   }
 
-  // Find the first world that satisfies all expects, or report the best failure.
-  val worldFailures =
-    possibleWorlds.map { world -> matchOutputAgainstExpects(stf.expects, world.toMutableList()) }
-  val failures = worldFailures.firstOrNull { it.isEmpty() } ?: worldFailures.minBy { it.size }
+  val failures = matchOutputAgainstExpects(stf.expects, outputQueue)
   if (failures.isNotEmpty()) {
     System.err.println("FAIL")
     for (f in failures) System.err.println("  $f")

--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -3,7 +3,6 @@ package fourward.e2e
 import com.google.protobuf.ByteString
 import com.google.protobuf.TextFormat
 import fourward.ir.PipelineConfig
-import fourward.simulator.MAX_POSSIBLE_OUTCOMES
 import fourward.simulator.Simulator
 import fourward.simulator.WriteResult
 import java.math.BigInteger
@@ -58,10 +57,7 @@ class StfRunner(private val pipelineConfigPath: Path, private val dropPortOverri
       return TestResult.Failure(e.message ?: "WriteEntry failed")
     }
 
-    // Each packet may have multiple possible outcomes (alternative forks, e.g. action selectors).
-    // We accumulate one output queue per "possible world" — the Cartesian product of outcomes
-    // across packets. If any world satisfies all expects, the test passes.
-    var possibleWorlds: List<List<ReceivedPacket>> = listOf(emptyList())
+    val outputQueue = mutableListOf<ReceivedPacket>()
 
     for (packet in stf.packets) {
       val result = sim.processPacket(packet.ingressPort, packet.payload)
@@ -70,28 +66,39 @@ class StfRunner(private val pipelineConfigPath: Path, private val dropPortOverri
         print(TextFormat.printer().printToString(result.trace))
         println("--- End trace tree ---")
       }
-      possibleWorlds =
-        possibleWorlds
-          .flatMap { world ->
-            result.possibleOutcomes.map { outcome ->
-              world +
-                outcome.map { pkt ->
-                  ReceivedPacket(pkt.dataplaneEgressPort, pkt.payload.toByteArray())
-                }
-            }
-          }
-          .let { if (it.size > MAX_POSSIBLE_OUTCOMES) it.take(MAX_POSSIBLE_OUTCOMES) else it }
+      appendBestOutcome(result.possibleOutcomes, stf.expects, outputQueue)
     }
 
-    // Find the first world that satisfies all expects, or report the best failure.
-    val worldFailures =
-      possibleWorlds.map { world -> matchOutputAgainstExpects(stf.expects, world.toMutableList()) }
-    val passWorld = worldFailures.firstOrNull { it.isEmpty() }
-    if (passWorld != null) return TestResult.Pass
-    // Report failures from the world with fewest issues.
-    val bestFailures = worldFailures.minBy { it.size }
-    return TestResult.Failure(bestFailures.joinToString("\n"))
+    val failures = matchOutputAgainstExpects(stf.expects, outputQueue)
+    return if (failures.isEmpty()) TestResult.Pass
+    else TestResult.Failure(failures.joinToString("\n"))
   }
+}
+
+/**
+ * Appends the best-matching possible world's outputs to [outputQueue].
+ *
+ * For each world in [possibleOutcomes], scores how well it satisfies [expects] when combined with
+ * already-accumulated outputs, and picks the world with the fewest failures. For the common case of
+ * a single possible world (no alternative forks), skips scoring entirely.
+ */
+fun appendBestOutcome(
+  possibleOutcomes: List<List<fourward.sim.SimulatorProto.OutputPacket>>,
+  expects: List<StfExpectedOutput>,
+  outputQueue: MutableList<ReceivedPacket>,
+) {
+  val bestWorld =
+    if (possibleOutcomes.size == 1) {
+      possibleOutcomes[0]
+    } else {
+      possibleOutcomes.minBy { world ->
+        val candidate =
+          outputQueue +
+            world.map { ReceivedPacket(it.dataplaneEgressPort, it.payload.toByteArray()) }
+        matchOutputAgainstExpects(expects, candidate.toMutableList()).size
+      }
+    }
+  outputQueue += bestWorld.map { ReceivedPacket(it.dataplaneEgressPort, it.payload.toByteArray()) }
 }
 
 /**

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -199,12 +199,6 @@ class Simulator(
 }
 
 /**
- * Maximum number of possible worlds before truncation. Guards against exponential blowup when
- * alternative forks are nested inside parallel forks (e.g. 10 packets × 16-member selector each).
- */
-const val MAX_POSSIBLE_OUTCOMES = 1024
-
-/**
  * Collects all possible outcome sets from a trace tree, respecting fork semantics.
  * - **Parallel forks** (clone, multicast, resubmit, recirculate): outputs from all branches are
  *   combined within each possible world (Cartesian product of branch outcomes).
@@ -214,7 +208,7 @@ const val MAX_POSSIBLE_OUTCOMES = 1024
  * - **Leaf (drop):** one possible world with no packets.
  *
  * Returns a non-empty list. Each inner list is one complete set of output packets that could result
- * from a single real execution. Capped at [MAX_POSSIBLE_OUTCOMES] worlds to prevent blowup.
+ * from a single real execution.
  */
 fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
   if (!tree.hasForkOutcome()) {
@@ -227,18 +221,14 @@ fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
   val fork = tree.forkOutcome
   val branchOutcomes = fork.branchesList.map { collectPossibleOutcomes(it.subtree) }
   if (branchOutcomes.isEmpty()) return listOf(emptyList())
-  val outcomes =
-    when (forkModeOf(fork.reason)) {
-      // Alternative: each branch adds its worlds to the result.
-      ForkMode.ALTERNATIVE -> branchOutcomes.flatten()
-      // Parallel: Cartesian product across branches — for each combination of one world per
-      // branch, concatenate the packets.
-      ForkMode.PARALLEL ->
-        branchOutcomes.reduce { acc, next ->
-          val product = acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
-          if (product.size > MAX_POSSIBLE_OUTCOMES) product.take(MAX_POSSIBLE_OUTCOMES) else product
-        }
-    }
-  return if (outcomes.size > MAX_POSSIBLE_OUTCOMES) outcomes.take(MAX_POSSIBLE_OUTCOMES)
-  else outcomes
+  return when (forkModeOf(fork.reason)) {
+    // Alternative: each branch adds its worlds to the result.
+    ForkMode.ALTERNATIVE -> branchOutcomes.flatten()
+    // Parallel: Cartesian product across branches — for each combination of one world per
+    // branch, concatenate the packets.
+    ForkMode.PARALLEL ->
+      branchOutcomes.reduce { acc, next ->
+        acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
+      }
+  }
 }


### PR DESCRIPTION
## Summary

The STF runner and CLI accumulated possible worlds across packets via Cartesian product — O(worlds^packets), silently capped at 1024. But the product is unnecessary: each packet's outputs are consumed by disjoint expect slots (FIFO per port), so world choices don't interact across packets.

Replaces with a greedy per-packet strategy: for each packet, pick the world whose outputs best satisfy the remaining expects. Linear in packets x worlds, no cap needed, no silent truncation.

Also removes `MAX_POSSIBLE_OUTCOMES` cap from `collectPossibleOutcomes` — the per-trace-tree world count is already bounded by the program's fork structure and the existing `PIPELINE_EXECUTION_LIMIT_REACHED` guard.

Net: 3 files changed, -22 lines. Simpler and correct.

## Test plan

- [x] All 60 non-heavy tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)