### PR TITLE
Drop p4c fork — use BCR p4c 1.2.5.11.bcr.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,18 +28,7 @@ bazel_dep(name = "grpc_kotlin", version = "1.5.0")
 bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
 
 # p4c provides the compiler frontend and midend that our backend builds on.
-# The git_override adds targets not yet in upstream p4c:
-#   - //p4include package (exports_files + filegroup for individual includes)
-#   - //testdata/p4_16_samples:* (exports_files for corpus/BMv2 tests)
-#   - macOS build fix (HAVE_PIPE2 / HAVE_UCONTEXT_H)
-# Upstream PR: https://github.com/p4lang/p4c/pull/5533
-# Once merged and released to BCR, drop the git_override.
-bazel_dep(name = "p4c", version = "1.2.5.11")
-git_override(
-    module_name = "p4c",
-    commit = "c7e38ae7a338973098ab73d08f631c98c470b71c",
-    remote = "https://github.com/smolkaj/p4c.git",
-)
+bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
 
 # p4-constraints validates @entry_restriction / @action_restriction annotations.
 bazel_dep(name = "p4_constraints", version = "20260311.0")

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -11,23 +11,11 @@ Blocked on buf support for proto edition 2024.
 
 ---
 
-## Drop p4c fork
-
-The `smolkaj/p4c` fork adds `//p4include` package, `//testdata/p4_16_samples`
-exports, and a macOS build fix. Upstream PR:
-https://github.com/p4lang/p4c/pull/5533. Once merged and released to BCR,
-drop the `git_override` in `MODULE.bazel`.
-
----
-
 ## Pinned dependencies inventory
 
-Three deps use `git_override` with pinned commits. `behavioral_model` and
-`bazel_clang_tidy` are dev-only (`dev_dependency = True`) and invisible to
-BCR consumers.
+Two deps use `git_override` with pinned commits. Both are dev-only
+(`dev_dependency = True`) and invisible to BCR consumers.
 
-- **p4c** (`smolkaj/p4c` fork, `2a38af8`): adds `//p4include` package,
-  testdata exports, macOS build fix. See "Drop p4c fork" above.
 - **bazel_clang_tidy** (`9e54bbb`): pinned before a commit (`c4d35e0`) that
   broke `-isystem` include ordering. Upstream bug never fixed — permanent
   workaround. Re-check if upstream ever resolves the issue.


### PR DESCRIPTION
## Summary

Drops the `smolkaj/p4c` git_override now that the needed changes
(p4lang/p4c#5533) are available via BCR as p4c 1.2.5.11.bcr.1.

This is the fourward-side companion to the BCR submissions:
- bazelbuild/bazel-central-registry#8179 (p4c@1.2.5.11.bcr.1)
- bazelbuild/bazel-central-registry#8180 (fourward@0.1.0)

**Merge after both BCR PRs land.**

## Test plan

- [ ] CI passes (will need the BCR entry to be available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)