### PR TITLE
Parallel packet scaling: Phase 1 diagnosis

### DIFF
--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -29,19 +29,40 @@ different cores. **Concurrent** = multiple tasks making progress over
 overlapping time, possibly interleaved on one core. Linear scaling is a
 **parallelism** concept. The benchmark runs packets on distinct worker
 threads via `ForkJoinPool`, scheduled onto distinct physical cores — that
-is parallelism, not concurrency. The code uses "parallel" in its naming
-(`measureParallel`, `parallelPoints`).
+is parallelism, not concurrency.
+
+The simulator has **two independent axes of parallelism**, and the
+distinction matters throughout this document:
+
+- **Intra-packet parallelism**: within a single packet's processing,
+  trace-tree fork branches (clone, multicast, action selector) run on
+  separate threads. Implemented in `V1ModelArchitecture.buildTraceTree`
+  via `parallelStream()`.
+- **Inter-packet parallelism**: multiple packets process on separate
+  threads simultaneously. Implemented by the `InjectPackets` streaming
+  RPC, which submits each packet to `ForkJoinPool.commonPool()`.
+
+Both sit on top of the same shared `ForkJoinPool.commonPool()`. They
+compose: a single packet with 32 fork branches can fan out to 32 threads
+intra-packet, and 100 packets in flight can each do the same
+inter-packet. In practice (as the measurements below show), intra-packet
+parallelism is helpful for single-packet latency but doesn't meaningfully
+improve throughput when inter-packet parallelism is already saturating
+the machine.
 
 ### Baseline methodology
 
 "Single-thread" means exactly one core doing all the work for one packet
-at a time. This requires temporarily disabling the within-packet
-`parallelStream()` in `V1ModelArchitecture.buildTraceTree` — without
-that change, single-threaded `InjectPacket` runs actually spread each
-packet's fork branches across `ForkJoinPool`, using ~5 cores per packet
-rather than 1. The right comparison for "N× on N cores" is **one thread
-doing all the work for one packet** vs **N threads each doing their own
-packets**.
+at a time — no inter-packet parallelism (sequential `InjectPacket` calls)
+and no intra-packet parallelism (fork branches processed sequentially on
+the same thread). Disabling intra-packet parallelism requires temporarily
+removing the `parallelStream()` call in
+`V1ModelArchitecture.buildTraceTree`. Without that, even a single-packet
+run fans out across cores — not what we want for the "1 core" baseline.
+
+The right comparison for "N× on N cores" is **one thread doing all the
+work** (both inter- and intra-packet parallelism disabled) vs **the
+machine doing packet processing with both axes enabled**.
 
 ## Current state
 
@@ -73,28 +94,31 @@ CPU under parallel load than under single-thread.
 
 ### The four-cell breakdown (wcmp128, for intuition)
 
-The within-packet `parallelStream()` complicates the story. Here are all
-four combinations, to disentangle:
+The two axes of parallelism compose, so there are four combinations.
+Here they are on the wcmp×128 workload:
 
-| Mode | parallelStream | Throughput | Speedup vs true ST | CPU util |
+| Inter-packet | Intra-packet | Throughput | Speedup vs true ST | CPU util |
 |---|---|---|---|---|
-| Sequential (1 packet at a time) | OFF | 203 pps | 1.00× | 3.4% |
-| Sequential (1 packet at a time) | ON | 633 pps | 3.12× | — |
-| Parallel (many packets on many cores) | OFF | 1,521 pps | **7.49×** | 83% |
-| Parallel (many packets on many cores) | ON | 1,506 pps | 7.42× | 88% |
+| OFF (1 packet at a time) | OFF | 203 pps | 1.00× (baseline) | 3.4% |
+| OFF (1 packet at a time) | ON | 633 pps | 3.12× | — |
+| ON (many packets in flight) | OFF | 1,521 pps | **7.49×** | 83% |
+| ON (many packets in flight) | ON | 1,506 pps | 7.42× | 88% |
 
 Observations:
 
-1. **`parallelStream` ON vs OFF in the parallel row is a wash on
-   throughput** (1,506 vs 1,521 — noise). Within-packet parallelism
-   neither helps nor hurts multi-packet throughput. It costs ~5% more
-   CPU for nothing (88% vs 83% utilization at the same throughput), but
-   the difference is small.
-2. **`parallelStream` ON helps single-packet latency 3×** (633 vs 203).
-   Worth keeping for CLI, STF, and playground use cases where there's
-   only one packet at a time.
-3. **The true single-thread baseline is parallelStream OFF** (203 pps).
-   That's what divides into parallel throughput to give the speedup.
+1. **Intra-packet parallelism doesn't help when inter-packet is already
+   active** (1,506 vs 1,521 — noise). With many packets in flight, the
+   `ForkJoinPool` workers are already busy processing different packets;
+   spreading one packet's forks across workers steals from the workers
+   processing other packets. Net effect: zero throughput change, ~5%
+   more CPU used for nothing (88% vs 83% utilization at the same pps).
+2. **Intra-packet parallelism helps single-packet latency 3×** (633 vs
+   203). When only one packet is in flight, the machine is idle
+   otherwise, and fanning out the forks across cores is pure gain.
+   Worth keeping for CLI, STF, and playground use cases.
+3. **The true single-thread baseline is both axes OFF** (203 pps).
+   That's what divides into the parallel throughput to compute the
+   "speedup on N cores" number.
 
 ## Why embarrassingly parallel isn't linear in practice
 
@@ -154,8 +178,9 @@ resource pressure, not restructuring the algorithm. Specifically:
 ## Phase 1 profile findings
 
 Two JFR profile pairs: direct single-thread vs direct parallel, and
-wcmp×128 single-thread vs wcmp×128 parallel. Both sides have
-`parallelStream()` disabled to get a clean apples-to-apples comparison.
+wcmp×128 single-thread vs wcmp×128 parallel. Both sides have intra-packet
+parallelism disabled to get a clean apples-to-apples comparison (with it
+on, sequential mode uses ~5 cores per packet, which confuses the diff).
 The diffs tell completely different stories.
 
 ### Direct L3 — scales cleanly
@@ -179,7 +204,7 @@ The workload has a 128-way action selector fork, producing 128 branches
 per packet. Each branch must deep-copy the packet state (headers +
 structs) so branches don't interfere with each other.
 
-**Parallel scaling overhead (clean diff, both sides parallelStream OFF):**
+**Parallel scaling overhead (clean diff, both sides intra-packet parallelism OFF):**
 
 | Delta | Frame | Source |
 |---|---|---|
@@ -283,21 +308,17 @@ DVaaS workload that's blocked by the current throughput.
   scaling reasons.** Lookup cost is real but does not affect scaling —
   direct L3 proves it scales cleanly. Lookup optimization is a separate
   absolute-throughput concern, not part of the scaling north star.
-- **Disabling within-packet `parallelStream()`.** Throughput-neutral in
-  parallel mode (1,506 vs 1,521 pps — noise) but 3× regression in
-  single-packet latency. Keep it for CLI/STF/playground users.
-
-**Also off the table:** optimizing lookup (`toUnsignedLong`, hash index,
-LPM trie) for scaling reasons. Lookup cost is real but does not affect
-scaling — direct L3 proves it scales cleanly. Lookup optimization is a
-separate absolute-throughput concern, not part of this north star.
+- **Disabling intra-packet parallelism.** Throughput-neutral in the
+  parallel (inter-packet) mode (1,506 vs 1,521 pps — noise) but 3×
+  regression in single-packet latency. Keep it for CLI/STF/playground
+  users.
 
 ### Phase 3: Validate
 
 For every optimization, run the benchmark and verify:
 
 1. **True single-thread throughput doesn't regress** — measured with
-   within-packet `parallelStream()` disabled.
+   intra-packet parallelism disabled.
 2. **Parallel scaling efficiency improves** — the ratio of
    `parallel_pps / (single_thread_pps × 16)` moves toward 1.0.
 3. **No correctness regressions** — all tests still pass.

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -135,10 +135,10 @@ and there are several that matter:
 
 2. **L3 cache pressure.** Each physical core has private L1/L2; all
    cores share L3. Single-threaded, one packet's working set fits in
-   L1/L2. At 15 parallel threads, the combined ephemeral working set
-   (HashMaps, BigIntegers, builders per thread) spills into L3, evicting
-   each other. What was an L2 hit becomes an L3 hit (3× slower), or
-   worse, a DRAM access (10× slower).
+   L1/L2. With many threads running in parallel, their combined
+   ephemeral working sets (HashMaps, BigIntegers, builders per thread)
+   spill into L3, evicting each other. What was an L2 hit becomes an
+   L3 hit (3× slower), or worse, a DRAM access (10× slower).
 
 3. **Memory bandwidth.** DRAM has finite bandwidth. Fresh allocations
    touch new cache lines; at gigabytes per second of allocation across
@@ -218,7 +218,9 @@ at ~9% combined. Total allocation-related scaling overhead: **~23-25%**.
 
 ### The mechanism, concretely
 
-When 15 threads each process a fork-heavy packet, they all call
+When many `ForkJoinPool` workers each process a fork-heavy packet at
+once (roughly 25-30 hw threads busy on this machine, judging by the
+81% CPU utilization in the wcmp×128 parallel run), they all call
 `HeaderVal.deepCopy()` and `StructVal.deepCopy()`, which do
 `fields.mapValuesTo(mutableMapOf()) { ... }`. That allocates:
 
@@ -226,7 +228,7 @@ When 15 threads each process a fork-heavy packet, they all call
 2. New nodes for each key-value pair inserted
 3. A resize when the map exceeds load factor
 
-With 15 threads × 128 branches per packet × multiple HeaderVals/StructVals
+With many threads × 128 branches per packet × multiple HeaderVals/StructVals
 per branch, the allocator is hit millions of times per second across all
 threads. TLAB refills become frequent; HashMap resize compounds the
 issue; `BigInteger.<init>` allocates fresh arrays for bit field

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -4,12 +4,12 @@
 
 ## North star
 
-**Packet processing should scale linearly with cores.** For N cores, the
-concurrent `InjectPackets` RPC should deliver N× the throughput of the
-sequential `InjectPacket` RPC. Packet processing is embarrassingly
-parallel — each packet is independent of every other packet (modulo a few
-shared stateful externs, which have their own lock-free data structures).
-Anything less than linear scaling is wasted hardware.
+**Packet processing should scale linearly with physical cores.** For N
+cores, the parallel `InjectPackets` RPC should deliver N× the throughput
+of a single-threaded run. Each packet is independent of every other
+packet (modulo a few shared stateful externs, which have their own
+lock-free data structures) — the algorithm is embarrassingly parallel.
+Anything well below linear is wasted hardware.
 
 This is the benchmark we want to hit:
 
@@ -17,57 +17,146 @@ This is the benchmark we want to hit:
 throughput(N cores) = N × throughput(1 core)
 ```
 
-It's ambitious by design. Real-world overheads mean we won't hit exactly
-linear, but anything more than ~10% off (e.g., 14.4x on 16 physical cores)
-should demand an explanation.
+Real-world overheads mean we won't hit exactly linear. On a well-optimized
+CPU-bound JVM workload with heavy allocation, 85-90% on 16 cores is
+ambitious but reachable; 50% is common without work. Anything more than
+~10% off demands an explanation.
 
-**Baseline methodology.** "Single-thread" means exactly one core doing
-all the work — including any within-packet parallelism that would
-otherwise fan out to the `ForkJoinPool`. This matters because
-`V1ModelArchitecture.buildTraceTree` uses `parallelStream()` for fork
-branches, so the "sequential" `InjectPacket` RPC actually uses multiple
-cores per packet. The right comparison is "one thread doing all the
-work" vs "N threads each doing their own packets" — measured with the
-`parallelStream()` temporarily disabled for the single-thread baseline.
+### Terminology
+
+**Parallel** = multiple tasks executing literally at the same instant on
+different cores. **Concurrent** = multiple tasks making progress over
+overlapping time, possibly interleaved on one core. Linear scaling is a
+**parallelism** concept. The benchmark runs packets on distinct worker
+threads via `ForkJoinPool`, scheduled onto distinct physical cores — that
+is parallelism, not concurrency. The code uses "parallel" in its naming
+(`measureParallel`, `parallelPoints`).
+
+### Baseline methodology
+
+"Single-thread" means exactly one core doing all the work for one packet
+at a time. This requires temporarily disabling the within-packet
+`parallelStream()` in `V1ModelArchitecture.buildTraceTree` — without
+that change, single-threaded `InjectPacket` runs actually spread each
+packet's fork branches across `ForkJoinPool`, using ~5 cores per packet
+rather than 1. The right comparison for "N× on N cores" is **one thread
+doing all the work for one packet** vs **N threads each doing their own
+packets**.
 
 ## Current state
 
 Verified measurements on a 16 physical core / 32 SMT thread AMD Ryzen 9
-7950X3D, SAI P4 middleblock, 10k routes. All numbers are **true
-single-thread** vs **concurrent** (`InjectPackets` RPC with 50k packets
-in flight). Single-thread is measured with the within-packet
-`parallelStream()` in `V1ModelArchitecture.buildTraceTree` temporarily
-disabled, so exactly one core does all the work.
+7950X3D, SAI P4 middleblock, 10k routes.
 
-| Workload | Single-thread | Concurrent | Speedup | **Efficiency vs 16 cores** | CPU utilization (concurrent) |
+| Workload | Single-thread | Parallel | Speedup | **Efficiency vs 16 cores** | CPU utilization (parallel) |
 |---|---|---|---|---|---|
 | direct | 2,512 pps | 38,147 pps | **15.19×** | **95%** | 66% — idle headroom |
 | wcmp×16+mirr | 678 pps | 5,534 pps | **8.16×** | **51%** | 94% — saturated |
+| wcmp×128 | 203 pps | 1,521 pps | **7.49×** | **47%** | 83% — saturated |
 
 **Direct L3 is essentially at linear scaling.** 15.19× on 16 physical
 cores = 95% efficiency. The machine isn't even CPU-saturated (JVM
-averaged 66% of total machine CPU), so the remaining 5% gap is not a
-compute bottleneck — it's dispatch overhead (gRPC, coroutines, or
-`ForkJoinPool` task submission serial fraction). Not worth chasing.
+averaged 66% of total machine CPU), so the remaining 5% gap is dispatch
+overhead (gRPC, coroutines, `ForkJoinPool` task submission serial
+fraction), not compute. Not worth chasing.
 
-**Fork-heavy workloads (wcmp×16+mirr) are at 51% efficiency.** That's
-the real scaling gap. Concurrent mode *does* saturate the machine (94%
-CPU utilization) — but each packet costs ~1.9× more CPU under concurrent
-load than under single-thread. More threads, more CPU consumed, less
-throughput per core. Classic contention signature.
+**Fork-heavy workloads are at ~50% efficiency** and **efficiency degrades
+slightly with higher fork counts** (51% at 32 branches per packet, 47% at
+128). These workloads saturate the machine but each packet costs ~2× more
+CPU under parallel load than under single-thread.
 
-> **Note on CPU utilization vs efficiency:** these are different metrics.
-> CPU utilization = how much of the machine is being used. Efficiency =
-> speedup / theoretical max. Direct has low CPU utilization but high
-> efficiency (it completes the work fast with fewer cores than the
-> machine has). wcmp has high CPU utilization but low efficiency (it
-> uses all the cores but doesn't get proportional throughput).
+> **CPU utilization ≠ efficiency.** CPU utilization = how much of the
+> machine is being used. Efficiency = speedup / theoretical max. Direct
+> has low CPU utilization but high efficiency (finishes fast without
+> needing all the cores). wcmp has high CPU utilization but low
+> efficiency (uses all the cores but each packet costs more).
 
-## Why the gap? (Phase 1 profile findings)
+### The four-cell breakdown (wcmp128, for intuition)
 
-Two JFR profiles compared: direct single-thread vs direct concurrent, and
-wcmp×16+mirr single-thread vs wcmp×16+mirr concurrent. The diffs tell
-completely different stories.
+The within-packet `parallelStream()` complicates the story. Here are all
+four combinations, to disentangle:
+
+| Mode | parallelStream | Throughput | Speedup vs true ST | CPU util |
+|---|---|---|---|---|
+| Sequential (1 packet at a time) | OFF | 203 pps | 1.00× | 3.4% |
+| Sequential (1 packet at a time) | ON | 633 pps | 3.12× | — |
+| Parallel (many packets on many cores) | OFF | 1,521 pps | **7.49×** | 83% |
+| Parallel (many packets on many cores) | ON | 1,506 pps | 7.42× | 88% |
+
+Observations:
+
+1. **`parallelStream` ON vs OFF in the parallel row is a wash on
+   throughput** (1,506 vs 1,521 — noise). Within-packet parallelism
+   neither helps nor hurts multi-packet throughput. It costs ~5% more
+   CPU for nothing (88% vs 83% utilization at the same throughput), but
+   the difference is small.
+2. **`parallelStream` ON helps single-packet latency 3×** (633 vs 203).
+   Worth keeping for CLI, STF, and playground use cases where there's
+   only one packet at a time.
+3. **The true single-thread baseline is parallelStream OFF** (203 pps).
+   That's what divides into parallel throughput to give the speedup.
+
+## Why embarrassingly parallel isn't linear in practice
+
+First, the theory. "Embarrassingly parallel" is a statement about the
+algorithm: the tasks have no inter-task dependencies, no synchronization,
+no shared state. That's true for packet processing (the snapshot is
+read-only at the data-plane layer; each packet is independent).
+
+But **the algorithm and the runtime live in different worlds**. The
+algorithm doesn't know about the machine's shared physical resources,
+and there are several that matter:
+
+1. **The JVM allocator.** Allocations normally go into a per-thread TLAB
+   (thread-local allocation buffer) — fast, no contention. But when a
+   TLAB fills, the thread has to request a new one from the shared heap,
+   which is a coordination point. At high allocation rates, TLAB refills
+   become frequent and contention becomes visible.
+
+2. **L3 cache pressure.** Each physical core has private L1/L2; all
+   cores share L3. Single-threaded, one packet's working set fits in
+   L1/L2. At 15 parallel threads, the combined ephemeral working set
+   (HashMaps, BigIntegers, builders per thread) spills into L3, evicting
+   each other. What was an L2 hit becomes an L3 hit (3× slower), or
+   worse, a DRAM access (10× slower).
+
+3. **Memory bandwidth.** DRAM has finite bandwidth. Fresh allocations
+   touch new cache lines; at gigabytes per second of allocation across
+   all threads, memory bandwidth becomes a real constraint.
+
+4. **Garbage collection.** G1GC steals CPU cycles for concurrent marking
+   and evacuation. At high allocation rates, GC runs more often,
+   reducing effective throughput even when pause times look small.
+
+5. **Cache coherency.** Even read-only data has coherency cost if
+   writes happen nearby (false sharing). JVM object allocations are
+   typically on fresh cache lines, so this is usually a non-issue — but
+   it can bite.
+
+6. **SMT interference.** Two SMT threads on the same physical core
+   share L1, L2, and execution units. For memory-bound work, they can
+   slow each other down.
+
+**For CPU-bound JVM workloads with heavy allocation, 50-60% efficiency
+on 16 cores is a normal outcome, not a failure.** The algorithm's
+embarrassing parallelism is preserved in the *logical* decomposition —
+each packet is still independent. But the *physical* execution shares
+allocator, caches, and memory bandwidth across all threads.
+
+This means: closing the gap to linear scaling requires reducing shared
+resource pressure, not restructuring the algorithm. Specifically:
+
+- **Reduce allocation volume** → less TLAB contention, less GC, less
+  memory bandwidth usage
+- **Reduce working set size** → less L3 pressure, more L2 hits
+- **Reduce per-allocation size** → fewer cache line fetches
+
+## Phase 1 profile findings
+
+Two JFR profile pairs: direct single-thread vs direct parallel, and
+wcmp×128 single-thread vs wcmp×128 parallel. Both sides have
+`parallelStream()` disabled to get a clean apples-to-apples comparison.
+The diffs tell completely different stories.
 
 ### Direct L3 — scales cleanly
 
@@ -75,36 +164,36 @@ completely different stories.
 at 65-73% of CPU. The O(n) linear scan over 10k LPM entries converts each
 entry's match field bytes to a Long for comparison.
 
-**Concurrent scaling overhead:** `TableStore.lookup` +4.3% — modest cache
-pressure from 10 threads each scanning the same 10k-entry table. The
-working set fits in L2/L3 well enough that contention is minimal.
+**Parallel scaling overhead:** `TableStore.lookup` +4.3% — modest cache
+pressure from threads each scanning the same 10k-entry table. The
+read-only table stays in L2/L3 well enough that contention is minimal.
 
 **Why direct scales well:** no trace tree forks → no header/struct deep
 copies → no allocation-heavy per-fork work. Each thread does the same
-lookup work independently. Cache-friendly, allocator-friendly.
+lookup work independently on the shared (read-only) snapshot.
+Cache-friendly and allocator-friendly.
 
-### wcmp×16+mirr — allocator contention
+### wcmp×128 — allocator contention
 
-The workload has a 16-way action selector fork (WCMP) and a 2-way clone
-fork (mirror), producing 32 branches per packet. Each branch must
-deep-copy the packet state (headers + structs) so the branches don't
-interfere with each other.
+The workload has a 128-way action selector fork, producing 128 branches
+per packet. Each branch must deep-copy the packet state (headers +
+structs) so branches don't interfere with each other.
 
-**Concurrent scaling overhead (diff vs single-thread):**
+**Parallel scaling overhead (clean diff, both sides parallelStream OFF):**
 
 | Delta | Frame | Source |
 |---|---|---|
-| **+17.9%** | `HashMap.put` / `putVal` / `getNode` / `resize` | Per-fork header/struct deep copy |
-| **+5.9%** | `BigInteger.<init>` | Per-fork arithmetic intermediates |
-| **+2.6%** | `TraceEvent$Builder.buildPartial` | Per-fork trace event allocation |
-| -21.8% | `toUnsignedLong` | Same absolute cost; smaller % of concurrent total |
+| **+7.3%** | `BigInteger.<init>` | Per-fork arithmetic intermediates |
+| **+7.0%** | `HashMap.putVal` | Per-fork header/struct deep copy |
+| **+2.4%** | `TraceEvent$Builder.buildPartial` | Per-fork trace event allocation |
+| **+2.4%** | `BitVector.<init>` | Related to `BigInteger` allocation |
+| **+2.3%** | `HashMap.put` | Per-fork header/struct deep copy |
+| +0.9% | `HashMap.resize` | HashMap growth during deep copy |
 
-**~26% of concurrent CPU is allocation-related overhead** — time spent in
-HashMap, BigInteger, and protobuf builder construction that only shows
-up under multi-threaded load. Under single-thread, these paths exist but
-don't dominate. Under concurrent load, allocator contention (TLAB
-exhaustion, shared-heap contention on node allocation, HashMap resize
-under pressure) inflates their cost per operation.
+HashMap put operations combined (`put` + `putVal` + `resize`) account
+for **+10.2%** — the single largest overhead bucket. BigInteger
+allocation is a close second at ~8% combined. Total allocation-related
+scaling overhead: **~25-26%**.
 
 ### The mechanism, concretely
 
@@ -116,11 +205,12 @@ When 15 threads each process a fork-heavy packet, they all call
 2. New nodes for each key-value pair inserted
 3. A resize when the map exceeds load factor
 
-With 15 threads × ~32 branches per packet × multiple HeaderVals/StructVals
-per branch, the allocator is hit hundreds of thousands of times per
-second from many threads at once. TLAB exhaustion forces threads into
-the shared allocator path; HashMap resize compounds the issue; cache
-lines for the HashMap's internal `table` array bounce between cores.
+With 15 threads × 128 branches per packet × multiple HeaderVals/StructVals
+per branch, the allocator is hit millions of times per second across all
+threads. TLAB refills become frequent; HashMap resize compounds the
+issue; `BigInteger.<init>` allocates fresh arrays for bit field
+arithmetic on every operation. Each of these is cheap in isolation, but
+in aggregate they dominate the scaling overhead.
 
 This is the bottleneck. It's specifically a **fork-induced
 allocation-pressure** problem, not a general scaling problem.
@@ -131,27 +221,6 @@ allocation-pressure** problem, not a general scaling problem.
 it applied to the lock-free dataplane too (where we discovered the lock
 wasn't the bottleneck after all). The same principle applies here: any
 optimization without a profiler-backed hypothesis is a guess.
-
-### Phase 1: Profile
-
-Wire `async-profiler` (CPU + allocation) into the `DataplaneBenchmark`
-target. Collect flame graphs for sequential and concurrent runs on the
-same workload. Diff them. The concurrent flame graph should show where
-time is spent that the sequential graph doesn't — that's the scaling
-bottleneck.
-
-Specific questions the profile should answer:
-
-- **CPU time**: is the concurrent path CPU-bound (good, means we're
-  running), GC-bound (bad, means allocation is the bottleneck), or
-  lock-bound (shouldn't happen post-lock-free, but worth checking)?
-- **Allocation**: what objects are allocated per packet? Which are the
-  fattest? Are any allocations avoidable?
-- **GC**: what's the young-gen pause rate and total pause time?
-- **Hot paths**: top 10 self-time methods in each run. Any surprises?
-
-**Done when:** we have a documented hypothesis ("the bottleneck is X,
-because Y in the flame graph shows Z") and a concrete optimization target.
 
 ### Phase 2: Optimize
 
@@ -167,40 +236,56 @@ plan beyond the next step.
 
 **Scope.** Phase 1 showed the scaling gap is **specific to fork-heavy
 workloads**. Direct L3 is already at 95% efficiency with no meaningful
-work left to do. So "optimize" here means "close the wcmp×16+mirr gap" —
-bring 51% efficiency closer to direct's 95%.
+work left to do. So "optimize" here means "close the wcmp×128 gap" —
+bring 47% efficiency closer to linear.
 
-The gap comes from per-fork header/struct deep copies allocating new
-HashMaps under heavy concurrent load. To close it, we need to **reduce
-per-fork allocation volume**. The available mechanisms, in order of
-complexity:
+The gap comes from per-fork allocation pressure. At realistic fork
+counts (128+) the two biggest buckets are roughly equal:
+
+- **~10% HashMap operations** from per-fork header/struct deep copies
+- **~8% BigInteger allocation** from per-fork bit field arithmetic
+- **~5% TraceEvent builders + BitVector init** — harder to avoid
+
+Candidate optimizations, in order of complexity:
 
 1. **HashMap preallocation in deepCopy.** Eliminates resize churn.
-   Two-line change. Expected impact: ~2% (measured — the resize cost
-   is real but small).
+   Two-line change. Expected impact: ~2% (measured — real but small).
 
 2. **Copy-on-write for HeaderVal/StructVal.** Share the underlying map
-   between branches; copy only on write. Most forks touch a small
-   subset of fields, so most of the deep-copy work is wasted. Biggest
-   potential impact: approaches the 17.9% HashMap overhead budget.
+   between fork branches; copy only on write. Most branches touch a
+   small subset of fields, so most of the deep-copy work is wasted.
+   Structural change — mutation model goes from in-place to persistent.
+   Expected impact: most of the ~10% HashMap bucket.
 
-3. **Value arena allocation.** Per-thread pools for BitVal/BitVector
-   objects. Targets the 5.9% BigInteger allocation.
+3. **`Long` fast path for narrow bit fields.** Use `Long` instead of
+   `BigInteger` for `bit<N>` ≤ 63. Partially exists in
+   `matchesFieldMatch`; extend to `BitVector` arithmetic. Expected
+   impact: most of the ~8% BigInteger bucket.
 
-**Next step: prototype copy-on-write HeaderVal/StructVal.** It's the
-largest potential win and it's contained to `Values.kt`. The API stays
-the same; only the deepCopy semantics change. Risk: mutation semantics
-during a fork branch can't accidentally affect sibling branches — the
-copy-on-write mechanism must be correct.
+**The honest realization:** fixing any one of these only closes a
+fraction of the gap. Getting to truly linear scaling would require
+fixing *all* of them — a broader refactor than any single PR. A single
+win of 10% (HashMap) or 8% (BigInteger) takes efficiency from 47% to
+maybe 55% — meaningful but still well below linear.
 
-**Before committing:** measure it. If copy-on-write doesn't close a
-significant part of the gap, don't land it. The simplicity budget is
-real and the test is "did efficiency improve measurably?"
+**Before committing to anything:** the simplicity budget matters. The
+lock-free dataplane PR was a clear simplification AND had measurable
+value (correctness improvement). A performance-only PR that adds
+complexity for a bounded gain needs a stronger justification: a concrete
+DVaaS workload that's blocked by the current throughput.
 
-**Explicitly off the table:** replacing `for (x in list)` with
-index-based loops to reduce iterator allocation. Kotlin idiom is the
-for-loop; index loops are a readability regression. Iterator allocation
-is not the current bottleneck (GC pauses <0.5% of wall time).
+**Explicitly off the table:**
+
+- **Replacing `for (x in list)` with index-based loops.** Kotlin idiom
+  is the for-loop; index loops are a readability regression. Iterator
+  allocation is real but not the current bottleneck.
+- **Optimizing lookup (`toUnsignedLong`, hash index, LPM trie) for
+  scaling reasons.** Lookup cost is real but does not affect scaling —
+  direct L3 proves it scales cleanly. Lookup optimization is a separate
+  absolute-throughput concern, not part of the scaling north star.
+- **Disabling within-packet `parallelStream()`.** Throughput-neutral in
+  parallel mode (1,506 vs 1,521 pps — noise) but 3× regression in
+  single-packet latency. Keep it for CLI/STF/playground users.
 
 **Also off the table:** optimizing lookup (`toUnsignedLong`, hash index,
 LPM trie) for scaling reasons. Lookup cost is real but does not affect
@@ -213,12 +298,12 @@ For every optimization, run the benchmark and verify:
 
 1. **True single-thread throughput doesn't regress** — measured with
    within-packet `parallelStream()` disabled.
-2. **Concurrent scaling efficiency improves** — the ratio of
-   `concurrent_pps / (single_thread_pps × 16)` moves toward 1.0.
+2. **Parallel scaling efficiency improves** — the ratio of
+   `parallel_pps / (single_thread_pps × 16)` moves toward 1.0.
 3. **No correctness regressions** — all tests still pass.
 
-**Done when:** wcmp×16+mirr concurrent efficiency reaches ≥80% of
-linear on 16 physical cores. (Direct L3 is already at 95%.)
+**Done when:** wcmp×128 parallel efficiency reaches ≥80% of linear on
+16 physical cores. (Direct L3 is already at 95%.)
 
 ## Non-goals
 
@@ -234,7 +319,7 @@ linear on 16 physical cores. (Direct L3 is already at 95%.)
 
 ## Open questions
 
-- **Why is concurrent direct at 66% CPU utilization, not 100%?** The JVM
+- **Why is parallel direct at 66% CPU utilization, not 100%?** The JVM
   has idle capacity that isn't being used — meaning the bottleneck isn't
   compute, it's dispatch (gRPC, coroutines, or `ForkJoinPool` task
   submission serial fraction). Not worth chasing — direct is already at

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -253,9 +253,9 @@ smallest thing → re-measure → decide what's next. Don't pre-commit to a
 multi-step plan beyond the next step.
 
 **Scope.** Phase 1 showed the scaling gap is **specific to fork-heavy
-workloads**. Direct L3 is already at 95% efficiency with no meaningful
+workloads**. Direct L3 is already at 94% efficiency with no meaningful
 work left to do. So "optimize" here means "close the wcmp×128 gap" —
-bring 47% efficiency closer to linear.
+bring 45% efficiency closer to linear.
 
 The gap comes from per-fork allocation pressure. At realistic fork
 counts (128+) the two biggest buckets are roughly equal:
@@ -316,7 +316,7 @@ DVaaS workload that's blocked by the current throughput.
 3. **No correctness regressions** — all tests still pass.
 
 **Done when:** wcmp×128 parallel efficiency reaches ≥80% of linear on
-16 physical cores. (Direct L3 is already at 95%.)
+16 physical cores. (Direct L3 is already at 94%.)
 
 ## Non-goals
 

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -70,24 +70,26 @@ speedup with no confounding from intra-packet behavior.
 ## Current state
 
 Verified measurements on a 16 physical core / 32 SMT thread AMD Ryzen 9
-7950X3D, SAI P4 middleblock, 10k routes.
+7950X3D, SAI P4 middleblock, 10k routes. Both sides have intra-packet
+parallelism disabled (`-Dfourward.simulator.intraPacketParallelism=false`).
+Measured via the `profile focused` test in `DataplaneBenchmark`.
 
 | Workload | Single-thread | Parallel | Speedup | **Efficiency vs 16 cores** | CPU utilization (parallel) |
 |---|---|---|---|---|---|
-| direct | 2,512 pps | 38,147 pps | **15.19×** | **95%** | 66% — idle headroom |
-| wcmp×16+mirr | 678 pps | 5,534 pps | **8.16×** | **51%** | 94% — saturated |
-| wcmp×128 | 203 pps | 1,521 pps | **7.49×** | **47%** | 83% — saturated |
+| direct | 2,568 pps | 38,449 pps | **14.97×** | **94%** | 65% — idle headroom |
+| wcmp×16+mirr | 664 pps | 5,624 pps | **8.47×** | **53%** | 91% — saturated |
+| wcmp×128 | 207 pps | 1,501 pps | **7.25×** | **45%** | 81% — saturated |
 
-**Direct L3 is essentially at linear scaling.** 15.19× on 16 physical
-cores = 95% efficiency. The machine isn't even CPU-saturated (JVM
-averaged 66% of total machine CPU), so the remaining 5% gap is dispatch
+**Direct L3 is essentially at linear scaling.** 14.97× on 16 physical
+cores = 94% efficiency. The machine isn't even CPU-saturated (JVM
+averaged 65% of total machine CPU), so the remaining 6% gap is dispatch
 overhead (gRPC, coroutines, `ForkJoinPool` task submission serial
 fraction), not compute. Not worth chasing.
 
-**Fork-heavy workloads are at ~50% efficiency** and **efficiency degrades
-slightly with higher fork counts** (51% at 32 branches per packet, 47% at
-128). These workloads saturate the machine but each packet costs ~2× more
-CPU under parallel load than under single-thread.
+**Fork-heavy workloads are at ~45-53% efficiency** and **efficiency
+degrades with higher fork counts** (53% at 32 branches per packet, 45%
+at 128). These workloads saturate the machine but each packet costs ~2×
+more CPU under parallel load than under single-thread.
 
 > **CPU utilization ≠ efficiency.** CPU utilization = how much of the
 > machine is being used. Efficiency = speedup / theoretical max. Direct
@@ -102,16 +104,16 @@ parallelism toggled on and off:
 
 | Mode | Intra-packet | Throughput | CPU util |
 |---|---|---|---|
-| Single-thread | OFF | 203 pps | 3.4% |
+| Single-thread | OFF | 207 pps | 3.4% |
 | Single-thread | ON | 633 pps | — |
-| Parallel (inter-packet) | OFF | 1,521 pps | 83% |
+| Parallel (inter-packet) | OFF | 1,501 pps | 81% |
 | Parallel (inter-packet) | ON | 1,506 pps | 88% |
 
 Under parallel load, intra-packet is a wash on throughput (1,506 vs
-1,521 — noise) but burns ~5% more CPU. Under single-packet load, it's
-a 3× latency win (633 vs 203). Keep it enabled by default — CLI, STF,
+1,501 — noise) but burns ~7% more CPU. Under single-packet load, it's
+a 3× latency win (633 vs 207). Keep it enabled by default — CLI, STF,
 and playground users benefit, parallel users don't pay. The scaling
-measurements below use intra-packet **off** on both sides to keep the
+measurements above use intra-packet **off** on both sides to keep the
 comparison clean.
 
 ## Why embarrassingly parallel isn't linear in practice
@@ -202,17 +204,17 @@ structs) so branches don't interfere with each other.
 
 | Delta | Frame | Source |
 |---|---|---|
-| **+7.3%** | `BigInteger.<init>` | Per-fork arithmetic intermediates |
-| **+7.0%** | `HashMap.putVal` | Per-fork header/struct deep copy |
-| **+2.4%** | `TraceEvent$Builder.buildPartial` | Per-fork trace event allocation |
-| **+2.4%** | `BitVector.<init>` | Related to `BigInteger` allocation |
-| **+2.3%** | `HashMap.put` | Per-fork header/struct deep copy |
-| +0.9% | `HashMap.resize` | HashMap growth during deep copy |
+| **+7.7%** | `BigInteger.<init>(int[], int)` | Per-fork arithmetic intermediates |
+| **+7.4%** | `HashMap.putVal` | Per-fork header/struct deep copy |
+| **+2.9%** | `TraceEvent$Builder.buildPartial` | Per-fork trace event allocation |
+| **+2.1%** | `BitVector.<init>(BigInteger, int)` | Related to `BigInteger` allocation |
+| **+1.4%** | `HashMap.put` | Per-fork header/struct deep copy |
+| +0.9% | `BitVector.concat` | Bit field operations |
+| +0.7% | `BigInteger.<init>(int[])` | More BigInteger allocation |
 
-HashMap put operations combined (`put` + `putVal` + `resize`) account
-for **+10.2%** — the single largest overhead bucket. BigInteger
-allocation is a close second at ~8% combined. Total allocation-related
-scaling overhead: **~25-26%**.
+**BigInteger allocation is the single largest overhead bucket at ~9%
+combined.** HashMap put operations (`put` + `putVal`) are a close second
+at ~9% combined. Total allocation-related scaling overhead: **~23-25%**.
 
 ### The mechanism, concretely
 
@@ -256,8 +258,8 @@ bring 47% efficiency closer to linear.
 The gap comes from per-fork allocation pressure. At realistic fork
 counts (128+) the two biggest buckets are roughly equal:
 
-- **~10% HashMap operations** from per-fork header/struct deep copies
-- **~8% BigInteger allocation** from per-fork bit field arithmetic
+- **~9% BigInteger allocation** from per-fork bit field arithmetic
+- **~9% HashMap operations** from per-fork header/struct deep copies
 - **~5% TraceEvent builders + BitVector init** — harder to avoid
 
 Candidate optimizations, in order of complexity:
@@ -265,22 +267,22 @@ Candidate optimizations, in order of complexity:
 1. **HashMap preallocation in deepCopy.** Eliminates resize churn.
    Two-line change. Expected impact: ~2% (measured — real but small).
 
-2. **Copy-on-write for HeaderVal/StructVal.** Share the underlying map
+2. **`Long` fast path for narrow bit fields.** Use `Long` instead of
+   `BigInteger` for `bit<N>` ≤ 63. Partially exists in
+   `matchesFieldMatch`; extend to `BitVector` arithmetic. Expected
+   impact: most of the ~9% BigInteger bucket.
+
+3. **Copy-on-write for HeaderVal/StructVal.** Share the underlying map
    between fork branches; copy only on write. Most branches touch a
    small subset of fields, so most of the deep-copy work is wasted.
    Structural change — mutation model goes from in-place to persistent.
-   Expected impact: most of the ~10% HashMap bucket.
-
-3. **`Long` fast path for narrow bit fields.** Use `Long` instead of
-   `BigInteger` for `bit<N>` ≤ 63. Partially exists in
-   `matchesFieldMatch`; extend to `BitVector` arithmetic. Expected
-   impact: most of the ~8% BigInteger bucket.
+   Expected impact: most of the ~9% HashMap bucket.
 
 **The honest realization:** fixing any one of these only closes a
 fraction of the gap. Getting to truly linear scaling would require
 fixing *all* of them — a broader refactor than any single PR. A single
-win of 10% (HashMap) or 8% (BigInteger) takes efficiency from 47% to
-maybe 55% — meaningful but still well below linear.
+win of ~9% takes efficiency from 45% to maybe 55% — meaningful but
+still well below linear.
 
 **Before committing to anything:** the simplicity budget matters. The
 lock-free dataplane PR was a clear simplification AND had measurable
@@ -298,7 +300,7 @@ DVaaS workload that's blocked by the current throughput.
   direct L3 proves it scales cleanly. Lookup optimization is a separate
   absolute-throughput concern, not part of the scaling north star.
 - **Disabling intra-packet parallelism.** Throughput-neutral in the
-  parallel (inter-packet) mode (1,506 vs 1,521 pps — noise) but 3×
+  parallel (inter-packet) mode (1,506 vs 1,501 pps — noise) but 3×
   regression in single-packet latency. Keep it for CLI/STF/playground
   users.
 

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -1,6 +1,6 @@
 # Parallel Packet Scaling
 
-**Status: Phase 1 complete (profiled)**
+**Status: Phase 1 complete (profiled and diagnosed)**
 
 ## North star
 
@@ -18,60 +18,101 @@ throughput(N cores) = N × throughput(1 core)
 ```
 
 It's ambitious by design. Real-world overheads mean we won't hit exactly
-linear, but anything more than ~10% off (e.g., 14.4x on 16 cores) should
-demand an explanation.
+linear, but anything more than ~10% off (e.g., 14.4x on 16 physical cores)
+should demand an explanation.
+
+**Baseline methodology.** "Single-thread" means exactly one core doing
+all the work — including any within-packet parallelism that would
+otherwise fan out to the `ForkJoinPool`. This matters because
+`V1ModelArchitecture.buildTraceTree` uses `parallelStream()` for fork
+branches, so the "sequential" `InjectPacket` RPC actually uses multiple
+cores per packet. The right comparison is "one thread doing all the
+work" vs "N threads each doing their own packets" — measured with the
+`parallelStream()` temporarily disabled for the single-thread baseline.
 
 ## Current state
 
-Baseline measurements on a 16-core (32-thread SMT) AMD Ryzen 9 7950X3D,
-SAI P4 middleblock, 10k routes:
+Verified measurements on a 16 physical core / 32 SMT thread AMD Ryzen 9
+7950X3D, SAI P4 middleblock, 10k routes. All numbers are **true
+single-thread** vs **concurrent** (`InjectPackets` RPC with 50k packets
+in flight). Single-thread is measured with the within-packet
+`parallelStream()` in `V1ModelArchitecture.buildTraceTree` temporarily
+disabled, so exactly one core does all the work.
 
-| Metric | Sequential | Concurrent | Speedup |
-|--------|-----------|------------|---------|
-| direct | 2,551 pps | 32,040 pps | **12.6×** |
-| wcmp×16 | 1,743 pps | 10,561 pps | **6.1×** |
-| wcmp×16+mirr | 1,194 pps | 5,555 pps | **4.7×** |
+| Workload | Single-thread | Concurrent | Physical cores used (con) | Speedup | **Efficiency vs 16 cores** |
+|---|---|---|---|---|---|
+| direct | 2,512 pps | 38,147 pps | 10.6 | **15.19×** | **95%** |
+| wcmp×16+mirr | 678 pps | 5,534 pps | 15.0 | **8.16×** | **51%** |
 
-Direct is at 12.6× of 16× (79% efficiency). WCMP is worse — only 6.1× on
-16 cores (38% efficiency). The trace-tree-heavy workloads scale the worst.
+**Direct L3 is essentially at linear scaling.** 15.19× on 16 cores = 95%
+efficiency. The machine isn't even saturated (10.6/16 cores used). No
+meaningful work to do here.
 
-## Why the gap from 16×?
+**Fork-heavy workloads (wcmp×16+mirr) are at ~51% efficiency.** That's
+the real scaling gap. Concurrent mode saturates the machine (15/16 cores)
+but each packet costs ~2× more CPU in concurrent than in single-thread.
 
-We don't know. This is the most important sentence in the document.
+## Why the gap? (Phase 1 profile findings)
 
-Possible causes, ranked by my prior:
+Two JFR profiles compared: direct single-thread vs direct concurrent, and
+wcmp×16+mirr single-thread vs wcmp×16+mirr concurrent. The diffs tell
+completely different stories.
 
-1. **GC pressure.** Packet processing allocates heavily: protobuf trace
-   tree builders, `BigInteger` wrappers for bit<N> arithmetic, lists for
-   match scoring, fresh `TraceTree` objects per fork. 16 threads allocating
-   in parallel stress the JVM allocator and trigger frequent young-gen
-   collections. GC pauses serialize all threads.
+### Direct L3 — scales cleanly
 
-2. **Protobuf allocation on the hot path.** Every table hit builds a new
-   `TableEntry`, every trace event builds a new event proto. Protobuf
-   builders are not cheap — each `.build()` call walks all fields and
-   allocates.
+**Dominant cost (same in both modes):** `TableStoreKt.toUnsignedLong(ByteString)`
+at 65-73% of CPU. The O(n) linear scan over 10k LPM entries converts each
+entry's match field bytes to a Long for comparison.
 
-3. **Memory bandwidth / L3 cache pressure.** 16 threads reading the same
-   forwarding snapshot means the cache lines are replicated across 16
-   L1/L2 caches. L3 is shared but limited. `BigInteger` objects and
-   protobuf messages are heap-allocated, not inlined.
+**Concurrent scaling overhead:** `TableStore.lookup` +4.3% — modest cache
+pressure from 10 threads each scanning the same 10k-entry table. The
+working set fits in L2/L3 well enough that contention is minimal.
 
-4. **`BigInteger` overhead.** Every `bit<N>` operation allocates a new
-   `BigInteger`. For wide fields (IPv6 at 128 bits) this is unavoidable,
-   but for narrow fields (ports, VRF IDs) it's wasteful.
+**Why direct scales well:** no trace tree forks → no header/struct deep
+copies → no allocation-heavy per-fork work. Each thread does the same
+lookup work independently. Cache-friendly, allocator-friendly.
 
-5. **Amdahl's law — serial fraction.** Some work is inherently serial:
-   gRPC stream collection, `ForkJoinPool` task submission, result joining.
-   At high parallelism, the serial fraction caps speedup.
+### wcmp×16+mirr — allocator contention
 
-6. **Thread scheduling overhead.** `ForkJoinPool` task submission has
-   per-task overhead. For packets that process in ~400μs each, scheduling
-   overhead could be significant.
+The workload has a 16-way action selector fork (WCMP) and a 2-way clone
+fork (mirror), producing 32 branches per packet. Each branch must
+deep-copy the packet state (headers + structs) so the branches don't
+interfere with each other.
 
-7. **WCMP trace tree fan-out.** WCMP×16 forks 16 ways, creating 16× more
-   trace events and 16× more allocation per packet. This could explain why
-   WCMP scales worse than direct.
+**Concurrent scaling overhead (diff vs single-thread):**
+
+| Delta | Frame | Source |
+|---|---|---|
+| **+17.9%** | `HashMap.put` / `putVal` / `getNode` / `resize` | Per-fork header/struct deep copy |
+| **+5.9%** | `BigInteger.<init>` | Per-fork arithmetic intermediates |
+| **+2.6%** | `TraceEvent$Builder.buildPartial` | Per-fork trace event allocation |
+| -21.8% | `toUnsignedLong` | Same absolute cost; smaller % of concurrent total |
+
+**~26% of concurrent CPU is allocation-related overhead** — time spent in
+HashMap, BigInteger, and protobuf builder construction that only shows
+up under multi-threaded load. Under single-thread, these paths exist but
+don't dominate. Under concurrent load, allocator contention (TLAB
+exhaustion, shared-heap contention on node allocation, HashMap resize
+under pressure) inflates their cost per operation.
+
+### The mechanism, concretely
+
+When 15 threads each process a fork-heavy packet, they all call
+`HeaderVal.deepCopy()` and `StructVal.deepCopy()`, which do
+`fields.mapValuesTo(mutableMapOf()) { ... }`. That allocates:
+
+1. A new empty HashMap (default capacity 16)
+2. New nodes for each key-value pair inserted
+3. A resize when the map exceeds load factor
+
+With 15 threads × ~32 branches per packet × multiple HeaderVals/StructVals
+per branch, the allocator is hit hundreds of thousands of times per
+second from many threads at once. TLAB exhaustion forces threads into
+the shared allocator path; HashMap resize compounds the issue; cache
+lines for the HashMap's internal `table` array bounce between cores.
+
+This is the bottleneck. It's specifically a **fork-induced
+allocation-pressure** problem, not a general scaling problem.
 
 ## The discipline
 
@@ -101,48 +142,6 @@ Specific questions the profile should answer:
 **Done when:** we have a documented hypothesis ("the bottleneck is X,
 because Y in the flame graph shows Z") and a concrete optimization target.
 
-#### Phase 1 results
-
-JFR profile of the full `DataplaneBenchmark` run (sequential + concurrent
-workloads, SAI P4 middleblock, 10k routes, 16-core machine). 1507 CPU
-samples, ~18s of runtime.
-
-**Top packet-processing CPU (274 samples in `lookup` / `processPacket`
-paths):**
-
-| % of run | Method | Why |
-|---|---|---|
-| **68%** | `TableStoreKt.toUnsignedLong(ByteString)` | Per-FieldMatch byte→long conversion in `matchLong` |
-| 11% | `TableStore.lookup` self | The for-loop scanning all 10k entries |
-| 11% | `HashMap.getNode` | Delegating-property lookups (`snapshot.tables`) |
-| <2% | `matchLong` self | The actual comparison after conversion |
-| <2% | `scoreEntry` self | LPM prefix + ternary priority bookkeeping |
-
-**The bottleneck is `toUnsignedLong`.** Every table lookup walks every
-entry (O(n) scan, 10k entries) and for each entry calls `toUnsignedLong`
-on each match field's `ByteString`, allocating no objects but doing a
-loop over `byteAt(i)` per byte. For 10k LPM entries on a 32-bit IPv4
-field, that's 10k × 4 bytes = 40k `byteAt` calls per packet lookup.
-
-**Allocation profile (27 GB sampled across 18s):**
-
-| % | Class | Source |
-|---|---|---|
-| 42% | `ArrayList$Itr` | Kotlin `for (x in list)` everywhere |
-| 14% | `Collections$UnmodifiableCollection$1` | Iterators for unmodifiable collections |
-| 6% | `BigInteger` | Wide bit field arithmetic |
-| 3% | `TraceEvent$Builder` | Protobuf trace event allocation |
-
-GC was active but pauses were short (~1ms each, ~0.3% of wall time). GC
-is not the dominant bottleneck — allocation pressure exists but isn't
-causing pauses long enough to matter at this benchmark scale.
-
-**Conclusion:** The scaling ceiling is **table lookup cost**, not
-synchronization, GC, or allocation. The fix is structural: avoid the
-O(n) byte-by-byte conversion, either by caching the long values at
-insert time or by replacing the linear scan with an O(1) hash index for
-exact-match tables.
-
 ### Phase 2: Optimize
 
 **Discipline.** Performance work is bounded by simplicity. The project
@@ -153,63 +152,62 @@ must clear that bar before it lands.
 
 **Approach.** One optimization at a time. Measure → fix the smallest
 thing → re-measure → decide what's next. Don't pre-commit to a multi-step
-plan beyond the next step. The Phase 1 result already invalidated most of
-my pre-profile guesses (GC, BigInteger, allocation), so committing to a
-sequence of fixes ahead of measurement would be the same mistake again.
+plan beyond the next step.
 
-**Next step: cache `Long` values for match field bytes at insert time.**
+**Scope.** Phase 1 showed the scaling gap is **specific to fork-heavy
+workloads**. Direct L3 is already at 95% efficiency with no meaningful
+work left to do. So "optimize" here means "close the wcmp×16+mirr gap" —
+bring 51% efficiency closer to direct's 95%.
 
-The 68% hot spot is `toUnsignedLong(ByteString)`, called per-FieldMatch
-on every entry of every linear-scan lookup. The fix: compute the Long
-once when the entry is inserted, cache it, read it on lookup. Fields > 63
-bits still go through the `BigInteger` path.
+The gap comes from per-fork header/struct deep copies allocating new
+HashMaps under heavy concurrent load. To close it, we need to **reduce
+per-fork allocation volume**. The available mechanisms, in order of
+complexity:
 
-Implementation: wrap each stored entry in a small internal class
-(`StoredEntry(entry, longCache)`) inside `TableStore`. The protobuf
-`TableEntry` is immutable, so the cache can't go stale. The wrapper is
-private to `TableStore` — no public API change.
+1. **HashMap preallocation in deepCopy.** Eliminates resize churn.
+   Two-line change. Expected impact: ~2% (measured — the resize cost
+   is real but small).
 
-Complexity cost: one new internal class, one extra layer of indirection
-when accessing entries inside `TableStore`. Bounded and contained.
+2. **Copy-on-write for HeaderVal/StructVal.** Share the underlying map
+   between branches; copy only on write. Most forks touch a small
+   subset of fields, so most of the deep-copy work is wasted. Biggest
+   potential impact: approaches the 17.9% HashMap overhead budget.
 
-Expected impact: eliminates the 68% hot spot. The remaining lookup cost
-is the linear scan + comparison itself, which should be much cheaper.
+3. **Value arena allocation.** Per-thread pools for BitVal/BitVector
+   objects. Targets the 5.9% BigInteger allocation.
 
-**After that:** re-run the benchmark, look at the new profile, decide
-what (if anything) needs to change next. Possible follow-ups, in
-descending order of complexity acceptability:
+**Next step: prototype copy-on-write HeaderVal/StructVal.** It's the
+largest potential win and it's contained to `Values.kt`. The API stays
+the same; only the deepCopy semantics change. Risk: mutation semantics
+during a fork branch can't accidentally affect sibling branches — the
+copy-on-write mechanism must be correct.
 
-- *More caching / micro-optimizations within the existing data structure
-  layout.* Cheap if the profile points there.
-- *Hash index for exact-match tables.* Adds a parallel index that must
-  be kept in sync with the entry list. Real complexity cost. Worth doing
-  only if the linear scan is still the bottleneck *and* we have a
-  workload that's dominated by exact-match (SAI middleblock isn't —
-  it's LPM-heavy).
-- *LPM trie.* Substantial new data structure. Same bar: only if measured
-  necessary.
-
-These are *possible* directions, not commitments. Each requires its own
-profile-backed justification before landing.
+**Before committing:** measure it. If copy-on-write doesn't close a
+significant part of the gap, don't land it. The simplicity budget is
+real and the test is "did efficiency improve measurably?"
 
 **Explicitly off the table:** replacing `for (x in list)` with
 index-based loops to reduce iterator allocation. Kotlin idiom is the
-for-loop; index loops are a readability regression. The 56% iterator
-allocation churn does not currently cause GC pauses (<0.5% of wall time),
-so there is no measured problem to solve.
+for-loop; index loops are a readability regression. Iterator allocation
+is not the current bottleneck (GC pauses <0.5% of wall time).
+
+**Also off the table:** optimizing lookup (`toUnsignedLong`, hash index,
+LPM trie) for scaling reasons. Lookup cost is real but does not affect
+scaling — direct L3 proves it scales cleanly. Lookup optimization is a
+separate absolute-throughput concern, not part of this north star.
 
 ### Phase 3: Validate
 
-For every optimization, run the benchmark on both sequential and
-concurrent paths and verify:
+For every optimization, run the benchmark and verify:
 
-1. **Sequential throughput doesn't regress** (no CPU cost added to the
-   single-core path).
-2. **Concurrent scaling improves** (closer to N× on N cores).
-3. **No correctness regressions** (all 63+ tests still pass).
+1. **True single-thread throughput doesn't regress** — measured with
+   within-packet `parallelStream()` disabled.
+2. **Concurrent scaling efficiency improves** — the ratio of
+   `concurrent_pps / (single_thread_pps × 16)` moves toward 1.0.
+3. **No correctness regressions** — all tests still pass.
 
-**Done when:** concurrent throughput reaches ≥90% of N× sequential
-throughput on the SAI P4 middleblock workload.
+**Done when:** wcmp×16+mirr concurrent efficiency reaches ≥80% of
+linear on 16 physical cores. (Direct L3 is already at 95%.)
 
 ## Non-goals
 
@@ -225,15 +223,14 @@ throughput on the SAI P4 middleblock workload.
 
 ## Open questions
 
-- **Phase 1 used JFR, not async-profiler.** JFR's allocation sampling is
-  coarser. async-profiler would give a more precise allocation flame graph
-  if we want one later. JFR's CPU sampling was sufficient to identify the
-  68% hot spot.
+- **Why does concurrent direct use only 10.6 physical cores (not 16)?**
+  Direct completes 50k packets in 1.3s; the machine isn't even saturated.
+  Likely the gRPC server's request dispatch or the `ForkJoinPool` task
+  submission path is the serial bottleneck. Not worth chasing — direct
+  is already at 95% efficiency on the cores it does use.
 - **Is `InjectPackets` (streaming RPC) the right benchmark?** Real DVaaS
   workloads may use many short-lived streams, not one long stream of
-  10,000 packets. The scaling characteristics could differ.
-- **What's the theoretical floor for table lookup?** Even with a hash
-  index, an exact-match lookup needs to hash the key, walk a bucket,
-  and compare. ~50ns per lookup is plausible — that's 20M lookups/sec
-  per core, vs the current ~2,500 packets/sec/core sequential. The gap
-  would be in trace tree construction, not lookup.
+  10k packets. Scaling characteristics could differ.
+- **How much does copy-on-write help in practice?** The 17.9% HashMap
+  overhead is the ceiling; actual gain depends on how much of that is
+  allocation volume vs allocator contention. Measurement will tell.

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -22,14 +22,7 @@ CPU-bound JVM workload with heavy allocation, 85-90% on 16 cores is
 ambitious but reachable; 50% is common without work. Anything more than
 ~10% off demands an explanation.
 
-### Terminology
-
-**Parallel** = multiple tasks executing literally at the same instant on
-different cores. **Concurrent** = multiple tasks making progress over
-overlapping time, possibly interleaved on one core. Linear scaling is a
-**parallelism** concept. The benchmark runs packets on distinct worker
-threads via `ForkJoinPool`, scheduled onto distinct physical cores — that
-is parallelism, not concurrency.
+### Two axes of parallelism
 
 The simulator has **two independent axes of parallelism**, and the
 distinction matters throughout this document:

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -1,6 +1,6 @@
 # Parallel Packet Scaling
 
-**Status: proposed**
+**Status: Phase 1 complete (profiled)**
 
 ## North star
 
@@ -101,22 +101,80 @@ Specific questions the profile should answer:
 **Done when:** we have a documented hypothesis ("the bottleneck is X,
 because Y in the flame graph shows Z") and a concrete optimization target.
 
+#### Phase 1 results
+
+JFR profile of the full `DataplaneBenchmark` run (sequential + concurrent
+workloads, SAI P4 middleblock, 10k routes, 16-core machine). 1507 CPU
+samples, ~18s of runtime.
+
+**Top packet-processing CPU (274 samples in `lookup` / `processPacket`
+paths):**
+
+| % of run | Method | Why |
+|---|---|---|
+| **68%** | `TableStoreKt.toUnsignedLong(ByteString)` | Per-FieldMatch byte→long conversion in `matchLong` |
+| 11% | `TableStore.lookup` self | The for-loop scanning all 10k entries |
+| 11% | `HashMap.getNode` | Delegating-property lookups (`snapshot.tables`) |
+| <2% | `matchLong` self | The actual comparison after conversion |
+| <2% | `scoreEntry` self | LPM prefix + ternary priority bookkeeping |
+
+**The bottleneck is `toUnsignedLong`.** Every table lookup walks every
+entry (O(n) scan, 10k entries) and for each entry calls `toUnsignedLong`
+on each match field's `ByteString`, allocating no objects but doing a
+loop over `byteAt(i)` per byte. For 10k LPM entries on a 32-bit IPv4
+field, that's 10k × 4 bytes = 40k `byteAt` calls per packet lookup.
+
+**Allocation profile (27 GB sampled across 18s):**
+
+| % | Class | Source |
+|---|---|---|
+| 42% | `ArrayList$Itr` | Kotlin `for (x in list)` everywhere |
+| 14% | `Collections$UnmodifiableCollection$1` | Iterators for unmodifiable collections |
+| 6% | `BigInteger` | Wide bit field arithmetic |
+| 3% | `TraceEvent$Builder` | Protobuf trace event allocation |
+
+GC was active but pauses were short (~1ms each, ~0.3% of wall time). GC
+is not the dominant bottleneck — allocation pressure exists but isn't
+causing pauses long enough to matter at this benchmark scale.
+
+**Conclusion:** The scaling ceiling is **table lookup cost**, not
+synchronization, GC, or allocation. The fix is structural: avoid the
+O(n) byte-by-byte conversion, either by caching the long values at
+insert time or by replacing the linear scan with an O(1) hash index for
+exact-match tables.
+
 ### Phase 2: Optimize
 
-Targets depend on what Phase 1 finds. Likely candidates, ordered by my
-current prior (to be revised after profiling):
+Targets ordered by expected impact, based on Phase 1 profile:
 
-- **Arena allocation for trace events.** Instead of allocating fresh
-  protobuf builders per event, reuse a per-thread arena that resets
-  between packets. Eliminates most trace-tree allocation.
-- **`Long` fast path for narrow bit fields.** Use `Long` instead of
-  `BigInteger` for fields ≤ 63 bits. Most bit<N> operations in practice
-  are narrow.
-- **Direct counter key optimization.** Replace `ConcurrentHashMap<TableEntry,
-  AtomicLongArray>` with something that avoids protobuf `equals`/`hashCode`
-  on every table hit (e.g., integer index assigned at insert time).
-- **Hash index for exact-match tables.** O(1) lookup instead of O(n).
-  Already on the roadmap as Track 10 Phase 2.
+1. **Pre-compute Long values for match field bytes at insert time.**
+   Instead of converting `ByteString → Long` on every match, store the
+   converted Long alongside each entry. Eliminates the 68% hot spot.
+   Easy: single field on the per-table entry storage. Caveat: only works
+   for fields ≤ 63 bits; wider fields fall back to `BigInteger`.
+
+2. **Hash index for exact-match tables.** O(1) lookup instead of O(n)
+   linear scan. Even with optimization #1, the linear scan over 10k
+   entries is wasteful for exact-match. Already on the roadmap.
+
+3. **LPM trie for LPM-only tables.** O(W) lookup where W is the bit
+   width, instead of O(n). For SAI P4 routing tables, W=32 (IPv4) or
+   W=128 (IPv6); n is in the thousands, so the trie wins.
+
+4. **Iterator allocation reduction.** Replace `for (x in list)` with
+   index-based loops in the hot path (`scoreEntry`, `lookup`,
+   `matchesFieldMatch`). Eliminates the 56% iterator allocation churn.
+   Per-packet GC pressure isn't the bottleneck *yet*, but it would be
+   after the lookup optimizations land.
+
+5. **`Long` fast path for narrow bit fields.** Use `Long` instead of
+   `BigInteger` for `bit<N>` ≤ 63. Already partially done in
+   `matchesFieldMatch`; extend to `BitVector` arithmetic.
+
+Items 1 and 2 should be done first. Item 3 is bigger but could be
+deferred until 1+2 ship and we re-measure. Items 4 and 5 are
+allocation-side optimizations that pay off once compute is no longer
+the bottleneck.
 
 ### Phase 3: Validate
 
@@ -145,13 +203,15 @@ throughput on the SAI P4 middleblock workload.
 
 ## Open questions
 
-- **Is per-packet cost actually the bottleneck, or is it task scheduling?**
-  A benchmark that processes very simple packets (e.g., no forks, no
-  complex actions) would isolate scheduling overhead from compute cost.
-- **How much of the sequential→concurrent gap is warmup?** JIT compilation
-  of the concurrent code paths may not happen until the benchmark runs.
-  The current benchmark warms up the sequential path but not the
-  concurrent one.
+- **Phase 1 used JFR, not async-profiler.** JFR's allocation sampling is
+  coarser. async-profiler would give a more precise allocation flame graph
+  if we want one later. JFR's CPU sampling was sufficient to identify the
+  68% hot spot.
 - **Is `InjectPackets` (streaming RPC) the right benchmark?** Real DVaaS
   workloads may use many short-lived streams, not one long stream of
   10,000 packets. The scaling characteristics could differ.
+- **What's the theoretical floor for table lookup?** Even with a hash
+  index, an exact-match lookup needs to hash the key, walk a bucket,
+  and compare. ~50ns per lookup is plausible — that's 20M lookups/sec
+  per core, vs the current ~2,500 packets/sec/core sequential. The gap
+  would be in trace tree construction, not lookup.

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -332,14 +332,11 @@ DVaaS workload that's blocked by the current throughput.
 
 ## Open questions
 
-- **Why is parallel direct at 66% CPU utilization, not 100%?** The JVM
+- **Why is parallel direct at 65% CPU utilization, not 100%?** The JVM
   has idle capacity that isn't being used — meaning the bottleneck isn't
   compute, it's dispatch (gRPC, coroutines, or `ForkJoinPool` task
   submission serial fraction). Not worth chasing — direct is already at
-  95% efficiency despite leaving cores idle.
-- **Is `InjectPackets` (streaming RPC) the right benchmark?** Real DVaaS
-  workloads may use many short-lived streams, not one long stream of
-  10k packets. Scaling characteristics could differ.
-- **How much does copy-on-write help in practice?** The 17.9% HashMap
+  94% efficiency despite leaving cores idle.
+- **How much does copy-on-write help in practice?** The ~9% HashMap
   overhead is the ceiling; actual gain depends on how much of that is
   allocation volume vs allocator contention. Measurement will tell.

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -39,18 +39,29 @@ in flight). Single-thread is measured with the within-packet
 `parallelStream()` in `V1ModelArchitecture.buildTraceTree` temporarily
 disabled, so exactly one core does all the work.
 
-| Workload | Single-thread | Concurrent | Physical cores used (con) | Speedup | **Efficiency vs 16 cores** |
+| Workload | Single-thread | Concurrent | Speedup | **Efficiency vs 16 cores** | CPU utilization (concurrent) |
 |---|---|---|---|---|---|
-| direct | 2,512 pps | 38,147 pps | 10.6 | **15.19×** | **95%** |
-| wcmp×16+mirr | 678 pps | 5,534 pps | 15.0 | **8.16×** | **51%** |
+| direct | 2,512 pps | 38,147 pps | **15.19×** | **95%** | 66% — idle headroom |
+| wcmp×16+mirr | 678 pps | 5,534 pps | **8.16×** | **51%** | 94% — saturated |
 
-**Direct L3 is essentially at linear scaling.** 15.19× on 16 cores = 95%
-efficiency. The machine isn't even saturated (10.6/16 cores used). No
-meaningful work to do here.
+**Direct L3 is essentially at linear scaling.** 15.19× on 16 physical
+cores = 95% efficiency. The machine isn't even CPU-saturated (JVM
+averaged 66% of total machine CPU), so the remaining 5% gap is not a
+compute bottleneck — it's dispatch overhead (gRPC, coroutines, or
+`ForkJoinPool` task submission serial fraction). Not worth chasing.
 
-**Fork-heavy workloads (wcmp×16+mirr) are at ~51% efficiency.** That's
-the real scaling gap. Concurrent mode saturates the machine (15/16 cores)
-but each packet costs ~2× more CPU in concurrent than in single-thread.
+**Fork-heavy workloads (wcmp×16+mirr) are at 51% efficiency.** That's
+the real scaling gap. Concurrent mode *does* saturate the machine (94%
+CPU utilization) — but each packet costs ~1.9× more CPU under concurrent
+load than under single-thread. More threads, more CPU consumed, less
+throughput per core. Classic contention signature.
+
+> **Note on CPU utilization vs efficiency:** these are different metrics.
+> CPU utilization = how much of the machine is being used. Efficiency =
+> speedup / theoretical max. Direct has low CPU utilization but high
+> efficiency (it completes the work fast with fewer cores than the
+> machine has). wcmp has high CPU utilization but low efficiency (it
+> uses all the cores but doesn't get proportional throughput).
 
 ## Why the gap? (Phase 1 profile findings)
 
@@ -223,11 +234,11 @@ linear on 16 physical cores. (Direct L3 is already at 95%.)
 
 ## Open questions
 
-- **Why does concurrent direct use only 10.6 physical cores (not 16)?**
-  Direct completes 50k packets in 1.3s; the machine isn't even saturated.
-  Likely the gRPC server's request dispatch or the `ForkJoinPool` task
-  submission path is the serial bottleneck. Not worth chasing — direct
-  is already at 95% efficiency on the cores it does use.
+- **Why is concurrent direct at 66% CPU utilization, not 100%?** The JVM
+  has idle capacity that isn't being used — meaning the bottleneck isn't
+  compute, it's dispatch (gRPC, coroutines, or `ForkJoinPool` task
+  submission serial fraction). Not worth chasing — direct is already at
+  95% efficiency despite leaving cores idle.
 - **Is `InjectPackets` (streaming RPC) the right benchmark?** Real DVaaS
   workloads may use many short-lived streams, not one long stream of
   10k packets. Scaling characteristics could differ.

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -145,36 +145,58 @@ exact-match tables.
 
 ### Phase 2: Optimize
 
-Targets ordered by expected impact, based on Phase 1 profile:
+**Discipline.** Performance work is bounded by simplicity. The project
+rules are explicit: "correctness over performance" and "readability over
+performance." An optimization that makes the code harder to read or
+reason about is not worth it, even if the benchmark improves. Each step
+must clear that bar before it lands.
 
-1. **Pre-compute Long values for match field bytes at insert time.**
-   Instead of converting `ByteString → Long` on every match, store the
-   converted Long alongside each entry. Eliminates the 68% hot spot.
-   Easy: single field on the per-table entry storage. Caveat: only works
-   for fields ≤ 63 bits; wider fields fall back to `BigInteger`.
+**Approach.** One optimization at a time. Measure → fix the smallest
+thing → re-measure → decide what's next. Don't pre-commit to a multi-step
+plan beyond the next step. The Phase 1 result already invalidated most of
+my pre-profile guesses (GC, BigInteger, allocation), so committing to a
+sequence of fixes ahead of measurement would be the same mistake again.
 
-2. **Hash index for exact-match tables.** O(1) lookup instead of O(n)
-   linear scan. Even with optimization #1, the linear scan over 10k
-   entries is wasteful for exact-match. Already on the roadmap.
+**Next step: cache `Long` values for match field bytes at insert time.**
 
-3. **LPM trie for LPM-only tables.** O(W) lookup where W is the bit
-   width, instead of O(n). For SAI P4 routing tables, W=32 (IPv4) or
-   W=128 (IPv6); n is in the thousands, so the trie wins.
+The 68% hot spot is `toUnsignedLong(ByteString)`, called per-FieldMatch
+on every entry of every linear-scan lookup. The fix: compute the Long
+once when the entry is inserted, cache it, read it on lookup. Fields > 63
+bits still go through the `BigInteger` path.
 
-4. **Iterator allocation reduction.** Replace `for (x in list)` with
-   index-based loops in the hot path (`scoreEntry`, `lookup`,
-   `matchesFieldMatch`). Eliminates the 56% iterator allocation churn.
-   Per-packet GC pressure isn't the bottleneck *yet*, but it would be
-   after the lookup optimizations land.
+Implementation: wrap each stored entry in a small internal class
+(`StoredEntry(entry, longCache)`) inside `TableStore`. The protobuf
+`TableEntry` is immutable, so the cache can't go stale. The wrapper is
+private to `TableStore` — no public API change.
 
-5. **`Long` fast path for narrow bit fields.** Use `Long` instead of
-   `BigInteger` for `bit<N>` ≤ 63. Already partially done in
-   `matchesFieldMatch`; extend to `BitVector` arithmetic.
+Complexity cost: one new internal class, one extra layer of indirection
+when accessing entries inside `TableStore`. Bounded and contained.
 
-Items 1 and 2 should be done first. Item 3 is bigger but could be
-deferred until 1+2 ship and we re-measure. Items 4 and 5 are
-allocation-side optimizations that pay off once compute is no longer
-the bottleneck.
+Expected impact: eliminates the 68% hot spot. The remaining lookup cost
+is the linear scan + comparison itself, which should be much cheaper.
+
+**After that:** re-run the benchmark, look at the new profile, decide
+what (if anything) needs to change next. Possible follow-ups, in
+descending order of complexity acceptability:
+
+- *More caching / micro-optimizations within the existing data structure
+  layout.* Cheap if the profile points there.
+- *Hash index for exact-match tables.* Adds a parallel index that must
+  be kept in sync with the entry list. Real complexity cost. Worth doing
+  only if the linear scan is still the bottleneck *and* we have a
+  workload that's dominated by exact-match (SAI middleblock isn't —
+  it's LPM-heavy).
+- *LPM trie.* Substantial new data structure. Same bar: only if measured
+  necessary.
+
+These are *possible* directions, not commitments. Each requires its own
+profile-backed justification before landing.
+
+**Explicitly off the table:** replacing `for (x in list)` with
+index-based loops to reduce iterator allocation. Kotlin idiom is the
+for-loop; index loops are a readability regression. The 56% iterator
+allocation churn does not currently cause GC pauses (<0.5% of wall time),
+so there is no measured problem to solve.
 
 ### Phase 3: Validate
 

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -4,12 +4,13 @@
 
 ## North star
 
-**Packet processing should scale linearly with physical cores.** For N
-cores, the parallel `InjectPackets` RPC should deliver N× the throughput
-of a single-threaded run. Each packet is independent of every other
-packet (modulo a few shared stateful externs, which have their own
-lock-free data structures) — the algorithm is embarrassingly parallel.
-Anything well below linear is wasted hardware.
+**Inter-packet parallelism should scale linearly with physical cores.**
+For N cores, the parallel `InjectPackets` RPC should deliver N× the
+throughput of a single-threaded run. Each packet is independent of every
+other packet (modulo a few shared stateful externs, which have their own
+lock-free data structures) — the algorithm is truly embarrassingly
+parallel at the packet level. Anything well below linear is wasted
+hardware.
 
 This is the benchmark we want to hit:
 
@@ -22,40 +23,49 @@ CPU-bound JVM workload with heavy allocation, 85-90% on 16 cores is
 ambitious but reachable; 50% is common without work. Anything more than
 ~10% off demands an explanation.
 
-### Two axes of parallelism
+### Why inter-packet parallelism specifically
 
-The simulator has **two independent axes of parallelism**, and the
-distinction matters throughout this document:
+The simulator actually has two independent parallelism mechanisms:
 
-- **Intra-packet parallelism**: within a single packet's processing,
-  trace-tree fork branches (clone, multicast, action selector) run on
-  separate threads. Implemented in `V1ModelArchitecture.buildTraceTree`
-  via `parallelStream()`.
 - **Inter-packet parallelism**: multiple packets process on separate
-  threads simultaneously. Implemented by the `InjectPackets` streaming
-  RPC, which submits each packet to `ForkJoinPool.commonPool()`.
+  threads simultaneously. Each packet is an independent task with no
+  shared state — genuinely embarrassingly parallel. Implemented by
+  `InjectPackets` dispatching each packet to `ForkJoinPool.commonPool()`.
+- **Intra-packet parallelism**: within a single packet, trace-tree fork
+  branches (clone, multicast, action selector) run on separate threads.
+  Branches start from a shared packet state that must be deep-copied
+  per branch — parallelism, but not embarrassingly so. Implemented in
+  `V1ModelArchitecture.buildTraceTree` via `parallelStream()`.
 
-Both sit on top of the same shared `ForkJoinPool.commonPool()`. They
-compose: a single packet with 32 fork branches can fan out to 32 threads
-intra-packet, and 100 packets in flight can each do the same
-inter-packet. In practice (as the measurements below show), intra-packet
-parallelism is helpful for single-packet latency but doesn't meaningfully
-improve throughput when inter-packet parallelism is already saturating
-the machine.
+**The north star is about inter-packet parallelism only**, because:
+
+1. It's the only genuinely embarrassingly parallel axis (no shared
+   starting state between tasks).
+2. It's the axis that matters for throughput-oriented workloads
+   (DVaaS, replay testing, fuzz testing) — users who need to process
+   many packets.
+3. It composes cleanly with single-threaded reasoning: "one thread does
+   one packet, N threads do N packets."
+
+Intra-packet parallelism is an orthogonal optimization for a different
+use case (single-packet latency — CLI, STF tests, playground) and is
+out of scope for this document. Measurements below confirm that intra-
+and inter-packet parallelism don't meaningfully compose — inter-packet
+alone saturates the machine, so intra-packet on top adds nothing.
 
 ### Baseline methodology
 
 "Single-thread" means exactly one core doing all the work for one packet
-at a time — no inter-packet parallelism (sequential `InjectPacket` calls)
-and no intra-packet parallelism (fork branches processed sequentially on
-the same thread). Disabling intra-packet parallelism requires temporarily
-removing the `parallelStream()` call in
-`V1ModelArchitecture.buildTraceTree`. Without that, even a single-packet
-run fans out across cores — not what we want for the "1 core" baseline.
+at a time. Both parallelism axes are disabled:
 
-The right comparison for "N× on N cores" is **one thread doing all the
-work** (both inter- and intra-packet parallelism disabled) vs **the
-machine doing packet processing with both axes enabled**.
+- **Inter-packet**: sequential `InjectPacket` calls (one packet at a time).
+- **Intra-packet**: `parallelStream()` in `buildTraceTree` disabled via
+  the `fourward.simulator.intraPacketParallelism=false` system property.
+
+"Parallel" means many packets in flight via `InjectPackets`, with
+intra-packet parallelism **also disabled** — apples-to-apples with the
+single-thread baseline. The comparison measures pure inter-packet
+speedup with no confounding from intra-packet behavior.
 
 ## Current state
 
@@ -85,33 +95,24 @@ CPU under parallel load than under single-thread.
 > needing all the cores). wcmp has high CPU utilization but low
 > efficiency (uses all the cores but each packet costs more).
 
-### The four-cell breakdown (wcmp128, for intuition)
+### Aside: intra-packet parallelism is orthogonal
 
-The two axes of parallelism compose, so there are four combinations.
-Here they are on the wcmp×128 workload:
+Confirming the claim above, wcmp×128 throughput with intra-packet
+parallelism toggled on and off:
 
-| Inter-packet | Intra-packet | Throughput | Speedup vs true ST | CPU util |
-|---|---|---|---|---|
-| OFF (1 packet at a time) | OFF | 203 pps | 1.00× (baseline) | 3.4% |
-| OFF (1 packet at a time) | ON | 633 pps | 3.12× | — |
-| ON (many packets in flight) | OFF | 1,521 pps | **7.49×** | 83% |
-| ON (many packets in flight) | ON | 1,506 pps | 7.42× | 88% |
+| Mode | Intra-packet | Throughput | CPU util |
+|---|---|---|---|
+| Single-thread | OFF | 203 pps | 3.4% |
+| Single-thread | ON | 633 pps | — |
+| Parallel (inter-packet) | OFF | 1,521 pps | 83% |
+| Parallel (inter-packet) | ON | 1,506 pps | 88% |
 
-Observations:
-
-1. **Intra-packet parallelism doesn't help when inter-packet is already
-   active** (1,506 vs 1,521 — noise). With many packets in flight, the
-   `ForkJoinPool` workers are already busy processing different packets;
-   spreading one packet's forks across workers steals from the workers
-   processing other packets. Net effect: zero throughput change, ~5%
-   more CPU used for nothing (88% vs 83% utilization at the same pps).
-2. **Intra-packet parallelism helps single-packet latency 3×** (633 vs
-   203). When only one packet is in flight, the machine is idle
-   otherwise, and fanning out the forks across cores is pure gain.
-   Worth keeping for CLI, STF, and playground use cases.
-3. **The true single-thread baseline is both axes OFF** (203 pps).
-   That's what divides into the parallel throughput to compute the
-   "speedup on N cores" number.
+Under parallel load, intra-packet is a wash on throughput (1,506 vs
+1,521 — noise) but burns ~5% more CPU. Under single-packet load, it's
+a 3× latency win (633 vs 203). Keep it enabled by default — CLI, STF,
+and playground users benefit, parallel users don't pay. The scaling
+measurements below use intra-packet **off** on both sides to keep the
+comparison clean.
 
 ## Why embarrassingly parallel isn't linear in practice
 
@@ -233,14 +234,7 @@ in aggregate they dominate the scaling overhead.
 This is the bottleneck. It's specifically a **fork-induced
 allocation-pressure** problem, not a general scaling problem.
 
-## The discipline
-
-**Measure first, optimize second.** This is Track 10 Phase 1's mantra and
-it applied to the lock-free dataplane too (where we discovered the lock
-wasn't the bottleneck after all). The same principle applies here: any
-optimization without a profiler-backed hypothesis is a guess.
-
-### Phase 2: Optimize
+## Phase 2: optimize (proposed)
 
 **Discipline.** Performance work is bounded by simplicity. The project
 rules are explicit: "correctness over performance" and "readability over
@@ -248,9 +242,11 @@ performance." An optimization that makes the code harder to read or
 reason about is not worth it, even if the benchmark improves. Each step
 must clear that bar before it lands.
 
-**Approach.** One optimization at a time. Measure → fix the smallest
-thing → re-measure → decide what's next. Don't pre-commit to a multi-step
-plan beyond the next step.
+**Approach.** Measure first, optimize second — same mantra that governed
+the lock-free dataplane work (where we discovered the lock wasn't the
+bottleneck after all). One optimization at a time. Measure → fix the
+smallest thing → re-measure → decide what's next. Don't pre-commit to a
+multi-step plan beyond the next step.
 
 **Scope.** Phase 1 showed the scaling gap is **specific to fork-heavy
 workloads**. Direct L3 is already at 95% efficiency with no meaningful
@@ -306,13 +302,12 @@ DVaaS workload that's blocked by the current throughput.
   regression in single-packet latency. Keep it for CLI/STF/playground
   users.
 
-### Phase 3: Validate
-
-For every optimization, run the benchmark and verify:
+**Validation.** For every optimization, run the benchmark and verify:
 
 1. **True single-thread throughput doesn't regress** — measured with
-   intra-packet parallelism disabled.
-2. **Parallel scaling efficiency improves** — the ratio of
+   intra-packet parallelism disabled (set
+   `-Dfourward.simulator.intraPacketParallelism=false`).
+2. **Parallel scaling efficiency improves** — the ratio
    `parallel_pps / (single_thread_pps × 16)` moves toward 1.0.
 3. **No correctness regressions** — all tests still pass.
 

--- a/p4runtime/DataplaneBenchmark.kt
+++ b/p4runtime/DataplaneBenchmark.kt
@@ -34,8 +34,107 @@ import p4.v1.P4RuntimeOuterClass.Update
 @Suppress("FunctionNaming", "MagicNumber")
 class DataplaneBenchmark {
 
+  /**
+   * Single-workload, single-mode profile test for measuring parallel scaling.
+   *
+   * The main [`dataplane benchmark`] sweeps many scale points, which is good for a comprehensive
+   * snapshot but hard to profile — each workload only runs for ~1s, below the JFR/async-profiler
+   * sampling settle time. This test runs one (workload, mode) combination for many thousands of
+   * packets, long enough for steady-state profiling.
+   *
+   * Usage:
+   * ```
+   * bazel build //p4runtime:DataplaneBenchmark -c opt
+   * ./bazel-bin/p4runtime/DataplaneBenchmark \
+   *     --jvm_flag=-DprofileWorkload=wcmp128 \
+   *     --jvm_flag=-DprofileMode=parallel \
+   *     --jvm_flag=-Dfourward.simulator.intraPacketParallelism=false \
+   *     --jvm_flag=-XX:StartFlightRecording=filename=/tmp/profile.jfr,settings=profile
+   * ```
+   *
+   * Parameters (JVM system properties):
+   * - `profileMode`: `sequential` (one packet at a time via InjectPacket) or `parallel` (many
+   *   packets via InjectPackets). If unset, the test is skipped.
+   * - `profileWorkload`: `direct` (L3 forwarding, no forks), `wcmp16mirr` (16-way WCMP + mirror
+   *   clone), or `wcmp128` (128-way WCMP, DVaaS-realistic). Default: `wcmp128`.
+   *
+   * For clean scaling measurements, set `-Dfourward.simulator.intraPacketParallelism=false` on both
+   * sides — see `designs/parallel_packet_scaling.md`.
+   */
+  @Test
+  fun `profile focused`() {
+    val mode = System.getProperty("profileMode") ?: return // skip unless explicitly invoked
+    val workload = System.getProperty("profileWorkload") ?: "wcmp128"
+    println("=== Profile: workload=$workload mode=$mode ===")
+
+    // JIT warmup on a throwaway pipeline.
+    val warmupHarness = createHarness()
+    installEntries(warmupHarness, routeCount = 100, nexthopCount = 100)
+    val warmupPacket = buildIpv4Packet(dstIp = ipForRoute(0))
+    repeat(JIT_WARMUP_PACKETS) {
+      warmupHarness.injectPacket(ingressPort = 0, payload = warmupPacket)
+    }
+    warmupHarness.close()
+
+    val sp =
+      when (workload) {
+        "direct" -> ScalePoint("direct", routes = 10_000, nexthops = 100, aclEntries = ACL_ENTRIES)
+        "wcmp16mirr" ->
+          ScalePoint(
+            "wcmp×16+mirr",
+            routes = 10_000,
+            nexthops = 100,
+            wcmpMembers = 16,
+            mirror = true,
+            aclEntries = ACL_ENTRIES,
+          )
+        "wcmp128" ->
+          ScalePoint(
+            "wcmp×128",
+            routes = 10_000,
+            nexthops = 100,
+            wcmpMembers = 128,
+            aclEntries = ACL_ENTRIES,
+          )
+        else -> error("unknown profileWorkload: $workload (expected direct, wcmp16mirr, wcmp128)")
+      }
+
+    val harness = createHarness()
+    installEntries(harness, sp.routes, 100, sp.wcmpMembers, sp.mirror, sp.aclEntries)
+    val warmupPkt = buildIpv4Packet(dstIp = ipForRoute(0))
+    repeat(SCALE_WARMUP_PACKETS) { harness.injectPacket(ingressPort = 0, payload = warmupPkt) }
+
+    // Packet count scales inversely with per-packet cost so each run takes ~10-200s.
+    val totalPackets =
+      when (workload) {
+        "direct" -> 500_000
+        "wcmp16mirr" -> 50_000
+        "wcmp128" -> 10_000
+        else -> 50_000
+      }
+    val packets =
+      (0 until totalPackets).map { i -> 0 to buildIpv4Packet(dstIp = ipForRoute(i % sp.routes)) }
+
+    val startNs = System.nanoTime()
+    when (mode) {
+      "sequential" ->
+        for ((port, payload) in packets) {
+          harness.injectPacket(ingressPort = port, payload = payload)
+        }
+      "parallel" ->
+        // Chunk to avoid any per-stream limits in InjectPackets at very large batches.
+        for (batch in packets.chunked(10_000)) harness.injectPackets(batch)
+      else -> error("unknown profileMode: $mode (expected sequential or parallel)")
+    }
+    val elapsedMs = (System.nanoTime() - startNs) / NS_PER_MS
+    val pps = totalPackets / elapsedMs * 1000
+    println("$workload $mode: $totalPackets packets in %.0f ms = %.0f pps".format(elapsedMs, pps))
+    harness.close()
+  }
+
   @Test
   fun `dataplane benchmark`() {
+    if (System.getProperty("profileMode") != null) return // skip when running the focused test
     // --- JIT warmup on a throwaway pipeline ---
     val warmupHarness = createHarness()
     installEntries(warmupHarness, routeCount = 100, nexthopCount = 100)


### PR DESCRIPTION
## Summary

Establishes the **north star** (N× throughput on N cores for inter-packet
parallelism) and captures the Phase 1 diagnosis in
\`designs/parallel_packet_scaling.md\`.

**Headline:** direct L3 already scales near-linearly (**94%** efficiency,
14.97× on 16 physical cores). The scaling gap is **specific to fork-heavy
workloads** — wcmp×128 tops out at **45%** efficiency — and the profile
points squarely at **per-fork allocation pressure**:

- ~9% BigInteger allocation (bit field arithmetic)
- ~9% HashMap operations (HeaderVal / StructVal deep copies)
- ~5% TraceEvent builders + BitVector init

Total: ~23–25% of parallel-mode CPU is allocation overhead that doesn't
exist in the single-thread baseline. Not the table lookup, not the lock
(#489 already proved that), not GC pauses.

## What's new

- \`designs/parallel_packet_scaling.md\` — north star, baseline methodology,
  verified measurements, theory of why embarrassingly-parallel work isn't
  linear in practice, Phase 1 profile findings, and a simplicity-first
  Phase 2 proposal (one step at a time, each gated on the readability
  budget).
- \`DataplaneBenchmark.profile focused\` — permanent benchmark infra for
  steady-state profiling of a single workload (the main sweep is too
  noisy for JFR diffing).

## Phase 2 direction

Candidate optimizations in order of complexity, with the honest caveat
that **no single one closes the full gap** — getting to truly linear
would require all of them, and each must clear the \"correctness and
readability over performance\" bar before it lands:

1. HashMap preallocation in \`deepCopy\` — ~2% (two-line change)
2. \`Long\` fast path for \`bit<N≤63>\` in BitVector arithmetic — most of
   the ~9% BigInteger bucket
3. Copy-on-write HeaderVal / StructVal — most of the ~9% HashMap bucket

## Test plan

- [ ] Design review — does the framing hold up, does Phase 2 have a
  strong enough justification to proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)