### PR TITLE
Bump direct deps to match resolved versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,13 +7,13 @@ module(
 # --- Core build rules ---
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_kotlin", version = "2.3.0")
 bazel_dep(name = "rules_java", version = "9.3.0")
-bazel_dep(name = "rules_python", version = "1.4.1")
+bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "rules_jvm_external", version = "6.10")
 
 # --- Protobuf & gRPC ---


### PR DESCRIPTION
## Summary

Silences two \`WARNING: root module requires X, but got Y\` lines that
bazel printed on every invocation. Transitive deps already pulled the
higher versions, so the pins were stale noise:

- \`platforms\` 0.0.11 → 1.0.0
- \`rules_python\` 1.4.1 → 1.7.0

No other rule logic changes. The lockfile isn't tracked (gitignored).

## Test plan

- [x] \`bazel build //...\` — green
- [x] \`bazel mod graph\` — no mismatch warnings
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)