### PR TITLE
Add release process docs and version scheme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ e2e_tests/p4testgen/         p4testgen-generated STF tests (one target per P4 pr
 e2e_tests/*/                 Per-feature STF tests (passthrough, basic_table, lpm, …).
 designs/                     Design documents (architecture decisions, feature proposals).
 docs/                        Project documentation.
+docs/RELEASING.md            How to cut a release and publish to the BCR.
 userdocs/                    User-facing documentation site (mkdocs).
 tools/                       Developer scripts (format, lint, coverage, …).
 ```

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "fourward",
-    version = "0.1.0",
+    version = "head",  # Updated to yyyymmdd.p on release branches.
     bazel_compatibility = [">=9.0.0"],
 )
 

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Developer docs (in [`docs/`](docs/)):
 | [P4RUNTIME_COMPLIANCE.md](docs/P4RUNTIME_COMPLIANCE.md) | P4Runtime spec compliance matrix |
 | [SAI_P4_CONFIDENCE.md](docs/SAI_P4_CONFIDENCE.md) | SAI P4 confidence gaps and action plan |
 | [LIMITATIONS.md](docs/LIMITATIONS.md) | Known shortcuts and gaps |
+| [RELEASING.md](docs/RELEASING.md) | How to cut a release and publish to the BCR |
 | [REFACTORING.md](docs/REFACTORING.md) | Tech debt and cleanup backlog |
 | [AGENTS.md](AGENTS.md) | Guide for AI coding agents |
 | [designs/](designs/) | Design proposals |

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -13,10 +13,14 @@ Blocked on buf support for proto edition 2024.
 
 ## Drop p4c fork
 
-The `smolkaj/p4c` fork adds `//p4include` package, `//testdata/p4_16_samples`
-exports, and a macOS build fix. Upstream PR:
-https://github.com/p4lang/p4c/pull/5533. Once merged and released to BCR,
-drop the `git_override` in `MODULE.bazel`.
+The `smolkaj/p4c` fork adds the PNA STF backend for p4testgen and a
+PNA drop-by-default fix. Upstream PRs:
+- https://github.com/p4lang/p4c/pull/5570 (PNA STF backend)
+- https://github.com/p4lang/p4c/issues/5569 (drop-by-default)
+
+The `//p4include` and macOS fixes (p4lang/p4c#5533) already landed and
+are available in BCR as p4c 1.2.5.11.bcr.1. Once the remaining changes
+are merged and released, drop the `git_override` in `MODULE.bazel`.
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,47 @@
+# Cutting a Release
+
+Versions use the **yyyymmdd.patch** format (e.g. `20260328.0`).
+
+## Prerequisites
+
+All `git_override` blocks in `MODULE.bazel` that are **not** `dev_dependency`
+must be resolved before a release. Dev-only overrides (`behavioral_model`,
+`bazel_clang_tidy`) are invisible to BCR consumers and don't block releases.
+
+## Steps
+
+### 1. Create a release branch
+
+```sh
+git checkout -b release-yyyymmdd
+```
+
+Retain the branch permanently — it serves as a release archive and makes
+patch releases easy.
+
+### 2. Update the version in MODULE.bazel
+
+```starlark
+module(
+    name = "fourward",
+    version = "yyyymmdd.0",
+    ...
+)
+```
+
+### 3. Create a GitHub release
+
+- **Tag**: `yyyymmdd.0`
+- **Title**: `4ward yyyymmdd.0 (month year)`
+- Attach the source `.tar.gz` archive to the release to ensure archive
+  checksum stability for the BCR. GitHub's auto-generated archives are
+  [not guaranteed to be stable](https://github.com/orgs/community/discussions/45830),
+  so download the auto-generated archive and re-upload it as an explicit
+  release asset.
+
+### 4. Submit to the Bazel Central Registry
+
+Submit a PR to [`bazelbuild/bazel-central-registry`](https://github.com/bazelbuild/bazel-central-registry)
+following the [contribution guidelines](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md).
+Previous submissions live under
+[`modules/fourward/`](https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/fourward).


### PR DESCRIPTION
## Summary

Prepares for the first BCR release:

- **`docs/RELEASING.md`** — step-by-step release process using
  `yyyymmdd.patch` versioning.
- **`MODULE.bazel` version → `head`** — concrete versions are set on
  release branches only.
- **AGENTS.md / README.md** — link to RELEASING.md.
- **REFACTORING.md** — updated p4c fork status (p4include landed,
  PNA STF backend still pending).

The p4c fork pin stays at HEAD — the BCR submission will patch it out.

## Test plan

- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)