### PR TITLE
Fix gRPC stream multiplexing deadlock: add executor to server builder

### DIFF
--- a/p4runtime/P4RuntimeServer.kt
+++ b/p4runtime/P4RuntimeServer.kt
@@ -3,6 +3,7 @@ package fourward.p4runtime
 import fourward.simulator.Simulator
 import io.grpc.Server
 import io.grpc.netty.NettyServerBuilder
+import java.util.concurrent.Executors
 
 /** Wraps a P4Runtime + Dataplane gRPC server backed by a 4ward [Simulator]. */
 class P4RuntimeServer(
@@ -29,6 +30,14 @@ class P4RuntimeServer(
   fun start(): P4RuntimeServer {
     server =
       NettyServerBuilder.forPort(port)
+        // Decouple RPC processing from Netty I/O threads. Without this, gRPC-Java
+        // runs server call handlers on the Netty event loop, which assigns one thread
+        // per HTTP/2 connection. That causes deadlocks when a gRPC C++ client
+        // multiplexes a long-lived bidirectional stream (StreamChannel) and a
+        // server-streaming RPC (Read) on the same connection: the suspended
+        // StreamChannel coroutine and the Read coroutine contend for the single
+        // event loop thread assigned to that connection.
+        .executor(Executors.newCachedThreadPool())
         .addService(service)
         .addService(dataplaneService)
         .build()


### PR DESCRIPTION
## Root cause

NettyServerBuilder without an explicit executor runs gRPC handlers on the
Netty event loop. Netty assigns one thread per HTTP/2 connection. When a
client has both a StreamChannel (arbitration) and a Read RPC on the same
connection, both coroutines contend for that single thread → deadlock.

This only affects gRPC-Java servers (4ward), not gRPC-C++ servers (BMv2,
real switches) which handle multiplexing differently.

## Fix

`executor(Executors.newCachedThreadPool())` on the server builder decouples
RPC processing from Netty I/O threads.

Fixes https://github.com/smolkaj/4ward/issues/458

🤖 Generated with [Claude Code](https://claude.com/claude-code)