### PR TITLE
Consistent field order: trace first, possible_outcomes second

### DIFF
--- a/p4runtime/PacketBrokerTest.kt
+++ b/p4runtime/PacketBrokerTest.kt
@@ -15,7 +15,7 @@ class PacketBrokerTest {
       .build()
 
   private fun result(vararg outputs: OutputPacket) =
-    ProcessPacketResult(listOf(outputs.toList()), TraceTree.getDefaultInstance())
+    ProcessPacketResult(TraceTree.getDefaultInstance(), listOf(outputs.toList()))
 
   private fun fakeProcessor(
     vararg results: Pair<Int, ProcessPacketResult>

--- a/p4runtime/dataplane.proto
+++ b/p4runtime/dataplane.proto
@@ -66,20 +66,20 @@ message PacketSet {
 
 // InjectPacket response. Omits the input (the caller already has it).
 message InjectPacketResponse {
+  fourward.sim.TraceTree trace = 1;
   // Each entry is one possible set of output packets from a single real
   // execution.  Programs with only parallel forks have exactly one entry.
   // Programs with alternative forks (action selectors) have one entry per
   // alternative — each representing a "possible world".
-  repeated PacketSet possible_outcomes = 3;
-  fourward.sim.TraceTree trace = 2;
+  repeated PacketSet possible_outcomes = 2;
 }
 
 // Result bundle for SubscribeResults: input + outputs + trace.
 message ProcessPacketResult {
   InputPacket input_packet = 1;
-  fourward.sim.TraceTree trace = 3;
+  fourward.sim.TraceTree trace = 2;
   // Possible outcome sets (see InjectPacketResponse.possible_outcomes).
-  repeated PacketSet possible_outcomes = 4;
+  repeated PacketSet possible_outcomes = 3;
 }
 
 message SubscribeResultsRequest {}

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -20,7 +20,7 @@ import fourward.sim.SimulatorProto.TraceTree
  * Decouples the simulator from the gRPC wire format ([fourward.sim.SimulatorProto
  * .InjectPacketResponse]). Each RPC method builds its own wire proto from this data class.
  */
-data class ProcessPacketResult(val possibleOutcomes: List<List<OutputPacket>>, val trace: TraceTree)
+data class ProcessPacketResult(val trace: TraceTree, val possibleOutcomes: List<List<OutputPacket>>)
 
 /**
  * The top-level simulator state machine.


### PR DESCRIPTION
## Summary

Reorders fields so `trace` consistently comes before `possible_outcomes` in both the proto wire format and the Kotlin data class. Retags proto field numbers (breaking wire-format change, as discussed).

3 files, +6/-6.

## Test plan

- [x] All 60 non-heavy tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)