### PR TITLE
Prune four unused @fourward_maven artifacts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -97,7 +97,6 @@ maven.install(
     artifacts = [
         "com.google.protobuf:protobuf-java:4.29.3",
         "com.google.protobuf:protobuf-java-util:4.29.3",
-        "com.google.protobuf:protobuf-kotlin:4.29.3",
         "junit:junit:4.13.2",
         "com.facebook:ktfmt:0.61",
         "io.gitlab.arturbosch.detekt:detekt-cli:1.23.8",
@@ -108,12 +107,9 @@ maven.install(
         "io.grpc:grpc-inprocess:1.78.0",
         "io.grpc:grpc-kotlin-stub:1.4.3",
         "io.grpc:grpc-netty:1.78.0",
-        "io.grpc:grpc-netty-shaded:1.78.0",
-        "io.grpc:grpc-services:1.78.0",
         "io.grpc:grpc-stub:1.78.0",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
-        "javax.annotation:javax.annotation-api:1.3.2",
     ],
     repositories = [
         "https://repo1.maven.org/maven2",


### PR DESCRIPTION
## Summary

Audit of \`maven.install(name = "fourward_maven")\` — checked each
artifact for (a) BUILD file references and (b) source-file imports,
then validated removal against the test suite and the bcr_test_module
consumer build. Four turned out to be truly unused:

- \`com.google.protobuf:protobuf-kotlin\` — Kotlin proto DSL; no
  \`kt_proto_library\` or generated Kotlin-builder DSL in use.
- \`io.grpc:grpc-netty-shaded\` — redundant with \`grpc-netty\` which
  is actually imported from p4runtime code.
- \`io.grpc:grpc-services\` — health/reflection services; never
  registered on any server.
- \`javax.annotation:javax.annotation-api\` — \`@Generated\` annotations
  in grpc-java codegen. Our codegen doesn't reference it (modern
  grpc-java uses \`javax.annotation.processing.Generated\` from the JDK).

Kept \`grpc-stub\`, \`grpc-kotlin-stub\`, and the rest — those are
runtime-required by generated stubs even though no BUILD file
references them by label.

## Test plan

- [x] \`bazel build //...\` — green
- [x] \`bazel test //... --test_tag_filters=-heavy\` — 63/63 pass
- [x] \`bazel clean\` + binary rebuild (p4runtime_server_jar, playground,
  cli) — green (exercises grpc codegen paths)
- [x] bcr_test_module consumer build — green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)