### PR TITLE
Showcase error message quality in README and userdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ enough for production test workloads.
 | Architecture-generic | ish | [**by design**](docs/ROADMAP.md#track-6-multi-architecture-support) | ✅ v1model + PSA + PNA |
 | Architecture customization | no | [**by design**](docs/ROADMAP.md#track-5-architecture-customization) | ✅ |
 | Interactive playground | no | [**browser-based IDE with trace playback & packet decoding**](#web-playground) | ✅ |
+| Error messages | opaque | [**actionable, with valid options**](docs/ROADMAP.md#track-11-error-quality) | ✅ [74 golden-tested](p4runtime/golden_errors/) |
 | Throughput (16-way selector) | [~4,500 pps ÷ 16 paths](docs/PERFORMANCE.md#bmv2-comparison) | [**~1,400 pps, all 16 paths**](docs/PERFORMANCE.md) | ✅ [head-to-head on SAI P4](docs/PERFORMANCE.md#bmv2-comparison) |
 | Parallelism (16-way selector) | single-threaded | [**10,000 pps on 16 cores**](docs/PERFORMANCE.md) | ✅ parallel across packets and forks |
 | Easy to extend | ehh | [**if AI can extend it, anyone can**](docs/ROADMAP.md#why-4ward-is-easier-to-extend) | ✅ |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,5 +72,6 @@ nav:
       - Trace Trees: concepts/traces.md
       - Type Translation: concepts/type-translation.md
       - Architectures: concepts/architectures.md
+      - Error Messages: reference/errors.md
       - Architecture Modifications: concepts/architecture-modifications.md
   - Examples: examples.md

--- a/userdocs/index.md
+++ b/userdocs/index.md
@@ -47,6 +47,9 @@ all possible outcomes in a single pass.
 - **[P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.5.0/P4Runtime-Spec.html) server** — spec-compliant gRPC server
   with full arbitration, table management, PacketIO, and clone/multicast
   support.
+- **Actionable error messages** — every error tells you what went wrong, shows
+  the value you sent, and lists the valid options. 74 golden-tested error paths.
+  [Learn more](reference/errors.md).
 - **Type translation** — `@p4runtime_translation` types (string port names,
   translated IDs) flow through the entire stack, including traces.
   [Learn more](concepts/type-translation.md).

--- a/userdocs/reference/errors.md
+++ b/userdocs/reference/errors.md
@@ -1,0 +1,77 @@
+# Error Messages
+
+4ward produces actionable, specific error messages for every P4Runtime
+operation. Every error tells you what went wrong, shows the value you sent,
+and lists the valid options.
+
+## Examples
+
+**Unknown table ID:**
+```
+NOT_FOUND: unknown table ID 99999 (valid tables: 'port_table' (44171635))
+```
+
+**Wrong action for a table:**
+```
+INVALID_ARGUMENT: unknown action ID 99999 in table 'port_table'
+  (valid actions: 'MyIngress.forward' (29683729),
+   'MyIngress.drop' (25652968), 'NoAction' (21257015))
+```
+
+**Match field type mismatch:**
+```
+INVALID_ARGUMENT: match field 'hdr.ethernet.etherType' expects EXACT but got TERNARY
+```
+
+**Table full:**
+```
+RESOURCE_EXHAUSTED: table 'port_table' is full (1024 entries)
+```
+
+**@refers_to violation:**
+```
+INVALID_ARGUMENT: @refers_to violation: no entry in 'target_table'
+  with 'id' = 0xaabbccddeeff
+```
+
+**Constraint violation** (with source location from `@entry_restriction`):
+```
+INVALID_ARGUMENT: All entries must satisfy:
+
+In @entry_restriction of table 'MyIngress.acl'; at offset line 2, columns 9 to 58:
+  |
+2 |         ipv4_dst::mask != 0 -> ether_type::value == 0x0800;
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+But your entry does not.
+```
+
+**Simulator error** (with P4 source location):
+```
+INTERNAL: undefined variable: x (at my_program.p4:42:3)
+```
+
+## Design principles
+
+- **What, not just that.** Every error includes the entity name, the value
+  that caused the problem, and the constraint that was violated.
+- **How to fix it.** "Unknown" errors list valid options with their numeric
+  IDs. Enum errors list valid values.
+- **Where in the P4 source.** Simulator errors include the P4 file, line, and
+  column from the IR source info.
+- **Proper gRPC status codes.** `NOT_FOUND` for missing entities,
+  `INVALID_ARGUMENT` for malformed requests, `RESOURCE_EXHAUSTED` for capacity
+  limits, `FAILED_PRECONDITION` for state requirements, `PERMISSION_DENIED` for
+  arbitration, `UNIMPLEMENTED` for unsupported features.
+- **Structured error details.** Batch writes include per-update status with
+  `space` and `code` fields per P4Runtime spec section 12.3.
+- **Golden-tested.** All 74 error paths are locked down by golden tests.
+  Messages cannot silently degrade. Update with:
+  ```
+  bazel test //p4runtime:GoldenErrorTest --test_env=UPDATE_GOLDEN=1
+  ```
+
+## All error messages
+
+See [`p4runtime/golden_errors/`](https://github.com/smolkaj/4ward/tree/main/p4runtime/golden_errors)
+for the complete list of golden-tested error messages.


### PR DESCRIPTION
## Summary

Error messages are a first-class feature — we should sell them.

- **README**: new row in comparison table (74 golden-tested, actionable errors)
- **userdocs/index.md**: error messages listed as a key feature  
- **userdocs/reference/errors.md**: new page with examples, design principles, and link to golden test suite

Resurrects content from #434 and #436, both now superseded by #441.

Closes #434
Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)