### PR TITLE
Make trace booleans visible in text proto output

### DIFF
--- a/e2e_tests/BUILD.bazel
+++ b/e2e_tests/BUILD.bazel
@@ -1,7 +1,17 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 bzl_library(
     name = "corpus_bzl",
     srcs = ["corpus.bzl"],
     visibility = ["//visibility:public"],
+)
+
+kt_jvm_library(
+    name = "golden_file",
+    srcs = ["GoldenFile.kt"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@maven//:junit_junit",
+    ],
 )

--- a/e2e_tests/GoldenFile.kt
+++ b/e2e_tests/GoldenFile.kt
@@ -1,0 +1,49 @@
+package fourward.e2e
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import org.junit.Assert.fail
+
+/**
+ * Asserts that [actual] matches the content of a golden file.
+ * - [goldenFileName]: e.g. "my_test.golden.txtpb". Resolved relative to the test's package
+ *   directory in runfiles.
+ * - [pkg]: the Bazel package path, e.g. "e2e_tests/trace_tree".
+ * - [actual]: the string to compare against the golden file.
+ *
+ * In update mode (`bazel run <target> -- --update`), writes [actual] to the source golden file
+ * instead of comparing.
+ */
+fun assertMatchesGoldenFile(goldenFileName: String, pkg: String, actual: String) {
+  val goldenPath = runfilePath(pkg, goldenFileName)
+
+  if (isUpdateMode()) {
+    val workspace =
+      System.getenv("BUILD_WORKSPACE_DIRECTORY")
+        ?: error("BUILD_WORKSPACE_DIRECTORY not set. Run via `bazel run`, not `bazel test`.")
+    val sourcePath = Paths.get(workspace, pkg, goldenFileName)
+    sourcePath.toFile().writeText(actual)
+    println("Updated: $sourcePath")
+    return
+  }
+
+  val expected = goldenPath.toFile().readText()
+  if (expected != actual) {
+    val target = System.getenv("TEST_TARGET") ?: "<this target>"
+    fail(
+      "Golden file mismatch: $goldenFileName\n" +
+        "To update: bazel run $target -- --update\n\n" +
+        "Expected:\n$expected\n" +
+        "Actual:\n$actual"
+    )
+  }
+}
+
+/** Returns true if `-- --update` was passed on the command line. */
+fun isUpdateMode(): Boolean = System.getProperty("sun.java.command")?.contains("--update") == true
+
+/** Resolves a file path relative to a Bazel package in runfiles. */
+fun runfilePath(pkg: String, fileName: String): Path {
+  val runfiles = System.getenv("JAVA_RUNFILES") ?: "."
+  return Paths.get(runfiles, "_main", pkg, fileName)
+}

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -65,6 +65,7 @@ p4c_compile(
 )
 
 _TEST_DEPS = [
+    "//e2e_tests:golden_file",
     "//e2e_tests/stf:stf_runner",
     "//simulator:ir_java_proto",
     "//simulator:p4runtime_java_proto",

--- a/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
+++ b/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
@@ -2,13 +2,13 @@ package fourward.e2e.tracetree
 
 import com.google.protobuf.TextFormat
 import fourward.e2e.StfFile
+import fourward.e2e.assertMatchesGoldenFile
 import fourward.e2e.installStfEntries
 import fourward.e2e.loadPipelineConfig
+import fourward.e2e.runfilePath
 import fourward.sim.SimulatorProto.TraceTree
 import fourward.simulator.Simulator
 import java.nio.file.Path
-import java.nio.file.Paths
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -22,9 +22,8 @@ import org.junit.runners.Parameterized.Parameters
  * - An STF file (.stf) with optional table entries and at least one packet
  * - An expected TraceTree (.golden.txtpb)
  *
- * The test sends the first packet through the simulator and compares the resulting TraceTree
- * against the golden file. This is the TDD harness for Track 3 (trace trees): all tests are written
- * up front and expected to fail until the corresponding feature is implemented.
+ * To update golden files after an intentional change: bazel run
+ * //e2e_tests/trace_tree:golden_trace_tree_test -- --update
  */
 @RunWith(Parameterized::class)
 class GoldenTraceTreeTest(private val testName: String) {
@@ -35,8 +34,7 @@ class GoldenTraceTreeTest(private val testName: String) {
     @JvmStatic
     @Parameters(name = "{0}")
     fun testCases(): List<Array<String>> {
-      val r = System.getenv("JAVA_RUNFILES") ?: "."
-      val dir = Paths.get(r, "_main/$PKG").toFile()
+      val dir = runfilePath(PKG, "").toFile()
       return dir
         .listFiles { f -> f.name.endsWith(".golden.txtpb") }
         ?.map { arrayOf(it.name.removeSuffix(".golden.txtpb")) }
@@ -46,45 +44,23 @@ class GoldenTraceTreeTest(private val testName: String) {
 
   @Test
   fun `trace tree matches golden file`() {
-    val r = System.getenv("JAVA_RUNFILES") ?: "."
-    val configPath = Paths.get(r, "_main/$PKG/$testName.txtpb")
-    val stfPath = Paths.get(r, "_main/$PKG/$testName.stf")
-    val goldenPath = Paths.get(r, "_main/$PKG/$testName.golden.txtpb")
-
-    val expected = loadGoldenTraceTree(goldenPath)
+    val configPath = runfilePath(PKG, "$testName.txtpb")
+    val stfPath = runfilePath(PKG, "$testName.stf")
     val actual = captureTraceTree(configPath, stfPath)
-    if (System.getenv("PRINT_TRACE") != null) {
-      println("--- Trace tree for $testName ---")
-      print(TextFormat.printer().printToString(actual))
-      println("--- End trace tree ---")
-    }
-    if (expected != actual) {
-      fail(
-        "Trace tree mismatch for $testName.\n" +
-          "Expected:\n${TextFormat.printer().printToString(expected)}\n" +
-          "Actual:\n${TextFormat.printer().printToString(actual)}"
-      )
-    }
+
+    assertMatchesGoldenFile(
+      goldenFileName = "$testName.golden.txtpb",
+      pkg = PKG,
+      actual = TextFormat.printer().printToString(actual),
+    )
   }
 
-  private fun loadGoldenTraceTree(path: Path): TraceTree {
-    val builder = TraceTree.newBuilder()
-    TextFormat.merge(path.toFile().readText(), builder)
-    return builder.build()
-  }
-
-  /**
-   * Creates a simulator, loads the pipeline, installs table entries from the STF file, sends the
-   * first packet, and returns the TraceTree from the response.
-   */
   private fun captureTraceTree(configPath: Path, stfPath: Path): TraceTree {
     val config = loadPipelineConfig(configPath)
     val stf = StfFile.parse(stfPath)
-
     val sim = Simulator()
     sim.loadPipeline(config)
     installStfEntries(sim, stf, config.p4Info)
-
     val packet = stf.packets.first()
     return sim.processPacket(packet.ingressPort, packet.payload).trace
   }

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -53,6 +53,7 @@ events {
 events {
   table_lookup {
     table_name: "ecmp"
+    hit: false
     action_name: "drop"
   }
   source_info {

--- a/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
@@ -83,6 +83,7 @@ fork_outcome {
       events {
         branch {
           control_name: "MyEgress"
+          taken: false
         }
         source_info {
           file: "e2e_tests/trace_tree/clone_preserve_meta.p4"

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -72,6 +72,7 @@ fork_outcome {
       events {
         branch {
           control_name: "MyEgress"
+          taken: false
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
@@ -203,6 +204,7 @@ fork_outcome {
       events {
         branch {
           control_name: "MyEgress"
+          taken: false
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -148,7 +148,8 @@ message ParserTransitionEvent {
 // action.
 message TableLookupEvent {
   string table_name = 1;
-  bool hit = 2;
+  // Explicit presence so `hit: false` (miss) is visible in text proto.
+  optional bool hit = 2;
   // Matched table entry in dataplane representation. Present on hit; absent on
   // miss.
   p4.v1.TableEntry matched_entry = 3;
@@ -167,7 +168,9 @@ message ActionExecutionEvent {
 // Fired on every if/else branch.
 message BranchEvent {
   string control_name = 1;
-  bool taken = 2;  // true = then-branch; false = else-branch
+  // Explicit presence so `taken: false` is visible in text proto output
+  // (plain `bool` would be suppressed as a proto3 default value).
+  optional bool taken = 2;  // true = then-branch; false = else-branch
 }
 
 // Fired on every extern method call.
@@ -191,7 +194,7 @@ message CloneEvent {
 // manager resolves a pending clone session.
 message CloneSessionLookupEvent {
   uint32 session_id = 1;
-  bool session_found =
+  optional bool session_found =
       2;  // false = session not configured, clone silently dropped
   uint32 dataplane_egress_port =
       3;  // clone destination; only meaningful when session_found


### PR DESCRIPTION
Proto3 suppresses default values in text proto, making `taken: false` and
`hit: false` invisible in traces. Mark key boolean fields as `optional`
so they always appear.

Motivated by debugging SAI P4 VLAN checks in the DVaaS E2E test — the
trace showed branch events but the `taken` field was invisible, making
it hard to follow the control flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)