### PR TITLE
Declare Apache-2.0 license on every package via rules_license

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,10 +1,16 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 load("@rules_license//rules:license.bzl", "license")
 
+package(
+    default_applicable_licenses = [":license"],
+    licenses = ["notice"],
+)
+
 exports_files(["LICENSE"])
 
 license(
     name = "license",
+    package_name = "fourward",
     license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
     license_text = "LICENSE",
 )

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,1 +1,6 @@
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
 # Build rules and patches for third-party dependencies.

--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm_test")
 
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
 exports_files(
     ["run_cram.py"],
     visibility = ["//:__subpackages__"],

--- a/e2e_tests/BUILD.bazel
+++ b/e2e_tests/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 bzl_library(
     name = "corpus_bzl",

--- a/e2e_tests/assert_log_msg/BUILD.bazel
+++ b/e2e_tests/assert_log_msg/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "assert_log_msg",

--- a/e2e_tests/basic_table/BUILD.bazel
+++ b/e2e_tests/basic_table/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "basic_table",

--- a/e2e_tests/bmv2_diff/BUILD.bazel
+++ b/e2e_tests/bmv2_diff/BUILD.bazel
@@ -2,7 +2,11 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:bmv2_diff.bzl", "bmv2_diff_test_suite")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 cc_binary(
     name = "bmv2_driver",

--- a/e2e_tests/constrained_table/BUILD.bazel
+++ b/e2e_tests/constrained_table/BUILD.bazel
@@ -1,4 +1,8 @@
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 genrule(
     name = "constrained_table_pb",

--- a/e2e_tests/corpus/BUILD.bazel
+++ b/e2e_tests/corpus/BUILD.bazel
@@ -1,7 +1,11 @@
 load("//e2e_tests:compile_test.bzl", "compile_test_suite")
 load("//e2e_tests:corpus.bzl", "corpus_test_suite")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 # p4c corpus STF tests run in CI. All entries must pass.
 #

--- a/e2e_tests/golden_errors/BUILD.bazel
+++ b/e2e_tests/golden_errors/BUILD.bazel
@@ -1,6 +1,10 @@
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "stateful",

--- a/e2e_tests/lpm_routing/BUILD.bazel
+++ b/e2e_tests/lpm_routing/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "lpm_routing",

--- a/e2e_tests/multi_table/BUILD.bazel
+++ b/e2e_tests/multi_table/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "multi_table",

--- a/e2e_tests/network/BUILD.bazel
+++ b/e2e_tests/network/BUILD.bazel
@@ -1,6 +1,10 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 exports_files(
     [

--- a/e2e_tests/p4testgen/BUILD.bazel
+++ b/e2e_tests/p4testgen/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("//e2e_tests:p4testgen.bzl", "p4_testgen_suite", "p4_testgen_test")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 kt_jvm_library(
     name = "p4testgen_test_class",

--- a/e2e_tests/passthrough/BUILD.bazel
+++ b/e2e_tests/passthrough/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "passthrough",

--- a/e2e_tests/sai_p4/BUILD.bazel
+++ b/e2e_tests/sai_p4/BUILD.bazel
@@ -1,4 +1,8 @@
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 # SAI P4 (middleblock instantiation) — vendored from sonic-net/sonic-pins.
 # Used for E2E testing of the P4Runtime server with @p4runtime_translation.

--- a/e2e_tests/switch_action_run/BUILD.bazel
+++ b/e2e_tests/switch_action_run/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "switch_action_run",

--- a/e2e_tests/ternary_acl/BUILD.bazel
+++ b/e2e_tests/ternary_acl/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "ternary_acl",

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 # P4/STF files used by bmv2_diff tests (cross-package reference).
 exports_files([

--- a/e2e_tests/translated_port/BUILD.bazel
+++ b/e2e_tests/translated_port/BUILD.bazel
@@ -1,6 +1,10 @@
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "translated_port",

--- a/e2e_tests/translated_type/BUILD.bazel
+++ b/e2e_tests/translated_type/BUILD.bazel
@@ -1,6 +1,10 @@
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 p4c_compile(
     name = "translated_type",

--- a/e2e_tests/wide_port/BUILD.bazel
+++ b/e2e_tests/wide_port/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//e2e_tests:p4c.bzl", "p4c_compile")
 
-package(default_testonly = True)
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
 
 # Derive a v1model.p4 with 16-bit port fields from the upstream file.
 # This guarantees our test always tracks upstream with exactly one change.

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2,6 +2,11 @@
 
 load("//cli:cram.bzl", "cram_test")
 
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
 exports_files(
     [
         "passthrough.p4",

--- a/p4c_backend/BUILD.bazel
+++ b/p4c_backend/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
 cc_library(
     name = "p4c_backend_lib",
     srcs = [

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -8,6 +8,11 @@ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm_test")
 
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
 # =============================================================================
 # Dataplane gRPC service (packet injection + result observation)
 # =============================================================================

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -3,6 +3,11 @@ load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
 # =============================================================================
 # Proto
 # =============================================================================

--- a/stf/BUILD.bazel
+++ b/stf/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
 # STF (Simple Test Framework) parser and runner. STF is a test-input format
 # originating with BMv2's simple_switch; 4ward supports it as a first-class
 # format for driving the simulator from both the `4ward sim` CLI and from

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm_test")
 
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
 kt_jvm_library(
     name = "web_lib",
     srcs = glob(


### PR DESCRIPTION
## Summary

Adopt the `rules_license` boilerplate across the whole tree so license
metadata is discoverable to SBOM and compliance tooling — and so we're
ready when a future third-party dep asks us to aggregate license info.

- Set `package_name = \"fourward\"` on the root `license()` target.
- Add `package(default_applicable_licenses = [\"//:license\"], licenses = [\"notice\"])` to every `BUILD.bazel`.
- Merge the new attrs into the existing `package(default_testonly = True)` calls under `e2e_tests/` rather than duplicating.

No rule logic changes, no behavior changes.

## Test plan

- [x] `./tools/format.sh` — no diff
- [x] `./tools/lint.sh` — clean
- [x] `bazel build //...` — green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)