### PR TITLE
Add private benchmark knob for intra-packet parallelism

### DIFF
--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -63,6 +63,14 @@ private fun evalIntArg(eval: ExternEvaluator, index: Int): Int =
     else -> error("expected integer argument at index $index, got: $arg")
   }
 
+/**
+ * Benchmark-only knob for measuring the scaling impact of intra-packet parallelism. Not a public
+ * API — no user documentation, no CLI flag. Normal users should leave this at the default (`true`).
+ * See `designs/parallel_packet_scaling.md`.
+ */
+private val INTRA_PACKET_PARALLELISM_ENABLED =
+  System.getProperty("fourward.simulator.intraPacketParallelism", "true").toBoolean()
+
 class V1ModelArchitecture(
   /**
    * Override for the drop port. When null (default), derived from `standard_metadata` port width:
@@ -145,13 +153,19 @@ class V1ModelArchitecture(
       val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
       val (reason, specs) = forkSpecs(ctx, decisions, fork)
 
-      // Run fork branches in parallel. Each branch recursively builds its own subtree,
-      // handling nested forks (clone after selector, etc.) independently.
+      // Intra-packet parallelism: runs fork branches on ForkJoinPool. Helpful for
+      // single-packet latency (CLI, STF, playground), neutral for throughput under
+      // inter-packet parallelism. See designs/parallel_packet_scaling.md for the
+      // measured trade-off.
       val subtrees =
-        specs
-          .parallelStream()
-          .map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
-          .toList()
+        if (INTRA_PACKET_PARALLELISM_ENABLED) {
+          specs
+            .parallelStream()
+            .map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
+            .toList()
+        } else {
+          specs.map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
+        }
 
       val branches =
         specs.zip(subtrees).map { (spec, result) ->


### PR DESCRIPTION
## Summary

Adds a JVM system property \`fourward.simulator.intraPacketParallelism\`
(default true) that controls whether trace-tree fork branches run on
\`ForkJoinPool\` or sequentially on the current thread.

**This is a benchmark-only knob** — not a public API, not mentioned in
user docs or CLI flags. Namespaced under \`fourward.simulator.*\` to signal
internal status, following the convention of JDK diagnostic flags like
\`sun.java2d.uiScale\` or \`kotlinx.coroutines.debug\`.

Also adds a doc comment at the site explaining the measured trade-off:

- **Intra-packet parallelism ON** (default): 3× better single-packet
  latency. Helpful for CLI, STF tests, playground.
- **Intra-packet parallelism OFF**: neutral for throughput under
  inter-packet parallelism (\`InjectPackets\`) — the two axes compose,
  and with inter-packet already saturating the machine, intra-packet
  just adds ForkJoinPool overhead without finding more cores.

Normal users should leave this at the default. The knob exists so that
benchmarks measuring pure inter-packet scaling can disable intra-packet
on both sides without editing source — a one-line JVM arg instead of a
source edit + rebuild.

See \`designs/parallel_packet_scaling.md\` (#506) for the measurement details.

## Test plan

- [x] All 63 tests pass
- [x] Format + lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)