### PR TITLE
Flat packet buffer: design + foundation + consolidated buffers

### DIFF
--- a/designs/flat_packet_buffer.md
+++ b/designs/flat_packet_buffer.md
@@ -1,0 +1,749 @@
+# Flat Packet Buffer Rewrite
+
+**Status: Design + consolidated implementation. The design below
+describes the optimal end state. The branch lands the foundation,
+buffer-backed values, consolidated per-packet buffers, and
+cache-forwarding on fork — delivering **+6.3%** on the fork-heavy
+wcmp×128 parallel workload (see "Measured results and what's left").
+Further closing the gap to the 2-3x target requires attacking the
+per-fork Java-object churn directly.**
+
+## The goal
+
+Replace the heap-of-objects packet-state representation with a flat
+byte-buffer representation that delivers a meaningful performance
+improvement on fork-heavy workloads (target: ~2–3× on `wcmp×128`
+parallel) without adding architectural complexity that bleeds into
+the rest of the codebase.
+
+The diagnosis is in `designs/parallel_packet_scaling.md`: L3 cache
+exhaustion under concurrent fork-heavy work caps useful scaling at
+~8 worker threads. Per-packet state today is ~12 MB; the design
+below brings it to ~256 bytes — fits in L1, removes the L3 ceiling.
+
+## Foundational principle
+
+The P4 IR carries the **complete static schema** of every program at
+pipeline-load time: every header type's fields, every struct's
+members, every action's locals, every field-access expression's
+target. The runtime should derive everything from this schema once
+at load and then, on the hot path, only touch bytes.
+
+Every design decision below is an instance of this principle.
+
+## What "optimal" means here
+
+A design is optimal when:
+- The runtime concepts are few and named after what they are
+  (`PacketBuffer`, `PacketLayout`, `HeaderView`, `Interpreter`).
+- A reader can hold the whole runtime model in their head.
+- Tests, debuggers, and trace consumers see the same types as the
+  interpreter — no separate "user-facing" vs "internal" hierarchy.
+- Performance comes from doing less work, not from clever tricks.
+- Each layer hides bit-fiddling from the layer above. The bit math
+  exists in exactly one place (`PacketBuffer.readBits` /
+  `writeBits`).
+- The codebase is **smaller** after the rewrite, not bigger.
+
+Things that are *not* optimal by this definition, even though they
+would be faster:
+- AOT bytecode generation per pipeline. Adds a generator, two
+  execution paths (interpret vs run-compiled), pipeline reload
+  semantics, debugger story, cached-jar hygiene. Massive blast
+  radius for a multiplier on top of the simple design.
+- Off-heap storage (`MemorySegment`, `Unsafe`). Manual lifecycle,
+  no GC safety net, JNI-adjacent debugging.
+- SIMD across packets via Panama's Vector API. Different code
+  style; the rest of the code can't use it.
+- Profile-guided fast paths and specialised generated variants.
+  Multiple paths to maintain, fragile under workload changes.
+- Specialised table data structures keyed off P4 match kind. The
+  existing tables work fine; this is a separate concern from the
+  storage rewrite.
+
+The simple design below gets us most of the perf without any of
+these.
+
+## The design
+
+Seven properties. They compose; the design is the conjunction.
+
+### 1. One contiguous byte buffer per packet
+
+All headers, all metadata, all action locals, all parser-extracted
+data live in one contiguous `ByteArray`. Sized once per pipeline by
+the layout computer: `packetLayout.totalBytes`. Typical: ~256 bytes.
+Fork is one bulk `Arrays.copyOf` — sequential memory access, fits
+in L1.
+
+```kotlin
+class PacketBuffer(internal val bytes: ByteArray) {
+    fun readBits(offset: Int, width: Int): Long
+    fun writeBits(offset: Int, width: Int, value: Long)
+    fun zeroRange(offset: Int, width: Int)
+    fun copyOf(): PacketBuffer
+}
+```
+
+This already exists on the branch. Stays.
+
+### 2. `PacketLayout`: one per pipeline, places every type at an absolute offset
+
+Computed once at pipeline load by walking the IR. Maps each
+top-level named type (the headers struct, the metadata struct,
+`standard_metadata`, each action's locals scope) to its absolute
+bit offset within the packet buffer. Each header/struct/stack's
+per-type layout is reused unchanged from the existing foundation.
+
+```kotlin
+data class PacketLayout(
+    val typeOffsets: Map<String, Int>,           // "headers" -> 0, "meta" -> 113, ...
+    val headers: Map<String, HeaderLayout>,      // already exists
+    val structs: Map<String, StructLayout>,      // already exists
+    val stacks: Map<String, HeaderStackLayout>,  // see (4)
+    val locals: Map<String, FieldSlot>,          // action local name -> slot
+    val totalBits: Int,
+)
+```
+
+### 3. `HeaderView` / `StructView` are the runtime representation of headers and structs
+
+Not a wrapper around something else — *the* runtime type.
+`HeaderView`/`StructView` extend `Value` directly. The interpreter
+holds them, the trace inspector holds them, tests construct them.
+No `HeaderVal`/`StructVal` data classes alongside; one type, one
+purpose.
+
+```kotlin
+sealed class Value { ... }
+
+class HeaderView(
+    val buffer: PacketBuffer,
+    val layout: HeaderLayout,
+    val base: Int,
+) : Value() {
+    var isValid: Boolean
+    operator fun get(field: String): Value
+    operator fun set(field: String, value: Value)
+}
+
+class StructView(
+    val buffer: PacketBuffer,
+    val layout: StructLayout,
+    val base: Int,
+) : Value() {
+    operator fun get(field: String): Value
+    operator fun set(field: String, value: Value)
+    fun header(field: String): HeaderView
+    fun struct(field: String): StructView
+    fun stack(field: String): HeaderStackView
+}
+```
+
+Construction is O(1) — three references, no allocation of contained
+values. Two views over the same buffer at the same offset behave as
+the same object (P4 reference semantics line up exactly).
+
+### 4. Header stacks: `HeaderStackView` over a flat region of the buffer
+
+A header stack is a fixed-size array of headers plus a `nextIndex`
+counter. In the buffer, it's laid out as:
+
+```
+[nextIndex: ~8 bits | element[0]: layout.totalBits | element[1] | ... | element[size-1]]
+```
+
+A `HeaderStackLayout` captures this:
+
+```kotlin
+data class HeaderStackLayout(
+    val typeName: String,
+    val elementLayout: HeaderLayout,
+    val size: Int,
+    val nextIndexOffset: Int,    // bit offset of the counter within the stack
+    val totalBits: Int,
+)
+```
+
+A `HeaderStackView` exposes the stack:
+
+```kotlin
+class HeaderStackView(
+    val buffer: PacketBuffer,
+    val layout: HeaderStackLayout,
+    val base: Int,
+) : Value() {
+    var nextIndex: Int
+    val size: Int get() = layout.size
+
+    operator fun get(index: Int): HeaderView   // constant-offset for static `index`,
+                                               // multiply-add for dynamic
+    fun pushFront(count: Int)                  // block memcpy within the buffer
+    fun popFront(count: Int)                   // block memcpy within the buffer
+}
+```
+
+`StructMember` (the sealed class for struct members) gains a
+`NestedStack` variant alongside `PrimitiveField`, `NestedHeader`,
+and `NestedStruct`. The layout computer's `computeStruct` dispatches
+to a new `computeStack` branch when it sees `type.hasHeaderStack()`.
+
+Indexed access `stack[i]`:
+- Static `i` (most cases — `stack.next`, `stack[0]`): the layout
+  resolves at pipeline load to a constant offset.
+- Dynamic `i` (rare — runtime-computed index): one multiply-add at
+  access time, then a `HeaderView` over the result.
+
+`HeaderStackVal` (the data class) goes away. `HeaderStackView`
+replaces it everywhere it's used.
+
+### 5. Field access in the interpreter goes via pre-resolved `ResolvedSlot`s
+
+The IR's `FieldAccess` nodes are resolved at pipeline load to
+`(absoluteOffset, width, kind)` and cached on the Interpreter. At
+evaluation time the interpreter never hashes a field name; it reads
+bits at a known offset.
+
+```kotlin
+data class ResolvedSlot(val offset: Int, val width: Int, val kind: PrimitiveKind)
+
+class Interpreter(config: BehavioralConfig) {
+    val packetLayout: PacketLayout = computePacketLayout(config)
+    private val resolved: Map<FieldAccess, ResolvedSlot> = preResolve(config, packetLayout)
+}
+```
+
+The interpreter keeps **one** `evalExpr` method, returning `Value`,
+matching today's API. The performance comes from `Value` itself
+becoming cheap to allocate (see (6)) — not from splitting into
+multiple typed eval methods. A single eval method is clearer and
+preserves the current dispatch model unchanged.
+
+```kotlin
+inner class Execution(val state: PacketState) {
+    fun evalExpr(e: Expr): Value = when {
+        e.hasFieldAccess() -> {
+            val s = resolved[e.fieldAccess]!!
+            readSlotAsValue(s)                  // (6) — one allocation
+        }
+        e.hasBinaryOp() -> applyBinaryOp(e.binaryOp.op, evalExpr(e.binaryOp.left), evalExpr(e.binaryOp.right))
+        // ...
+    }
+
+    fun setLValue(lhs: Expr, value: Value) {
+        val s = resolved[lhs.fieldAccess]!!
+        writeSlotFromValue(s, value)
+        state.trace.emitFieldWrite(s.offset, s.width, valueAsBits(value))
+    }
+}
+```
+
+**Decision point:** kept as single `evalExpr(Expr): Value` rather
+than split `evalNarrow`/`evalWide`/`evalView`. Single entry point
+matches what the existing interpreter does, keeps add-a-new-Expr-kind
+to one site, and is what a reader expects. The cost is one `Value`
+allocation per primitive eval — kept manageable by (6).
+
+### 6. `BitVal` becomes a sealed class with cheap narrow variant
+
+The current `BitVal(BitVector(BigInteger, width))` is three nested
+allocations per primitive read. The optimal-in-our-sense `BitVal`
+splits into narrow and wide, with the narrow path holding only a
+primitive `Long`:
+
+```kotlin
+sealed class BitVal : Value() {
+    abstract val width: Int
+
+    /** ≤ 64-bit primitive bit value. One allocation, no nested boxing. */
+    data class Narrow(val bits: Long, override val width: Int) : BitVal() {
+        init { require(width in 1..64) }
+    }
+
+    /** > 64-bit bit value, falls back to BigInteger via BitVector. */
+    data class Wide(val bitVector: BitVector) : BitVal() {
+        override val width: Int = bitVector.width
+    }
+}
+```
+
+A primitive read of `bit<48>` returns `BitVal.Narrow(bits, 48)` —
+one heap object instead of three. Operations on it use Long
+arithmetic (a few JVM-intrinsic instructions) and dispatch on
+`Narrow` vs `Wide` only when constructing or destructuring; most
+arithmetic stays on the `Narrow` path with no `BitVector`
+involvement.
+
+Same shape applies to `IntVal` (signed). `BoolVal` stays as today.
+
+### 7. Action locals laid out in the same buffer
+
+Action local variables have static, known widths (P4 doesn't have
+unbounded recursion). The layout computer reserves space for them
+at the end of the packet buffer, indexed by action name.
+
+No stack frames, no scope-stack `ArrayDeque<MutableMap<String,
+Value>>`, no per-call allocation. The `Environment` class shrinks
+to "thin shim over `state.buffer` for named-variable access."
+
+### 8. `PacketState` and the fork path
+
+```kotlin
+class PacketState(
+    val buffer: PacketBuffer,
+    val layout: PacketLayout,
+    val trace: TraceBuilder = TraceBuilder(),
+) {
+    fun fork(): PacketState =
+        PacketState(buffer.copyOf(), layout, trace.fork())
+}
+```
+
+Replaces the relevant portions of `Environment`. Fork is one bulk
+memcpy of ~256 bytes — typically a single cache-line fill. The
+trace forks too: parent's deltas-so-far are shared by reference;
+future deltas go to the child's own log.
+
+The trace itself is `(initial bytes, deltas, output bytes)` —
+already designed. `TraceBuilder.emitFieldWrite(offset, width, value)`
+appends to a list. At the end of the packet,
+`TraceBuilder.build()` produces a `PacketTrace` for consumers;
+trace consumers materialise `HeaderView`/`StructView` snapshots on
+demand via lazy projection.
+
+## End-to-end runtime sketch
+
+```kotlin
+class V1ModelArchitecture(...) : Architecture {
+    private val interpreterCache = Interpreter.Cache()
+
+    override fun processPacket(
+        ingressPort: UInt,
+        payload: ByteArray,
+        config: BehavioralConfig,
+        tableStore: TableStore,
+    ): PipelineResult {
+        val interp = interpreterCache.get(config)
+        val state = PacketState(
+            buffer = PacketBuffer(interp.packetLayout.totalBits),
+            layout = interp.packetLayout,
+        )
+
+        // standard_metadata is a StructView at packetLayout.typeOffsets["standard_metadata_t"].
+        val stdMeta = StructView(
+            state.buffer,
+            interp.packetLayout.structs["standard_metadata_t"]!!,
+            interp.packetLayout.typeOffsets["standard_metadata_t"]!!,
+        )
+        stdMeta["ingress_port"] = BitVal.Narrow(ingressPort.toLong(), portBits)
+
+        interp.Execution(state).run {
+            runParser(...)
+            runIngressControls(...)
+            runDeparser(...)
+        }
+
+        return PipelineResult(state.trace.build())
+    }
+}
+```
+
+The hot path is: a few method calls, one allocation per primitive
+expression eval (`BitVal.Narrow`), and `readBits`/`writeBits`
+against one `ByteArray`. No per-packet object trees, no recursive
+deep-copies, no HashMap allocations.
+
+## The architecture in one picture
+
+```
+                    ┌──────────────────────┐
+                    │  IR (ir.proto)       │
+                    │  static schema       │
+                    └──────────┬───────────┘
+                               │ pipeline load
+                               ▼
+                    ┌──────────────────────┐
+                    │  PacketLayout        │
+                    │  + ResolvedSlots     │
+                    │  (per pipeline)      │
+                    └──────────┬───────────┘
+                               │ per packet
+                               ▼
+   ┌───────────────────────────────────────────────────┐
+   │              PacketState                          │
+   │   ┌─────────────┐  ┌──────────────┐               │
+   │   │PacketBuffer │  │ TraceBuilder │               │
+   │   │  ~256 bytes │  │  delta log   │               │
+   │   └─────────────┘  └──────────────┘               │
+   └───────────────────────────────────────────────────┘
+                               ▲
+              hot path         │       cold path
+              (Value via       │       (HeaderView/StructView)
+              BitVal.Narrow)   │
+              ┌────────────────┼────────────────┐
+              │                                  │
+   ┌──────────┴────────┐              ┌─────────┴────────┐
+   │  Interpreter      │              │  Tests, trace    │
+   │  evalExpr         │              │  inspector, UI   │
+   │  setLValue        │              │  views over      │
+   │                   │              │  the same buffer │
+   └───────────────────┘              └──────────────────┘
+```
+
+## What changes from the existing simulator
+
+These bullets describe the end state, not a migration path.
+
+- `HeaderVal`, `StructVal`, `HeaderStackVal` data classes go away.
+  Replaced by `HeaderView`, `StructView`, `HeaderStackView` as
+  `Value` subtypes.
+- `Environment.scopes: ArrayDeque<MutableMap<String, Value>>` goes
+  away. Replaced by direct buffer access via the per-pipeline
+  `ResolvedSlot` table.
+- `BitVal` becomes a sealed class with `Narrow(Long, Int)` and
+  `Wide(BitVector)` subtypes. `IntVal` similarly. The current
+  `BitVal(BitVector(BigInteger, ...))` triple-allocation goes away
+  for narrow primitives.
+- `Interpreter.evalExpr` keeps a single signature returning
+  `Value`. Field access goes via pre-resolved slots.
+- The deep-copy machinery on `Value` goes away. Forking is
+  `state.fork()`, which calls `buffer.copyOf()`. Other `Value`
+  subtypes are immutable so they don't need copying.
+- The trace event proto is replaced by `PacketTrace` /
+  `TraceDelta`. The trace inspector reads them and projects
+  `HeaderView` snapshots on demand.
+- The codebase is smaller, not bigger.
+
+## Concrete consequences of the simplicity choices
+
+These are the things we explicitly *don't* get because we chose
+simplicity. Worth being honest about up front.
+
+- **No code generation per pipeline.** The interpreter dispatch
+  loop (`when` over `Expr.kind`) stays. Each dispatch is a few
+  cycles; bounded but real. We don't get the JIT-friendly
+  straight-line code that AOT would produce.
+- **No off-heap storage.** GC sees the `PacketBuffer`s. Per-packet
+  buffer allocation is small (~256 bytes) but not zero.
+- **No SIMD.** Packets are processed scalar-per-thread.
+- **No specialised table data structures.** Tables stay as they
+  are.
+- **Per-eval `BitVal.Narrow` allocation.** One `Value` object per
+  primitive eval, instead of the legacy "return cached `BitVal`
+  from HashMap" path. We pay this for a single, simple `evalExpr`
+  signature; the alternative (split `evalNarrow`/`evalWide` methods
+  returning primitives) would eliminate it but requires three eval
+  methods instead of one.
+
+The expected result is **2–3× on fork-heavy workloads**. That's
+the cost of choosing simplicity. Going to AOT or split-method
+evals would push it to 5–10× at the cost of significantly more
+complexity.
+
+## Honest complexity assessment and ROI
+
+### Where complexity goes up
+
+- **One new lifecycle stage at pipeline load: layout + resolution.**
+  Walking the IR, building `PacketLayout`, pre-resolving every
+  `FieldAccess`. ~200 lines of well-tested code, runs once per
+  pipeline. Conceptually one new step ("compute layouts") between
+  IR load and packet processing.
+- **Bit-level math in `PacketBuffer`.** ~100 lines, fully
+  encapsulated, tested independently. Correctness-critical but
+  contained — no other file does bit math.
+- **New types for views and layouts.** ~400 lines of definitions
+  (`HeaderView`, `StructView`, `HeaderStackView`, `HeaderLayout`,
+  `StructLayout`, `HeaderStackLayout`, `FieldSlot`, sealed
+  `StructMember`, `PrimitiveKind`, `PacketLayout`, `ResolvedSlot`).
+  Each is small, clearly-purposed, and tested.
+- **Sealed `BitVal`.** Adds two subtypes where there was one data
+  class. ~30 lines of definition, plus updates to ~30 call sites
+  that pattern-match on or construct `BitVal`.
+- **Trace delta types.** Already designed. `TraceBuilder` is a few
+  dozen lines; `PacketTrace` and `TraceDelta` are existing types.
+
+**Estimated new code: ~800 lines.** All of it small, focused,
+testable in isolation.
+
+### Where complexity goes down
+
+- **`HeaderVal`, `StructVal`, `HeaderStackVal` deleted.** ~200 lines
+  of class definitions plus the recursive `deepCopy` machinery
+  that's hard to reason about. Gone.
+- **`Environment.scopes` machinery deleted.** The `ArrayDeque<
+  MutableMap<String, Value>>` for nested scopes goes away;
+  replaced by buffer-offset lookups. The trickiest piece of state
+  in the existing simulator simplifies to pointer arithmetic.
+- **`BufferBackedFieldMap` deleted.** Wrong-layer bridge from the
+  earlier attempt. ~150 lines of map-adapter complexity that no
+  longer needs to exist.
+- **HashMap-of-Value field storage everywhere.** No more
+  `headerVal.fields[name] = ...`. Field access is via views or
+  pre-resolved slots.
+- **Recursive `Value.deepCopy()` walk.** Replaced by one
+  `buffer.copyOf()`.
+
+**Estimated removed code: ~500 lines, plus harder-to-quantify
+"complexity that's gone."**
+
+### Net code change
+
+**+300 to +500 lines of net code.** But the new code is more
+regular, more focused, and individually-testable; the removed code
+was the "tricky" part of the simulator (recursive Value deep-copy,
+nested HashMap storage, scope-stack lifecycle).
+
+### Cognitive load
+
+A reader holding the new model in their head needs to know:
+
+1. The IR has types (already known).
+2. Layouts are derived from types at pipeline load.
+3. A packet's state is one `PacketBuffer` shaped by the layout.
+4. Headers/structs are views over offsets in the buffer.
+5. The interpreter resolves field accesses to byte offsets at load
+   time and reads bits at runtime.
+
+Five concepts, each named after what it is. Compare with the
+current model: HeaderVal → fields(MutableMap) → BitVal →
+BitVector → BigInteger, plus the recursive deepCopy semantics
+across the tree, plus Environment.scopes' nested HashMap stack,
+plus trace event proto generation. The new model is **simpler to
+hold in your head** than the current one, even after the new types
+are added.
+
+### Performance ROI
+
+Working set per fork branch: ~50 KB → ~256 bytes (~200×
+reduction). L3 pressure is the dominant bottleneck per Phase 1.5;
+this lifts it.
+
+Per-fork copy: recursive object-tree walk allocating ~50 KB →
+single ~256-byte memcpy.
+
+Per-field-access CPU: HashMap lookup + cached BitVal read → one
+bit-shift on a Long, plus one `BitVal.Narrow` allocation. Roughly
+break-even on read CPU; significant win on the surrounding
+allocation pressure.
+
+Per-packet allocations: ~250 wrapper objects → one `PacketBuffer`
+plus a small trace log plus per-eval `BitVal.Narrow`s.
+
+**Estimated end-state speedup on `wcmp×128` parallel: 2–3×.**
+Sequential performance roughly unchanged (no L3 pressure to
+relieve in the single-thread case). Direct L3 forwarding roughly
+unchanged (already at 94% efficiency, no fork-heavy state).
+
+### The honest trade-off
+
+We're adding ~400 net lines of code and one new pipeline-load
+lifecycle stage. We're getting:
+
+- A 2–3× throughput multiplier on the workload that's currently
+  scaling-bound.
+- The L3 ceiling lifted (the wcmp scaling curve straightens past
+  the current 8-worker knee).
+- A simpler runtime model overall (one storage shape for headers,
+  structs, stacks, locals — not three).
+- A foundation that future optimisations (pooling,
+  consumer-aware tracing, more aggressive escape analysis) can
+  build on without further architectural changes.
+
+The complexity is **contained to one subsystem** (storage). It
+doesn't bleed into the IR, the architectures, the table store, or
+the P4Runtime adapter. The interpreter changes are confined to the
+field-access primitives and the eval/setLValue methods.
+
+If the throughput target weren't the primary motivation — if 1500
+pps were enough — this rewrite wouldn't be worth doing. With the
+target being "DVaaS-class throughput" (10K pps and beyond), the
+ROI is clearly positive.
+
+## Open design questions
+
+- **Per-thread `PacketBuffer` pooling.** Deferred per your call. If
+  benchmarks later show GC pressure mattering, ~30 lines of pool
+  code in the architecture, no API impact.
+- **Trace cost when traces are unconsumed.** Some workloads (raw
+  forwarding throughput) don't read the trace. The trace emission
+  cost (one list `add` per field write) is small but not zero. If
+  it matters, gate emit on a per-execution flag.
+- **Custom error types beyond the seven standard ones.**
+  `ErrorCodes` (already on the branch) covers the standard errors.
+  Custom errors would be discovered by walking the IR's
+  `Literal.errorMember` references at pipeline load and assigned
+  codes. Defer until a program needs it.
+- **Field assignments where both sides are aggregates** (e.g.,
+  `headers.a = headers.b` where both are headers). Becomes a
+  buffer-to-buffer block copy at the right offsets. Generated
+  inline in `setLValue` for the aggregate case.
+- **Externs (hash, checksum, register, counter).** They take and
+  return `Value`s today. The interpreter passes `BitVal.Narrow`
+  through to externs unchanged; externs operate on `bits.value`
+  (Long) directly. For specific hot externs (CRC, simple hashes),
+  specialise: read bytes from the buffer directly, compute, write
+  back.
+
+## What about table entries?
+
+This design is scoped to **per-packet state** — the heap-tree of
+`HeaderVal`/`StructVal` that forks copy recursively and that Phase 1.5
+identified as the L3-pressure source. Table entries are a separate
+concern, but they share the same underlying principle and deserve
+their own parallel design.
+
+Phase 1 profiling found `TableStoreKt.toUnsignedLong(ByteString)` at
+65–73% of CPU on direct L3 forwarding — a bigger per-packet cost than
+packet-state access on that workload. The cause: match-key bytes are
+re-decoded (`ByteString` → `BigInteger` → `Long`) on every lookup for
+every installed entry. For 10k LPM entries × 1000s of packets/sec,
+that's a lot of redundant work.
+
+The analogous design for table entries looks like:
+
+- **Pre-compute at install time, not lookup time.** When the control
+  plane installs an entry, convert its match key to the internal
+  `Long`/`LongArray`/`ByteArray` form once. Cache per-entry. Never
+  decode a `ByteString` at lookup.
+- **Flat byte storage for action parameters.** Action params have
+  known widths (the IR carries them); store each entry's params
+  contiguously in bytes instead of as a `List<Value>`. At lookup time,
+  hand the interpreter a pre-shaped "action invocation" whose params
+  are byte ranges at known offsets.
+- **Match-kind-specific lookup structures.** Exact-match tables →
+  `HashMap<Long, Entry>` (or `Long2ObjectMap` for primitive keys). LPM
+  → radix trie keyed by prefix. Ternary → sorted array of (mask,
+  value, action) tuples scanned by priority. The generic "linear scan
+  with per-entry decode" is catastrophic; specialised structures are
+  O(1) or O(W).
+
+These share infrastructure with the packet-state design — the same
+`PacketBuffer` primitive can back action-parameter storage, and the
+same `FieldSlot`/`PrimitiveKind` machinery describes where each param
+lives.
+
+**Scope decision**: out of scope for this document. Table entries
+deserve their own design doc (`designs/flat_table_store.md` or
+similar) once the packet-state rewrite lands and we have
+benchmark-grade confidence in the primitives. The two designs compose
+cleanly — neither blocks the other — so sequencing them as separate
+pieces of work is safe.
+
+## Measured results and what's left
+
+The branch lands **two layers** of runtime:
+
+1. **Buffer-backed values**: `HeaderVal.bufferBacked` /
+   `StructVal.bufferBacked` factories. `BufferBackedFieldMap` replaces
+   `HashMap<String, Value>` with a bit-addressable view into a
+   `PacketBuffer`. Per-slot `Value` caching makes reads
+   zero-allocation after warmup.
+
+2. **Consolidated per-packet buffers** (the "next piece" from a prior
+   revision of this section — now landed). `ConsolidatedPacketAllocator`
+   lays every top-level type (hdr, meta, standard_metadata) at fixed
+   absolute offsets in a single `PacketBuffer` per packet. The full
+   value tree — including the nested headers inside a `headers_t`
+   container struct — points into that one buffer. `Environment.deepCopy`
+   on a fork does **one** `buffer.copyOf()` and a `rewire()` pass that
+   swaps each value's buffer reference to the copy, instead of
+   per-value `deepCopy()` with per-value memcpy.
+
+**Measured** (AMD Ryzen 9 7950X3D, SAI middleblock, 10K packets for
+fork workloads / 500K for direct, intra-packet parallelism off):
+
+| Workload | Baseline | This branch (3-run mean) | Δ |
+|---|---|---|---|
+| wcmp×128 parallel | 1528 pps | **1625 pps** (1629 / 1625 / 1620) | +6.3% |
+| wcmp×128 sequential | 207 pps | 200 pps (200 / 198 / 203) | within noise |
+| direct parallel | 39,800 pps | 39,743 pps (39,137 / 40,710 / 39,382) | within noise |
+
+The consolidation is **engaged** — the SAI pipeline's three top-level
+types land in a single ~540-byte `PacketBuffer` per packet — the
+fork path does one memcpy + rewire, and each rewired
+`BufferBackedFieldMap` **inherits a copy of the pre-fork value cache**
+so fork branches re-read fields without re-allocating `BitVal` /
+`IntVal` / `BoolVal` wrappers. Correctness is rock-solid (73/73 tests)
+and the target workload (fork-heavy wcmp×128 parallel) sees a
+measurable 6.3% win; other workloads unchanged.
+
+### Where the 6.3% came from
+
+Two layered wins:
+
+1. **One memcpy + rewire per fork** (consolidation): replaces
+   ~25 per-value `copyOf()` calls with one
+   `packetBuffer.copyOf()` + a `Value.rewire()` walk. The
+   packet-data memcpy is tiny (~540 bytes); the savings are the
+   absence of per-value HashMap rebuilds and the shared buffer
+   locality.
+
+2. **Cache forwarding on rewire**: a buffer-backed
+   `HeaderVal` / `StructVal` caches each slot's last-returned
+   `Value`. At fork time, the rewire carries the pre-fork cache
+   forward into the new `BufferBackedFieldMap` (safe because the
+   fresh buffer has identical bits; writes through the new map
+   still invalidate per slot). Fork branches re-read the same fields
+   as the pre-fork snapshot and return the **already-materialised**
+   `BitVal` instead of allocating a fresh one. This is the bulk of
+   the win on fork-heavy workloads.
+
+### What still gates 2-3×
+
+The original diagnosis (`designs/parallel_packet_scaling.md`)
+pointed at L3 cache exhaustion from ~12 MB of concurrent per-packet
+state. Consolidation collapses that to ~540 bytes per packet's
+data. But the dominant per-fork cost is still **Java-object churn**
+from the wrapper tree (`HeaderVal`, `StructVal`,
+`BufferBackedFieldMap`, scope HashMaps) — not the packet data the
+diagnosis focused on.
+
+To reach the 2-3× target, the follow-ups most likely to pay off:
+
+- **Pool `HeaderVal` / `BufferBackedFieldMap` / scope HashMap
+  instances** across forks. Fork branches currently create ~25
+  fresh `HeaderVal` + `BufferBackedFieldMap` pairs each; if those
+  came from a thread-local pool, the allocation cost would collapse.
+
+- **Pre-resolve `FieldAccess` to `(offset, width, kind)` at pipeline
+  load and read the packet buffer directly on the interpreter hot
+  path.** Tried in an earlier revision of this branch and reverted
+  because bypassing `BufferBackedFieldMap`'s per-slot `Value` cache
+  cost more than it saved — repeated reads of the same field re-
+  allocated `BitVal`. The idea is still right, but needs its own
+  caching layer to be a win; straightforward to revisit once the
+  cache layer exists at interpreter scope rather than per-map.
+
+- **Arena-allocate fork-branch state** in one slab so GC sees
+  short-lived, contiguous allocations instead of a wrapper graph.
+
+All three keep the flat-buffer primitive as-is. This branch's
+contribution is getting the primitive correct, consolidated, **and
+cache-forwarding-friendly** — the scaffolding required to attempt
+any of the above. None of them are blocked on more data-layout work.
+
+### Lessons for the next iteration
+
+Two things the original design doc under-weighted:
+
+- Per-fork **object churn** from wrapper allocations dwarfs
+  packet-data cache pressure on realistic workloads. The flat-
+  buffer primitive reduces it somewhat, but doesn't eliminate it.
+
+- The `BufferBackedFieldMap` per-slot cache is load-bearing for
+  performance. Any future optimisation that reads buffer bits
+  directly (bypassing the cache) needs a matching cache at its
+  layer — the repeat-access pattern inside a single packet's
+  pipeline stage really is the hot path.
+
+## Non-goals
+
+- Backward compatibility of the trace proto wire format. We break
+  and re-issue it.
+- Backward compatibility of any of the simulator's internal types
+  outside `Value` (and even `Value`'s subtypes change shape).
+- Keeping any layer of the legacy object-tree storage alongside
+  the new design. There's one runtime representation.
+- Migrating one architecture at a time. Either the storage rewrite
+  is in or it's out; partial migration creates two execution paths.

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -60,19 +60,20 @@ internal fun buildBlockParamsMap(config: BehavioralConfig): Map<String, List<Blo
 internal fun createDefaultValues(
   config: BehavioralConfig,
   typesByName: Map<String, TypeDecl>,
+  layouts: PipelineLayouts? = null,
 ): MutableMap<String, Value> {
   val values = mutableMapOf<String, Value>()
   for (parser in config.parsersList) {
     for (param in parser.paramsList) {
       if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
-        values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
+        values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName, layouts) }
       }
     }
   }
   for (control in config.controlsList) {
     for (param in control.paramsList) {
       if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
-        values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
+        values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName, layouts) }
       }
     }
   }

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -149,6 +149,99 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "PacketBufferTest",
+    srcs = ["PacketBufferTest.kt"],
+    associates = [":simulator_lib"],
+    test_class = "fourward.simulator.PacketBufferTest",
+    deps = [
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "HeaderViewTest",
+    srcs = ["HeaderViewTest.kt"],
+    test_class = "fourward.simulator.HeaderViewTest",
+    deps = [
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "StructViewTest",
+    srcs = ["StructViewTest.kt"],
+    test_class = "fourward.simulator.StructViewTest",
+    deps = [
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "LayoutComputerTest",
+    srcs = ["LayoutComputerTest.kt"],
+    test_class = "fourward.simulator.LayoutComputerTest",
+    deps = [
+        ":ir_java_proto",
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "PacketTraceTest",
+    srcs = ["PacketTraceTest.kt"],
+    test_class = "fourward.simulator.PacketTraceTest",
+    deps = [
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "PipelineLayoutsFromConfigTest",
+    srcs = ["PipelineLayoutsFromConfigTest.kt"],
+    test_class = "fourward.simulator.PipelineLayoutsFromConfigTest",
+    deps = [
+        ":ir_java_proto",
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "FlatBufferIntegrationTest",
+    srcs = ["FlatBufferIntegrationTest.kt"],
+    test_class = "fourward.simulator.FlatBufferIntegrationTest",
+    deps = [
+        ":ir_java_proto",
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "HeaderStackViewTest",
+    srcs = ["HeaderStackViewTest.kt"],
+    test_class = "fourward.simulator.HeaderStackViewTest",
+    deps = [
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "PacketStateTest",
+    srcs = ["PacketStateTest.kt"],
+    test_class = "fourward.simulator.PacketStateTest",
+    deps = [
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "MatchesFieldMatchTest",
     srcs = ["MatchesFieldMatchTest.kt"],
     test_class = "fourward.simulator.MatchesFieldMatchTest",

--- a/simulator/BufferBackedFieldMap.kt
+++ b/simulator/BufferBackedFieldMap.kt
@@ -1,0 +1,219 @@
+package fourward.simulator
+
+import java.math.BigInteger
+
+private val TWO_TO_64: BigInteger = BigInteger.ONE.shiftLeft(Long.SIZE_BITS)
+
+/**
+ * A `MutableMap<String, Value>` whose entries live as bit ranges in a [PacketBuffer].
+ *
+ * Acts as a drop-in replacement for the `HashMap<String, Value>` that backs `HeaderVal.fields` /
+ * `StructVal.fields`. Reads produce [BitVal] / [IntVal] / [BoolVal] / [ErrorVal] wrappers from the
+ * underlying bit pattern; writes unwrap those into bits and write to the buffer.
+ *
+ * **Caching:** each slot's returned [Value] is cached. Subsequent reads of the same slot reuse the
+ * cached object (zero-allocation), mirroring the legacy `HashMap.get` behaviour. A write
+ * invalidates the cache entry by overwriting it.
+ *
+ * Primitive members only. Nested header/struct/stack members aren't addressable through this map —
+ * callers use the view's dedicated `header(name)` / `struct(name)` / `stack(name)` accessors.
+ *
+ * See `designs/flat_packet_buffer.md`.
+ */
+class BufferBackedFieldMap(
+  val buffer: PacketBuffer,
+  val slots: Map<String, FieldSlot>,
+  val base: Int,
+) : AbstractMutableMap<String, Value>() {
+
+  /**
+   * Cache of last-returned values keyed by field name. Invalidated on write. Allocated lazily on
+   * first insertion so a just-rewired map that is only read from once doesn't pay the HashMap
+   * allocation cost.
+   */
+  private var cache: HashMap<String, Value>? = null
+
+  private fun cacheOrCreate(): HashMap<String, Value> =
+    cache ?: HashMap<String, Value>(slots.size).also { cache = it }
+
+  /** Returns an independent copy: new buffer (copied), shared slots, fresh cache. */
+  fun copy(): BufferBackedFieldMap = BufferBackedFieldMap(buffer.copyOf(), slots, base)
+
+  /**
+   * Returns a new map pointing at [newBuffer] (shared, not copied) with the same slots/base. The
+   * new map inherits a *copy* of this map's value cache — safe because [newBuffer] carries
+   * identical bits to this map's [buffer] at the relevant offsets (the caller copied the buffer
+   * byte-for-byte), and subsequent writes through the new map invalidate per-slot cache entries.
+   * Carrying the cache forward avoids re-allocating `BitVal` / `IntVal` / `BoolVal` wrappers for
+   * fields that were already cached pre-fork — the primary allocation cost on fork-heavy workloads.
+   */
+  fun withBuffer(newBuffer: PacketBuffer): BufferBackedFieldMap {
+    val copy = BufferBackedFieldMap(newBuffer, slots, base)
+    cache?.let { copy.cache = HashMap(it) }
+    return copy
+  }
+
+  override val size: Int
+    get() = slots.size
+
+  override fun containsKey(key: String): Boolean = key in slots
+
+  override fun get(key: String): Value? {
+    val slot = slots[key] ?: return null
+    cache?.get(key)?.let {
+      return it
+    }
+    val value =
+      if (slot.width <= Long.SIZE_BITS) {
+        val bits = buffer.readBits(base + slot.offset, slot.width)
+        when (slot.kind) {
+          PrimitiveKind.BIT -> BitVal(BitVector(unsignedBigInt(bits), slot.width))
+          PrimitiveKind.INT ->
+            IntVal(SignedBitVector.fromUnsignedBits(unsignedBigInt(bits), slot.width))
+          PrimitiveKind.BOOL -> BoolVal(bits != 0L)
+          PrimitiveKind.ERROR -> ErrorVal(ErrorCodes.decode(bits))
+        }
+      } else {
+        val bits = buffer.readBigInt(base + slot.offset, slot.width)
+        when (slot.kind) {
+          PrimitiveKind.BIT -> BitVal(BitVector(bits, slot.width))
+          PrimitiveKind.INT -> IntVal(SignedBitVector.fromUnsignedBits(bits, slot.width))
+          else -> error("kind ${slot.kind} not supported at width ${slot.width}")
+        }
+      }
+    cacheOrCreate()[key] = value
+    return value
+  }
+
+  /**
+   * Reinterprets [bits] (a [Long] that may be negative when the high bit is set, for 64-bit fields)
+   * as a non-negative [BigInteger]. For widths < 64, [bits] is already non-negative.
+   */
+  private fun unsignedBigInt(bits: Long): BigInteger =
+    if (bits >= 0L) BigInteger.valueOf(bits) else BigInteger.valueOf(bits).add(TWO_TO_64)
+
+  override fun put(key: String, value: Value): Value? {
+    val slot =
+      slots[key]
+        ?: throw IllegalArgumentException("no such field: '$key' (available: ${slots.keys})")
+    val old = get(key)
+    if (slot.width <= Long.SIZE_BITS) {
+      buffer.writeBits(base + slot.offset, slot.width, encode(value, slot, key))
+    } else {
+      buffer.writeBigInt(base + slot.offset, slot.width, encodeBig(value, slot, key))
+    }
+    // Cache the written value so subsequent reads don't have to rematerialise.
+    cacheOrCreate()[key] = value
+    return old
+  }
+
+  /**
+   * For a fixed-schema P4 field map, [clear] zeros each field's bit range in place — removing keys
+   * isn't meaningful for a layout with declared fields. Matches `HeaderVal.setValid`'s `clear();
+   * putAll(newFields)` pattern.
+   */
+  override fun clear() {
+    for (slot in slots.values) {
+      buffer.zeroRange(base + slot.offset, slot.width)
+    }
+    cache?.clear()
+  }
+
+  private fun encodeBig(value: Value, slot: FieldSlot, key: String): java.math.BigInteger =
+    when (slot.kind) {
+      PrimitiveKind.BIT -> {
+        require(value is BitVal) {
+          "$key expects a BitVal (bit<${slot.width}>), got ${value.javaClass.simpleName}"
+        }
+        require(value.bits.width == slot.width) {
+          "$key expects bit<${slot.width}>, got bit<${value.bits.width}>"
+        }
+        value.bits.value
+      }
+      PrimitiveKind.INT -> {
+        require(value is IntVal) {
+          "$key expects an IntVal (int<${slot.width}>), got ${value.javaClass.simpleName}"
+        }
+        require(value.bits.width == slot.width) {
+          "$key expects int<${slot.width}>, got int<${value.bits.width}>"
+        }
+        value.bits.toUnsigned().value
+      }
+      else -> error("kind ${slot.kind} not supported at width ${slot.width}")
+    }
+
+  private fun encode(value: Value, slot: FieldSlot, key: String): Long =
+    when (slot.kind) {
+      PrimitiveKind.BIT -> {
+        require(value is BitVal) {
+          "$key expects a BitVal (bit<${slot.width}>), got ${value.javaClass.simpleName}"
+        }
+        require(value.bits.width == slot.width) {
+          "$key expects bit<${slot.width}>, got bit<${value.bits.width}>"
+        }
+        value.bits.value.toLong()
+      }
+      PrimitiveKind.INT -> {
+        require(value is IntVal) {
+          "$key expects an IntVal (int<${slot.width}>), got ${value.javaClass.simpleName}"
+        }
+        require(value.bits.width == slot.width) {
+          "$key expects int<${slot.width}>, got int<${value.bits.width}>"
+        }
+        value.bits.toUnsigned().value.toLong()
+      }
+      PrimitiveKind.BOOL -> {
+        require(value is BoolVal) { "$key expects a BoolVal, got ${value.javaClass.simpleName}" }
+        if (value.value) 1L else 0L
+      }
+      PrimitiveKind.ERROR -> {
+        require(value is ErrorVal) { "$key expects an ErrorVal, got ${value.javaClass.simpleName}" }
+        ErrorCodes.encode(value.member)
+      }
+    }
+
+  override val entries: MutableSet<MutableMap.MutableEntry<String, Value>>
+    get() =
+      object : AbstractMutableSet<MutableMap.MutableEntry<String, Value>>() {
+        override val size: Int
+          get() = slots.size
+
+        override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, Value>> {
+          val keyIter = slots.keys.iterator()
+          return object : MutableIterator<MutableMap.MutableEntry<String, Value>> {
+            override fun hasNext(): Boolean = keyIter.hasNext()
+
+            override fun next(): MutableMap.MutableEntry<String, Value> =
+              BufferEntry(keyIter.next())
+
+            override fun remove() {
+              throw UnsupportedOperationException("cannot remove keys from a buffer-backed map")
+            }
+          }
+        }
+
+        override fun add(element: MutableMap.MutableEntry<String, Value>): Boolean {
+          put(element.key, element.value)
+          return true
+        }
+      }
+
+  private inner class BufferEntry(override val key: String) :
+    MutableMap.MutableEntry<String, Value> {
+    override val value: Value
+      get() = get(key)!!
+
+    override fun setValue(newValue: Value): Value {
+      val old = value
+      put(key, newValue)
+      return old
+    }
+
+    override fun toString(): String = "$key=$value"
+
+    override fun equals(other: Any?): Boolean =
+      other is Map.Entry<*, *> && other.key == key && other.value == value
+
+    override fun hashCode(): Int = key.hashCode() xor value.hashCode()
+  }
+}

--- a/simulator/ConsolidatedPacketAllocator.kt
+++ b/simulator/ConsolidatedPacketAllocator.kt
@@ -1,0 +1,185 @@
+// Copyright 2026 4ward Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package fourward.simulator
+
+import fourward.ir.FieldDecl
+import fourward.ir.TypeDecl
+
+/**
+ * Static pipeline-load plan for placing every top-level P4 type that a packet touches into a single
+ * per-packet [PacketBuffer] at known absolute bit offsets. See the "Measured results and what's
+ * left" section of `designs/flat_packet_buffer.md`.
+ *
+ * The plan is computed once per pipeline from the IR + [PipelineLayouts]. Each packet allocates one
+ * buffer of [totalBits] bits and constructs a matching tree of [HeaderVal] / [StructVal] instances,
+ * all of which share that single buffer at the right offsets. Fork copies one buffer and rewires
+ * the value tree — no per-header `copyOf()`.
+ */
+class ConsolidatedPacketAllocator(
+  /** Every requested top-level type, in input order. */
+  private val topLevelTypeNames: List<String>,
+  private val plan: List<TopLevelPlacement>,
+  private val typesByName: Map<String, TypeDecl>,
+  private val layouts: PipelineLayouts,
+  /** Total packet-buffer size in bits. */
+  val totalBits: Int,
+) {
+  /** Top-level type name → absolute offset in the packet buffer, for types actually placed. */
+  val baseByType: Map<String, Int> = plan.associate { it.typeName to it.base }
+
+  /**
+   * Allocates a fresh per-packet [PacketBuffer] and constructs a [Value] for every top-level type.
+   * Types placed in [plan] share the buffer; any type that couldn't be laid out (missing layout,
+   * header union, varbit) falls back to the legacy per-instance [defaultValue] path.
+   */
+  fun allocate(): PerPacketValues {
+    val buffer = PacketBuffer(totalBits)
+    val byType = LinkedHashMap<String, Value>(topLevelTypeNames.size)
+    for (name in topLevelTypeNames) {
+      val placed = baseByType[name]
+      byType[name] =
+        if (placed != null) buildValue(name, buffer, placed)
+        else defaultValue(name, typesByName, layouts)
+    }
+    return PerPacketValues(buffer, byType)
+  }
+
+  private fun buildValue(typeName: String, buffer: PacketBuffer, base: Int): Value {
+    val decl = typesByName[typeName] ?: return UnitVal
+    return when {
+      decl.hasHeader() -> {
+        val headerLayout =
+          layouts.headers[typeName] ?: return defaultValue(typeName, typesByName, layouts)
+        HeaderVal.bufferBacked(headerLayout, buffer, base)
+      }
+      decl.hasStruct() -> buildStruct(typeName, decl.struct.fieldsList, buffer, base)
+      decl.hasHeaderUnion() -> buildStruct(typeName, decl.headerUnion.fieldsList, buffer, base)
+      else -> defaultValue(typeName, typesByName, layouts)
+    }
+  }
+
+  private fun buildStruct(
+    typeName: String,
+    fieldDecls: List<FieldDecl>,
+    buffer: PacketBuffer,
+    base: Int,
+  ): StructVal {
+    val structLayout = layouts.structs[typeName] ?: return legacyStruct(typeName, fieldDecls)
+    if (structLayout.allPrimitive && allBufferSafe(fieldDecls)) {
+      return StructVal.bufferBacked(structLayout, buffer, base)
+    }
+    // Mixed struct: keep the HashMap container, but place nested named members into the shared
+    // buffer at their absolute offsets. Primitive members stay as independent Value objects (this
+    // branch is only taken for structs that contain at least one nested header/struct/stack, which
+    // is rare — the headers container typically).
+    val fields = LinkedHashMap<String, Value>(structLayout.members.size)
+    for ((name, member) in structLayout.members) {
+      fields[name] =
+        when (member) {
+          is PrimitiveField -> primitiveDefault(member)
+          is NestedHeader -> HeaderVal.bufferBacked(member.layout, buffer, base + member.offset)
+          is NestedStruct -> buildNested(member.layout, buffer, base + member.offset)
+          is NestedStack ->
+            // Header stacks aren't yet consolidated — fall back to the legacy per-instance path.
+            defaultValue(fieldByName(fieldDecls, name).type, typesByName, layouts)
+        }
+    }
+    return StructVal(typeName, fields)
+  }
+
+  private fun buildNested(layout: StructLayout, buffer: PacketBuffer, base: Int): StructVal {
+    if (layout.allPrimitive && typeAllBufferSafe(layout.typeName)) {
+      return StructVal.bufferBacked(layout, buffer, base)
+    }
+    val fields = LinkedHashMap<String, Value>(layout.members.size)
+    for ((name, member) in layout.members) {
+      fields[name] =
+        when (member) {
+          is PrimitiveField -> primitiveDefault(member)
+          is NestedHeader -> HeaderVal.bufferBacked(member.layout, buffer, base + member.offset)
+          is NestedStruct -> buildNested(member.layout, buffer, base + member.offset)
+          is NestedStack -> UnitVal // not reached for V1Model; nested stacks use legacy path above
+        }
+    }
+    return StructVal(layout.typeName, fields)
+  }
+
+  private fun fieldByName(fields: List<FieldDecl>, name: String): FieldDecl =
+    fields.first { it.name == name }
+
+  /**
+   * A struct is safe to route through the buffer-backed encoder iff every declared field has a type
+   * whose encoder contract is unambiguous: primitives (bit/int/bool/error). Enum-typed fields
+   * receive unconverted [InfIntVal]s in some interpreter paths, which the encoder rejects — keep
+   * those on the HashMap path.
+   */
+  private fun allBufferSafe(fieldDecls: List<FieldDecl>): Boolean =
+    fieldDecls.all { isBufferSafeType(it.type) }
+
+  private fun typeAllBufferSafe(typeName: String): Boolean {
+    val decl = typesByName[typeName] ?: return false
+    return when {
+      decl.hasStruct() -> allBufferSafe(decl.struct.fieldsList)
+      decl.hasHeaderUnion() -> allBufferSafe(decl.headerUnion.fieldsList)
+      else -> false
+    }
+  }
+
+  private fun isBufferSafeType(type: fourward.ir.Type): Boolean =
+    type.hasBit() ||
+      type.hasSignedInt() ||
+      type.hasBoolean() ||
+      type.hasError() ||
+      (type.hasNamed() && type.named == "error")
+
+  private fun primitiveDefault(m: PrimitiveField): Value =
+    when (m.kind) {
+      PrimitiveKind.BIT -> BitVal(0L, m.width)
+      PrimitiveKind.INT -> IntVal(SignedBitVector(java.math.BigInteger.ZERO, m.width))
+      PrimitiveKind.BOOL -> BoolVal.FALSE
+      PrimitiveKind.ERROR -> ErrorVal("NoError")
+    }
+
+  private fun legacyStruct(typeName: String, fieldDecls: List<FieldDecl>): StructVal =
+    StructVal(
+      typeName,
+      fieldDecls.associateTo(mutableMapOf()) {
+        it.name to defaultValue(it.type, typesByName, layouts)
+      },
+    )
+
+  /** Planned placement of one top-level type in the packet buffer. */
+  data class TopLevelPlacement(val typeName: String, val base: Int, val widthBits: Int)
+
+  /** Output of [allocate]. */
+  class PerPacketValues(val buffer: PacketBuffer, val byType: Map<String, Value>)
+
+  companion object {
+    /**
+     * Builds a [ConsolidatedPacketAllocator] for the given set of top-level type names. Types that
+     * can't be laid out (missing header/struct layout, header unions, unresolved) are silently
+     * skipped and fall back to the legacy per-instance path on allocation — callers get null back
+     * from [ConsolidatedPacketAllocator.baseByType] for those names.
+     */
+    fun build(
+      topLevelTypeNames: List<String>,
+      layouts: PipelineLayouts,
+      typesByName: Map<String, TypeDecl>,
+    ): ConsolidatedPacketAllocator {
+      val plan = mutableListOf<TopLevelPlacement>()
+      var cursor = 0
+      for (name in topLevelTypeNames) {
+        val width = layouts.headers[name]?.totalBits ?: layouts.structs[name]?.totalBits ?: continue
+        plan += TopLevelPlacement(name, cursor, width)
+        cursor += width
+      }
+      return ConsolidatedPacketAllocator(topLevelTypeNames, plan, typesByName, layouts, cursor)
+    }
+  }
+}

--- a/simulator/DefaultValues.kt
+++ b/simulator/DefaultValues.kt
@@ -21,62 +21,94 @@ import java.math.BigInteger
 /**
  * Creates a zero/default [Value] for [type].
  *
- * bit<N> → [BitVal] zero, int<N> → [IntVal] zero, bool → [BoolVal] false, named types → recursively
- * initialised header (invalid), struct, or [BitVal] zero for serializable enums. varbit<N> and
- * unrecognised types → [UnitVal].
+ * When [layouts] is non-null, headers and primitive-only structs are constructed via
+ * [HeaderVal.bufferBacked] / [StructVal.bufferBacked] — their `fields` maps live as bit ranges in a
+ * [PacketBuffer] rather than as entries in a `HashMap`. Types whose layout isn't known (header
+ * unions, varbits, non-serialisable enums) fall through to the legacy HashMap path.
  */
-internal fun defaultValue(type: Type, types: Map<String, TypeDecl>): Value =
+internal fun defaultValue(
+  type: Type,
+  types: Map<String, TypeDecl>,
+  layouts: PipelineLayouts? = null,
+): Value =
   when {
     type.hasBit() -> BitVal(0L, type.bit.width)
-    type.hasSignedInt() -> IntVal(SignedBitVector(java.math.BigInteger.ZERO, type.signedInt.width))
+    type.hasSignedInt() -> IntVal(SignedBitVector(BigInteger.ZERO, type.signedInt.width))
     type.hasBoolean() -> BoolVal(false)
-    type.hasNamed() -> defaultValue(type.named, types)
+    type.hasNamed() -> defaultValue(type.named, types, layouts)
     type.hasHeaderStack() ->
       HeaderStackVal(
         elementTypeName = type.headerStack.elementType,
         headers =
           MutableList(type.headerStack.size.toInt()) {
-            defaultValue(type.headerStack.elementType, types)
+            defaultValue(type.headerStack.elementType, types, layouts)
           },
       )
-    else -> UnitVal // varbit<N>: variable-length; no fixed default
+    else -> UnitVal
   }
 
-/**
- * Creates a zero/default [Value] for the named type.
- *
- * Looks up [typeName] in [types]; returns [UnitVal] if not found. Headers are initially invalid
- * with zeroed fields; structs are recursively initialised. Serializable enums default to a zero
- * [BitVal] of their underlying width.
- */
-internal fun defaultValue(typeName: String, types: Map<String, TypeDecl>): Value {
+/** Creates a zero/default [Value] for the named type. */
+internal fun defaultValue(
+  typeName: String,
+  types: Map<String, TypeDecl>,
+  layouts: PipelineLayouts? = null,
+): Value {
   val typeDecl = types[typeName] ?: return UnitVal
   return when {
-    typeDecl.hasHeader() ->
-      HeaderVal(
-        typeName = typeName,
-        fields =
-          typeDecl.header.fieldsList.associateTo(mutableMapOf()) { f ->
-            f.name to defaultValue(f.type, types)
-          },
-        valid = false,
-      )
-    typeDecl.hasStruct() -> defaultStruct(typeName, typeDecl.struct.fieldsList, types)
-    // Header union (P4 spec §8.20): represented as a StructVal so field access works
-    // uniformly; per-member validity is tracked via HeaderVal.valid.
-    typeDecl.hasHeaderUnion() -> defaultStruct(typeName, typeDecl.headerUnion.fieldsList, types)
-    // Serializable enum: default to zero of the underlying bit width.
+    typeDecl.hasHeader() -> defaultHeader(typeName, typeDecl, types, layouts)
+    typeDecl.hasStruct() -> defaultStruct(typeName, typeDecl.struct.fieldsList, types, layouts)
+    typeDecl.hasHeaderUnion() ->
+      defaultStruct(typeName, typeDecl.headerUnion.fieldsList, types, layouts)
     typeDecl.hasEnum() && typeDecl.enum.width > 0 -> BitVal(0L, typeDecl.enum.width)
     else -> UnitVal
   }
+}
+
+private fun defaultHeader(
+  typeName: String,
+  typeDecl: TypeDecl,
+  types: Map<String, TypeDecl>,
+  layouts: PipelineLayouts?,
+): HeaderVal {
+  val headerLayout = layouts?.headers?.get(typeName)
+  if (headerLayout != null) return HeaderVal.bufferBacked(headerLayout)
+  return HeaderVal(
+    typeName = typeName,
+    fields =
+      typeDecl.header.fieldsList.associateTo(mutableMapOf()) { f ->
+        f.name to defaultValue(f.type, types, layouts)
+      },
+    valid = false,
+  )
 }
 
 private fun defaultStruct(
   typeName: String,
   fieldDecls: List<fourward.ir.FieldDecl>,
   types: Map<String, TypeDecl>,
-): StructVal =
-  StructVal(
+  layouts: PipelineLayouts?,
+): StructVal {
+  val structLayout = layouts?.structs?.get(typeName)
+  if (structLayout != null && fieldDecls.all { isBufferSafeField(it.type) }) {
+    return StructVal.bufferBacked(structLayout)
+  }
+  return StructVal(
     typeName = typeName,
-    fields = fieldDecls.associateTo(mutableMapOf()) { f -> f.name to defaultValue(f.type, types) },
+    fields =
+      fieldDecls.associateTo(mutableMapOf()) { f -> f.name to defaultValue(f.type, types, layouts) },
   )
+}
+
+/**
+ * A field type is safe to place in a buffer-backed map iff the interpreter only writes values that
+ * the encoder can losslessly round-trip. Primitives (bit/int/bool/error) qualify; enum- typed
+ * fields don't because the interpreter sometimes assigns unconverted [InfIntVal]s to them, which
+ * the buffer-backed encoder rejects. Header stacks and nested structs are handled through a
+ * different path and don't belong in a primitive field map.
+ */
+private fun isBufferSafeField(type: fourward.ir.Type): Boolean =
+  type.hasBit() ||
+    type.hasSignedInt() ||
+    type.hasBoolean() ||
+    type.hasError() ||
+    (type.hasNamed() && type.named == "error")

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -16,6 +16,14 @@ class Environment {
 
   private val scopes: ArrayDeque<MutableMap<String, Value>> = ArrayDeque()
 
+  /**
+   * The shared per-packet [PacketBuffer] — or null on the legacy path. When set, every
+   * buffer-backed [Value] in [scopes] points into this buffer, and [deepCopy] performs one bulk
+   * [PacketBuffer.copyOf] followed by a cheap rewire of the value tree instead of per-value
+   * `buffer.copyOf()` calls.
+   */
+  var packetBuffer: PacketBuffer? = null
+
   init {
     pushScope()
   } // top-level scope
@@ -60,12 +68,26 @@ class Environment {
     error("undefined variable: $name")
   }
 
-  /** Returns an independent deep copy of this environment (all scopes and values). */
+  /**
+   * Returns an independent deep copy of this environment (all scopes and values).
+   *
+   * When [packetBuffer] is non-null, copies that single buffer once and rewires every buffer-backed
+   * value to the copy — avoiding the per-value `buffer.copyOf()` that the legacy path performs.
+   * Non-buffer-backed values still flow through [Value.deepCopy].
+   */
   fun deepCopy(): Environment {
     val copy = Environment()
     copy.scopes.clear()
+    val oldBuf = packetBuffer
+    val newBuf = oldBuf?.copyOf()
+    copy.packetBuffer = newBuf
     for (scope in scopes) {
-      copy.scopes.addLast(scope.mapValuesTo(mutableMapOf()) { it.value.deepCopy() })
+      val newScope = HashMap<String, Value>(scope.size)
+      for ((k, v) in scope) {
+        newScope[k] =
+          if (oldBuf != null && newBuf != null) v.rewire(oldBuf, newBuf) else v.deepCopy()
+      }
+      copy.scopes.addLast(newScope)
     }
     return copy
   }
@@ -87,7 +109,7 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
   // -------------------------------------------------------------------------
 
   /** Remaining bytes in the input packet, consumed by parser extract(). */
-  private val buffer: PacketBuffer = PacketBuffer(payload, initialOffset)
+  private val buffer: ParserCursor = ParserCursor(payload, initialOffset)
 
   /** Number of bytes consumed from the input buffer so far (parser extract position). */
   val bytesConsumed: Int
@@ -138,8 +160,8 @@ class PacketTooShortException(message: String) : ParserErrorException("PacketToo
 /** Thrown by the interpreter when a parser error occurs (P4 spec §12.8). */
 open class ParserErrorException(val errorName: String, message: String) : Exception(message)
 
-/** A simple byte-level cursor over a packet buffer. */
-private class PacketBuffer(private val data: ByteArray, initialOffset: Int = 0) {
+/** A simple byte-level cursor over a packet buffer, used by the parser. */
+private class ParserCursor(private val data: ByteArray, initialOffset: Int = 0) {
   private var offset: Int = initialOffset
 
   /** Number of bytes consumed from the start of the buffer. */

--- a/simulator/ErrorCodes.kt
+++ b/simulator/ErrorCodes.kt
@@ -1,0 +1,57 @@
+package fourward.simulator
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Bidirectional name ↔ integer-code mapping for P4 error members.
+ *
+ * P4 errors are nominally a distinct type ([fourward.ir.Type.hasError]), but p4c lowers them to a
+ * fixed-width bit field — V1Model's `standard_metadata_t.parser_error` is emitted as `bit<32>`
+ * after the midend. To round-trip [ErrorVal]s through a buffer-backed field map, we need a stable
+ * name↔bit-pattern mapping.
+ *
+ * The seven spec errors (§7.1.5) get fixed low codes. Program-declared errors (e.g.
+ * `IPv4IncorrectVersion`) get codes lazily assigned on first encode, keyed off the name so the
+ * mapping is stable for decode. Lookups are thread-safe.
+ */
+internal object ErrorCodes {
+
+  @Suppress("MagicNumber")
+  private val STANDARD: Map<String, Int> =
+    linkedMapOf(
+      "NoError" to 0,
+      "PacketTooShort" to 1,
+      "NoMatch" to 2,
+      "StackOutOfBounds" to 3,
+      "HeaderTooShort" to 4,
+      "ParserTimeout" to 5,
+      "ParserInvalidArgument" to 6,
+    )
+
+  private const val DYNAMIC_BASE = 1024
+
+  /** Live mapping (includes [STANDARD] plus any dynamically registered names). */
+  private val nameToCode: ConcurrentHashMap<String, Int> = ConcurrentHashMap(STANDARD)
+  private val codeToName: ConcurrentHashMap<Int, String> =
+    ConcurrentHashMap<Int, String>().apply { STANDARD.forEach { (n, c) -> put(c, n) } }
+
+  /** Next code to hand out for a previously unseen error name. */
+  private var nextDynamicCode: Int = DYNAMIC_BASE
+
+  @Synchronized
+  private fun registerDynamic(name: String): Int {
+    nameToCode[name]?.let {
+      return it
+    }
+    val code = nextDynamicCode++
+    nameToCode[name] = code
+    codeToName[code] = name
+    return code
+  }
+
+  fun encode(name: String): Long = (nameToCode[name] ?: registerDynamic(name)).toLong()
+
+  fun decode(code: Long): String =
+    codeToName[code.toInt()]
+      ?: throw IllegalArgumentException("no P4 error registered for code $code")
+}

--- a/simulator/FlatBufferIntegrationTest.kt
+++ b/simulator/FlatBufferIntegrationTest.kt
@@ -1,0 +1,220 @@
+package fourward.simulator
+
+import fourward.ir.BehavioralConfig
+import fourward.ir.BitType
+import fourward.ir.DeviceConfig
+import fourward.ir.FieldDecl
+import fourward.ir.HeaderDecl
+import fourward.ir.PipelineConfig
+import fourward.ir.StructDecl
+import fourward.ir.Type
+import fourward.ir.TypeDecl
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * End-to-end integration: prove that the flat-buffer stack hangs together end-to-end.
+ *
+ * Takes a minimal synthetic pipeline (ethernet header in a headers struct + a metadata struct),
+ * computes layouts, allocates a packet buffer, writes field values through views, forks the buffer,
+ * mutates the fork, captures the whole thing as a delta-encoded trace, and replays the trace to
+ * recover final state. Exercises: [computeLayouts], [PacketBuffer], [HeaderView], [StructView],
+ * [TraceDelta], [PacketTrace].
+ *
+ * No interpreter involvement — this validates the design before that migration. See
+ * `designs/flat_packet_buffer.md`.
+ */
+class FlatBufferIntegrationTest {
+
+  /** A minimal pipeline: headers = { ethernet }, meta = { ingress_port, drop }. */
+  private val pipeline =
+    PipelineConfig.newBuilder()
+      .setDevice(
+        DeviceConfig.newBuilder()
+          .setBehavioral(
+            BehavioralConfig.newBuilder()
+              .addTypes(
+                typeDecl(
+                  "ethernet_t",
+                  header("dstAddr" to bit(48), "srcAddr" to bit(48), "etherType" to bit(16)),
+                )
+              )
+              .addTypes(typeDecl("headers_t", struct("ethernet" to named("ethernet_t"))))
+              .addTypes(typeDecl("meta_t", struct("ingress_port" to bit(9), "drop" to bool())))
+              .addTypes(
+                typeDecl(
+                  "packet_state_t",
+                  struct("hdrs" to named("headers_t"), "meta" to named("meta_t")),
+                )
+              )
+          )
+      )
+      .build()
+
+  @Test
+  fun `fork copies buffer, mutations are independent, trace replays faithfully`() {
+    // 1. Compute layouts from the pipeline config.
+    val layouts = computeLayouts(pipeline)
+    val packetStateLayout = layouts.structs.getValue("packet_state_t")
+
+    // 2. Allocate a packet buffer sized for the top-level layout.
+    val parentBuffer = PacketBuffer(packetStateLayout.totalBits)
+    val parentView = StructView(parentBuffer, packetStateLayout)
+
+    // 3. "Parse" phase: fill in the ethernet header and set metadata.
+    val eth = parentView.struct("hdrs").header("ethernet")
+    eth["dstAddr"] = BitVal(0xAABB_CCDD_EEFFL, 48)
+    eth["srcAddr"] = BitVal(0x1122_3344_5566L, 48)
+    eth["etherType"] = BitVal(0x0800L, 16)
+    eth.isValid = true
+
+    val meta = parentView.struct("meta")
+    meta["ingress_port"] = BitVal(3L, 9)
+
+    // Sanity check: writes round-trip.
+    assertEquals(BitVal(0x0800L, 16), eth["etherType"])
+    assertTrue(eth.isValid)
+    assertEquals(BitVal(3L, 9), meta["ingress_port"])
+
+    // 4. Capture initial state for the trace.
+    val initialBytes = parentBuffer.toBytes()
+
+    // 5. "Fork" phase: copy the buffer. The fork is a second, independent copy of the same state.
+    val forkBuffer = parentBuffer.copyOf()
+    val forkView = StructView(forkBuffer, packetStateLayout)
+
+    // The fork sees the parent's state.
+    val forkEth = forkView.struct("hdrs").header("ethernet")
+    assertEquals(BitVal(0xAABB_CCDD_EEFFL, 48), forkEth["dstAddr"])
+    assertTrue(forkEth.isValid)
+
+    // 6. "Action" phase: modify the fork. Build up a trace of what we did.
+    val forkEvents = mutableListOf<TraceDelta>()
+    forkEvents += TraceDelta.ControlFlow("action: rewrite_dst_mac")
+
+    // Compute the global bit offset of hdrs.ethernet.dstAddr within the packet buffer.
+    val hdrsOffset = (packetStateLayout.members.getValue("hdrs") as NestedStruct).offset
+    val ethOffset =
+      (layouts.structs.getValue("headers_t").members.getValue("ethernet") as NestedHeader).offset
+    val dstAddrSlot = layouts.headers.getValue("ethernet_t").fields.getValue("dstAddr")
+    val dstAddrGlobalOffset = hdrsOffset + ethOffset + dstAddrSlot.offset
+
+    // Apply: rewrite dstAddr on the fork.
+    val newDst = 0xDEAD_BEEF_CAFEL
+    forkEth["dstAddr"] = BitVal(newDst, 48)
+    forkEvents +=
+      TraceDelta.FieldWrite(bitOffset = dstAddrGlobalOffset, width = 48, newValue = newDst)
+
+    // Also drop the packet in metadata.
+    val metaOffset = (packetStateLayout.members.getValue("meta") as NestedStruct).offset
+    val dropSlot = layouts.structs.getValue("meta_t").members.getValue("drop") as PrimitiveField
+    val dropGlobalOffset = metaOffset + dropSlot.offset
+    forkView.struct("meta")["drop"] = BitVal(1L, 1)
+    forkEvents += TraceDelta.FieldWrite(bitOffset = dropGlobalOffset, width = 1, newValue = 1L)
+    forkEvents += TraceDelta.ControlFlow("drop")
+
+    // 7. Invariant check: parent is untouched.
+    val parentEth = parentView.struct("hdrs").header("ethernet")
+    assertEquals(BitVal(0xAABB_CCDD_EEFFL, 48), parentEth["dstAddr"])
+    assertEquals(BitVal(0L, 1), parentView.struct("meta")["drop"])
+
+    // 8. Build the trace: initial snapshot + fork's event log.
+    val trace = PacketTrace(initial = initialBytes, events = forkEvents)
+
+    // 9. Replay the trace and verify final state matches the fork exactly.
+    val replayed = trace.replay()
+    assertArrayEquals(forkBuffer.toBytes(), replayed.toBytes())
+
+    val replayedView = StructView(replayed, packetStateLayout)
+    val replayedEth = replayedView.struct("hdrs").header("ethernet")
+    assertEquals(BitVal(newDst, 48), replayedEth["dstAddr"])
+    assertEquals(BitVal(0x0800L, 16), replayedEth["etherType"]) // unchanged by deltas
+    assertEquals(BitVal(1L, 1), replayedView.struct("meta")["drop"])
+
+    // 10. Also verify stateAt() at an intermediate event gives an intermediate state.
+    //     Event index 1 = after the first FieldWrite (dstAddr rewrite) but before the drop.
+    val midway = trace.stateAt(2)
+    val midEth = StructView(midway, packetStateLayout).struct("hdrs").header("ethernet")
+    assertEquals(BitVal(newDst, 48), midEth["dstAddr"])
+    // drop hasn't been applied yet
+    assertEquals(BitVal(0L, 1), StructView(midway, packetStateLayout).struct("meta")["drop"])
+  }
+
+  @Test
+  fun `packet state fits in a small buffer`() {
+    // Validates the working-set-size claim: a realistic packet's state is on the order of a
+    // cache line, not a heap-tree.
+    val layouts = computeLayouts(pipeline)
+    val packetStateLayout = layouts.structs.getValue("packet_state_t")
+
+    // ethernet (48+48+16+1=113) + headers.ethernet nested + meta.ingress_port (9) + meta.drop (1).
+    // packet_state nests headers_t (113) and meta_t (10) -> 123 bits total.
+    assertEquals(113 + 9 + 1, packetStateLayout.totalBits)
+    val buffer = PacketBuffer(packetStateLayout.totalBits)
+    // Buffer is a literal handful of bytes — fits in a single cache line.
+    assertTrue("buffer size: ${buffer.toBytes().size} bytes", buffer.toBytes().size <= 64)
+  }
+
+  @Test
+  fun `header invalidation zeros the header's portion of a shared buffer only`() {
+    // Validates that the HeaderInvalidated delta's (bitOffset, totalBits) reliably targets just
+    // one header in a larger packet state — important for the interpreter migration, where
+    // setInvalid() on one header must not disturb its neighbours.
+    val layouts = computeLayouts(pipeline)
+    val packetStateLayout = layouts.structs.getValue("packet_state_t")
+
+    val buffer = PacketBuffer(packetStateLayout.totalBits)
+    val root = StructView(buffer, packetStateLayout)
+
+    // Fill ethernet and metadata.
+    val eth = root.struct("hdrs").header("ethernet")
+    eth["dstAddr"] = BitVal(0xFFFF_FFFF_FFFFL, 48)
+    eth["srcAddr"] = BitVal(0xFFFF_FFFF_FFFFL, 48)
+    eth["etherType"] = BitVal(0xFFFFL, 16)
+    eth.isValid = true
+    root.struct("meta")["ingress_port"] = BitVal(0x1AAL, 9)
+    root.struct("meta")["drop"] = BitVal(1L, 1)
+
+    // Invalidate ethernet via the delta (not via eth.isValid=false, to exercise the delta path).
+    val ethOffsetInPacket =
+      (packetStateLayout.members.getValue("hdrs") as NestedStruct).offset +
+        (layouts.structs.getValue("headers_t").members.getValue("ethernet") as NestedHeader).offset
+    val ethTotalBits = layouts.headers.getValue("ethernet_t").totalBits
+    TraceDelta.HeaderInvalidated(ethOffsetInPacket, ethTotalBits).applyTo(buffer)
+
+    // Ethernet is now zeroed and invalid.
+    assertEquals(BitVal(0L, 48), eth["dstAddr"])
+    assertFalse(eth.isValid)
+    // But metadata is intact.
+    assertEquals(BitVal(0x1AAL, 9), root.struct("meta")["ingress_port"])
+    assertEquals(BitVal(1L, 1), root.struct("meta")["drop"])
+  }
+
+  // =====================================================================
+  // Helpers — tiny proto-building DSL.
+  // =====================================================================
+
+  private fun typeDecl(name: String, content: (TypeDecl.Builder) -> Unit): TypeDecl =
+    TypeDecl.newBuilder().setName(name).also(content).build()
+
+  private fun header(vararg fields: Pair<String, Type>): (TypeDecl.Builder) -> Unit = { b ->
+    b.setHeader(HeaderDecl.newBuilder().addAllFields(fields.map { fieldDecl(it.first, it.second) }))
+  }
+
+  private fun struct(vararg fields: Pair<String, Type>): (TypeDecl.Builder) -> Unit = { b ->
+    b.setStruct(StructDecl.newBuilder().addAllFields(fields.map { fieldDecl(it.first, it.second) }))
+  }
+
+  private fun fieldDecl(name: String, type: Type): FieldDecl =
+    FieldDecl.newBuilder().setName(name).setType(type).build()
+
+  private fun bit(width: Int): Type =
+    Type.newBuilder().setBit(BitType.newBuilder().setWidth(width)).build()
+
+  private fun bool(): Type = Type.newBuilder().setBoolean(true).build()
+
+  private fun named(name: String): Type = Type.newBuilder().setNamed(name).build()
+}

--- a/simulator/HeaderStackView.kt
+++ b/simulator/HeaderStackView.kt
@@ -1,0 +1,129 @@
+package fourward.simulator
+
+/**
+ * Static layout of a P4 header stack: a fixed-size array of headers plus a `nextIndex` counter (P4
+ * spec §8.18).
+ *
+ * Memory layout within the buffer (relative to the stack's [base]):
+ * ```
+ * [nextIndex: nextIndexWidth bits | element[0] | element[1] | ... | element[size-1]]
+ * ```
+ *
+ * Static `stack[i]` indexing compiles to a constant offset; dynamic `i` becomes one
+ * multiply-and-add at access time.
+ */
+data class HeaderStackLayout(
+  val typeName: String,
+  val elementLayout: HeaderLayout,
+  val size: Int,
+  val nextIndexWidth: Int = NEXT_INDEX_WIDTH,
+) {
+  init {
+    require(size > 0) { "header stack size must be positive, got $size" }
+  }
+
+  /** Bit offset of the `nextIndex` counter within the stack. */
+  val nextIndexOffset: Int = 0
+
+  /** Bit offset of the first element (just past the counter). */
+  val firstElementOffset: Int = nextIndexWidth
+
+  /** Bit offset of element `[index]` within the stack. */
+  fun elementOffset(index: Int): Int = firstElementOffset + index * elementLayout.totalBits
+
+  /** Total bit width of this stack: counter + size × element. */
+  val totalBits: Int = nextIndexWidth + size * elementLayout.totalBits
+
+  companion object {
+    /** Width of the `nextIndex` counter. 8 bits supports stacks up to 255 deep, plenty for P4. */
+    const val NEXT_INDEX_WIDTH: Int = 8
+  }
+}
+
+/**
+ * A view onto a [HeaderStackLayout]'s elements in a [PacketBuffer], anchored at a [base] bit
+ * offset.
+ *
+ * Replaces the legacy `HeaderStackVal` (a heap-allocated `MutableList<Value>` plus an `Int`
+ * `nextIndex`). All state — counter and elements — lives in the buffer; `pushFront`/`popFront`
+ * become block memcpys within the buffer.
+ */
+class HeaderStackView(val buffer: PacketBuffer, val layout: HeaderStackLayout, val base: Int = 0) :
+  Value() {
+
+  /** Returns a view over an independent copy of [buffer]. */
+  override fun deepCopy(): HeaderStackView = HeaderStackView(buffer.copyOf(), layout, base)
+
+  /** Current `nextIndex` value, stored in the first [layout.nextIndexWidth] bits of the stack. */
+  var nextIndex: Int
+    get() = buffer.readBits(base + layout.nextIndexOffset, layout.nextIndexWidth).toInt()
+    set(value) {
+      require(value in 0..layout.size) { "nextIndex must be in 0..${layout.size}, got $value" }
+      buffer.writeBits(base + layout.nextIndexOffset, layout.nextIndexWidth, value.toLong())
+    }
+
+  /** Number of slots in the stack. Fixed at layout time. */
+  val size: Int
+    get() = layout.size
+
+  /** Returns a [HeaderView] for element `[index]`. Throws on out-of-range. */
+  operator fun get(index: Int): HeaderView {
+    require(index in 0 until layout.size) {
+      "header-stack index $index out of range 0..${layout.size}"
+    }
+    return HeaderView(buffer, layout.elementLayout, base + layout.elementOffset(index))
+  }
+
+  /**
+   * Shifts elements towards higher indices by [count] (P4 spec §8.18). Elements that fall off the
+   * end are lost; the first [count] slots become invalid (zeroed).
+   */
+  fun pushFront(count: Int) {
+    require(count >= 0) { "pushFront count must be non-negative, got $count" }
+    if (count == 0) return
+    val effectiveCount = minOf(count, layout.size)
+    val elementBits = layout.elementLayout.totalBits
+    // Move elements [0..size-effectiveCount-1] to [effectiveCount..size-1].
+    // Iterate from the high end downwards so we don't overwrite source data.
+    for (i in (layout.size - effectiveCount - 1) downTo 0) {
+      copyElement(srcIndex = i, dstIndex = i + effectiveCount, elementBits = elementBits)
+    }
+    // Zero the new low slots.
+    for (i in 0 until effectiveCount) {
+      buffer.zeroRange(base + layout.elementOffset(i), elementBits)
+    }
+    nextIndex = minOf(nextIndex + count, layout.size)
+  }
+
+  /**
+   * Shifts elements towards lower indices by [count] (P4 spec §8.18). The first [count] elements
+   * are dropped; the last [count] slots become invalid (zeroed).
+   */
+  fun popFront(count: Int) {
+    require(count >= 0) { "popFront count must be non-negative, got $count" }
+    if (count == 0) return
+    val effectiveCount = minOf(count, layout.size)
+    val elementBits = layout.elementLayout.totalBits
+    for (i in 0 until (layout.size - effectiveCount)) {
+      copyElement(srcIndex = i + effectiveCount, dstIndex = i, elementBits = elementBits)
+    }
+    for (i in (layout.size - effectiveCount) until layout.size) {
+      buffer.zeroRange(base + layout.elementOffset(i), elementBits)
+    }
+    nextIndex = maxOf(nextIndex - count, 0)
+  }
+
+  /** Block-copies element [srcIndex] over element [dstIndex]. */
+  private fun copyElement(srcIndex: Int, dstIndex: Int, elementBits: Int) {
+    var remaining = elementBits
+    var srcBit = base + layout.elementOffset(srcIndex)
+    var dstBit = base + layout.elementOffset(dstIndex)
+    while (remaining > 0) {
+      val chunk = minOf(Long.SIZE_BITS, remaining)
+      buffer.writeBits(dstBit, chunk, buffer.readBits(srcBit, chunk))
+      srcBit += chunk
+      dstBit += chunk
+      remaining -= chunk
+    }
+  }
+}

--- a/simulator/HeaderStackViewTest.kt
+++ b/simulator/HeaderStackViewTest.kt
@@ -1,0 +1,154 @@
+package fourward.simulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit tests for [HeaderStackLayout] and [HeaderStackView]. */
+class HeaderStackViewTest {
+
+  // A tiny header type for the stack's elements: 16-bit value plus a validity bit.
+  private val element =
+    HeaderLayout(
+      typeName = "elt_t",
+      fields = linkedMapOf("v" to FieldSlot(0, 16, PrimitiveKind.BIT)),
+      validBitOffset = 16,
+    )
+
+  private val stack3 = HeaderStackLayout(typeName = "elt_t[3]", elementLayout = element, size = 3)
+
+  private fun newStack(): HeaderStackView {
+    val buffer = PacketBuffer(stack3.totalBits)
+    return HeaderStackView(buffer, stack3)
+  }
+
+  @Test
+  fun `totalBits equals counter plus size times element bits`() {
+    val expected = HeaderStackLayout.NEXT_INDEX_WIDTH + 3 * element.totalBits
+    assertEquals(expected, stack3.totalBits)
+  }
+
+  @Test
+  fun `nextIndex round-trips through the buffer`() {
+    val s = newStack()
+    assertEquals(0, s.nextIndex)
+    s.nextIndex = 2
+    assertEquals(2, s.nextIndex)
+  }
+
+  @Test
+  fun `nextIndex of size is allowed, out-of-range throws`() {
+    val s = newStack()
+    s.nextIndex = stack3.size // valid: stack is full
+    assertEquals(stack3.size, s.nextIndex)
+    assertThrows(IllegalArgumentException::class.java) { s.nextIndex = stack3.size + 1 }
+    assertThrows(IllegalArgumentException::class.java) { s.nextIndex = -1 }
+  }
+
+  @Test
+  fun `get returns a HeaderView at the right offset`() {
+    val s = newStack()
+    s[0]["v"] = BitVal(0xAAAAL, 16)
+    s[1]["v"] = BitVal(0xBBBBL, 16)
+    s[2]["v"] = BitVal(0xCCCCL, 16)
+    s[1].isValid = true
+
+    assertEquals(BitVal(0xAAAAL, 16), s[0]["v"])
+    assertEquals(BitVal(0xBBBBL, 16), s[1]["v"])
+    assertEquals(BitVal(0xCCCCL, 16), s[2]["v"])
+    assertTrue(s[1].isValid)
+    assertFalse(s[0].isValid)
+    assertFalse(s[2].isValid)
+  }
+
+  @Test
+  fun `out-of-range index throws`() {
+    val s = newStack()
+    assertThrows(IllegalArgumentException::class.java) { s[stack3.size] }
+    assertThrows(IllegalArgumentException::class.java) { s[-1] }
+  }
+
+  @Test
+  fun `pushFront shifts elements up and zeros the low slots`() {
+    val s = newStack()
+    s[0]["v"] = BitVal(0x1111L, 16)
+    s[0].isValid = true
+    s[1]["v"] = BitVal(0x2222L, 16)
+    s[1].isValid = true
+    s.nextIndex = 2
+
+    s.pushFront(1)
+
+    assertEquals(BitVal(0L, 16), s[0]["v"])
+    assertFalse(s[0].isValid)
+    assertEquals(BitVal(0x1111L, 16), s[1]["v"])
+    assertTrue(s[1].isValid)
+    assertEquals(BitVal(0x2222L, 16), s[2]["v"])
+    assertTrue(s[2].isValid)
+    assertEquals(3, s.nextIndex)
+  }
+
+  @Test
+  fun `pushFront greater than size clamps and zeros everything`() {
+    val s = newStack()
+    s[0]["v"] = BitVal(0x1111L, 16)
+    s[1]["v"] = BitVal(0x2222L, 16)
+
+    s.pushFront(stack3.size + 5)
+
+    assertEquals(BitVal(0L, 16), s[0]["v"])
+    assertEquals(BitVal(0L, 16), s[1]["v"])
+    assertEquals(BitVal(0L, 16), s[2]["v"])
+  }
+
+  @Test
+  fun `popFront shifts elements down and zeros the high slots`() {
+    val s = newStack()
+    s[0]["v"] = BitVal(0x1111L, 16)
+    s[0].isValid = true
+    s[1]["v"] = BitVal(0x2222L, 16)
+    s[1].isValid = true
+    s[2]["v"] = BitVal(0x3333L, 16)
+    s[2].isValid = true
+    s.nextIndex = 3
+
+    s.popFront(1)
+
+    assertEquals(BitVal(0x2222L, 16), s[0]["v"])
+    assertTrue(s[0].isValid)
+    assertEquals(BitVal(0x3333L, 16), s[1]["v"])
+    assertTrue(s[1].isValid)
+    assertEquals(BitVal(0L, 16), s[2]["v"])
+    assertFalse(s[2].isValid)
+    assertEquals(2, s.nextIndex)
+  }
+
+  @Test
+  fun `pushFront then popFront preserves the original middle elements`() {
+    val s = newStack()
+    s[0]["v"] = BitVal(0xAAAAL, 16)
+    s[1]["v"] = BitVal(0xBBBBL, 16)
+
+    s.pushFront(1)
+    s.popFront(1)
+
+    assertEquals(BitVal(0xAAAAL, 16), s[0]["v"])
+    assertEquals(BitVal(0xBBBBL, 16), s[1]["v"])
+  }
+
+  @Test
+  fun `nested stack via StructView`() {
+    val outer =
+      StructLayout(
+        typeName = "outer_t",
+        members = linkedMapOf<String, StructMember>("stk" to NestedStack(0, stack3)),
+      )
+    val buffer = PacketBuffer(outer.totalBits)
+    val view = StructView(buffer, outer)
+    val s = view.stack("stk")
+    s[0]["v"] = BitVal(0xCAFEL, 16)
+    assertEquals(BitVal(0xCAFEL, 16), s[0]["v"])
+  }
+}

--- a/simulator/HeaderView.kt
+++ b/simulator/HeaderView.kt
@@ -1,0 +1,103 @@
+package fourward.simulator
+
+/**
+ * Location of a primitive field within a [HeaderLayout] or [StructLayout]: bit offset from the
+ * layout's base, bit width, and primitive kind (so readers can return the right [Value] subtype).
+ */
+data class FieldSlot(val offset: Int, val width: Int, val kind: PrimitiveKind = PrimitiveKind.BIT) {
+  init {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+    require(width >= 1) { "width must be positive, got $width" }
+    if (kind == PrimitiveKind.BOOL) {
+      require(width == 1) { "bool field width must be 1, got $width" }
+    }
+    if (kind == PrimitiveKind.ERROR) {
+      require(width <= Long.SIZE_BITS) { "error field width must be ≤ 64, got $width" }
+    }
+  }
+}
+
+/**
+ * The P4 primitive type kind a [FieldSlot] represents. Preserves enough of the source type so that
+ * buffer reads can produce the correct [Value] subtype (`BitVal`, `IntVal`, `BoolVal`).
+ *
+ * Enums map to [BIT] (with their underlying width); errors are recorded with [ERROR] so readers can
+ * look up the error name from the pipeline's error-code table.
+ */
+enum class PrimitiveKind {
+  BIT,
+  INT,
+  BOOL,
+  ERROR,
+}
+
+/**
+ * Static layout of a P4 header type: where each field sits, how wide it is, and where the validity
+ * bit lives. Computed once per header type at pipeline load, then immutable and shared across all
+ * [HeaderView]s of that type.
+ *
+ * Field iteration order is the declaration order, preserved by passing a [LinkedHashMap] as
+ * [fields]. The trace and serialization emit fields in declaration order.
+ */
+data class HeaderLayout(
+  val typeName: String,
+  val fields: Map<String, FieldSlot>,
+  /** Bit offset within the layout where the validity bit lives. */
+  val validBitOffset: Int,
+) {
+  /** Total width of this header in bits, including the validity bit. */
+  val totalBits: Int =
+    maxOf(validBitOffset + 1, fields.values.maxOfOrNull { it.offset + it.width } ?: 0)
+}
+
+/**
+ * A view onto a [HeaderLayout]'s fields in a [PacketBuffer], anchored at a [base] bit offset.
+ *
+ * Multiple views can share a buffer at different bases (e.g., successive headers in a packet), or
+ * share a layout at the same base after a fork copy. The view itself is cheap — it holds three
+ * references and no mutable state.
+ *
+ * Extends [Value] so it can flow through the [Environment] alongside other runtime values once the
+ * buffer-backed migration is complete. A view's [deepCopy] returns a view over a fresh buffer copy
+ * — the optimal-design alternative to walking and copying an object tree.
+ */
+class HeaderView(val buffer: PacketBuffer, val layout: HeaderLayout, val base: Int = 0) : Value() {
+
+  /** Returns a view over an independent copy of [buffer]. Used by the fork path. */
+  override fun deepCopy(): HeaderView = HeaderView(buffer.copyOf(), layout, base)
+
+  /** Whether the header is currently valid (the P4 validity bit). */
+  var isValid: Boolean
+    get() = buffer.readBits(base + layout.validBitOffset, 1) == 1L
+    set(value) {
+      if (!value) {
+        // P4 spec section 8.17: setInvalid resets all fields to default values.
+        // BMv2 treats fields of an invalid header as zero, so we zero the entire layout.
+        buffer.zeroRange(base, layout.totalBits)
+      }
+      buffer.writeBits(base + layout.validBitOffset, 1, if (value) 1L else 0L)
+    }
+
+  /** Reads the named field. Throws if [field] is not declared in this header's layout. */
+  operator fun get(field: String): BitVal {
+    val slot = slotOf(field)
+    val bits = buffer.readBits(base + slot.offset, slot.width)
+    return BitVal(bits, slot.width)
+  }
+
+  /**
+   * Writes the named field. Throws if [field] is not declared in this header's layout, or if
+   * [value]'s width differs from the declared width.
+   */
+  operator fun set(field: String, value: BitVal) {
+    val slot = slotOf(field)
+    require(value.bits.width == slot.width) {
+      "${layout.typeName}.$field expects bit<${slot.width}>, got bit<${value.bits.width}>"
+    }
+    buffer.writeBits(base + slot.offset, slot.width, value.bits.value.toLong())
+  }
+
+  private fun slotOf(field: String): FieldSlot =
+    layout.fields[field]
+      ?: throw IllegalArgumentException("${layout.typeName} has no field '$field'")
+}

--- a/simulator/HeaderViewTest.kt
+++ b/simulator/HeaderViewTest.kt
@@ -1,0 +1,162 @@
+package fourward.simulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit tests for [HeaderLayout] and [HeaderView]. */
+class HeaderViewTest {
+
+  // An ethernet header layout: dstAddr(48) | srcAddr(48) | etherType(16) | valid(1).
+  // Total 113 bits; field offsets are bit-aligned from 0.
+  private val ethernet =
+    HeaderLayout(
+      typeName = "ethernet_t",
+      fields =
+        linkedMapOf(
+          "dstAddr" to FieldSlot(offset = 0, width = 48),
+          "srcAddr" to FieldSlot(offset = 48, width = 48),
+          "etherType" to FieldSlot(offset = 96, width = 16),
+        ),
+      validBitOffset = 112,
+    )
+
+  private fun newBuffer() = PacketBuffer(ethernet.totalBits)
+
+  private fun newHeader() = HeaderView(newBuffer(), ethernet, base = 0)
+
+  // =====================================================================
+  // Layout sanity
+  // =====================================================================
+
+  @Test
+  fun `totalBits includes all fields plus validity bit`() {
+    assertEquals(48 + 48 + 16 + 1, ethernet.totalBits)
+  }
+
+  // =====================================================================
+  // Field read/write
+  // =====================================================================
+
+  @Test
+  fun `set and get individual fields`() {
+    val h = newHeader()
+    h["dstAddr"] = BitVal(0xAABB_CCDD_EEFFL, 48)
+    h["srcAddr"] = BitVal(0x1122_3344_5566L, 48)
+    h["etherType"] = BitVal(0x0800L, 16)
+
+    assertEquals(BitVal(0xAABB_CCDD_EEFFL, 48), h["dstAddr"])
+    assertEquals(BitVal(0x1122_3344_5566L, 48), h["srcAddr"])
+    assertEquals(BitVal(0x0800L, 16), h["etherType"])
+  }
+
+  @Test
+  fun `reading an unknown field name throws`() {
+    val h = newHeader()
+    assertThrows(IllegalArgumentException::class.java) { h["missing"] }
+  }
+
+  @Test
+  fun `writing an unknown field name throws`() {
+    val h = newHeader()
+    assertThrows(IllegalArgumentException::class.java) { h["missing"] = BitVal(0L, 8) }
+  }
+
+  @Test
+  fun `writing a value of the wrong width throws`() {
+    val h = newHeader()
+    assertThrows(IllegalArgumentException::class.java) {
+      h["etherType"] = BitVal(0L, 8) // etherType is 16 bits
+    }
+  }
+
+  // =====================================================================
+  // Validity
+  // =====================================================================
+
+  @Test
+  fun `new headers are invalid by default`() {
+    val h = newHeader()
+    assertFalse(h.isValid)
+  }
+
+  @Test
+  fun `setting isValid toggles the validity bit`() {
+    val h = newHeader()
+    h.isValid = true
+    assertTrue(h.isValid)
+    h.isValid = false
+    assertFalse(h.isValid)
+  }
+
+  @Test
+  fun `setInvalid zeros all fields (P4 spec section 8_17)`() {
+    val h = newHeader()
+    h["dstAddr"] = BitVal(0xFFFF_FFFF_FFFFL, 48)
+    h["srcAddr"] = BitVal(0xFFFF_FFFF_FFFFL, 48)
+    h["etherType"] = BitVal(0xFFFFL, 16)
+    h.isValid = true
+
+    h.isValid = false
+
+    assertFalse(h.isValid)
+    assertEquals(BitVal(0L, 48), h["dstAddr"])
+    assertEquals(BitVal(0L, 48), h["srcAddr"])
+    assertEquals(BitVal(0L, 16), h["etherType"])
+  }
+
+  // =====================================================================
+  // Base offset (multiple headers in one buffer)
+  // =====================================================================
+
+  @Test
+  fun `views at different base offsets do not interfere`() {
+    // A buffer holding two ethernet headers back to back.
+    val buf = PacketBuffer(ethernet.totalBits * 2)
+    val first = HeaderView(buf, ethernet, base = 0)
+    val second = HeaderView(buf, ethernet, base = ethernet.totalBits)
+
+    first["dstAddr"] = BitVal(0xAAAAAAAAAAAAL, 48)
+    second["dstAddr"] = BitVal(0xBBBBBBBBBBBBL, 48)
+
+    assertEquals(BitVal(0xAAAAAAAAAAAAL, 48), first["dstAddr"])
+    assertEquals(BitVal(0xBBBBBBBBBBBBL, 48), second["dstAddr"])
+  }
+
+  @Test
+  fun `isValid at a non-zero base refers to the right bit`() {
+    val buf = PacketBuffer(ethernet.totalBits * 2)
+    val first = HeaderView(buf, ethernet, base = 0)
+    val second = HeaderView(buf, ethernet, base = ethernet.totalBits)
+
+    first.isValid = true
+
+    assertTrue(first.isValid)
+    assertFalse(second.isValid)
+  }
+
+  // =====================================================================
+  // Fork / copy
+  // =====================================================================
+
+  @Test
+  fun `views over a copied buffer are independent`() {
+    val h = newHeader()
+    h["dstAddr"] = BitVal(0x111111111111L, 48)
+    h.isValid = true
+
+    val forkedBuffer = h.buffer.copyOf()
+    val forked = HeaderView(forkedBuffer, ethernet, base = 0)
+
+    // The fork sees the parent's state.
+    assertEquals(BitVal(0x111111111111L, 48), forked["dstAddr"])
+    assertTrue(forked.isValid)
+
+    // Mutating the fork doesn't affect the parent.
+    forked["dstAddr"] = BitVal(0x222222222222L, 48)
+    assertEquals(BitVal(0x111111111111L, 48), h["dstAddr"])
+    assertEquals(BitVal(0x222222222222L, 48), forked["dstAddr"])
+  }
+}

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -27,11 +27,11 @@ import java.math.BigInteger
 /**
  * Long-lived P4 interpreter engine, built once per pipeline config.
  *
- * Holds config-derived maps (parsers, controls, actions, tables, types) that never change between
- * packets. Call [execution] for each pipeline run — the [Execution] inner class walks the IR tree
- * and is cheap to construct (just field assignments). Variable scopes live in [Environment];
- * packet-level state (input buffer, output buffer, trace) lives in [PacketContext]; program-global
- * state (table entries, extern instances) lives in [TableStore].
+ * Holds config-derived maps (parsers, controls, actions, tables, typesByName) that never change
+ * between packets. Call [execution] for each pipeline run — the [Execution] inner class walks the
+ * IR tree and is cheap to construct (just field assignments). Variable scopes live in
+ * [Environment]; packet-level state (input buffer, output buffer, trace) lives in [PacketContext];
+ * program-global state (table entries, extern instances) lives in [TableStore].
  *
  * The interpreter is deliberately simple: it pattern-matches on proto oneof fields and dispatches
  * to focused methods. There is no bytecode compilation or optimisation — correctness and
@@ -46,6 +46,16 @@ class Interpreter internal constructor(config: BehavioralConfig) {
   private val parsers: Map<String, ParserDecl> = config.parsersList.associateBy { it.name }
 
   private val controls: Map<String, ControlDecl> = config.controlsList.associateBy { it.name }
+
+  /** Type declarations indexed by name. Computed once per pipeline. */
+  val typesByName: Map<String, fourward.ir.TypeDecl> = config.typesList.associateBy { it.name }
+
+  /**
+   * Buffer-backed layouts for every type that supports them. Computed once per pipeline.
+   * Architectures pass this to [createDefaultValues] so per-packet setup produces buffer-backed
+   * values where possible.
+   */
+  val layouts: PipelineLayouts = tryComputeLayouts(typesByName)
 
   // Actions may be declared either at the top level or as local actions inside controls.
   // After the midend, all relevant actions end up in control.localActionsList.
@@ -68,8 +78,6 @@ class Interpreter internal constructor(config: BehavioralConfig) {
   }
 
   private val tables: Map<String, TableBehavior> = config.tablesList.associateBy { it.name }
-
-  private val types: Map<String, fourward.ir.TypeDecl> = config.typesList.associateBy { it.name }
 
   private data class TableResult(val hit: Boolean, val actionName: String)
 
@@ -319,7 +327,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         for (varDecl in localVars) {
           val init =
             if (varDecl.hasInitializer()) evalExpr(varDecl.initializer, env)
-            else defaultValue(varDecl.type, types)
+            else defaultValue(varDecl.type, typesByName)
           env.define(varDecl.name, init)
         }
         body()
@@ -447,6 +455,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           else -> error("unknown field '${fa.fieldName}' on table apply result${sourceContext()}")
         }
       }
+
       val target = evalExpr(fa.expr, env)
       return when (target) {
         is HeaderVal ->
@@ -490,7 +499,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         evalExpr(ai.expr, env) as? HeaderStackVal
           ?: error("array index on non-stack value${sourceContext()}")
       val index = intValue(evalExpr(ai.index, env))
-      if (index !in 0 until stack.size) return defaultValue(stack.elementTypeName, types)
+      if (index !in 0 until stack.size) return defaultValue(stack.elementTypeName, typesByName)
       return stack.headers[index]
     }
 
@@ -726,7 +735,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             stack.headers[i] = stack.headers[i - count]
           }
           for (i in 0 until count) {
-            stack.headers[i] = defaultValue(stack.elementTypeName, types)
+            stack.headers[i] = defaultValue(stack.elementTypeName, typesByName)
           }
           stack.nextIndex = (stack.nextIndex + count).coerceAtMost(stack.size)
           UnitVal
@@ -739,7 +748,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             stack.headers[i] = stack.headers[i + count]
           }
           for (i in stack.size - count until stack.size) {
-            stack.headers[i] = defaultValue(stack.elementTypeName, types)
+            stack.headers[i] = defaultValue(stack.elementTypeName, typesByName)
           }
           stack.nextIndex = (stack.nextIndex - count).coerceAtLeast(0)
           UnitVal
@@ -965,7 +974,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         override fun writeOutArg(index: Int, value: Value) =
           setLValue(call.argsList[index], value, env)
 
-        override fun defaultValue(type: Type): Value = defaultValue(type, types)
+        override fun defaultValue(type: Type): Value = defaultValue(type, typesByName)
 
         override fun traceEventBuilder(): TraceEvent.Builder = this@Execution.traceEventBuilder()
 
@@ -1012,7 +1021,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     private fun isUnionFieldAccess(expr: Expr): Boolean =
       expr.hasFieldAccess() &&
         expr.fieldAccess.expr.type.let { t ->
-          t.hasNamed() && types[t.named]?.hasHeaderUnion() == true
+          t.hasNamed() && typesByName[t.named]?.hasHeaderUnion() == true
         }
 
     /** If [expr] is a field access into a header union, enforce one-valid-at-a-time (P4 §8.20). */
@@ -1037,7 +1046,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       var unionHandled = false
       val header =
         if (arg.hasNameRef() && env.lookup(arg.nameRef.name) == null && arg.type.hasNamed()) {
-          defaultValue(arg.type.named, types) as? HeaderVal
+          defaultValue(arg.type.named, typesByName) as? HeaderVal
             ?: error("type not found for don't-care extract: ${arg.type.named}")
         } else if (isUnionFieldAccess(arg)) {
           // Parent is a header union — resolve it once, invalidate siblings (P4 §8.20).
@@ -1050,7 +1059,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           evalExpr(arg, env) as HeaderVal
         }
       val headerDecl =
-        (types[header.typeName] ?: error("type not found: ${header.typeName}")).header
+        (typesByName[header.typeName] ?: error("type not found: ${header.typeName}")).header
 
       // The 2-argument form b.extract(hdr, varbitBits) is used when the header contains a varbit
       // field. The second argument gives the varbit field's runtime length in bits.
@@ -1095,7 +1104,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       }
 
       val typeName = returnType.named
-      val typeDecl = types[typeName] ?: error("type not found for lookahead: $typeName")
+      val typeDecl = typesByName[typeName] ?: error("type not found for lookahead: $typeName")
       val fields =
         when {
           typeDecl.hasHeader() -> typeDecl.header.fieldsList
@@ -1156,7 +1165,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         type.hasBoolean() -> 1
         type.hasVarbit() -> varbitBits
         type.hasNamed() -> {
-          val decl = types[type.named]
+          val decl = typesByName[type.named]
           when {
             decl != null && decl.hasEnum() -> decl.enum.width
             else -> 0
@@ -1196,7 +1205,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         is HeaderVal -> emitHeader(value)
         is StructVal -> {
           // Emit in the declaration order from the TypeDecl; fall back to map order if unknown.
-          val typeDecl = types[value.typeName]
+          val typeDecl = typesByName[value.typeName]
           val fieldDecls =
             when {
               typeDecl != null && typeDecl.hasStruct() -> typeDecl.struct.fieldsList
@@ -1222,7 +1231,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     private fun emitHeader(header: HeaderVal) {
       if (!header.valid) return
       val headerDecl =
-        (types[header.typeName] ?: error("type not found: ${header.typeName}")).header
+        (typesByName[header.typeName] ?: error("type not found: ${header.typeName}")).header
       // Compute total wire bits from field declarations; varbit fields use their stored BitVal
       // width since we don't have the runtime length separately at emit time.
       val totalBits =

--- a/simulator/LayoutComputer.kt
+++ b/simulator/LayoutComputer.kt
@@ -1,0 +1,255 @@
+package fourward.simulator
+
+import fourward.ir.PipelineConfig
+import fourward.ir.Type
+import fourward.ir.TypeDecl
+
+/**
+ * Layouts for every header, struct, header union, and enum type in a pipeline.
+ *
+ * Computed once at pipeline-load time from the IR's [TypeDecl]s and then immutable. Every runtime
+ * [HeaderView] and [StructView] refers to an entry here.
+ */
+data class PipelineLayouts(
+  val headers: Map<String, HeaderLayout>,
+  val structs: Map<String, StructLayout>,
+  val stacks: Map<String, HeaderStackLayout>,
+  /** Serializable enum underlying bit widths, by type name. */
+  val enumWidths: Map<String, Int>,
+)
+
+/**
+ * Computes layouts for all the types in a pipeline from its [TypeDecl] list.
+ *
+ * Input is a map from type name to declaration (as stored in the runtime's type table). The
+ * computer handles nested named types by recursion and caches results so each type is computed at
+ * most once. Cycles between mutable (header/struct) types throw.
+ *
+ * Types currently handled:
+ * - [fourward.ir.HeaderDecl] with primitive fields (`bit<N>`, `int<N>`, `bool`)
+ * - [fourward.ir.StructDecl] with primitive or nested-named fields (struct-of-header,
+ *   struct-of-struct)
+ * - Serializable [fourward.ir.EnumDecl] (non-zero width; used as a bit field)
+ *
+ * Not yet handled (will throw `IllegalArgumentException`):
+ * - Header stacks, header unions, varbit, non-serializable enums, error types
+ *
+ * These gaps are filled in subsequent milestones. See `designs/flat_packet_buffer.md`.
+ */
+fun computeLayouts(typeDecls: Map<String, TypeDecl>): PipelineLayouts {
+  val computer = LayoutComputation(typeDecls)
+  for (name in typeDecls.keys) {
+    computer.layoutFor(name)
+  }
+  return PipelineLayouts(
+    headers = computer.headers.toMap(),
+    structs = computer.structs.toMap(),
+    stacks = computer.stacks.toMap(),
+    enumWidths = computer.enumWidths.toMap(),
+  )
+}
+
+/**
+ * Lenient version of [computeLayouts]: types whose layout can't be computed yet (header stacks,
+ * unions, varbits, error fields, non-serialisable enums) are silently skipped instead of throwing.
+ * The returned [PipelineLayouts] contains layouts only for types the runtime can use buffer-backed.
+ *
+ * Use this from runtime paths (architectures, defaultValue) where partial coverage is fine — the
+ * legacy HashMap representation handles types without a layout. Tests that assert specific layout
+ * shapes should use the strict [computeLayouts] overload.
+ */
+fun tryComputeLayouts(typeDecls: Map<String, TypeDecl>): PipelineLayouts {
+  val computer = LayoutComputation(typeDecls)
+  for (name in typeDecls.keys) {
+    runCatching { computer.layoutFor(name) }
+  }
+  return PipelineLayouts(
+    headers = computer.headers.toMap(),
+    structs = computer.structs.toMap(),
+    stacks = computer.stacks.toMap(),
+    enumWidths = computer.enumWidths.toMap(),
+  )
+}
+
+/**
+ * Convenience overload: computes layouts directly from a [PipelineConfig], extracting the type
+ * declarations from `config.device.behavioral.typesList`.
+ */
+fun computeLayouts(config: PipelineConfig): PipelineLayouts {
+  val types = config.device.behavioral.typesList.associateBy { it.name }
+  return computeLayouts(types)
+}
+
+/** Lenient overload of [tryComputeLayouts] taking a [PipelineConfig]. */
+fun tryComputeLayouts(config: PipelineConfig): PipelineLayouts {
+  val types = config.device.behavioral.typesList.associateBy { it.name }
+  return tryComputeLayouts(types)
+}
+
+/**
+ * Internal state for a single layout computation run. Memoises resolved layouts and tracks the
+ * in-progress set for cycle detection.
+ */
+private class LayoutComputation(private val typeDecls: Map<String, TypeDecl>) {
+  val headers = mutableMapOf<String, HeaderLayout>()
+  val structs = mutableMapOf<String, StructLayout>()
+  val stacks = mutableMapOf<String, HeaderStackLayout>()
+  val enumWidths = mutableMapOf<String, Int>()
+
+  /** Names currently being resolved. If we see one twice, we've hit a cycle. */
+  private val inProgress = mutableSetOf<String>()
+
+  /**
+   * Resolves the layout for [typeName], recursively computing dependencies as needed. Returns the
+   * width in bits of the resolved type (for use in parent layouts).
+   */
+  fun layoutFor(typeName: String): Int {
+    headers[typeName]?.let {
+      return it.totalBits
+    }
+    structs[typeName]?.let {
+      return it.totalBits
+    }
+    enumWidths[typeName]?.let {
+      return it
+    }
+
+    val decl =
+      typeDecls[typeName] ?: throw IllegalArgumentException("unknown type reference: '$typeName'")
+
+    if (!inProgress.add(typeName)) {
+      error("cycle detected in type layout computation: $typeName")
+    }
+    try {
+      return when {
+        decl.hasHeader() -> {
+          val layout = computeHeader(decl)
+          headers[typeName] = layout
+          layout.totalBits
+        }
+        decl.hasStruct() -> {
+          val layout = computeStruct(decl)
+          structs[typeName] = layout
+          layout.totalBits
+        }
+        decl.hasEnum() -> computeEnum(decl).also { enumWidths[typeName] = it }
+        decl.hasHeaderUnion() ->
+          throw IllegalArgumentException("header unions not yet supported: $typeName")
+        else -> throw IllegalArgumentException("unrecognised TypeDecl kind for $typeName")
+      }
+    } finally {
+      inProgress.remove(typeName)
+    }
+  }
+
+  private fun computeHeader(decl: TypeDecl): HeaderLayout {
+    val fields = linkedMapOf<String, FieldSlot>()
+    var offset = 0
+    for (field in decl.header.fieldsList) {
+      val slot = primitiveSlot(field.type, field.name, offset)
+      fields[field.name] = slot
+      offset += slot.width
+    }
+    return HeaderLayout(typeName = decl.name, fields = fields, validBitOffset = offset)
+  }
+
+  private fun computeStruct(decl: TypeDecl): StructLayout {
+    val members = linkedMapOf<String, StructMember>()
+    var offset = 0
+    for (field in decl.struct.fieldsList) {
+      val member = structMember(field.type, field.name, offset)
+      members[field.name] = member
+      offset += member.widthBits
+    }
+    return StructLayout(typeName = decl.name, members = members)
+  }
+
+  /**
+   * Builds a [StructMember] for a field: primitive slot, nested header, nested struct, or nested
+   * header stack.
+   */
+  private fun structMember(type: Type, fieldName: String, offset: Int): StructMember =
+    when {
+      type.hasBit() ->
+        PrimitiveField(offset, type.bit.width, primitiveKindOf(fieldName, type.bit.width))
+      type.hasSignedInt() -> PrimitiveField(offset, type.signedInt.width, PrimitiveKind.INT)
+      type.hasBoolean() -> PrimitiveField(offset, 1, PrimitiveKind.BOOL)
+      // P4's built-in `error` type — p4c emits it either as the dedicated [Type.error] variant
+      // or as a named reference to "error". Tag it as ERROR so the buffer-backed encoder
+      // round-trips via [ErrorCodes].
+      type.hasError() -> PrimitiveField(offset, ERROR_FIELD_WIDTH_BITS, PrimitiveKind.ERROR)
+      type.hasNamed() && type.named == "error" ->
+        PrimitiveField(offset, ERROR_FIELD_WIDTH_BITS, PrimitiveKind.ERROR)
+      type.hasHeaderStack() -> {
+        // The IR's HeaderStackType references the element type by name and carries the size.
+        layoutFor(type.headerStack.elementType)
+        val elementLayout =
+          headers[type.headerStack.elementType]
+            ?: throw IllegalArgumentException(
+              "header stack '$fieldName' references non-header element type " +
+                "'${type.headerStack.elementType}'"
+            )
+        val stackLayout =
+          HeaderStackLayout(
+            typeName = "${type.headerStack.elementType}[${type.headerStack.size}]",
+            elementLayout = elementLayout,
+            size = type.headerStack.size,
+          )
+        NestedStack(offset, stackLayout)
+      }
+      type.hasNamed() -> {
+        // Resolve the nested type; dispatch on whether it's a header, struct, or enum.
+        layoutFor(type.named)
+        when {
+          headers.containsKey(type.named) -> NestedHeader(offset, headers.getValue(type.named))
+          structs.containsKey(type.named) -> NestedStruct(offset, structs.getValue(type.named))
+          enumWidths.containsKey(type.named) ->
+            PrimitiveField(offset, enumWidths.getValue(type.named), PrimitiveKind.BIT)
+          else ->
+            throw IllegalArgumentException(
+              "type '${type.named}' has no layout (unsupported kind for field '$fieldName')"
+            )
+        }
+      }
+      else ->
+        throw IllegalArgumentException(
+          "unsupported type for struct field '$fieldName': ${type.kindCase.name}"
+        )
+    }
+
+  private fun computeEnum(decl: TypeDecl): Int {
+    require(decl.enum.width > 0) {
+      "non-serializable enum '${decl.name}' not yet supported (requires integer code assignment)"
+    }
+    return decl.enum.width
+  }
+
+  /** Primitive slot for a header field — headers can't contain nested named types. */
+  private fun primitiveSlot(type: Type, fieldName: String, offset: Int): FieldSlot =
+    when {
+      type.hasBit() -> FieldSlot(offset, type.bit.width, primitiveKindOf(fieldName, type.bit.width))
+      type.hasSignedInt() -> FieldSlot(offset, type.signedInt.width, PrimitiveKind.INT)
+      type.hasBoolean() -> FieldSlot(offset, 1, PrimitiveKind.BOOL)
+      type.hasError() -> FieldSlot(offset, ERROR_FIELD_WIDTH_BITS, PrimitiveKind.ERROR)
+      type.hasNamed() && type.named == "error" ->
+        FieldSlot(offset, ERROR_FIELD_WIDTH_BITS, PrimitiveKind.ERROR)
+      else ->
+        throw IllegalArgumentException(
+          "header field '$fieldName' has non-primitive type ${type.kindCase.name}; " +
+            "headers may only contain bit<N>, int<N>, or bool"
+        )
+    }
+
+  /**
+   * p4c lowers P4 errors to `bit<32>` after the midend, losing the type-level signal. A `bit<32>`
+   * field literally named `parser_error` is tagged [PrimitiveKind.ERROR] so [BufferBackedFieldMap]
+   * can transparently encode/decode via [ErrorCodes].
+   */
+  private fun primitiveKindOf(fieldName: String, width: Int): PrimitiveKind =
+    if (fieldName == "parser_error" && width == ERROR_FIELD_WIDTH_BITS) PrimitiveKind.ERROR
+    else PrimitiveKind.BIT
+
+  companion object {
+    private const val ERROR_FIELD_WIDTH_BITS = 32
+  }
+}

--- a/simulator/LayoutComputerTest.kt
+++ b/simulator/LayoutComputerTest.kt
@@ -1,0 +1,203 @@
+package fourward.simulator
+
+import fourward.ir.FieldDecl
+import fourward.ir.HeaderDecl
+import fourward.ir.StructDecl
+import fourward.ir.Type
+import fourward.ir.TypeDecl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/** Unit tests for [computeLayouts]. */
+class LayoutComputerTest {
+
+  // =====================================================================
+  // Headers with primitive fields
+  // =====================================================================
+
+  @Test
+  fun `header with bit fields computes sequential offsets`() {
+    val ethernet =
+      headerDecl("ethernet_t", "dstAddr" to bit(48), "srcAddr" to bit(48), "etherType" to bit(16))
+    val layouts = computeLayouts(mapOf("ethernet_t" to ethernet))
+
+    val h = layouts.headers.getValue("ethernet_t")
+    assertEquals(FieldSlot(0, 48), h.fields["dstAddr"])
+    assertEquals(FieldSlot(48, 48), h.fields["srcAddr"])
+    assertEquals(FieldSlot(96, 16), h.fields["etherType"])
+    // Validity bit sits right after the last field.
+    assertEquals(112, h.validBitOffset)
+    assertEquals(113, h.totalBits)
+  }
+
+  @Test
+  fun `header with mixed bit int and bool fields`() {
+    val decl = headerDecl("mixed_t", "a" to bit(8), "b" to signedInt(16), "c" to bool())
+    val layouts = computeLayouts(mapOf("mixed_t" to decl))
+    val h = layouts.headers.getValue("mixed_t")
+    assertEquals(FieldSlot(0, 8, PrimitiveKind.BIT), h.fields["a"])
+    assertEquals(FieldSlot(8, 16, PrimitiveKind.INT), h.fields["b"])
+    assertEquals(FieldSlot(24, 1, PrimitiveKind.BOOL), h.fields["c"])
+    assertEquals(25, h.validBitOffset)
+  }
+
+  @Test
+  fun `empty header has only the validity bit`() {
+    val decl = headerDecl("empty_t")
+    val layouts = computeLayouts(mapOf("empty_t" to decl))
+    val h = layouts.headers.getValue("empty_t")
+    assertEquals(0, h.validBitOffset)
+    assertEquals(1, h.totalBits)
+  }
+
+  // =====================================================================
+  // Structs with primitive fields
+  // =====================================================================
+
+  @Test
+  fun `struct with primitive fields gets sequential offsets and no validity bit`() {
+    val decl =
+      structDecl(
+        "stdmeta_t",
+        "ingress_port" to bit(9),
+        "egress_spec" to bit(9),
+        "instance_type" to bit(32),
+      )
+    val layouts = computeLayouts(mapOf("stdmeta_t" to decl))
+    val s = layouts.structs.getValue("stdmeta_t")
+    assertEquals(PrimitiveField(0, 9), s.members["ingress_port"])
+    assertEquals(PrimitiveField(9, 9), s.members["egress_spec"])
+    assertEquals(PrimitiveField(18, 32), s.members["instance_type"])
+    assertEquals(50, s.totalBits)
+  }
+
+  @Test
+  fun `empty struct has zero total bits`() {
+    val decl = structDecl("empty_t")
+    val layouts = computeLayouts(mapOf("empty_t" to decl))
+    assertEquals(0, layouts.structs.getValue("empty_t").totalBits)
+  }
+
+  // =====================================================================
+  // Nested named types (struct-of-header, struct-of-struct)
+  // =====================================================================
+
+  @Test
+  fun `struct can contain a named header`() {
+    val ethernet = headerDecl("ethernet_t", "dstAddr" to bit(48), "etherType" to bit(16))
+    val headers = structDecl("headers_t", "ethernet" to named("ethernet_t"))
+    val layouts = computeLayouts(mapOf("ethernet_t" to ethernet, "headers_t" to headers))
+
+    val ethLayout = layouts.headers.getValue("ethernet_t")
+    assertEquals(48 + 16 + 1, ethLayout.totalBits)
+
+    val hdrsLayout = layouts.structs.getValue("headers_t")
+    // The nested ethernet becomes a NestedHeader member with the ethernet layout attached.
+    assertEquals(NestedHeader(offset = 0, layout = ethLayout), hdrsLayout.members["ethernet"])
+    assertEquals(ethLayout.totalBits, hdrsLayout.totalBits)
+  }
+
+  @Test
+  fun `struct can contain nested structs`() {
+    val inner = structDecl("inner_t", "x" to bit(16), "y" to bit(16))
+    val outer =
+      structDecl("outer_t", "head" to bit(8), "body" to named("inner_t"), "tail" to bit(8))
+    val layouts = computeLayouts(mapOf("inner_t" to inner, "outer_t" to outer))
+
+    val innerLayout = layouts.structs.getValue("inner_t")
+    val out = layouts.structs.getValue("outer_t")
+    assertEquals(PrimitiveField(0, 8), out.members["head"])
+    assertEquals(NestedStruct(offset = 8, layout = innerLayout), out.members["body"])
+    assertEquals(PrimitiveField(40, 8), out.members["tail"])
+    assertEquals(48, out.totalBits)
+  }
+
+  @Test
+  fun `layouts are computed in dependency order regardless of input order`() {
+    // 'outer' references 'inner', but the map iteration order might not be dependency order.
+    val inner = structDecl("inner_t", "x" to bit(8))
+    val outer = structDecl("outer_t", "nested" to named("inner_t"))
+    // Intentionally list outer first.
+    val layouts = computeLayouts(linkedMapOf("outer_t" to outer, "inner_t" to inner))
+    assertEquals(8, layouts.structs.getValue("inner_t").totalBits)
+    assertEquals(8, layouts.structs.getValue("outer_t").totalBits)
+  }
+
+  // =====================================================================
+  // Serializable enums
+  // =====================================================================
+
+  @Test
+  fun `serializable enum has its underlying bit width`() {
+    val e = enumDecl("MyEnum", listOf("A", "B", "C"), width = 8)
+    val layouts = computeLayouts(mapOf("MyEnum" to e))
+    assertEquals(8, layouts.enumWidths["MyEnum"])
+  }
+
+  @Test
+  fun `struct can contain a serializable enum field`() {
+    val e = enumDecl("Color", listOf("RED", "GREEN"), width = 4)
+    val s = structDecl("thing_t", "c" to named("Color"), "extra" to bit(4))
+    val layouts = computeLayouts(mapOf("Color" to e, "thing_t" to s))
+    val t = layouts.structs.getValue("thing_t")
+    assertEquals(PrimitiveField(0, 4), t.members["c"])
+    assertEquals(PrimitiveField(4, 4), t.members["extra"])
+  }
+
+  // =====================================================================
+  // Error handling
+  // =====================================================================
+
+  @Test
+  fun `unknown named type reference throws`() {
+    val decl = structDecl("bad_t", "field" to named("nonexistent"))
+    assertThrows(IllegalArgumentException::class.java) { computeLayouts(mapOf("bad_t" to decl)) }
+  }
+
+  @Test
+  fun `direct cycle between struct types throws`() {
+    val a = structDecl("A", "b" to named("B"))
+    val b = structDecl("B", "a" to named("A"))
+    assertThrows(IllegalStateException::class.java) { computeLayouts(mapOf("A" to a, "B" to b)) }
+  }
+
+  // =====================================================================
+  // Helpers — tiny DSL for constructing IR proto messages.
+  // =====================================================================
+
+  private fun headerDecl(name: String, vararg fields: Pair<String, Type>): TypeDecl =
+    TypeDecl.newBuilder()
+      .setName(name)
+      .setHeader(
+        HeaderDecl.newBuilder().addAllFields(fields.map { fieldDecl(it.first, it.second) })
+      )
+      .build()
+
+  private fun structDecl(name: String, vararg fields: Pair<String, Type>): TypeDecl =
+    TypeDecl.newBuilder()
+      .setName(name)
+      .setStruct(
+        StructDecl.newBuilder().addAllFields(fields.map { fieldDecl(it.first, it.second) })
+      )
+      .build()
+
+  private fun enumDecl(name: String, members: List<String>, width: Int): TypeDecl =
+    TypeDecl.newBuilder()
+      .setName(name)
+      .setEnum(fourward.ir.EnumDecl.newBuilder().addAllMembers(members).setWidth(width).build())
+      .build()
+
+  private fun fieldDecl(name: String, type: Type): FieldDecl =
+    FieldDecl.newBuilder().setName(name).setType(type).build()
+
+  private fun bit(width: Int): Type =
+    Type.newBuilder().setBit(fourward.ir.BitType.newBuilder().setWidth(width)).build()
+
+  private fun signedInt(width: Int): Type =
+    Type.newBuilder().setSignedInt(fourward.ir.IntType.newBuilder().setWidth(width)).build()
+
+  private fun bool(): Type = Type.newBuilder().setBoolean(true).build()
+
+  private fun named(name: String): Type = Type.newBuilder().setNamed(name).build()
+}

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -36,7 +36,8 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
   // misconfigured pipelines.
   private val interpreter: Interpreter = Interpreter(config)
   private val blockParams: Map<String, List<BlockParam>> = buildBlockParamsMap(config)
-  private val typesByName: Map<String, TypeDecl> = config.typesList.associateBy { it.name }
+  private val typesByName: Map<String, TypeDecl> = interpreter.typesByName
+  private val layouts: PipelineLayouts = interpreter.layouts
   private val externInstances: Map<String, ExternInstanceDecl> = buildExternInstancesMap(config)
   private val mainParser: PipelineStage = resolveStage(config, "PNA", "main_parser")
   private val preControl: PipelineStage = resolveStage(config, "PNA", "pre_control")
@@ -52,6 +53,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     val tableStore: TableStore,
     val blockParams: Map<String, List<BlockParam>>,
     val typesByName: Map<String, TypeDecl>,
+    val layouts: PipelineLayouts,
     val externInstances: Map<String, ExternInstanceDecl>,
     val interpreter: Interpreter,
     val mainParser: PipelineStage,
@@ -87,6 +89,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
         tableStore,
         blockParams,
         typesByName,
+        layouts,
         externInstances,
         interpreter,
         mainParser,
@@ -130,7 +133,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     val ctx = PacketContext(payload)
     val env = Environment()
-    val values = createDefaultValues(pipeline.config, pipeline.typesByName)
+    val values = createDefaultValues(pipeline.config, pipeline.typesByName, pipeline.layouts)
     val forwardingState = ForwardingState()
 
     initMetadata(values, ingressPort, passNumber)

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -40,7 +40,8 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   // misconfigured pipelines.
   private val interpreter: Interpreter = Interpreter(config)
   private val blockParams: Map<String, List<BlockParam>> = buildBlockParamsMap(config)
-  private val typesByName: Map<String, TypeDecl> = config.typesList.associateBy { it.name }
+  private val typesByName: Map<String, TypeDecl> = interpreter.typesByName
+  private val layouts: PipelineLayouts = interpreter.layouts
   private val externInstances: Map<String, ExternInstanceDecl> = buildExternInstancesMap(config)
   private val ingressParser: PipelineStage = resolveStage(config, "PSA", "ingress_parser")
   private val ingress: PipelineStage = resolveStage(config, "PSA", "ingress")
@@ -58,6 +59,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val tableStore: TableStore,
     val blockParams: Map<String, List<BlockParam>>,
     val typesByName: Map<String, TypeDecl>,
+    val layouts: PipelineLayouts,
     val externInstances: Map<String, ExternInstanceDecl>,
     val interpreter: Interpreter,
     val ingressParser: PipelineStage,
@@ -79,6 +81,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         tableStore,
         blockParams,
         typesByName,
+        layouts,
         externInstances,
         interpreter,
         ingressParser,
@@ -221,7 +224,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   ): IngressResult {
     val ctx = PacketContext(payload)
     val env = Environment()
-    val values = createDefaultValues(pipeline.config, pipeline.typesByName)
+    val values = createDefaultValues(pipeline.config, pipeline.typesByName, pipeline.layouts)
 
     initIngressMetadata(values, ingressPort, packetPath)
     val output = values["psa_ingress_output_metadata_t"] as? StructVal
@@ -418,7 +421,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val p = state.pipeline
     val egressCtx = PacketContext(deparsedBytes)
     val egressEnv = Environment()
-    val egressValues = createDefaultValues(p.config, p.typesByName)
+    val egressValues = createDefaultValues(p.config, p.typesByName, p.layouts)
 
     initEgressMetadata(egressValues, egressPort, instance, packetPath, state.ingressOutput)
     val egressOutput = egressValues["psa_egress_output_metadata_t"] as? StructVal

--- a/simulator/PacketBuffer.kt
+++ b/simulator/PacketBuffer.kt
@@ -1,0 +1,171 @@
+package fourward.simulator
+
+import java.math.BigInteger
+
+/**
+ * A fixed-size byte buffer with bit-level read/write access.
+ *
+ * This is the storage layer for the flat packet-state representation: all P4 header and struct
+ * fields for a single packet live as bit ranges in one of these buffers, at offsets determined by
+ * the pipeline's static layout (see [HeaderLayout], [StructLayout]).
+ *
+ * The buffer uses big-endian bit ordering: bit 0 is the most significant bit of byte 0. This
+ * matches the wire-order convention used by P4's `extract` / `emit` operations and by the existing
+ * `BitVector` / `SignedBitVector` representations. A `bit<N>` field at offset `o` with value `v`
+ * occupies bits `o..o+N-1`, stored MSB-first.
+ *
+ * See `designs/flat_packet_buffer.md`.
+ */
+class PacketBuffer internal constructor(internal val bytes: ByteArray) {
+
+  /** Creates a zero-filled buffer of the given bit size (rounded up to byte alignment). */
+  constructor(bitSize: Int) : this(ByteArray((bitSize + 7) / 8))
+
+  /** Total size of the buffer in bits. */
+  val bitSize: Int
+    get() = bytes.size * 8
+
+  /**
+   * Reads [width] bits starting at bit [offset] (big-endian). Returns the value as an unsigned
+   * integer in the low [width] bits of the result.
+   */
+  fun readBits(offset: Int, width: Int): Long {
+    checkRange(offset, width)
+    var result = 0L
+    var bitsRemaining = width
+    var bitIndex = offset
+    while (bitsRemaining > 0) {
+      val byteIndex = bitIndex ushr 3
+      val bitInByte = bitIndex and 7
+      val bitsAvailableInByte = 8 - bitInByte
+      val bitsToRead = minOf(bitsAvailableInByte, bitsRemaining)
+      val byteValue = bytes[byteIndex].toInt() and 0xFF
+      // The slice we want is bits [bitInByte .. bitInByte + bitsToRead - 1] of the byte,
+      // with the high bit of that slice being the MSB.
+      val shift = bitsAvailableInByte - bitsToRead
+      val mask = (1 shl bitsToRead) - 1
+      val slice = (byteValue ushr shift) and mask
+      result = (result shl bitsToRead) or slice.toLong()
+      bitIndex += bitsToRead
+      bitsRemaining -= bitsToRead
+    }
+    return result
+  }
+
+  /**
+   * Writes the low [width] bits of [value] to bit [offset] (big-endian). Upper bits of [value] are
+   * ignored — `writeBits(o, 4, 0xFF)` writes `0xF`.
+   */
+  fun writeBits(offset: Int, width: Int, value: Long) {
+    checkRange(offset, width)
+    // Mask `value` to the low `width` bits to avoid trampling neighbours.
+    val masked = if (width == Long.SIZE_BITS) value else value and ((1L shl width) - 1)
+    var bitsRemaining = width
+    var bitIndex = offset
+    while (bitsRemaining > 0) {
+      val byteIndex = bitIndex ushr 3
+      val bitInByte = bitIndex and 7
+      val bitsAvailableInByte = 8 - bitInByte
+      val bitsToWrite = minOf(bitsAvailableInByte, bitsRemaining)
+      val shift = bitsAvailableInByte - bitsToWrite
+      // Slice of `masked` corresponding to this byte's portion of the field.
+      val slice =
+        ((masked ushr (bitsRemaining - bitsToWrite)) and ((1L shl bitsToWrite) - 1)).toInt()
+      val mask = ((1 shl bitsToWrite) - 1) shl shift
+      val old = bytes[byteIndex].toInt() and 0xFF
+      bytes[byteIndex] = ((old and mask.inv()) or (slice shl shift)).toByte()
+      bitIndex += bitsToWrite
+      bitsRemaining -= bitsToWrite
+    }
+  }
+
+  /** Zeros [width] bits starting at bit [offset]. */
+  fun zeroRange(offset: Int, width: Int) {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+    require(width >= 0) { "width must be non-negative, got $width" }
+    require(offset + width <= bitSize) { "zeroRange $offset..${offset + width} exceeds $bitSize" }
+    if (width == 0) return
+    // Do it in chunks of up to Long.SIZE_BITS to reuse writeBits's correctness.
+    var remaining = width
+    var bitIndex = offset
+    while (remaining > 0) {
+      val chunk = minOf(Long.SIZE_BITS, remaining)
+      writeBits(bitIndex, chunk, 0L)
+      bitIndex += chunk
+      remaining -= chunk
+    }
+  }
+
+  /**
+   * Reads [width] bits starting at bit [offset] into a non-negative [BigInteger]. Used for fields
+   * wider than 64 bits (e.g. `bit<128>` IPv6 addresses). For widths ≤ 64 bits, [readBits] is
+   * faster.
+   */
+  fun readBigInt(offset: Int, width: Int): BigInteger {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+    require(width >= 0) { "width must be non-negative, got $width" }
+    require(offset + width <= bitSize) {
+      "field at $offset..${offset + width} exceeds buffer size $bitSize"
+    }
+    if (width == 0) return BigInteger.ZERO
+    var result = BigInteger.ZERO
+    var bitIndex = offset
+    var remaining = width
+    while (remaining > 0) {
+      val chunk = minOf(Long.SIZE_BITS, remaining)
+      val value = readBits(bitIndex, chunk)
+      val unsigned =
+        if (value >= 0L) BigInteger.valueOf(value)
+        else BigInteger.valueOf(value).add(BigInteger.ONE.shiftLeft(Long.SIZE_BITS))
+      result = result.shiftLeft(chunk).or(unsigned)
+      bitIndex += chunk
+      remaining -= chunk
+    }
+    return result
+  }
+
+  /**
+   * Writes the low [width] bits of [value] to bit [offset] in big-endian order (most significant
+   * chunk first). Used for fields wider than 64 bits; for widths ≤ 64, [writeBits] is faster.
+   */
+  fun writeBigInt(offset: Int, width: Int, value: BigInteger) {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+    require(width >= 0) { "width must be non-negative, got $width" }
+    require(offset + width <= bitSize) {
+      "field at $offset..${offset + width} exceeds buffer size $bitSize"
+    }
+    if (width == 0) return
+    val mask = BigInteger.ONE.shiftLeft(width).subtract(BigInteger.ONE)
+    val masked = value.and(mask)
+    var bitIndex = offset
+    var remaining = width
+    while (remaining > 0) {
+      val chunk = minOf(Long.SIZE_BITS, remaining)
+      val chunkMask = BigInteger.ONE.shiftLeft(chunk).subtract(BigInteger.ONE)
+      // Extract the `chunk` most-significant remaining bits (big-endian chunk order).
+      val chunkBits = masked.shiftRight(remaining - chunk).and(chunkMask).toLong()
+      writeBits(bitIndex, chunk, chunkBits)
+      bitIndex += chunk
+      remaining -= chunk
+    }
+  }
+
+  /** Returns an independent copy. Mutations to the copy do not affect the original. */
+  fun copyOf(): PacketBuffer = PacketBuffer(bytes.copyOf())
+
+  /** Returns a defensive copy of the underlying bytes. */
+  fun toBytes(): ByteArray = bytes.copyOf()
+
+  private fun checkRange(offset: Int, width: Int) {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+    require(width in 1..Long.SIZE_BITS) { "width must be in 1..${Long.SIZE_BITS}, got $width" }
+    require(offset + width <= bitSize) {
+      "field at $offset..${offset + width} exceeds buffer size $bitSize"
+    }
+  }
+
+  companion object {
+    /** Constructs a buffer from the given byte array (defensively copied). */
+    fun fromBytes(bytes: ByteArray): PacketBuffer = PacketBuffer(bytes.copyOf())
+  }
+}

--- a/simulator/PacketBufferTest.kt
+++ b/simulator/PacketBufferTest.kt
@@ -1,0 +1,216 @@
+package fourward.simulator
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+
+/** Unit tests for [PacketBuffer]. */
+class PacketBufferTest {
+
+  // =====================================================================
+  // Aligned reads/writes
+  // =====================================================================
+
+  @Test
+  fun `read and write an 8-bit value at byte boundary`() {
+    val buf = PacketBuffer(64)
+    buf.writeBits(0, 8, 0xABL)
+    assertEquals(0xABL, buf.readBits(0, 8))
+  }
+
+  @Test
+  fun `read and write a 16-bit value at byte boundary`() {
+    val buf = PacketBuffer(32)
+    buf.writeBits(0, 16, 0x1234L)
+    assertEquals(0x1234L, buf.readBits(0, 16))
+  }
+
+  @Test
+  fun `read and write a 32-bit value at byte boundary`() {
+    val buf = PacketBuffer(32)
+    buf.writeBits(0, 32, 0xDEADBEEFL)
+    assertEquals(0xDEADBEEFL, buf.readBits(0, 32))
+  }
+
+  @Test
+  fun `read and write a 48-bit MAC address at byte boundary`() {
+    val buf = PacketBuffer(64)
+    buf.writeBits(0, 48, 0x0011_2233_4455L)
+    assertEquals(0x0011_2233_4455L, buf.readBits(0, 48))
+  }
+
+  @Test
+  fun `read and write a 64-bit value at byte boundary`() {
+    val buf = PacketBuffer(64)
+    val v = 0x0123_4567_89AB_CDEFL
+    buf.writeBits(0, 64, v)
+    assertEquals(v, buf.readBits(0, 64))
+  }
+
+  // =====================================================================
+  // Unaligned reads/writes (the interesting cases)
+  // =====================================================================
+
+  @Test
+  fun `read and write a 1-bit flag`() {
+    val buf = PacketBuffer(8)
+    buf.writeBits(0, 1, 1L)
+    assertEquals(1L, buf.readBits(0, 1))
+    buf.writeBits(0, 1, 0L)
+    assertEquals(0L, buf.readBits(0, 1))
+  }
+
+  @Test
+  fun `read and write a 9-bit value at non-byte offset`() {
+    val buf = PacketBuffer(32)
+    // P4 port numbers are typically 9 bits wide.
+    buf.writeBits(3, 9, 0x1ABL)
+    assertEquals(0x1ABL, buf.readBits(3, 9))
+  }
+
+  @Test
+  fun `read and write adjacent narrow fields share bytes`() {
+    val buf = PacketBuffer(16)
+    // Two 4-bit fields packed into one byte.
+    buf.writeBits(0, 4, 0xA)
+    buf.writeBits(4, 4, 0xB)
+    assertEquals(0xAL, buf.readBits(0, 4))
+    assertEquals(0xBL, buf.readBits(4, 4))
+    // And the underlying byte is 0xAB.
+    assertEquals(0xABL, buf.readBits(0, 8))
+  }
+
+  @Test
+  fun `writes do not corrupt neighbouring bits`() {
+    val buf = PacketBuffer(32)
+    // Fill with all ones.
+    buf.writeBits(0, 32, 0xFFFFFFFFL)
+    // Overwrite a 4-bit field in the middle.
+    buf.writeBits(10, 4, 0x0)
+    // Everything else should still be 1.
+    assertEquals(0x3FFL, buf.readBits(0, 10))
+    assertEquals(0x0L, buf.readBits(10, 4))
+    assertEquals(0x3FFFFL, buf.readBits(14, 18))
+  }
+
+  @Test
+  fun `read and write a value spanning multiple bytes at an unaligned offset`() {
+    val buf = PacketBuffer(64)
+    // 40 bits (5 bytes) starting at bit 3.
+    val v = 0xAB_CD_EF_01_23L
+    buf.writeBits(3, 40, v)
+    assertEquals(v, buf.readBits(3, 40))
+  }
+
+  @Test
+  fun `writing a narrow value masks the upper bits`() {
+    val buf = PacketBuffer(16)
+    // Writing 0xFF into a 4-bit slot should store only 0xF.
+    buf.writeBits(0, 4, 0xFFL)
+    assertEquals(0xFL, buf.readBits(0, 4))
+    // And the adjacent 4-bit slot should remain 0.
+    assertEquals(0x0L, buf.readBits(4, 4))
+  }
+
+  // =====================================================================
+  // Bulk operations
+  // =====================================================================
+
+  @Test
+  fun `zeroRange clears exactly the specified bits`() {
+    val buf = PacketBuffer(32)
+    buf.writeBits(0, 32, 0xFFFFFFFFL)
+    buf.zeroRange(8, 16)
+    assertEquals(0xFFL, buf.readBits(0, 8))
+    assertEquals(0x0L, buf.readBits(8, 16))
+    assertEquals(0xFFL, buf.readBits(24, 8))
+  }
+
+  @Test
+  fun `zeroRange works at unaligned boundaries`() {
+    val buf = PacketBuffer(32)
+    buf.writeBits(0, 32, 0xFFFFFFFFL)
+    // Zero 5 bits starting at bit 3.
+    buf.zeroRange(3, 5)
+    assertEquals(0xE0FFFFFFL.toInt().toLong() and 0xFFFFFFFFL, buf.readBits(0, 32))
+  }
+
+  @Test
+  fun `copyOf produces an independent buffer`() {
+    val buf = PacketBuffer(32)
+    buf.writeBits(0, 32, 0x12345678L)
+    val copy = buf.copyOf()
+
+    // Same contents.
+    assertEquals(0x12345678L, copy.readBits(0, 32))
+    // Different underlying array.
+    assertNotSame(buf.bytes, copy.bytes)
+
+    // Mutation in one doesn't affect the other.
+    copy.writeBits(0, 32, 0xDEADBEEFL)
+    assertEquals(0x12345678L, buf.readBits(0, 32))
+    assertEquals(0xDEADBEEFL, copy.readBits(0, 32))
+  }
+
+  @Test
+  fun `fromBytes constructs a buffer with given contents`() {
+    val bytes = byteArrayOf(0x12, 0x34, 0x56, 0x78)
+    val buf = PacketBuffer.fromBytes(bytes)
+    assertEquals(0x12345678L, buf.readBits(0, 32))
+  }
+
+  @Test
+  fun `fromBytes does not share the input array`() {
+    val bytes = byteArrayOf(0x12, 0x34)
+    val buf = PacketBuffer.fromBytes(bytes)
+    bytes[0] = 0x00
+    // Buffer should still see the original value.
+    assertEquals(0x1234L, buf.readBits(0, 16))
+  }
+
+  @Test
+  fun `toBytes returns a snapshot copy`() {
+    val buf = PacketBuffer(16)
+    buf.writeBits(0, 16, 0xABCDL)
+    val out = buf.toBytes()
+    assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xCD.toByte()), out)
+    // Mutating the snapshot doesn't change the buffer.
+    out[0] = 0x00
+    assertEquals(0xABCDL, buf.readBits(0, 16))
+  }
+
+  // =====================================================================
+  // Bounds checking
+  // =====================================================================
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `read beyond buffer end throws`() {
+    val buf = PacketBuffer(16)
+    buf.readBits(8, 16) // would read bits 8..23, but buffer is only 16 bits
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `write beyond buffer end throws`() {
+    val buf = PacketBuffer(16)
+    buf.writeBits(8, 16, 0L)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `negative offset throws`() {
+    val buf = PacketBuffer(32)
+    buf.readBits(-1, 8)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `width greater than 64 throws`() {
+    val buf = PacketBuffer(16)
+    buf.readBits(0, 65)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `zero width throws`() {
+    val buf = PacketBuffer(32)
+    buf.readBits(0, 0)
+  }
+}

--- a/simulator/PacketLayout.kt
+++ b/simulator/PacketLayout.kt
@@ -1,0 +1,31 @@
+package fourward.simulator
+
+/**
+ * Top-level layout describing how an entire packet's runtime state is placed within a single
+ * [PacketBuffer]. Computed once per pipeline at load time and reused across every packet.
+ *
+ * This is the optimal-design successor to the per-instance `HeaderVal` / `StructVal` storage:
+ * instead of each header/struct allocating its own `HashMap`, every named runtime type a packet
+ * touches (the headers struct, the metadata struct, `standard_metadata`, action locals) is laid out
+ * at a known absolute bit offset within one contiguous buffer. The interpreter and architecture
+ * code translate field accesses to absolute offsets via [ResolvedSlot]s without ever allocating
+ * intermediate maps or wrapper objects.
+ *
+ * See `designs/flat_packet_buffer.md`.
+ */
+data class PacketLayout(
+  /**
+   * Absolute bit offset of each top-level named type within the packet buffer. Keys are the type
+   * names referenced from the architecture's parser/control parameter list (e.g., the headers
+   * struct type name, the user metadata struct type name, `standard_metadata_t`).
+   */
+  val typeOffsets: Map<String, Int>,
+  /** Per-type header layouts. Reused as-is from the per-type [LayoutComputer]. */
+  val headers: Map<String, HeaderLayout>,
+  /** Per-type struct layouts. Reused as-is from the per-type [LayoutComputer]. */
+  val structs: Map<String, StructLayout>,
+  /** Per-type header-stack layouts. */
+  val stacks: Map<String, HeaderStackLayout>,
+  /** Total bit width of the packet buffer required to hold every laid-out type. */
+  val totalBits: Int,
+)

--- a/simulator/PacketState.kt
+++ b/simulator/PacketState.kt
@@ -1,0 +1,59 @@
+package fourward.simulator
+
+/**
+ * Per-packet runtime state: one [PacketBuffer] sized by the pipeline's [PacketLayout], plus a trace
+ * builder for delta events. Replaces the per-instance `HeaderVal` / `StructVal` heap-tree
+ * representation.
+ *
+ * `PacketState.fork()` copies the buffer (one bulk memcpy of ~256 bytes for a typical packet) and
+ * forks the trace. Used by `V1ModelArchitecture` when re-executing fork branches; the parent and
+ * child branches mutate independent buffers without touching each other's state.
+ *
+ * See `designs/flat_packet_buffer.md`.
+ */
+class PacketState(
+  val buffer: PacketBuffer,
+  val layout: PacketLayout,
+  val trace: TraceBuilder = TraceBuilder(),
+) {
+  /** Allocates a fresh, zero-initialised state for [layout]. */
+  constructor(layout: PacketLayout) : this(PacketBuffer(layout.totalBits), layout)
+
+  /** Returns an independent copy with its own buffer and forked trace. */
+  fun fork(): PacketState = PacketState(buffer.copyOf(), layout, trace.fork())
+}
+
+/**
+ * Accumulates [TraceDelta]s during pipeline execution. The interpreter calls `emit*` methods at
+ * field writes and control-flow events; consumers call [build] at the end to materialise a
+ * [PacketTrace].
+ *
+ * Forking a builder shares the parent's accumulated events by snapshot — the child writes only its
+ * own future events to a fresh list. This matches the V1Model semantics where each fork branch's
+ * trace is the parent's prefix plus the branch's own deltas.
+ */
+class TraceBuilder(private val initial: List<TraceDelta> = emptyList()) {
+  private val own: MutableList<TraceDelta> = mutableListOf()
+
+  fun emitFieldWrite(bitOffset: Int, width: Int, newValue: Long) {
+    own.add(TraceDelta.FieldWrite(bitOffset, width, newValue))
+  }
+
+  fun emitHeaderInvalidated(bitOffset: Int, totalBits: Int) {
+    own.add(TraceDelta.HeaderInvalidated(bitOffset, totalBits))
+  }
+
+  fun emitControlFlow(description: String) {
+    own.add(TraceDelta.ControlFlow(description))
+  }
+
+  /** Returns a child builder that shares this builder's events as its prefix. */
+  fun fork(): TraceBuilder = TraceBuilder(initial = initial + own)
+
+  /** Returns the events accumulated so far (prefix + own), in order. */
+  fun events(): List<TraceDelta> = initial + own
+
+  /** Builds an immutable [PacketTrace] from [initialBytes] and the accumulated events. */
+  fun build(initialBytes: ByteArray): PacketTrace =
+    PacketTrace(initial = initialBytes, events = events())
+}

--- a/simulator/PacketStateTest.kt
+++ b/simulator/PacketStateTest.kt
@@ -1,0 +1,94 @@
+package fourward.simulator
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit tests for [PacketState] and [TraceBuilder]. */
+class PacketStateTest {
+
+  private val ethernet =
+    HeaderLayout(
+      typeName = "ethernet_t",
+      fields = linkedMapOf("dst" to FieldSlot(0, 48, PrimitiveKind.BIT)),
+      validBitOffset = 48,
+    )
+  private val layout =
+    PacketLayout(
+      typeOffsets = mapOf("ethernet_t" to 0),
+      headers = mapOf("ethernet_t" to ethernet),
+      structs = emptyMap(),
+      stacks = emptyMap(),
+      totalBits = ethernet.totalBits,
+    )
+
+  @Test
+  fun `default constructor allocates a zero buffer at least layout size`() {
+    val state = PacketState(layout)
+    assertTrue(
+      "buffer ${state.buffer.bitSize} bits should hold at least ${layout.totalBits} bits",
+      state.buffer.bitSize >= layout.totalBits,
+    )
+    val ethView = HeaderView(state.buffer, ethernet, base = 0)
+    assertEquals(BitVal(0L, 48), ethView["dst"])
+  }
+
+  @Test
+  fun `fork copies the buffer, mutations are independent`() {
+    val parent = PacketState(layout)
+    HeaderView(parent.buffer, ethernet)["dst"] = BitVal(0x111111111111L, 48)
+
+    val child = parent.fork()
+    HeaderView(child.buffer, ethernet)["dst"] = BitVal(0x222222222222L, 48)
+
+    assertEquals(BitVal(0x111111111111L, 48), HeaderView(parent.buffer, ethernet)["dst"])
+    assertEquals(BitVal(0x222222222222L, 48), HeaderView(child.buffer, ethernet)["dst"])
+    assertNotSame(parent.buffer, child.buffer)
+  }
+
+  @Test
+  fun `trace events accumulate via the builder`() {
+    val state = PacketState(layout)
+    state.trace.emitFieldWrite(0, 48, 0xAAAA_AAAA_AAAAL)
+    state.trace.emitControlFlow("table_hit")
+    state.trace.emitHeaderInvalidated(0, ethernet.totalBits)
+
+    val events = state.trace.events()
+    assertEquals(3, events.size)
+    assertEquals(TraceDelta.FieldWrite(0, 48, 0xAAAA_AAAA_AAAAL), events[0])
+    assertEquals(TraceDelta.ControlFlow("table_hit"), events[1])
+    assertEquals(TraceDelta.HeaderInvalidated(0, ethernet.totalBits), events[2])
+  }
+
+  @Test
+  fun `forked trace shares parent prefix and gets its own future events`() {
+    val state = PacketState(layout)
+    state.trace.emitControlFlow("parent_event")
+
+    val child = state.fork()
+    child.trace.emitControlFlow("child_event")
+
+    // Parent only sees its own event.
+    assertEquals(listOf(TraceDelta.ControlFlow("parent_event")), state.trace.events())
+    // Child sees parent prefix + child event.
+    assertEquals(
+      listOf(TraceDelta.ControlFlow("parent_event"), TraceDelta.ControlFlow("child_event")),
+      child.trace.events(),
+    )
+  }
+
+  @Test
+  fun `build produces a PacketTrace replayable to the final buffer`() {
+    val state = PacketState(layout)
+    val initialBytes = state.buffer.toBytes()
+
+    HeaderView(state.buffer, ethernet)["dst"] = BitVal(0xAABB_CCDD_EEFFL, 48)
+    state.trace.emitFieldWrite(0, 48, 0xAABB_CCDD_EEFFL)
+
+    val trace = state.trace.build(initialBytes)
+    val replayed = trace.replay()
+    assertArrayEquals(state.buffer.toBytes(), replayed.toBytes())
+  }
+}

--- a/simulator/PacketTrace.kt
+++ b/simulator/PacketTrace.kt
@@ -1,0 +1,85 @@
+package fourward.simulator
+
+/**
+ * A record of what happened to a packet during pipeline execution, stored as an initial state plus
+ * a sequence of deltas. This is the delta-encoded counterpart of the snapshot-based trace model —
+ * see `designs/flat_packet_buffer.md`.
+ *
+ * Consumers usually iterate [events] forward, or call [replay] / [stateAt] to reconstruct the
+ * packet buffer at a given point. Random-access state queries cost O(index) because we replay from
+ * [initial] up to the requested event.
+ */
+data class PacketTrace(
+  /** Packet buffer bytes captured at the entry point, before any delta was applied. */
+  val initial: ByteArray,
+  /** Deltas in the order they occurred during pipeline execution. */
+  val events: List<TraceDelta>,
+) {
+  /** Reconstructs the packet buffer after all events have been applied. */
+  fun replay(): PacketBuffer = stateAt(events.size)
+
+  /**
+   * Reconstructs the packet buffer after the first [eventCount] events have been applied. Useful
+   * for trace debuggers and consumers that need the state at a specific point in execution.
+   */
+  fun stateAt(eventCount: Int): PacketBuffer {
+    require(eventCount in 0..events.size) {
+      "eventCount $eventCount out of range 0..${events.size}"
+    }
+    val buf = PacketBuffer.fromBytes(initial)
+    for (i in 0 until eventCount) {
+      events[i].applyTo(buf)
+    }
+    return buf
+  }
+
+  // Arrays don't have structural equality, so data-class equality would compare by reference.
+  // Override.
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is PacketTrace) return false
+    return initial.contentEquals(other.initial) && events == other.events
+  }
+
+  override fun hashCode(): Int = 31 * initial.contentHashCode() + events.hashCode()
+}
+
+/**
+ * A single recorded event in a [PacketTrace]. Either a state-changing delta or a control-flow
+ * marker with no state effect.
+ *
+ * [FieldWrite] and [HeaderInvalidated] change the packet buffer; [ControlFlow] carries a semantic
+ * event (table lookup, action call, drop, etc.) with no buffer impact.
+ */
+sealed interface TraceDelta {
+  /** Applies this delta to [buffer]. Control-flow events are a no-op. */
+  fun applyTo(buffer: PacketBuffer)
+
+  /** A primitive field write at a known bit offset. */
+  data class FieldWrite(val bitOffset: Int, val width: Int, val newValue: Long) : TraceDelta {
+    override fun applyTo(buffer: PacketBuffer) {
+      buffer.writeBits(bitOffset, width, newValue)
+    }
+  }
+
+  /**
+   * A header was invalidated — the validity bit is cleared and all fields are zeroed (P4 spec
+   * §8.17). [bitOffset] is the start of the header layout within the buffer; [totalBits] spans the
+   * full layout including the validity bit.
+   */
+  data class HeaderInvalidated(val bitOffset: Int, val totalBits: Int) : TraceDelta {
+    override fun applyTo(buffer: PacketBuffer) {
+      buffer.zeroRange(bitOffset, totalBits)
+    }
+  }
+
+  /**
+   * A control-flow marker: table lookup, action call, drop, parser transition, etc. Carries a
+   * human-readable description; structured sub-types can be added as the interpreter grows.
+   */
+  data class ControlFlow(val description: String) : TraceDelta {
+    override fun applyTo(buffer: PacketBuffer) {
+      // No state change.
+    }
+  }
+}

--- a/simulator/PacketTraceTest.kt
+++ b/simulator/PacketTraceTest.kt
@@ -1,0 +1,170 @@
+package fourward.simulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit tests for [PacketTrace] and [TraceDelta]. */
+class PacketTraceTest {
+
+  private val ethernet =
+    HeaderLayout(
+      typeName = "ethernet_t",
+      fields = linkedMapOf("dstAddr" to FieldSlot(0, 48), "etherType" to FieldSlot(48, 16)),
+      validBitOffset = 64,
+    )
+
+  @Test
+  fun `empty trace replays to the initial state`() {
+    val buf = PacketBuffer(ethernet.totalBits)
+    HeaderView(buf, ethernet).let {
+      it["dstAddr"] = BitVal(0x111111111111L, 48)
+      it.isValid = true
+    }
+    val trace = PacketTrace(initial = buf.toBytes(), events = emptyList())
+
+    val replayed = trace.replay()
+    val h = HeaderView(replayed, ethernet)
+    assertEquals(BitVal(0x111111111111L, 48), h["dstAddr"])
+    assertTrue(h.isValid)
+  }
+
+  @Test
+  fun `fieldWrite delta applies the new value`() {
+    val buf = PacketBuffer(ethernet.totalBits)
+    val events =
+      listOf(TraceDelta.FieldWrite(bitOffset = 0, width = 48, newValue = 0xAAAAAAAAAAAAL))
+    val trace = PacketTrace(initial = buf.toBytes(), events = events)
+
+    val replayed = trace.replay()
+    assertEquals(BitVal(0xAAAAAAAAAAAAL, 48), HeaderView(replayed, ethernet)["dstAddr"])
+  }
+
+  @Test
+  fun `multiple fieldWrite deltas apply in order`() {
+    val buf = PacketBuffer(ethernet.totalBits)
+    val events =
+      listOf(
+        TraceDelta.FieldWrite(bitOffset = 0, width = 48, newValue = 0x111111111111L),
+        TraceDelta.FieldWrite(bitOffset = 48, width = 16, newValue = 0x0800L),
+        TraceDelta.FieldWrite(bitOffset = 0, width = 48, newValue = 0x222222222222L), // overwrite
+      )
+    val trace = PacketTrace(initial = buf.toBytes(), events = events)
+
+    val h = HeaderView(trace.replay(), ethernet)
+    assertEquals(BitVal(0x222222222222L, 48), h["dstAddr"])
+    assertEquals(BitVal(0x0800L, 16), h["etherType"])
+  }
+
+  @Test
+  fun `headerInvalidated delta zeros the layout and clears valid bit`() {
+    val buf = PacketBuffer(ethernet.totalBits)
+    HeaderView(buf, ethernet).let {
+      it["dstAddr"] = BitVal(0xFFFFFFFFFFFFL, 48)
+      it["etherType"] = BitVal(0xFFFFL, 16)
+      it.isValid = true
+    }
+    val events = listOf(TraceDelta.HeaderInvalidated(bitOffset = 0, totalBits = ethernet.totalBits))
+    val trace = PacketTrace(initial = buf.toBytes(), events = events)
+
+    val h = HeaderView(trace.replay(), ethernet)
+    assertFalse(h.isValid)
+    assertEquals(BitVal(0L, 48), h["dstAddr"])
+    assertEquals(BitVal(0L, 16), h["etherType"])
+  }
+
+  @Test
+  fun `controlFlow delta is recorded but does not change state`() {
+    val buf = PacketBuffer(ethernet.totalBits)
+    HeaderView(buf, ethernet)["dstAddr"] = BitVal(0x123456789ABCL, 48)
+    val events =
+      listOf<TraceDelta>(
+        TraceDelta.ControlFlow("entered_table: ipv4_lpm"),
+        TraceDelta.ControlFlow("action_called: set_nexthop"),
+      )
+    val trace = PacketTrace(initial = buf.toBytes(), events = events)
+
+    // State unchanged.
+    assertEquals(BitVal(0x123456789ABCL, 48), HeaderView(trace.replay(), ethernet)["dstAddr"])
+  }
+
+  @Test
+  fun `replay is idempotent and produces an independent buffer`() {
+    val initial = ByteArray(8) { 0xFF.toByte() }
+    val trace =
+      PacketTrace(
+        initial = initial,
+        events = listOf(TraceDelta.FieldWrite(bitOffset = 0, width = 8, newValue = 0x00L)),
+      )
+
+    val first = trace.replay()
+    val second = trace.replay()
+    // Same content, different buffer objects.
+    assertArrayEqualsByte(first.toBytes(), second.toBytes())
+    // Initial is unmodified.
+    assertEquals(0xFF.toByte(), initial[0])
+  }
+
+  @Test
+  fun `stateAt returns the prefix-replayed state`() {
+    val buf = PacketBuffer(ethernet.totalBits)
+    val events =
+      listOf(
+        TraceDelta.FieldWrite(bitOffset = 0, width = 48, newValue = 0x111111111111L),
+        TraceDelta.ControlFlow("some_event"),
+        TraceDelta.FieldWrite(bitOffset = 0, width = 48, newValue = 0x222222222222L),
+      )
+    val trace = PacketTrace(initial = buf.toBytes(), events = events)
+
+    // After event 1 only: dstAddr = 0x1111...
+    val after1 = HeaderView(trace.stateAt(1), ethernet)
+    assertEquals(BitVal(0x111111111111L, 48), after1["dstAddr"])
+
+    // After events 1 and 2: dstAddr still = 0x1111... (ControlFlow doesn't change state)
+    val after2 = HeaderView(trace.stateAt(2), ethernet)
+    assertEquals(BitVal(0x111111111111L, 48), after2["dstAddr"])
+
+    // After all 3 events: dstAddr = 0x2222...
+    val after3 = HeaderView(trace.stateAt(3), ethernet)
+    assertEquals(BitVal(0x222222222222L, 48), after3["dstAddr"])
+  }
+
+  @Test
+  fun `stateAt with zero returns the initial state`() {
+    val initial = ByteArray(2) { 0x42 }
+    val trace =
+      PacketTrace(
+        initial = initial,
+        events = listOf(TraceDelta.FieldWrite(bitOffset = 0, width = 8, newValue = 0x99L)),
+      )
+    val state = trace.stateAt(0)
+    assertEquals(0x42.toByte(), state.toBytes()[0])
+  }
+
+  @Test
+  fun `stateAt beyond events list throws`() {
+    val trace = PacketTrace(initial = ByteArray(1), events = emptyList())
+    assertThrows(IllegalArgumentException::class.java) { trace.stateAt(5) }
+  }
+
+  @Test
+  fun `trace events are preserved verbatim`() {
+    val events =
+      listOf<TraceDelta>(
+        TraceDelta.ControlFlow("entry"),
+        TraceDelta.FieldWrite(0, 8, 0x01L),
+        TraceDelta.HeaderInvalidated(0, 16),
+      )
+    val trace = PacketTrace(initial = ByteArray(2), events = events)
+    assertEquals(events, trace.events)
+  }
+
+  private fun assertArrayEqualsByte(expected: ByteArray, actual: ByteArray) {
+    assertEquals(expected.size, actual.size)
+    for (i in expected.indices) {
+      assertEquals("byte $i", expected[i], actual[i])
+    }
+  }
+}

--- a/simulator/PipelineLayoutsFromConfigTest.kt
+++ b/simulator/PipelineLayoutsFromConfigTest.kt
@@ -1,0 +1,77 @@
+package fourward.simulator
+
+import fourward.ir.BehavioralConfig
+import fourward.ir.BitType
+import fourward.ir.DeviceConfig
+import fourward.ir.FieldDecl
+import fourward.ir.HeaderDecl
+import fourward.ir.PipelineConfig
+import fourward.ir.StructDecl
+import fourward.ir.Type
+import fourward.ir.TypeDecl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Tests that [computeLayouts] pulls TypeDecls out of a real [PipelineConfig]. */
+class PipelineLayoutsFromConfigTest {
+
+  @Test
+  fun `computeLayouts extracts every TypeDecl from the pipeline config`() {
+    val config =
+      PipelineConfig.newBuilder()
+        .setDevice(
+          DeviceConfig.newBuilder()
+            .setBehavioral(
+              BehavioralConfig.newBuilder()
+                .addTypes(
+                  TypeDecl.newBuilder()
+                    .setName("ethernet_t")
+                    .setHeader(
+                      HeaderDecl.newBuilder()
+                        .addFields(fieldDecl("dstAddr", bit(48)))
+                        .addFields(fieldDecl("etherType", bit(16)))
+                    )
+                    .build()
+                )
+                .addTypes(
+                  TypeDecl.newBuilder()
+                    .setName("metadata_t")
+                    .setStruct(
+                      StructDecl.newBuilder()
+                        .addFields(fieldDecl("ingress_port", bit(9)))
+                        .addFields(fieldDecl("priority", bit(3)))
+                    )
+                    .build()
+                )
+                .build()
+            )
+            .build()
+        )
+        .build()
+
+    val layouts = computeLayouts(config)
+
+    val ethernet = layouts.headers.getValue("ethernet_t")
+    assertEquals(FieldSlot(0, 48), ethernet.fields["dstAddr"])
+    assertEquals(FieldSlot(48, 16), ethernet.fields["etherType"])
+
+    val meta = layouts.structs.getValue("metadata_t")
+    assertEquals(PrimitiveField(0, 9), meta.members["ingress_port"])
+    assertEquals(PrimitiveField(9, 3), meta.members["priority"])
+  }
+
+  @Test
+  fun `empty config yields empty layouts`() {
+    val config = PipelineConfig.newBuilder().build()
+    val layouts = computeLayouts(config)
+    assertEquals(emptyMap<String, HeaderLayout>(), layouts.headers)
+    assertEquals(emptyMap<String, StructLayout>(), layouts.structs)
+  }
+
+  // Helpers.
+  private fun fieldDecl(name: String, type: Type) =
+    FieldDecl.newBuilder().setName(name).setType(type).build()
+
+  private fun bit(width: Int): Type =
+    Type.newBuilder().setBit(BitType.newBuilder().setWidth(width)).build()
+}

--- a/simulator/ResolvedSlot.kt
+++ b/simulator/ResolvedSlot.kt
@@ -1,0 +1,13 @@
+package fourward.simulator
+
+/**
+ * A field access (e.g., `headers.ethernet.dstAddr`) resolved at pipeline-load time to an absolute
+ * bit offset and width within the packet buffer.
+ *
+ * The interpreter caches a `Map<FieldAccess, ResolvedSlot>` keyed by IR `FieldAccess` node identity
+ * and looks up the slot at runtime instead of walking the field-name path. Reads/writes against the
+ * slot become a single `buffer.readBits(offset, width)` / `writeBits(offset, width, value)`.
+ *
+ * See `designs/flat_packet_buffer.md`.
+ */
+data class ResolvedSlot(val offset: Int, val width: Int, val kind: PrimitiveKind)

--- a/simulator/StructView.kt
+++ b/simulator/StructView.kt
@@ -1,0 +1,163 @@
+package fourward.simulator
+
+/**
+ * A member of a [StructLayout]: either a primitive bit-field or a nested header/struct.
+ *
+ * Structs unlike headers can contain nested aggregate types (another struct, or a header).
+ * [PrimitiveField] reads through a single `readBits` call; [NestedHeader] and [NestedStruct]
+ * produce sub-views at the field's offset, with their own layouts.
+ */
+sealed interface StructMember {
+  val offset: Int
+  val widthBits: Int
+}
+
+/** A primitive bit-field: `bit<N>`, `int<N>`, `bool`, or enum, at a given bit offset. */
+data class PrimitiveField(
+  override val offset: Int,
+  val width: Int,
+  val kind: PrimitiveKind = PrimitiveKind.BIT,
+) : StructMember {
+  init {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+    require(width >= 1) { "width must be positive, got $width" }
+    if (kind == PrimitiveKind.BOOL) {
+      require(width == 1) { "bool field width must be 1, got $width" }
+    }
+    if (kind == PrimitiveKind.ERROR) {
+      require(width <= Long.SIZE_BITS) { "error field width must be ≤ 64, got $width" }
+    }
+  }
+
+  override val widthBits: Int
+    get() = width
+}
+
+/** A nested header member — a whole [HeaderLayout] embedded at [offset] inside a struct. */
+data class NestedHeader(override val offset: Int, val layout: HeaderLayout) : StructMember {
+  init {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+  }
+
+  override val widthBits: Int
+    get() = layout.totalBits
+}
+
+/** A nested struct member — a whole [StructLayout] embedded at [offset] inside a struct. */
+data class NestedStruct(override val offset: Int, val layout: StructLayout) : StructMember {
+  init {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+  }
+
+  override val widthBits: Int
+    get() = layout.totalBits
+}
+
+/**
+ * A nested header stack member — a whole [HeaderStackLayout] embedded at [offset] inside a struct.
+ */
+data class NestedStack(override val offset: Int, val layout: HeaderStackLayout) : StructMember {
+  init {
+    require(offset >= 0) { "offset must be non-negative, got $offset" }
+  }
+
+  override val widthBits: Int
+    get() = layout.totalBits
+}
+
+/**
+ * Static layout of a P4 struct type: member name → location+kind within the struct's bit layout.
+ *
+ * Unlike [HeaderLayout], structs can contain nested headers/structs (P4 spec §8.11). Each struct
+ * member is a [StructMember] variant carrying both the offset and the kind-specific payload
+ * (primitive width, nested header layout, nested struct layout). Structs have no validity bit.
+ */
+data class StructLayout(val typeName: String, val members: Map<String, StructMember>) {
+  /** Total width of this struct in bits. */
+  val totalBits: Int = members.values.maxOfOrNull { it.offset + it.widthBits } ?: 0
+
+  /**
+   * Precomputed [FieldSlot]s for just the primitive members, in declaration order. Used by
+   * [StructVal.bufferBacked] without per-call allocation.
+   */
+  val primitiveSlots: Map<String, FieldSlot> = buildMap {
+    for ((name, m) in members) if (m is PrimitiveField)
+      put(name, FieldSlot(m.offset, m.width, m.kind))
+  }
+
+  /**
+   * True when every member is a primitive (no nested headers / structs / stacks). Such structs can
+   * be constructed via [StructVal.bufferBacked] directly — see
+   * [DefaultValues][fourward.simulator.defaultValue].
+   */
+  val allPrimitive: Boolean = members.values.all { it is PrimitiveField }
+}
+
+/**
+ * A view onto a [StructLayout]'s members in a [PacketBuffer], anchored at a [base] bit offset.
+ *
+ * Primitive members are read/written with [get] / [set]. Nested members produce sub-views via
+ * [header] / [struct] / [stack] — cheap wrappers that share the parent's buffer at the nested
+ * offset.
+ *
+ * Extends [Value] so it can flow through the [Environment] alongside other runtime values once the
+ * buffer-backed migration is complete. [deepCopy] returns a view over a fresh buffer copy.
+ */
+class StructView(val buffer: PacketBuffer, val layout: StructLayout, val base: Int = 0) : Value() {
+
+  /** Returns a view over an independent copy of [buffer]. Used by the fork path. */
+  override fun deepCopy(): StructView = StructView(buffer.copyOf(), layout, base)
+
+  /** Reads a primitive member. Throws if [field] is nested or absent. */
+  operator fun get(field: String): BitVal {
+    val m = memberOf(field)
+    require(m is PrimitiveField) {
+      "${layout.typeName}.$field is a nested ${m::class.simpleName}; use header() or struct()"
+    }
+    val bits = buffer.readBits(base + m.offset, m.width)
+    return BitVal(bits, m.width)
+  }
+
+  /** Writes a primitive member. Throws if [field] is nested, absent, or the width mismatches. */
+  operator fun set(field: String, value: BitVal) {
+    val m = memberOf(field)
+    require(m is PrimitiveField) {
+      "${layout.typeName}.$field is a nested ${m::class.simpleName}; use header() or struct()"
+    }
+    require(value.bits.width == m.width) {
+      "${layout.typeName}.$field expects bit<${m.width}>, got bit<${value.bits.width}>"
+    }
+    buffer.writeBits(base + m.offset, m.width, value.bits.value.toLong())
+  }
+
+  /** Returns a view onto a nested header member. Throws if [field] is not a nested header. */
+  fun header(field: String): HeaderView {
+    val m = memberOf(field)
+    require(m is NestedHeader) {
+      "${layout.typeName}.$field is not a nested header (got ${m::class.simpleName})"
+    }
+    return HeaderView(buffer, m.layout, base + m.offset)
+  }
+
+  /** Returns a view onto a nested struct member. Throws if [field] is not a nested struct. */
+  fun struct(field: String): StructView {
+    val m = memberOf(field)
+    require(m is NestedStruct) {
+      "${layout.typeName}.$field is not a nested struct (got ${m::class.simpleName})"
+    }
+    return StructView(buffer, m.layout, base + m.offset)
+  }
+
+  /** Returns a view onto a nested header-stack member. Throws if [field] is not a nested stack. */
+  fun stack(field: String): HeaderStackView {
+    val m = memberOf(field)
+    require(m is NestedStack) {
+      "${layout.typeName}.$field is not a nested header stack (got ${m::class.simpleName})"
+    }
+    return HeaderStackView(buffer, m.layout, base + m.offset)
+  }
+
+  private fun memberOf(field: String): StructMember =
+    layout.members[field]
+      ?: throw IllegalArgumentException("${layout.typeName} has no member '$field'")
+}

--- a/simulator/StructViewTest.kt
+++ b/simulator/StructViewTest.kt
@@ -1,0 +1,130 @@
+package fourward.simulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/** Unit tests for [StructLayout] and [StructView]. */
+class StructViewTest {
+
+  // A simplified standard_metadata_t with primitive fields only.
+  private val stdMeta =
+    StructLayout(
+      typeName = "standard_metadata_t",
+      members =
+        linkedMapOf<String, StructMember>(
+          "ingress_port" to PrimitiveField(offset = 0, width = 9),
+          "egress_spec" to PrimitiveField(offset = 9, width = 9),
+          "egress_port" to PrimitiveField(offset = 18, width = 9),
+          "instance_type" to PrimitiveField(offset = 27, width = 32),
+        ),
+    )
+
+  private fun newStruct() = StructView(PacketBuffer(stdMeta.totalBits), stdMeta, base = 0)
+
+  @Test
+  fun `totalBits equals the sum of primitive field widths`() {
+    assertEquals(9 + 9 + 9 + 32, stdMeta.totalBits)
+  }
+
+  @Test
+  fun `set and get individual primitive members`() {
+    val s = newStruct()
+    s["ingress_port"] = BitVal(1L, 9)
+    s["egress_spec"] = BitVal(2L, 9)
+    s["egress_port"] = BitVal(3L, 9)
+    s["instance_type"] = BitVal(0x0DEADBEEL, 32)
+
+    assertEquals(BitVal(1L, 9), s["ingress_port"])
+    assertEquals(BitVal(2L, 9), s["egress_spec"])
+    assertEquals(BitVal(3L, 9), s["egress_port"])
+    assertEquals(BitVal(0x0DEADBEEL, 32), s["instance_type"])
+  }
+
+  @Test
+  fun `unknown member name throws`() {
+    val s = newStruct()
+    assertThrows(IllegalArgumentException::class.java) { s["missing"] }
+  }
+
+  @Test
+  fun `writing a value of the wrong width throws`() {
+    val s = newStruct()
+    assertThrows(IllegalArgumentException::class.java) {
+      s["ingress_port"] = BitVal(0L, 8) // ingress_port is 9 bits
+    }
+  }
+
+  @Test
+  fun `views at different bases do not interfere`() {
+    val buf = PacketBuffer(stdMeta.totalBits * 2)
+    val first = StructView(buf, stdMeta, base = 0)
+    val second = StructView(buf, stdMeta, base = stdMeta.totalBits)
+
+    first["ingress_port"] = BitVal(5L, 9)
+    second["ingress_port"] = BitVal(6L, 9)
+
+    assertEquals(BitVal(5L, 9), first["ingress_port"])
+    assertEquals(BitVal(6L, 9), second["ingress_port"])
+  }
+
+  // =====================================================================
+  // Nested members (struct-of-header, struct-of-struct)
+  // =====================================================================
+
+  private val ethernet =
+    HeaderLayout(
+      typeName = "ethernet_t",
+      fields =
+        linkedMapOf(
+          "dstAddr" to FieldSlot(0, 48),
+          "srcAddr" to FieldSlot(48, 48),
+          "etherType" to FieldSlot(96, 16),
+        ),
+      validBitOffset = 112,
+    )
+
+  private val headers =
+    StructLayout(
+      typeName = "headers_t",
+      members =
+        linkedMapOf<String, StructMember>(
+          "ethernet" to NestedHeader(offset = 0, layout = ethernet),
+          "meta" to NestedStruct(offset = ethernet.totalBits, layout = stdMeta),
+        ),
+    )
+
+  @Test
+  fun `struct view exposes nested header as HeaderView`() {
+    val buf = PacketBuffer(headers.totalBits)
+    val s = StructView(buf, headers)
+    val eth = s.header("ethernet")
+    eth["dstAddr"] = BitVal(0xAAAA_AAAA_AAAAL, 48)
+    eth.isValid = true
+    assertEquals(BitVal(0xAAAA_AAAA_AAAAL, 48), eth["dstAddr"])
+    assertEquals(true, eth.isValid)
+  }
+
+  @Test
+  fun `struct view exposes nested struct as StructView`() {
+    val buf = PacketBuffer(headers.totalBits)
+    val s = StructView(buf, headers)
+    val meta = s.struct("meta")
+    meta["ingress_port"] = BitVal(7L, 9)
+    assertEquals(BitVal(7L, 9), meta["ingress_port"])
+  }
+
+  @Test
+  fun `primitive access on a nested member throws`() {
+    val buf = PacketBuffer(headers.totalBits)
+    val s = StructView(buf, headers)
+    assertThrows(IllegalArgumentException::class.java) { s["ethernet"] }
+  }
+
+  @Test
+  fun `nested access on a primitive member throws`() {
+    val s = newStruct()
+    assertThrows(IllegalArgumentException::class.java) { s.header("ingress_port") }
+    assertThrows(IllegalArgumentException::class.java) { s.struct("ingress_port") }
+  }
+}

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -86,6 +86,34 @@ class V1ModelArchitecture(
   private val interpreter: Interpreter = Interpreter(config)
 
   /**
+   * Top-level parser user-param types (hdr, meta, standard_metadata), or null when the config has
+   * no parsers (minimal unit-test configs). v1model always declares: (packet_in, hdr, meta,
+   * standard_metadata).
+   */
+  private val parserUserTypes: List<String>? =
+    config.parsersList.firstOrNull()?.let { p ->
+      p.paramsList
+        .filter { it.type.hasNamed() && it.type.named !in IO_TYPES }
+        .map { it.type.named }
+        .also {
+          require(it.size == V1MODEL_USER_PARAM_COUNT) {
+            "Expected $V1MODEL_USER_PARAM_COUNT non-IO parser params, got ${it.size}"
+          }
+        }
+    }
+
+  /**
+   * Per-packet consolidated allocator — null when [parserUserTypes] is null. One [PacketBuffer]
+   * holds all three top-level values (hdr, meta, standard_metadata) at fixed offsets. Forks copy
+   * the buffer once and rewire the value tree — the primary lever for the flat-buffer rewrite's
+   * 2-3x target. See `designs/flat_packet_buffer.md`.
+   */
+  private val allocator: ConsolidatedPacketAllocator? =
+    parserUserTypes?.let {
+      ConsolidatedPacketAllocator.build(it, interpreter.layouts, interpreter.typesByName)
+    }
+
+  /**
    * Post-parser snapshot captured during the first [runPipeline] execution of a packet. Read by
    * [forkSpecs] when an [ActionSelectorFork] is caught, to pass to fork re-executions. Reset at the
    * start of each [processPacket] to prevent stale state across packets.
@@ -300,24 +328,19 @@ class V1ModelArchitecture(
       "max pipeline depth exceeded ($MAX_PIPELINE_DEPTH) — possible infinite resubmit/recirculate loop"
     }
     val config = ctx.config
-    val typesByName = config.typesList.associateBy { it.name }
+    val types =
+      checkNotNull(parserUserTypes) { "initPipelineState called on a config with no parsers" }
+    val alloc = checkNotNull(allocator) { "initPipelineState called on a config with no allocator" }
 
-    // Derive the type names for hdr/meta/standard_metadata from the parser's
-    // parameter list, filtering out the architecture-level packet I/O params.
-    // v1model always declares: (packet_in, hdr, meta, standard_metadata) in that order.
-    val parserUserParams =
-      config.parsersList.first().paramsList.filter {
-        it.type.hasNamed() && it.type.named !in IO_TYPES
-      }
-    require(parserUserParams.size == V1MODEL_USER_PARAM_COUNT) {
-      "Expected $V1MODEL_USER_PARAM_COUNT non-IO parser params, got ${parserUserParams.size}"
-    }
-    val headersTypeName = parserUserParams[0].type.named
-    val metaTypeName = parserUserParams[1].type.named
-    val standardMetaTypeName = parserUserParams[2].type.named
+    val headersTypeName = types[0]
+    val metaTypeName = types[1]
+    val standardMetaTypeName = types[2]
+
+    // One buffer, one value tree — all top-level headers/metadata share it.
+    val allocated = alloc.allocate()
 
     val standardMetadata =
-      (defaultValue(standardMetaTypeName, typesByName) as? StructVal)
+      (allocated.byType[standardMetaTypeName] as? StructVal)
         ?: error("$standardMetaTypeName not found in IR types; is v1model.p4 included?")
     check("ingress_port" in standardMetadata.fields) { "$standardMetaTypeName has no ingress_port" }
     check("packet_length" in standardMetadata.fields) {
@@ -330,7 +353,7 @@ class V1ModelArchitecture(
       standardMetadata.setBitField("instance_type", decisions.instanceTypeOverride)
     }
 
-    val metaValue = defaultValue(metaTypeName, typesByName)
+    val metaValue = allocated.byType.getValue(metaTypeName)
     if (decisions.preservedMetadata != null && metaValue is StructVal) {
       for ((name, value) in decisions.preservedMetadata) {
         metaValue.fields[name] = value
@@ -338,9 +361,10 @@ class V1ModelArchitecture(
     }
 
     val env = Environment()
+    env.packetBuffer = allocated.buffer
     val sharedByType =
       mapOf(
-        headersTypeName to defaultValue(headersTypeName, typesByName),
+        headersTypeName to allocated.byType.getValue(headersTypeName),
         metaTypeName to metaValue,
         standardMetaTypeName to standardMetadata,
       )
@@ -383,7 +407,7 @@ class V1ModelArchitecture(
       )
 
     val config = ctx.config
-    val typesByName = config.typesList.associateBy { it.name }
+    val typesByName = ctx.interpreter.typesByName
     val parserUserParams =
       config.parsersList.first().paramsList.filter {
         it.type.hasNamed() && it.type.named !in IO_TYPES

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -12,6 +12,16 @@ package fourward.simulator
 sealed class Value {
   /** Returns an independent deep copy. Immutable leaf types return `this`. */
   open fun deepCopy(): Value = this
+
+  /**
+   * Consolidated-fork variant of [deepCopy]: returns a value whose buffer-backed descendants point
+   * at [newBuffer] instead of [oldBuffer] — without copying the buffer (the caller copies it once
+   * for the entire packet tree).
+   *
+   * Leaf / non-buffer-backed values simply return `this` (they're immutable) or fall back to
+   * [deepCopy]. See [Environment.deepCopy] for the one-buffer-copy-per-fork invariant.
+   */
+  open fun rewire(oldBuffer: PacketBuffer, newBuffer: PacketBuffer): Value = deepCopy()
 }
 
 /** A bit<N> value. */
@@ -93,10 +103,38 @@ data class HeaderVal(
     }
   }
 
-  fun copy(): HeaderVal = HeaderVal(typeName, fields.toMutableMap(), valid)
+  fun copy(): HeaderVal = HeaderVal(typeName, copyFields(fields), valid)
 
-  override fun deepCopy(): HeaderVal =
-    HeaderVal(typeName, fields.mapValuesTo(mutableMapOf()) { it.value.deepCopy() }, valid)
+  override fun deepCopy(): HeaderVal = HeaderVal(typeName, deepCopyFields(fields), valid)
+
+  override fun rewire(oldBuffer: PacketBuffer, newBuffer: PacketBuffer): Value {
+    val bb = fields as? BufferBackedFieldMap
+    if (bb != null && bb.buffer === oldBuffer) {
+      return HeaderVal(typeName, bb.withBuffer(newBuffer), valid)
+    }
+    // Non-shared HashMap-backed: fall back to a full deep copy.
+    return deepCopy()
+  }
+
+  companion object {
+    /**
+     * Constructs a buffer-backed [HeaderVal] whose [fields] is a [BufferBackedFieldMap] over the
+     * supplied [buffer] at absolute bit offset [base]. Reads cache returned values per slot so
+     * repeated reads are zero-allocation. Writes invalidate the cached entry.
+     *
+     * When [base] is nonzero the caller is placing this header inside a larger shared packet buffer
+     * — see `designs/flat_packet_buffer.md` "Measured results and what's left".
+     */
+    fun bufferBacked(
+      layout: HeaderLayout,
+      buffer: PacketBuffer = PacketBuffer(layout.totalBits),
+      base: Int = 0,
+    ): HeaderVal {
+      val fields = BufferBackedFieldMap(buffer, layout.fields, base = base)
+      val valid = buffer.readBits(base + layout.validBitOffset, 1) == 1L
+      return HeaderVal(layout.typeName, fields, valid)
+    }
+  }
 }
 
 /**
@@ -105,10 +143,20 @@ data class HeaderVal(
  */
 data class StructVal(val typeName: String, val fields: MutableMap<String, Value> = mutableMapOf()) :
   Value() {
-  fun copy(): StructVal = StructVal(typeName, fields.toMutableMap())
+  fun copy(): StructVal = StructVal(typeName, copyFields(fields))
 
-  override fun deepCopy(): StructVal =
-    StructVal(typeName, fields.mapValuesTo(mutableMapOf()) { it.value.deepCopy() })
+  override fun deepCopy(): StructVal = StructVal(typeName, deepCopyFields(fields))
+
+  override fun rewire(oldBuffer: PacketBuffer, newBuffer: PacketBuffer): Value {
+    val bb = fields as? BufferBackedFieldMap
+    if (bb != null && bb.buffer === oldBuffer) {
+      return StructVal(typeName, bb.withBuffer(newBuffer))
+    }
+    // HashMap-backed: rewire each child (most will be buffer-backed headers sharing oldBuffer).
+    val rewired = HashMap<String, Value>(fields.size)
+    for ((k, v) in fields) rewired[k] = v.rewire(oldBuffer, newBuffer)
+    return StructVal(typeName, rewired)
+  }
 
   /** P4 spec §8.20: a header union is valid if any member header is valid. */
   fun isUnionValid(): Boolean = fields.values.any { it is HeaderVal && it.valid }
@@ -134,7 +182,38 @@ data class StructVal(val typeName: String, val fields: MutableMap<String, Value>
     val field = checkNotNull(fields[name] as? BitVal) { "$typeName.$name is not a bit field" }
     return field.bits.width
   }
+
+  companion object {
+    /**
+     * Constructs a buffer-backed [StructVal] whose [fields] is a [BufferBackedFieldMap] over the
+     * supplied [buffer] at absolute bit offset [base]. Only the struct's primitive members are
+     * exposed through the map — nested members (headers, structs, header stacks) aren't supported
+     * here; use a HashMap-backed [StructVal] with buffer-backed children instead.
+     */
+    fun bufferBacked(
+      layout: StructLayout,
+      buffer: PacketBuffer = PacketBuffer(layout.totalBits),
+      base: Int = 0,
+    ): StructVal {
+      val fields = BufferBackedFieldMap(buffer, layout.primitiveSlots, base = base)
+      return StructVal(layout.typeName, fields)
+    }
+  }
 }
+
+/** Shallow-copy [fields]: buffer-backed maps copy the buffer; HashMaps copy the entries. */
+private fun copyFields(fields: MutableMap<String, Value>): MutableMap<String, Value> =
+  when (fields) {
+    is BufferBackedFieldMap -> fields.copy()
+    else -> fields.toMutableMap()
+  }
+
+/** Deep-copy [fields]: buffer-backed maps copy the buffer; HashMaps recurse. */
+private fun deepCopyFields(fields: MutableMap<String, Value>): MutableMap<String, Value> =
+  when (fields) {
+    is BufferBackedFieldMap -> fields.copy()
+    else -> fields.mapValuesTo(mutableMapOf()) { it.value.deepCopy() }
+  }
 
 /**
  * A header stack (fixed-size array of headers with a next/last pointer).
@@ -152,6 +231,13 @@ data class HeaderStackVal(
 
   override fun deepCopy(): HeaderStackVal =
     HeaderStackVal(elementTypeName, headers.mapTo(mutableListOf()) { it.deepCopy() }, nextIndex)
+
+  override fun rewire(oldBuffer: PacketBuffer, newBuffer: PacketBuffer): Value =
+    HeaderStackVal(
+      elementTypeName,
+      headers.mapTo(mutableListOf()) { it.rewire(oldBuffer, newBuffer) },
+      nextIndex,
+    )
 }
 
 /** Sentinel for void returns and uninitialised variables. */


### PR DESCRIPTION
## Summary

Lands the flat-buffer packet-state rewrite in three layers: foundation
types, buffer-backed values, and consolidated per-packet buffers with
fork-time cache forwarding. Correctness is solid (73/73 tests); the
target workload (fork-heavy wcmp×128 parallel) sees a measured
**+6.3%** improvement.

- **Foundation** (`designs/flat_packet_buffer.md`): `PacketBuffer`
  (bit-addressable, with BigInteger paths for >64-bit fields),
  `HeaderLayout` / `StructLayout` / `HeaderStackLayout`, `HeaderView` /
  `StructView` / `HeaderStackView`, `PacketLayout`, `ResolvedSlot`,
  `PacketState` + `TraceBuilder`, `PacketTrace`, `ErrorCodes`
  (supports program-declared errors).
- **Buffer-backed values**: `BufferBackedFieldMap` with lazy per-slot
  `Value` cache. `HeaderVal.bufferBacked` / `StructVal.bufferBacked`
  factories accept an absolute base offset. `defaultHeader` /
  `defaultStruct` route through them when safe.
- **Consolidated per-packet buffers**: `ConsolidatedPacketAllocator`
  plans absolute offsets for every top-level type in a single
  per-packet `PacketBuffer`. `Environment.packetBuffer` owns it.
  `Environment.deepCopy` on a fork does **one** `buffer.copyOf()`
  plus a `Value.rewire` pass — no per-value memcpy.
- **Cache forwarding on fork**: `BufferBackedFieldMap.withBuffer`
  carries the pre-fork value cache forward onto the new buffer — so
  fork branches re-read fields as cache hits instead of re-
  allocating wrapper `BitVal` / `IntVal` / `BoolVal` instances. This
  is where the bulk of the measured win comes from.

## Measured

AMD Ryzen 9 7950X3D, SAI middleblock, 3-run mean, intra-packet parallelism off:

| Workload | Baseline | This branch | Δ |
|---|---|---|---|
| wcmp×128 parallel | 1528 pps | **1625 pps** (1629 / 1625 / 1620) | **+6.3%** |
| wcmp×128 sequential | 207 pps | 200 pps (200 / 198 / 203) | within noise |
| direct parallel | 39,800 pps | 39,743 pps (39,137 / 40,710 / 39,382) | within noise |

Meaningful win on the target fork-heavy workload; parity elsewhere.

## Along the way

Two correctness bugs fixed that the cache layer was hiding:

- `LayoutComputer` now handles both `Type.error` (the dedicated proto
  variant) and `Type.named == "error"` (the common p4c emission form)
  as 32-bit ERROR primitives. Previously SAI pipelines silently
  skipped top-level layouts.
- `PacketBuffer.writeBigInt` now writes chunks in big-endian order
  (high 64 first), matching `readBits`/`writeBits` and the wire
  format. The earlier draft wrote chunks in reverse; legacy reads
  never noticed because they hit the `BufferBackedFieldMap` cache
  before touching the buffer. IPv6 128-bit addresses are the first
  real-world fields that exercised the path.
- `ErrorCodes` now auto-registers program-declared errors
  (IPv4IncorrectVersion, etc.) — previously encoding one threw.

## What still gates 2-3×

The design doc's "Measured results and what's left" section documents
the gap honestly and three follow-ups that should close it: (1) pool
`HeaderVal` / `BufferBackedFieldMap` / scope HashMap instances across
forks, (2) pre-resolve `FieldAccess` with its own cache layer (tried
in an earlier revision of this branch and reverted — bypassing the
per-slot cache cost more than it saved, detailed in the doc), (3)
arena-allocate fork-branch state. All three build on this branch's
consolidation; none are blocked on further data-layout work.

## Test plan

- [x] `bazel test //... --test_tag_filters=-heavy` — 73/73 pass
- [x] `./tools/format.sh` clean
- [x] `./tools/lint.sh` clean
- [x] Benchmarked on wcmp×128 parallel + sequential + direct parallel
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)