### PR TITLE
Fix TAP failures: race in DataplaneServiceTest, missing srcs in p4testgen

### DIFF
--- a/e2e_tests/p4testgen.bzl
+++ b/e2e_tests/p4testgen.bzl
@@ -145,11 +145,12 @@ def p4_testgen_test(name, src_p4 = None, includes = [], max_tests = 0, seed = 0,
 
     kt_jvm_test(
         name = name + "_test",
+        srcs = ["P4TestgenSuiteTest.kt"],
         test_class = "fourward.e2e.p4testgen.P4TestgenSuiteTest",
         tags = tags + ["heavy"],
         data = data,
         deps = [
-            "//e2e_tests/p4testgen:p4testgen_test_class",
+            "//e2e_tests/stf:stf_runner",
             "@fourward_maven//:junit_junit",
         ],
     )
@@ -179,12 +180,13 @@ def p4_testgen_suite(name, tests, includes = {}, max_tests = {}, tags = [], targ
 
     kt_jvm_test(
         name = name,
+        srcs = ["P4TestgenSuiteTest.kt"],
         test_class = "fourward.e2e.p4testgen.P4TestgenSuiteTest",
         size = "large",  # 155 tests with Z3 constraint solving; needs 900s
         tags = tags + ["heavy"],
         data = data,
         deps = [
-            "//e2e_tests/p4testgen:p4testgen_test_class",
+            "//e2e_tests/stf:stf_runner",
             "@fourward_maven//:junit_junit",
         ],
     )

--- a/p4runtime/DataplaneServiceTest.kt
+++ b/p4runtime/DataplaneServiceTest.kt
@@ -3,6 +3,7 @@ package fourward.p4runtime
 import com.google.protobuf.ByteString
 import fourward.dataplane.DataplaneGrpcKt.DataplaneCoroutineStub
 import fourward.dataplane.SubscribeResultsRequest
+import fourward.dataplane.SubscribeResultsResponse
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.assertGrpcError
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildEthernetFrame
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildExactEntry
@@ -10,12 +11,15 @@ import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
 import io.grpc.Status
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
@@ -144,14 +148,16 @@ class DataplaneServiceTest {
     harness.loadPipeline(loadPassthroughConfig())
     val stub = DataplaneCoroutineStub(harness.channel)
 
-    // Collect 3 messages: SubscriptionActive + 2 results (one from each source).
-    val messages = async {
-      withTimeout(5000) {
-        stub.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).take(3).toList()
+    val channel = Channel<SubscribeResultsResponse>(UNLIMITED)
+    val job = launch {
+      stub.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
+        channel.send(it)
       }
     }
 
-    delay(100) // Let the subscription start.
+    // Wait for subscription to be active.
+    val first = withTimeout(5000) { channel.receive() }
+    assertTrue("first message should be SubscriptionActive", first.hasActive())
 
     // Source 1: InjectPacket via DataplaneService.
     harness.injectPacket(ingressPort = 0, payload = byteArrayOf(0xAA.toByte()))
@@ -167,11 +173,13 @@ class DataplaneServiceTest {
       )
     }
 
-    val result = messages.await()
-    assertEquals("expected 3 messages", 3, result.size)
-    assertTrue("first is SubscriptionActive", result[0].hasActive())
-    assertTrue("second is a result", result[1].hasResult())
-    assertTrue("third is a result", result[2].hasResult())
+    // Collect 2 results.
+    val results = withTimeout(5000) { listOf(channel.receive(), channel.receive()) }
+
+    assertTrue("should be a result", results[0].hasResult())
+    assertTrue("should be a result", results[1].hasResult())
+
+    job.cancel()
   }
 
   // =========================================================================


### PR DESCRIPTION
## Summary

Fixes two TAP failures:

1. **DataplaneServiceTest**: replaced flaky `delay(100)` synchronization with a channel-based approach — explicitly waits for `SubscriptionActive` before injecting packets. Cleaned up stale `DataplaneProto` FQN (superseded by `java_multiple_files` in #498) and replaced inline types with proper imports.

2. **p4testgen macro**: added missing `srcs` attribute and fixed dep from `p4testgen_test_class` to `stf_runner`.

Based on #502; supersedes it with import cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)