### PR TITLE
Drop dead kt_jvm_library p4testgen_test_class

### DIFF
--- a/e2e_tests/p4testgen/BUILD.bazel
+++ b/e2e_tests/p4testgen/BUILD.bazel
@@ -1,20 +1,9 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("//e2e_tests:p4testgen.bzl", "p4_testgen_suite", "p4_testgen_test")
 
 package(
     default_applicable_licenses = ["//:license"],
     default_testonly = True,
     licenses = ["notice"],
-)
-
-kt_jvm_library(
-    name = "p4testgen_test_class",
-    srcs = ["P4TestgenSuiteTest.kt"],
-    visibility = ["//e2e_tests:__subpackages__"],
-    deps = [
-        "//stf",
-        "@fourward_maven//:junit_junit",
-    ],
 )
 
 # p4testgen-generated STF tests. Each entry runs p4testgen (symbolic execution

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -34,6 +34,8 @@ java_proto_library(
     deps = [":dataplane_proto"],
 )
 
+# Public API for external C++ consumers of the dataplane service — kept
+# despite having no in-repo reverse deps.
 cc_proto_library(
     name = "dataplane_cc_proto",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## Summary

A \`bazel query\` for libraries with zero reverse deps flagged
\`//e2e_tests/p4testgen:p4testgen_test_class\` — a kt_jvm_library
wrapping \`P4TestgenSuiteTest.kt\`. Unused since the \`p4testgen.bzl\`
macro compiles the same source inline in each generated
\`kt_jvm_test\`, so the library wrapper was never consumed.

The same query also surfaced \`//p4runtime:dataplane_cc_grpc\` (and
its \`dataplane_cc_proto\` dep). Those look internally dead but are
part of 4ward's **public API** for external consumers embedding the
dataplane service in a C++ application. This PR leaves a comment on
the block so a future sweep doesn't trip on the same footgun.

## Test plan

- [x] \`bazel build //...\` — green
- [x] \`bazel test //... --test_tag_filters=-heavy\` — 63/63 pass
- [x] \`./tools/format.sh\` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)