### PR TITLE
Make matchOutputAgainstExpects take immutable List

### DIFF
--- a/e2e_tests/stf/Runner.kt
+++ b/e2e_tests/stf/Runner.kt
@@ -95,7 +95,7 @@ fun appendBestOutcome(
         val candidate =
           outputQueue +
             world.map { ReceivedPacket(it.dataplaneEgressPort, it.payload.toByteArray()) }
-        matchOutputAgainstExpects(expects, candidate.toMutableList()).size
+        matchOutputAgainstExpects(expects, candidate).size
       }
     }
   outputQueue += bestWorld.map { ReceivedPacket(it.dataplaneEgressPort, it.payload.toByteArray()) }
@@ -111,16 +111,17 @@ fun appendBestOutcome(
  */
 fun matchOutputAgainstExpects(
   expects: List<StfExpectedOutput>,
-  outputs: MutableList<ReceivedPacket>,
+  outputs: List<ReceivedPacket>,
 ): List<String> {
+  val remaining = outputs.toMutableList()
   val failures = mutableListOf<String>()
 
   for (expected in expects) {
-    val idx = outputs.indexOfFirst { it.egressPort == expected.port }
+    val idx = remaining.indexOfFirst { it.egressPort == expected.port }
     if (idx < 0) {
       failures += "expected packet on port ${expected.port} but got none"
     } else {
-      val actual = outputs.removeAt(idx)
+      val actual = remaining.removeAt(idx)
       if (!actual.payload.matchesMasked(expected.payload, expected.mask, expected.exactLength)) {
         failures +=
           "port ${expected.port}: payload mismatch\n" +
@@ -133,7 +134,7 @@ fun matchOutputAgainstExpects(
   // Reject unexpected output only when the STF has explicit expects — otherwise
   // the test is "send-only" and doesn't make claims about output.
   if (expects.isNotEmpty()) {
-    for (unexpected in outputs) {
+    for (unexpected in remaining) {
       failures += "unexpected packet on port ${unexpected.egressPort}: ${unexpected.payload.hex()}"
     }
   }

--- a/e2e_tests/stf/RunnerTest.kt
+++ b/e2e_tests/stf/RunnerTest.kt
@@ -19,14 +19,13 @@ class RunnerTest {
 
   @Test
   fun `all expects matched with no leftover output`() {
-    val failures =
-      matchOutputAgainstExpects(listOf(expect(1, 0xAA)), mutableListOf(received(1, 0xAA)))
+    val failures = matchOutputAgainstExpects(listOf(expect(1, 0xAA)), listOf(received(1, 0xAA)))
     assertTrue(failures.isEmpty())
   }
 
   @Test
   fun `missing expected output is a failure`() {
-    val failures = matchOutputAgainstExpects(listOf(expect(1, 0xAA)), mutableListOf())
+    val failures = matchOutputAgainstExpects(listOf(expect(1, 0xAA)), listOf())
     assertEquals(1, failures.size)
     assertTrue(failures[0].contains("expected packet on port 1 but got none"))
   }
@@ -36,7 +35,7 @@ class RunnerTest {
     val failures =
       matchOutputAgainstExpects(
         listOf(expect(1, 0xAA)),
-        mutableListOf(received(1, 0xAA), received(2, 0xBB)),
+        listOf(received(1, 0xAA), received(2, 0xBB)),
       )
     assertEquals(1, failures.size)
     assertTrue(failures[0].contains("unexpected packet on port 2"))
@@ -45,14 +44,13 @@ class RunnerTest {
   @Test
   fun `unexpected output ignored when no expects (send-only test)`() {
     val failures =
-      matchOutputAgainstExpects(emptyList(), mutableListOf(received(1, 0xAA), received(2, 0xBB)))
+      matchOutputAgainstExpects(emptyList(), listOf(received(1, 0xAA), received(2, 0xBB)))
     assertTrue(failures.isEmpty())
   }
 
   @Test
   fun `payload mismatch is a failure`() {
-    val failures =
-      matchOutputAgainstExpects(listOf(expect(1, 0xAA)), mutableListOf(received(1, 0xBB)))
+    val failures = matchOutputAgainstExpects(listOf(expect(1, 0xAA)), listOf(received(1, 0xBB)))
     assertEquals(1, failures.size)
     assertTrue(failures[0].contains("payload mismatch"))
   }
@@ -62,7 +60,7 @@ class RunnerTest {
     val failures =
       matchOutputAgainstExpects(
         listOf(expect(2, 0xBB), expect(1, 0xAA)),
-        mutableListOf(received(1, 0xAA), received(2, 0xBB)),
+        listOf(received(1, 0xAA), received(2, 0xBB)),
       )
     assertTrue(failures.isEmpty())
   }
@@ -72,7 +70,7 @@ class RunnerTest {
     val failures =
       matchOutputAgainstExpects(
         listOf(expect(1, 0xAA), expect(1, 0xBB)),
-        mutableListOf(received(1, 0xAA), received(1, 0xBB)),
+        listOf(received(1, 0xAA), received(1, 0xBB)),
       )
     assertTrue(failures.isEmpty())
   }
@@ -82,7 +80,7 @@ class RunnerTest {
     val failures =
       matchOutputAgainstExpects(
         listOf(expect(1, 0xAA), expect(1, 0xBB)),
-        mutableListOf(received(1, 0xBB), received(1, 0xAA)),
+        listOf(received(1, 0xBB), received(1, 0xAA)),
       )
     // FIFO pairs first-to-first and second-to-second — both mismatch.
     assertEquals(2, failures.size)


### PR DESCRIPTION
## Summary

`matchOutputAgainstExpects` destructively removes matched packets via `removeAt`, but its `MutableList` parameter put the burden on callers to pass a defensive copy. Passing the live output queue directly would silently corrupt it — a latent bug.

Now takes `List<ReceivedPacket>` and copies internally. The `.toMutableList()` call in `appendBestOutcome` is no longer needed.

2 files, -1 line net.

## Test plan

- [x] All 60 non-heavy tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)