### PR TITLE
Fix stale ForkMode reference in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,7 +161,7 @@ happens with this specific hash seed?"
 ### Parallel vs alternative forks
 
 Not all forks are created equal. The simulator distinguishes two kinds of
-nondeterminism (see `ForkMode` in `simulator.proto`):
+nondeterminism (see `ForkMode` and `forkModeOf` in `TraceHelpers.kt`):
 
 - **Parallel forks** (clone, multicast, resubmit, recirculate) — all branches
   execute simultaneously in a single real execution. The output packets are the


### PR DESCRIPTION
ForkMode was moved from simulator.proto to TraceHelpers.kt in #437. Updates the pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)