### PR TITLE
Phase 1.5 empirical deep-dive: it's DRAM, not the allocator

### DIFF
--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -125,9 +125,8 @@ read-only at the data-plane layer; each packet is independent).
 
 But **the algorithm and the runtime live in different worlds**. The
 algorithm doesn't know about the machine's shared physical resources,
-and there are several that matter. These are the six candidate
-mechanisms we went into Phase 1.5 with; the verdicts in brackets come
-from the measurement work below.
+and six of them could plausibly be in play. Bracketed verdicts below
+are the results of measuring each mechanism directly — see Phase 1.5.
 
 1. **The JVM allocator.** Allocations normally go into a per-thread TLAB
    (thread-local allocation buffer) — fast, no contention. But when a
@@ -147,7 +146,7 @@ from the measurement work below.
 3. **Memory bandwidth.** DRAM has finite bandwidth. Fresh allocations
    touch new cache lines; at gigabytes per second of allocation across
    all threads, memory bandwidth becomes a real constraint.
-   **[Contributory — shares root cause with (2). See Phase 1.5 #6.]**
+   **[Contributory — shares root cause with (2). See Phase 1.5 #6, #7.]**
 
 4. **Garbage collection.** G1GC steals CPU cycles for concurrent marking
    and evacuation. At high allocation rates, GC runs more often,
@@ -174,19 +173,14 @@ allocator, caches, and memory bandwidth across all threads.
 This means: closing the gap to linear scaling requires reducing shared
 resource pressure, not restructuring the algorithm. Specifically:
 
-- **Reduce working set size** → less L3 pressure, fewer DRAM misses
+- **Reduce working-set size** → less L3 pressure, fewer DRAM misses
 - **Reduce per-allocation size** → fewer cache lines touched per object
-- **Reduce allocation volume** → less memory bandwidth usage, fewer
-  TLAB refills
 
 ## Phase 1 profile findings
 
-JFR CPU profiles tell us *where* time is spent but not *why*. What
-follows are the raw profile observations from Phase 1; the Phase 1.5
-deep-dive reinterprets them in light of hardware counter measurements.
-Read them together — the profile numbers are right, the initial
-interpretation ("allocator-CPU-bound") turned out to be partially
-wrong.
+JFR CPU profiles tell us *where* time is spent, not *why*. The numbers
+below are raw sampling observations; the Phase 1.5 deep-dive
+reinterprets them using hardware counters.
 
 Two JFR profile pairs: direct single-thread vs direct parallel, and
 wcmp×128 single-thread vs wcmp×128 parallel. Both sides have intra-packet
@@ -229,7 +223,9 @@ structs) so branches don't interfere with each other.
 
 **BigInteger allocation is the single largest overhead bucket at ~9%
 combined.** HashMap put operations (`put` + `putVal`) are a close second
-at ~9% combined. Total allocation-related scaling overhead: **~23-25%**.
+at ~9% combined. The overhead inside these frames totals **~23-25%**
+of parallel-mode CPU — but Phase 1.5 shows those cycles are
+DRAM-stall cycles, not allocator-fast-path cycles.
 
 ### What the profile diff pointed at
 
@@ -254,11 +250,12 @@ Phase 1.5 answers that question.
 
 ## Phase 1.5: empirical deep-dive
 
-The Phase 1 profile told us *where* CPU time was spent
-(`HashMap.putVal`, `BigInteger.<init>`, etc.). It did not tell us
-*why*. Without that, Phase 2 priorities are guesses. Phase 1.5
-measures the six candidate mechanisms directly using JFR event data,
-hardware performance counters, and CPU pinning experiments.
+**TL;DR.** Of the six candidate mechanisms, only one is confirmed:
+**L3 capacity exhaustion**. Each thread's IPC collapses from 3.02 to
+0.88 in parallel — same total instructions, unchanged L1/L2 hit rates,
+but 3× more loads per packet miss all caches and reach DRAM. The
+allocator-adjacent hot spots from the Phase 1 profile are
+*memory-stall cycles* inside those methods, not allocator CPU cost.
 
 Nine experiments on the same machine and workload (AMD Ryzen 9
 7950X3D, SAI P4 middleblock, wcmp×128, intra-packet parallelism off on
@@ -283,7 +280,7 @@ both sides):
 | 3 | Memory bandwidth | Contributory | Aggregate ~13 GB/s allocation + 3× DRAM traffic per packet; shares root cause with (2). See Phase 1.5 #7. |
 | 4 | GC | **Refuted** | Pause share 1.8% of wall time; 2 GB ↔ 16 GB heap unchanged; best GC swap (ParallelGC) +1.9% |
 | 5 | False sharing | **Refuted** | 850 HITM events / 874K samples = 0.1%; top contended line 11 HITMs |
-| 6 | SMT interference | **Refuted** | Physical-only pinning 1436 vs 1460 baseline, within noise |
+| 6 | SMT interference | **Refuted** | Physical-only pinning (16 workers) 1436 pps vs unpinned 16-worker 1443 pps — within noise |
 
 ### The smoking gun: `perf stat`
 
@@ -309,10 +306,10 @@ the hallmark of a memory-stall-bound workload.
 L1 and L2 hit rates are essentially unchanged between modes. What
 *does* change is the small tail of loads that miss all caches: **3×
 more per packet** reach DRAM. Each DRAM miss is roughly 200 cycles of
-stall. `(228K − 73K) × 200 cycles ≈ 31M cycles ≈ 9 ms` of extra
-per-core stall per packet. The parallel per-packet core-time is ~16 ms
-vs sequential ~5 ms; the 9 ms DRAM-stall budget accounts for most of
-the 11 ms gap.
+stall. `(228K − 73K) × 200 cycles ≈ 31M extra cycles per packet`, or
+roughly 6–9 ms of per-core stall (depending on effective frequency).
+Parallel per-packet core-time is ~16 ms vs sequential ~5 ms, so the
+extra DRAM stalls account for the bulk of the 11 ms gap.
 
 ### The scaling curve
 
@@ -351,25 +348,25 @@ CCD). Pinning experiments:
 | CCD1 only (CPUs 8–15) | 8 | 8 | 1206 |
 | Both CCDs, physical only | 16 | 16 | 1436 |
 
-Three observations:
+Three observations, with the punchline first:
 
-1. **Saturation within a single CCD.** 8 workers on one CCD ≈ 8
+1. **The two CCDs don't scale additively, implicating DRAM bandwidth.**
+   CCD0 alone 1227 + CCD1 alone 1206 "should" sum to ~2400. Running
+   both together: 1436. The second CCD contributes only 17% of its
+   standalone capacity once the first is active. The only *relevant*
+   shared resource for this workload is the memory controller / DRAM
+   bandwidth — which is exactly what a DRAM-bound diagnosis predicts.
+
+2. **Saturation within a single CCD.** 8 workers on one CCD ≈ 8
    workers unpinned (1227 ≈ 1235 from the scaling curve). The
    bottleneck fills up at 8 threads on a single CCD — within one L3
    domain, we hit the ceiling long before we run out of cores.
 
-2. **3D V-cache doesn't help this workload.** CCD0 and CCD1 perform
+3. **3D V-cache doesn't help this workload.** CCD0 and CCD1 perform
    identically (1227 vs 1206). If V-cache were buying us anything,
    the V-cache CCD should be noticeably faster. Either the working
    set already exceeds 96 MB, or the allocation churn pattern doesn't
    benefit from the extra capacity. Either way: not a factor.
-
-3. **The two CCDs don't scale additively.** CCD0 alone 1227 +
-   CCD1 alone 1206 "should" sum to ~2400. Running both together: 1436.
-   The second CCD contributes only 17% of its standalone capacity once
-   the first is active. The only resource the CCDs share is the
-   memory controller / DRAM bandwidth — which is exactly what a
-   DRAM-bound diagnosis predicts.
 
 Also: `ls_any_fills_from_sys.far_cache` is **zero** in both modes. No
 cross-CCD coherency traffic. The OS scheduler keeps threads on their
@@ -377,16 +374,12 @@ home CCD. Inter-CCD contention is not the story.
 
 ### Reframed diagnosis
 
-The Phase 1 profile showed +9% HashMap and +9% BigInteger in the
-parallel-overhead diff, and the initial read was "allocator CPU cost."
-Phase 1.5 shows that framing was misleading.
-
-The extra cycles are real, and they *do* happen inside `HashMap.putVal`
-and `BigInteger.<init>`. But they're not allocator fast-path cycles —
-they're memory-stall cycles. Each `putVal` that shows up at +7% on the
-CPU profile is spending hundreds of cycles waiting for its new node's
-cache line to arrive from DRAM, because the L3 has been evicted by
-other threads doing the same thing.
+The extra cycles on the Phase 1 parallel-overhead diff *do* happen
+inside `HashMap.putVal` and `BigInteger.<init>`. They are not
+allocator fast-path cycles. They are memory-stall cycles: each
+`putVal` at +7% on the CPU profile is spending hundreds of cycles
+waiting for its new node's cache line to arrive from DRAM, because
+the L3 has been evicted by other threads doing the same thing.
 
 **The root cause is L3 capacity exhaustion under concurrent allocation
 churn.** Each wcmp×128 packet allocates on the order of 12 MB of
@@ -434,14 +427,12 @@ multi-step plan beyond the next step.
 work left to do. "Optimize" here means closing the wcmp×128 gap —
 bringing 45% efficiency closer to linear.
 
-**What to optimize for.** Phase 1.5 reframed the target. Minimize
-**per-thread working-set size**, not allocation count. Every candidate
+**What to optimize for.** Per the reframed diagnosis in Phase 1.5:
+per-thread working-set size, not allocation count. Every candidate
 should be evaluated on "does it reduce the bytes each thread touches
-per packet" — that's what directly reduces L3 footprint and therefore
-DRAM miss rate. Allocation count reductions help only to the degree
-they shrink the hot working set.
+per packet."
 
-Candidate optimizations, reordered by expected impact on working-set
+Candidate optimizations, ordered by expected impact on working-set
 size:
 
 1. **Copy-on-write `HeaderVal` / `StructVal`.** Share the underlying
@@ -512,10 +503,9 @@ DVaaS workload that's blocked by the current throughput.
 3. **No correctness regressions** — all tests still pass.
 
 **Done when:** wcmp×128 parallel efficiency reaches ≥80% of linear on
-16 physical cores. (Direct L3 is already at 94%.) Phase 1.5 showed the
-current ceiling is a hard one — hitting ≥80% is not a marginal
-improvement but requires breaking the L3-capacity bottleneck, which is
-exactly what (1) and (2) above are designed to do.
+16 physical cores. Hitting that target is not marginal tuning — it
+requires breaking the L3-capacity bottleneck, which is what candidates
+(1) and (2) above are designed to do.
 
 ## Non-goals
 

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -142,7 +142,7 @@ from the measurement work below.
    ephemeral working sets (HashMaps, BigIntegers, builders per thread)
    spill into L3, evicting each other. What was an L2 hit becomes an
    L3 hit (3× slower), or worse, a DRAM access (10× slower).
-   **[Confirmed — the dominant mechanism. See Phase 1.5 #2, #7.]**
+   **[Confirmed — the dominant mechanism. See Phase 1.5 #6, #7.]**
 
 3. **Memory bandwidth.** DRAM has finite bandwidth. Fresh allocations
    touch new cache lines; at gigabytes per second of allocation across
@@ -316,7 +316,12 @@ the 11 ms gap.
 
 ### The scaling curve
 
-Running wcmp×128 at varying `ForkJoinPool.common.parallelism`:
+Running wcmp×128 at varying `ForkJoinPool.common.parallelism`, all via
+the parallel (streaming `InjectPackets`) path so per-RPC overhead is
+amortized across the batch and only pure compute is being measured
+(this is why the 1-worker baseline below is 229 pps, not the 207 pps
+from the Current state table — the latter uses unary `InjectPacket`
+which pays per-call gRPC cost):
 
 | Workers | pps | Speedup vs 1 | Efficiency |
 |---|---|---|---|
@@ -447,10 +452,10 @@ size:
    this list that *directly* shrinks per-thread working set — on
    fork-heavy workloads, potentially by an order of magnitude.
    Structural change (mutation model goes from in-place to persistent)
-   but the public interface stays the same. **Expected impact: this is
-   where the ceiling lives.** Actual gain depends on what fraction of
-   deep-copied fields are never read by the branch; measurement will
-   tell.
+   but the public interface stays the same.
+   **Expected impact:** this is where the ceiling lives. Actual gain
+   depends on what fraction of deep-copied fields are never read by
+   the branch; measurement will tell.
 
 2. **`Long` fast path for narrow bit fields.** Use `Long` instead of
    `BigInteger` for `bit<N>` with N ≤ 63. A partial fast path exists
@@ -460,12 +465,15 @@ size:
    primitive `long` (often register-resident after escape analysis).
    Bit-fields are densely packed in header maps, so this compounds
    the working-set win from (1).
+   **Expected impact:** ~5× smaller per-value footprint, compounded
+   across dozens of bit-fields per header. Hard to forecast as a
+   single number without measurement.
 
 3. **`HashMap` preallocation in `deepCopy`.** Two-line change;
-   eliminates resize churn. Measured in isolation at ~2%. Small win,
-   no simplicity cost — same final maps, just fewer intermediate
+   eliminates resize churn. Same final maps, just fewer intermediate
    allocations along the way. Worth doing for cheap, but don't expect
    it to move the scaling needle.
+   **Expected impact:** ~2% (measured in isolation before Phase 1.5).
 
 **The honest realization.** None of these alone guarantees linear
 scaling. Working-set reduction from (1) has the highest ceiling by
@@ -504,7 +512,10 @@ DVaaS workload that's blocked by the current throughput.
 3. **No correctness regressions** — all tests still pass.
 
 **Done when:** wcmp×128 parallel efficiency reaches ≥80% of linear on
-16 physical cores. (Direct L3 is already at 94%.)
+16 physical cores. (Direct L3 is already at 94%.) Phase 1.5 showed the
+current ceiling is a hard one — hitting ≥80% is not a marginal
+improvement but requires breaking the L3-capacity bottleneck, which is
+exactly what (1) and (2) above are designed to do.
 
 ## Non-goals
 

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -1,6 +1,6 @@
 # Parallel Packet Scaling
 
-**Status: Phase 1 complete (profiled and diagnosed)**
+**Status: Phase 1.5 complete (empirically validated; diagnosis refined)**
 
 ## North star
 
@@ -125,13 +125,16 @@ read-only at the data-plane layer; each packet is independent).
 
 But **the algorithm and the runtime live in different worlds**. The
 algorithm doesn't know about the machine's shared physical resources,
-and there are several that matter:
+and there are several that matter. These are the six candidate
+mechanisms we went into Phase 1.5 with; the verdicts in brackets come
+from the measurement work below.
 
 1. **The JVM allocator.** Allocations normally go into a per-thread TLAB
    (thread-local allocation buffer) — fast, no contention. But when a
    TLAB fills, the thread has to request a new one from the shared heap,
    which is a coordination point. At high allocation rates, TLAB refills
    become frequent and contention becomes visible.
+   **[Refuted — see Phase 1.5 #1.]**
 
 2. **L3 cache pressure.** Each physical core has private L1/L2; all
    cores share L3. Single-threaded, one packet's working set fits in
@@ -139,23 +142,28 @@ and there are several that matter:
    ephemeral working sets (HashMaps, BigIntegers, builders per thread)
    spill into L3, evicting each other. What was an L2 hit becomes an
    L3 hit (3× slower), or worse, a DRAM access (10× slower).
+   **[Confirmed — the dominant mechanism. See Phase 1.5 #2, #7.]**
 
 3. **Memory bandwidth.** DRAM has finite bandwidth. Fresh allocations
    touch new cache lines; at gigabytes per second of allocation across
    all threads, memory bandwidth becomes a real constraint.
+   **[Contributory — shares root cause with (2). See Phase 1.5 #6.]**
 
 4. **Garbage collection.** G1GC steals CPU cycles for concurrent marking
    and evacuation. At high allocation rates, GC runs more often,
    reducing effective throughput even when pause times look small.
+   **[Refuted — see Phase 1.5 #3, #5, #9.]**
 
 5. **Cache coherency.** Even read-only data has coherency cost if
    writes happen nearby (false sharing). JVM object allocations are
    typically on fresh cache lines, so this is usually a non-issue — but
    it can bite.
+   **[Refuted — see Phase 1.5 #8.]**
 
 6. **SMT interference.** Two SMT threads on the same physical core
    share L1, L2, and execution units. For memory-bound work, they can
    slow each other down.
+   **[Refuted — see Phase 1.5 #6.]**
 
 **For CPU-bound JVM workloads with heavy allocation, 50-60% efficiency
 on 16 cores is a normal outcome, not a failure.** The algorithm's
@@ -166,12 +174,19 @@ allocator, caches, and memory bandwidth across all threads.
 This means: closing the gap to linear scaling requires reducing shared
 resource pressure, not restructuring the algorithm. Specifically:
 
-- **Reduce allocation volume** → less TLAB contention, less GC, less
-  memory bandwidth usage
-- **Reduce working set size** → less L3 pressure, more L2 hits
-- **Reduce per-allocation size** → fewer cache line fetches
+- **Reduce working set size** → less L3 pressure, fewer DRAM misses
+- **Reduce per-allocation size** → fewer cache lines touched per object
+- **Reduce allocation volume** → less memory bandwidth usage, fewer
+  TLAB refills
 
 ## Phase 1 profile findings
+
+JFR CPU profiles tell us *where* time is spent but not *why*. What
+follows are the raw profile observations from Phase 1; the Phase 1.5
+deep-dive reinterprets them in light of hardware counter measurements.
+Read them together — the profile numbers are right, the initial
+interpretation ("allocator-CPU-bound") turned out to be partially
+wrong.
 
 Two JFR profile pairs: direct single-thread vs direct parallel, and
 wcmp×128 single-thread vs wcmp×128 parallel. Both sides have intra-packet
@@ -194,7 +209,7 @@ copies → no allocation-heavy per-fork work. Each thread does the same
 lookup work independently on the shared (read-only) snapshot.
 Cache-friendly and allocator-friendly.
 
-### wcmp×128 — allocator contention
+### wcmp×128 — allocation-adjacent hot spots
 
 The workload has a 128-way action selector fork, producing 128 branches
 per packet. Each branch must deep-copy the packet state (headers +
@@ -216,27 +231,185 @@ structs) so branches don't interfere with each other.
 combined.** HashMap put operations (`put` + `putVal`) are a close second
 at ~9% combined. Total allocation-related scaling overhead: **~23-25%**.
 
-### The mechanism, concretely
+### What the profile diff pointed at
 
-When many `ForkJoinPool` workers each process a fork-heavy packet at
-once (roughly 25-30 hw threads busy on this machine, judging by the
-81% CPU utilization in the wcmp×128 parallel run), they all call
-`HeaderVal.deepCopy()` and `StructVal.deepCopy()`, which do
-`fields.mapValuesTo(mutableMapOf()) { ... }`. That allocates:
+The hot methods in the parallel-overhead bucket are all
+allocation-adjacent: `HashMap.putVal` is called from
+`HeaderVal.deepCopy()` / `StructVal.deepCopy()`, which each fork branch
+invokes to get an independent copy of packet state.
+`BigInteger.<init>` is called from `BitVector` arithmetic, which fires
+on every bit-field operation. At 128 fork branches per packet × 30-odd
+active workers, the allocator is hit millions of times per second.
 
-1. A new empty HashMap (default capacity 16)
-2. New nodes for each key-value pair inserted
-3. A resize when the map exceeds load factor
+Taken at face value, this looks like **fork-induced allocation
+pressure** — the fix would be "allocate less." But the profile alone
+can't distinguish "`HashMap.putVal` is slow because the allocator is
+contended" from "`HashMap.putVal` is slow because the new node's cache
+line has to be fetched from DRAM." The first would be solved by
+reducing allocation count; the second would be solved by reducing
+working-set size. These are correlated but not identical, and the
+right fix depends on which is actually happening.
 
-With many threads × 128 branches per packet × multiple HeaderVals/StructVals
-per branch, the allocator is hit millions of times per second across all
-threads. TLAB refills become frequent; HashMap resize compounds the
-issue; `BigInteger.<init>` allocates fresh arrays for bit field
-arithmetic on every operation. Each of these is cheap in isolation, but
-in aggregate they dominate the scaling overhead.
+Phase 1.5 answers that question.
 
-This is the bottleneck. It's specifically a **fork-induced
-allocation-pressure** problem, not a general scaling problem.
+## Phase 1.5: empirical deep-dive
+
+The Phase 1 profile told us *where* CPU time was spent
+(`HashMap.putVal`, `BigInteger.<init>`, etc.). It did not tell us
+*why*. Without that, Phase 2 priorities are guesses. Phase 1.5
+measures the six candidate mechanisms directly using JFR event data,
+hardware performance counters, and CPU pinning experiments.
+
+Nine experiments on the same machine and workload (AMD Ryzen 9
+7950X3D, SAI P4 middleblock, wcmp×128, intra-packet parallelism off on
+both sides):
+
+1. **JFR TLAB events** — `ObjectAllocationInNewTLAB` / `OutsideTLAB`
+2. **JFR allocation rate** — bytes per packet, bytes per second
+3. **JFR GC events** — pause share, young-gen sizing
+4. **Scaling curve** — wcmp×128 at 1/2/4/8/16/32 workers
+5. **Heap size sweep** — 2 GB / 4 GB / 8 GB / 16 GB
+6. **CPU pinning** — physical-only, single-CCD, both CCDs
+7. **`perf stat`** — IPC, cache hits, DRAM fills
+8. **`perf c2c`** — false-sharing detection via HITM events
+9. **GC collector swap** — G1 vs ParallelGC vs ZGC vs Shenandoah
+
+### Results summary
+
+| # | Mechanism | Status | Key evidence |
+|---|---|---|---|
+| 1 | TLAB contention | **Refuted** | Per-packet TLAB refills 4.1 → 8.1 (2×), but refill is an atomic bump — not a scaling bottleneck |
+| 2 | **L3 / DRAM stalls** | **CONFIRMED** | **IPC 3.02 → 0.88** (−3.4×), **DRAM fills/packet 73K → 228K** (+3.1×) |
+| 3 | Memory bandwidth | Contributory | Aggregate ~13 GB/s allocation + 3× DRAM traffic per packet; shares root cause with (2). See Phase 1.5 #7. |
+| 4 | GC | **Refuted** | Pause share 1.8% of wall time; 2 GB ↔ 16 GB heap unchanged; best GC swap (ParallelGC) +1.9% |
+| 5 | False sharing | **Refuted** | 850 HITM events / 874K samples = 0.1%; top contended line 11 HITMs |
+| 6 | SMT interference | **Refuted** | Physical-only pinning 1436 vs 1460 baseline, within noise |
+
+### The smoking gun: `perf stat`
+
+Single-threaded wcmp×128 vs parallel wcmp×128, both intra-packet off:
+
+| Metric | Sequential | Parallel | Δ |
+|---|---|---|---|
+| Total instructions | 886 B | 870 B | ~identical |
+| **IPC** | **3.02** | **0.88** | **−3.4×** |
+| Loads (dispatched) | 245 B | 238 B | ~same |
+| L2 fills (L2→L1) | 15.4 B | 13.0 B | ~same |
+| L3 (local CCX) fills | 2.10 B | 2.34 B | ~same |
+| **DRAM fills (all)** | **0.74 B** | **2.28 B** | **+3.1×** |
+| **DRAM fills / packet** | 73K | 228K | **+3.1×** |
+| Cross-CCD fills | 0 | 0 | — |
+
+Read the top row carefully: **the algorithm executes the same number
+of total instructions** (886 B vs 870 B for the same 10,000 packets).
+Parallel isn't doing more work; it's doing the same work much slower
+per cycle. IPC collapses from 3.02 (near-ideal for Zen 4) to 0.88 —
+the hallmark of a memory-stall-bound workload.
+
+L1 and L2 hit rates are essentially unchanged between modes. What
+*does* change is the small tail of loads that miss all caches: **3×
+more per packet** reach DRAM. Each DRAM miss is roughly 200 cycles of
+stall. `(228K − 73K) × 200 cycles ≈ 31M cycles ≈ 9 ms` of extra
+per-core stall per packet. The parallel per-packet core-time is ~16 ms
+vs sequential ~5 ms; the 9 ms DRAM-stall budget accounts for most of
+the 11 ms gap.
+
+### The scaling curve
+
+Running wcmp×128 at varying `ForkJoinPool.common.parallelism`:
+
+| Workers | pps | Speedup vs 1 | Efficiency |
+|---|---|---|---|
+| 1 | 229 | 1.00× | 100% |
+| 2 | 446 | 1.95× | 97% |
+| **4** | **858** | **3.75×** | **94%** |
+| **8** | **1235** | **5.39×** | **67%** |
+| 16 | 1443 | 6.30× | 39% |
+| 32 (SMT) | 1538 | 6.72× | 21% |
+
+The curve has a **clear knee between 4 and 8 workers** (94% → 67% in
+one doubling). That's a hard resource ceiling, not a graceful
+falloff. Doubling from 16 to 32 threads recovers only 95 pps — SMT
+provides almost no benefit on this workload, which is exactly what
+you'd expect when siblings are both waiting on DRAM instead of
+competing for execution units.
+
+### CCD topology
+
+The 7950X3D has two CCDs: 8 cores each, each with its own 32 MB L3,
+one with an additional 64 MB 3D V-cache stack (96 MB total on that
+CCD). Pinning experiments:
+
+| Config | Cores | Workers | pps |
+|---|---|---|---|
+| CCD0 only (CPUs 0–7) | 8 | 8 | 1227 |
+| CCD1 only (CPUs 8–15) | 8 | 8 | 1206 |
+| Both CCDs, physical only | 16 | 16 | 1436 |
+
+Three observations:
+
+1. **Saturation within a single CCD.** 8 workers on one CCD ≈ 8
+   workers unpinned (1227 ≈ 1235 from the scaling curve). The
+   bottleneck fills up at 8 threads on a single CCD — within one L3
+   domain, we hit the ceiling long before we run out of cores.
+
+2. **3D V-cache doesn't help this workload.** CCD0 and CCD1 perform
+   identically (1227 vs 1206). If V-cache were buying us anything,
+   the V-cache CCD should be noticeably faster. Either the working
+   set already exceeds 96 MB, or the allocation churn pattern doesn't
+   benefit from the extra capacity. Either way: not a factor.
+
+3. **The two CCDs don't scale additively.** CCD0 alone 1227 +
+   CCD1 alone 1206 "should" sum to ~2400. Running both together: 1436.
+   The second CCD contributes only 17% of its standalone capacity once
+   the first is active. The only resource the CCDs share is the
+   memory controller / DRAM bandwidth — which is exactly what a
+   DRAM-bound diagnosis predicts.
+
+Also: `ls_any_fills_from_sys.far_cache` is **zero** in both modes. No
+cross-CCD coherency traffic. The OS scheduler keeps threads on their
+home CCD. Inter-CCD contention is not the story.
+
+### Reframed diagnosis
+
+The Phase 1 profile showed +9% HashMap and +9% BigInteger in the
+parallel-overhead diff, and the initial read was "allocator CPU cost."
+Phase 1.5 shows that framing was misleading.
+
+The extra cycles are real, and they *do* happen inside `HashMap.putVal`
+and `BigInteger.<init>`. But they're not allocator fast-path cycles —
+they're memory-stall cycles. Each `putVal` that shows up at +7% on the
+CPU profile is spending hundreds of cycles waiting for its new node's
+cache line to arrive from DRAM, because the L3 has been evicted by
+other threads doing the same thing.
+
+**The root cause is L3 capacity exhaustion under concurrent allocation
+churn.** Each wcmp×128 packet allocates on the order of 12 MB of
+ephemeral state (128 fork branches × deep-copied `HeaderVal` and
+`StructVal` maps, plus `BigInteger` intermediates from every bit-field
+operation). Single-threaded, that working set fits comfortably in L2/L3.
+With 8+ threads each doing the same, combined working sets exceed L3
+capacity — even on the V-cache CCD's 96 MB — and what used to be L3
+hits become DRAM round-trips.
+
+**Implication for Phase 2.** The right metric to minimize is
+**per-thread working-set size**, not allocation count. These correlate
+but they aren't the same:
+
+- `HashMap` preallocation eliminates resize churn (fewer allocations)
+  but leaves the final map size unchanged → small working-set effect.
+- Copy-on-write `HeaderVal` / `StructVal` leaves allocation count
+  roughly the same but **shares** the underlying map across fork
+  branches → potentially order-of-magnitude working-set reduction on
+  fork-heavy workloads.
+- A `Long` fast path replaces `BigInteger` (~40 bytes of header + payload)
+  with a primitive `long` (8 bytes, often register-resident after escape
+  analysis) → shrinks every bit-field value by ~5×.
+
+The highest-leverage changes are the ones that reduce how many bytes
+each thread *touches* per packet. Allocation-count optimizations are
+the secondary axis, valuable only to the degree that they translate
+into footprint reduction.
 
 ## Phase 2: optimize (proposed)
 
@@ -252,39 +425,54 @@ bottleneck after all). One optimization at a time. Measure → fix the
 smallest thing → re-measure → decide what's next. Don't pre-commit to a
 multi-step plan beyond the next step.
 
-**Scope.** Phase 1 showed the scaling gap is **specific to fork-heavy
-workloads**. Direct L3 is already at 94% efficiency with no meaningful
-work left to do. So "optimize" here means "close the wcmp×128 gap" —
-bring 45% efficiency closer to linear.
+**Scope.** Direct L3 is already at 94% efficiency with no meaningful
+work left to do. "Optimize" here means closing the wcmp×128 gap —
+bringing 45% efficiency closer to linear.
 
-The gap comes from per-fork allocation pressure. At realistic fork
-counts (128+) the two biggest buckets are roughly equal:
+**What to optimize for.** Phase 1.5 reframed the target. Minimize
+**per-thread working-set size**, not allocation count. Every candidate
+should be evaluated on "does it reduce the bytes each thread touches
+per packet" — that's what directly reduces L3 footprint and therefore
+DRAM miss rate. Allocation count reductions help only to the degree
+they shrink the hot working set.
 
-- **~9% BigInteger allocation** from per-fork bit field arithmetic
-- **~9% HashMap operations** from per-fork header/struct deep copies
-- **~5% TraceEvent builders + BitVector init** — harder to avoid
+Candidate optimizations, reordered by expected impact on working-set
+size:
 
-Candidate optimizations, in order of complexity:
-
-1. **HashMap preallocation in deepCopy.** Eliminates resize churn.
-   Two-line change. Expected impact: ~2% (measured — real but small).
+1. **Copy-on-write `HeaderVal` / `StructVal`.** Share the underlying
+   map between fork branches; copy only on first write. Each fork
+   branch typically touches a small subset of fields, so most of the
+   deep-copy work produces bytes that are allocated, filled, and
+   evicted without ever being read. COW is the only optimization on
+   this list that *directly* shrinks per-thread working set — on
+   fork-heavy workloads, potentially by an order of magnitude.
+   Structural change (mutation model goes from in-place to persistent)
+   but the public interface stays the same. **Expected impact: this is
+   where the ceiling lives.** Actual gain depends on what fraction of
+   deep-copied fields are never read by the branch; measurement will
+   tell.
 
 2. **`Long` fast path for narrow bit fields.** Use `Long` instead of
-   `BigInteger` for `bit<N>` ≤ 63. Partially exists in
-   `matchesFieldMatch`; extend to `BitVector` arithmetic. Expected
-   impact: most of the ~9% BigInteger bucket.
+   `BigInteger` for `bit<N>` with N ≤ 63. A partial fast path exists
+   in `matchesFieldMatch`; extend it to `BitVector` arithmetic.
+   Doesn't change map structure, but shrinks each bit-field value from
+   ~40 bytes of `BigInteger` object + int[] payload to 8 bytes of
+   primitive `long` (often register-resident after escape analysis).
+   Bit-fields are densely packed in header maps, so this compounds
+   the working-set win from (1).
 
-3. **Copy-on-write for HeaderVal/StructVal.** Share the underlying map
-   between fork branches; copy only on write. Most branches touch a
-   small subset of fields, so most of the deep-copy work is wasted.
-   Structural change — mutation model goes from in-place to persistent.
-   Expected impact: most of the ~9% HashMap bucket.
+3. **`HashMap` preallocation in `deepCopy`.** Two-line change;
+   eliminates resize churn. Measured in isolation at ~2%. Small win,
+   no simplicity cost — same final maps, just fewer intermediate
+   allocations along the way. Worth doing for cheap, but don't expect
+   it to move the scaling needle.
 
-**The honest realization:** fixing any one of these only closes a
-fraction of the gap. Getting to truly linear scaling would require
-fixing *all* of them — a broader refactor than any single PR. A single
-win of ~9% takes efficiency from 45% to maybe 55% — meaningful but
-still well below linear.
+**The honest realization.** None of these alone guarantees linear
+scaling. Working-set reduction from (1) has the highest ceiling by
+far, but its actual size depends on how much of the deep-copy work is
+wasted in the average fork branch — an open empirical question.
+Getting to truly linear would likely require (1) to deliver big *and*
+stacking (2) on top.
 
 **Before committing to anything:** the simplicity budget matters. The
 lock-free dataplane PR was a clear simplification AND had measurable
@@ -337,6 +525,17 @@ DVaaS workload that's blocked by the current throughput.
   compute, it's dispatch (gRPC, coroutines, or `ForkJoinPool` task
   submission serial fraction). Not worth chasing — direct is already at
   94% efficiency despite leaving cores idle.
-- **How much does copy-on-write help in practice?** The ~9% HashMap
-  overhead is the ceiling; actual gain depends on how much of that is
-  allocation volume vs allocator contention. Measurement will tell.
+- **How much does copy-on-write help in practice?** The ceiling is set
+  by what fraction of deep-copied fields are *never read* in the
+  average fork branch. For wcmp×128 we don't know this fraction yet; it
+  could be small (5-10%) if most branches read most of the header, or
+  large (≥90%) if branches mostly touch the fields affected by the
+  selected action. The first prototype should measure this before
+  committing to the full refactor.
+- **Why doesn't the 7950X3D's V-cache help?** Both CCDs measured
+  identically despite one having 3× the L3 capacity. Possibilities: the
+  working set genuinely exceeds 96 MB; V-cache allocation policy
+  disfavors short-lived allocation churn; or the test process was
+  scheduled onto the non-V-cache CCD. Not worth chasing for the scaling
+  question (the answer is still "reduce working-set size") but would be
+  nice to understand.


### PR DESCRIPTION
## Summary

Nine experiments turned the Phase 1 scaling diagnosis on its head. We thought the wcmp×128 gap was fork-induced *allocator* pressure. It's fork-induced *L3* pressure.

The headline numbers from \`perf stat\` on the same workload, single-threaded vs parallel (both with intra-packet parallelism disabled):

|  | Sequential | Parallel | Δ |
|---|---|---|---|
| Total instructions | 886 B | 870 B | ~identical |
| **IPC** | **3.02** | **0.88** | **−3.4×** |
| L1/L2 hit rate | ~94% | ~94% | unchanged |
| **DRAM fills / packet** | **73K** | **228K** | **+3.1×** |

Same work. Same cache hit rates. But 3× more loads miss all caches and reach DRAM per packet — and each of those is ~200 cycles of stall. The \`HashMap.putVal\` and \`BigInteger.<init>\` hot spots from the Phase 1 profile aren't allocator-CPU-bound; they're *waiting for new cache lines to arrive from DRAM* because the L3 has been evicted by other threads doing the same thing.

## What changed in the doc

- Each of the six theoretical mechanisms in \`## Why embarrassingly parallel isn't linear in practice\` now carries a Phase 1.5 verdict in brackets. Five refuted, one confirmed, one contributory.
- New \`## Phase 1.5: empirical deep-dive\` section walks through all nine experiments, the scaling curve (clear knee at 4–8 workers), the CCD pinning experiments (both CCDs saturate identically — the 3D V-cache doesn't help), and the reframed diagnosis.
- \`## Phase 2: optimize (proposed)\` reordered around **per-thread working-set size**, not allocation count:
  1. **Copy-on-write \`HeaderVal\` / \`StructVal\`** (was #3) — now the headline because it directly shrinks working set.
  2. **\`Long\` fast path for narrow bit fields** (was #2) — still valuable; shrinks each BitVector from ~40 bytes to 8.
  3. **\`HashMap\` preallocation** (was #1) — demoted to "nice cheap win, won't move the scaling needle."
- \`## Open questions\` updated: the "does COW help?" question is now framed as "what fraction of deep-copied fields are never read?" — measurable before committing to the refactor. Added a question about why V-cache doesn't help.

## Experiments in brief

1. **JFR TLAB events** → per-packet TLAB refills double (4.1 → 8.1), but refills are cheap atomic bumps. Not a scaling bottleneck.
2. **JFR allocation rate** → per-packet bytes allocated are ~the same. Parallel isn't doing extra work.
3. **JFR GC events** → pause share 0.34% → 1.82%. GC is not the bottleneck.
4. **Scaling curve (1/2/4/8/16/32 workers)** → 94% efficient at 4 workers, 67% at 8, 39% at 16, 21% at 32. Hard ceiling, not graceful falloff.
5. **Heap sweep (2→16 GB)** → throughput essentially flat. Confirms GC is not the bottleneck.
6. **CPU pinning** → single-CCD saturates at 8 workers (1227 pps). Both CCDs together only add 17% of the second CCD's standalone capacity. Shared memory controller is the story.
7. **\`perf stat\`** → the smoking gun. IPC collapses, DRAM fills triple per packet, L1/L2/L3 hit rates unchanged.
8. **\`perf c2c\`** → 850 HITM events / 874K samples = 0.1%. Zero false sharing.
9. **GC collector swap** → G1 1520, ParallelGC 1549 (+1.9%), ZGC 707 (−54%), Shenandoah 1238 (−19%). Collector swap ceiling is under 2%.

## Test plan

- [ ] Design review — does the reframed diagnosis hold up? Specifically: is the jump from "profile shows HashMap" to "DRAM stalls inside HashMap" argued clearly enough?
- [ ] Is the simplicity budget reasoning in Phase 2 still intact? (It should be — nothing here authorizes code changes yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)