### PR TITLE
Fix TSan data race in Interpreter.Cache.get

### DIFF
--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -1,5 +1,6 @@
 package fourward.simulator
 
+import kotlin.jvm.Synchronized
 import fourward.ir.BehavioralConfig
 import fourward.ir.BinaryOperator
 import fourward.ir.ControlDecl
@@ -1327,6 +1328,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     private var cached: Interpreter? = null
     private var cachedConfig: BehavioralConfig? = null
 
+    @Synchronized
     fun get(config: BehavioralConfig): Interpreter {
       if (config === cachedConfig) return cached!!
       return Interpreter(config).also {


### PR DESCRIPTION
Identified a data race in Interpreter.Cache.get using ThreadSanitizer. Added @Synchronized to ensure thread-safe access to the cached interpreter instance. This was discovered during concurrent packet processing in the simulator.