### PR TITLE
Silence remaining buildifier --lint=warn findings

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,3 +1,9 @@
+"""Repo-wide Bazel settings for 4ward.
+
+Applies the Apache-2.0 license in //:license as default package metadata
+for every target and lists directories Bazel should ignore when globbing.
+"""
+
 repo(default_package_metadata = ["//:license"])
 
 ignore_directories([

--- a/e2e_tests/p4testgen.bzl
+++ b/e2e_tests/p4testgen.bzl
@@ -137,6 +137,9 @@ def p4_testgen_test(name, src_p4 = None, includes = [], max_tests = 0, seed = 0,
         seed: random seed for p4testgen's path exploration (default: 0).
               Different seeds explore different execution paths.
         tags: Bazel tags forwarded to the test.
+        defines: P4 preprocessor macros (-D flags) passed to p4c and p4testgen.
+        target: p4testgen --target (e.g. "bmv2").
+        arch: p4testgen --arch (e.g. "v1model").
     """
     if src_p4 == None:
         src_p4 = "@p4c//testdata/p4_16_samples:" + name + ".p4"
@@ -167,6 +170,8 @@ def p4_testgen_suite(name, tests, includes = {}, max_tests = {}, tags = [], targ
         includes:  dict mapping program names to lists of extra P4 include labels.
         max_tests: dict mapping program names to max-test limits.
         tags:      Bazel tags forwarded to the kt_jvm_test.
+        target:    p4testgen --target applied to every program in the suite.
+        arch:      p4testgen --arch applied to every program in the suite.
     """
     if not tests:
         return


### PR DESCRIPTION
## Summary

Clears the three warnings buildifier's strict lint mode reports that
`--lint=fix` can't auto-resolve:

- `REPO.bazel` — add a module docstring.
- `e2e_tests/p4testgen.bzl` — document `target`, `arch`, and `defines`
  params on `p4_testgen_test` and `p4_testgen_suite`.

Pure docs — no rule behavior change. Leaves us with a clean
`--lint=warn` baseline so future violations stand out.

## Test plan

- [x] \`bazel run @buildifier_prebuilt//:buildifier --lint=warn\` — clean
- [x] \`./tools/format.sh\` — no diff after
- [x] \`bazel build //...\` — green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)