### PR TITLE
Narrow p4c fork to a single patch on upstream main

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,14 +55,15 @@ bazel_dep(name = "googleapis-java", version = "1.0.0")
 # BCR consumers get p4c 1.2.5.11.bcr.1 (which has //p4include, testdata
 # exports, and the macOS build fix). Our own dev builds additionally pin
 # to the smolkaj/p4c fork via git_override — only honored when fourward
-# is the root module — because the fork carries the PNA p4testgen STF
-# backend (p4lang/p4c#5570) and drop-by-default fix (p4lang/p4c#5569)
-# that our e2e_tests/p4testgen PNA suite needs. Drop the git_override
-# once both are merged and released to BCR.
+# is the root module — because our e2e_tests/p4testgen PNA suite needs
+# the drop-by-default fix (p4lang/p4c#5569) that is still open upstream.
+# The fork is upstream main plus that single patch; PR #5570 (PNA STF
+# backend) is already in upstream main. Drop the git_override once
+# #5569 lands and ships in a released p4c.
 bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
 git_override(
     module_name = "p4c",
-    commit = "c7e38ae7a338973098ab73d08f631c98c470b71c",
+    commit = "93932df3cc9fe7de596ad257f6eee7bcddc0fd58",
     remote = "https://github.com/smolkaj/p4c.git",
 )
 

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -13,23 +13,13 @@ Blocked on buf support for proto edition 2024.
 
 ## Drop p4c fork
 
-The `smolkaj/p4c` fork adds the PNA STF backend for p4testgen and a
-PNA drop-by-default fix. Upstream status:
-- https://github.com/p4lang/p4c/pull/5570 (PNA STF backend) — **merged
-  2026-04-06**, not yet in a released p4c (v1.2.5.12 was tagged
-  2026-04-04, just before).
-- https://github.com/p4lang/p4c/issues/5569 (drop-by-default) — still
-  open.
-
-The `//p4include` and macOS fixes (p4lang/p4c#5533) already landed and
-are available in BCR as p4c 1.2.5.11.bcr.1. Once #5569 lands upstream
-and both fixes ship in a released p4c, drop the `git_override` in
-`MODULE.bazel`.
-
-**Interim narrowing opportunity**: the fork currently carries a
-redundant bazel/p4include/macOS patch (`2a38af8`) that duplicates the
-already-landed #5533 fix. Rebasing the fork onto a commit containing
-#5533 would shrink it from 3 patches to 2 (the two PNA fixes only).
+The `smolkaj/p4c` fork now carries a single patch on top of upstream
+`main`: the PNA drop-by-default fix (p4lang/p4c#5569, still open).
+The other two patches it used to carry — the bazel/p4include/macOS
+fixes (p4lang/p4c#5533) and the PNA STF backend (p4lang/p4c#5570) —
+are in upstream `main`. BCR consumers already get #5533 via p4c
+1.2.5.11.bcr.1. Drop the `git_override` in `MODULE.bazel` once #5569
+lands and both PNA fixes ship in a released p4c.
 
 ---
 
@@ -39,9 +29,9 @@ Three deps use `git_override` with pinned commits. `behavioral_model` and
 `bazel_clang_tidy` are dev-only (`dev_dependency = True`) and invisible to
 BCR consumers.
 
-- **p4c** (`smolkaj/p4c` fork, `c7e38ae`): carries three patches — the
-  two PNA fixes (p4lang/p4c#5570, #5569) plus a now-redundant bazel/
-  p4include/macOS patch. See "Drop p4c fork" above.
+- **p4c** (`smolkaj/p4c` fork, `93932df`): upstream main plus a single
+  cherry-picked patch, the PNA drop-by-default fix (p4lang/p4c#5569).
+  See "Drop p4c fork" above.
 - **bazel_clang_tidy** (`9e54bbb`): pinned before a commit (`c4d35e0`) that
   broke `-isystem` include ordering. Upstream bug never fixed — permanent
   workaround. Re-check if upstream ever resolves the issue.

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -14,13 +14,22 @@ Blocked on buf support for proto edition 2024.
 ## Drop p4c fork
 
 The `smolkaj/p4c` fork adds the PNA STF backend for p4testgen and a
-PNA drop-by-default fix. Upstream PRs:
-- https://github.com/p4lang/p4c/pull/5570 (PNA STF backend)
-- https://github.com/p4lang/p4c/issues/5569 (drop-by-default)
+PNA drop-by-default fix. Upstream status:
+- https://github.com/p4lang/p4c/pull/5570 (PNA STF backend) — **merged
+  2026-04-06**, not yet in a released p4c (v1.2.5.12 was tagged
+  2026-04-04, just before).
+- https://github.com/p4lang/p4c/issues/5569 (drop-by-default) — still
+  open.
 
 The `//p4include` and macOS fixes (p4lang/p4c#5533) already landed and
-are available in BCR as p4c 1.2.5.11.bcr.1. Once the remaining changes
-are merged and released, drop the `git_override` in `MODULE.bazel`.
+are available in BCR as p4c 1.2.5.11.bcr.1. Once #5569 lands upstream
+and both fixes ship in a released p4c, drop the `git_override` in
+`MODULE.bazel`.
+
+**Interim narrowing opportunity**: the fork currently carries a
+redundant bazel/p4include/macOS patch (`2a38af8`) that duplicates the
+already-landed #5533 fix. Rebasing the fork onto a commit containing
+#5533 would shrink it from 3 patches to 2 (the two PNA fixes only).
 
 ---
 
@@ -30,8 +39,9 @@ Three deps use `git_override` with pinned commits. `behavioral_model` and
 `bazel_clang_tidy` are dev-only (`dev_dependency = True`) and invisible to
 BCR consumers.
 
-- **p4c** (`smolkaj/p4c` fork, `2a38af8`): adds `//p4include` package,
-  testdata exports, macOS build fix. See "Drop p4c fork" above.
+- **p4c** (`smolkaj/p4c` fork, `c7e38ae`): carries three patches — the
+  two PNA fixes (p4lang/p4c#5570, #5569) plus a now-redundant bazel/
+  p4include/macOS patch. See "Drop p4c fork" above.
 - **bazel_clang_tidy** (`9e54bbb`): pinned before a commit (`c4d35e0`) that
   broke `-isystem` include ordering. Upstream bug never fixed — permanent
   workaround. Re-check if upstream ever resolves the issue.

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -25,13 +25,16 @@ lands and both PNA fixes ship in a released p4c.
 
 ## Pinned dependencies inventory
 
-Three deps use `git_override` with pinned commits. `behavioral_model` and
+Four deps use `git_override` with pinned commits. `behavioral_model` and
 `bazel_clang_tidy` are dev-only (`dev_dependency = True`) and invisible to
-BCR consumers.
+BCR consumers; `p4c` and `grpc` affect BCR consumers too.
 
 - **p4c** (`smolkaj/p4c` fork, `93932df`): upstream main plus a single
   cherry-picked patch, the PNA drop-by-default fix (p4lang/p4c#5569).
   See "Drop p4c fork" above.
+- **grpc** (`smolkaj/grpc` fork, `a09a3af`): Bazel 9 compatibility patches
+  (`native.objc_library` and friends) on top of upstream 1.80.0. Drop once
+  grpc publishes a Bazel-9-compatible release to BCR.
 - **bazel_clang_tidy** (`9e54bbb`): pinned before a commit (`c4d35e0`) that
   broke `-isystem` include ordering. Upstream bug never fixed — permanent
   workaround. Re-check if upstream ever resolves the issue.


### PR DESCRIPTION
## Summary

The \`smolkaj/p4c\` fork used to carry three patches. Two of them are now obsolete — time to slim down.

**What moved upstream:**
- p4lang/p4c#5533 (bazel/p4include/macOS fixes): already in BCR as 1.2.5.11.bcr.1.
- p4lang/p4c#5570 (PNA STF backend): merged 2026-04-06, in upstream main.
- p4lang/p4c#5569 (PNA drop-by-default): still open.

**What this PR does:** re-points the \`git_override\` at a rebuilt fork branch (\`smolkaj/p4c:narrow-for-fourward\`) that is upstream main plus one cherry-picked patch — the #5569 fix. Fork shrinks from 3 patches to 1. Dev builds now track upstream main directly, so bumping the pin later is just \"re-cherry-pick on newer main.\"

Also refreshes the \`REFACTORING.md\` \"Drop p4c fork\" entry to match reality. Once #5569 lands and both PNA fixes ship in a released p4c, the \`git_override\` goes away entirely.

## Test plan

- [x] \`bazel build //...\` from cold cache — succeeds (14 min)
- [x] \`bazel test //... --test_tag_filters=-heavy\` — 63/63 pass
- [x] \`bazel test //e2e_tests/p4testgen/...\` (PNA-exercising heavy tests) — 3/3 pass
- [x] \`./tools/format.sh\` / \`./tools/lint.sh\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)