### PR TITLE
Bump seven direct BCR deps to their latest releases

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
-bazel_dep(name = "rules_kotlin", version = "2.3.0")
+bazel_dep(name = "rules_kotlin", version = "2.3.20")
 
 # `dev_dependency` so the strict-deps toolchain only activates when
 # 4ward is the root module; BCR consumers see the default rules_kotlin
@@ -21,15 +21,15 @@ register_toolchains(
     dev_dependency = True,
 )
 
-bazel_dep(name = "rules_java", version = "9.3.0")
-bazel_dep(name = "rules_python", version = "1.7.0")
+bazel_dep(name = "rules_java", version = "9.6.1")
+bazel_dep(name = "rules_python", version = "1.9.0")
 bazel_dep(name = "rules_jvm_external", version = "6.10")
 
 # --- Protobuf & gRPC ---
 
 bazel_dep(name = "protobuf", version = "33.5")
 bazel_dep(name = "grpc", version = "1.80.0")  # For cc_grpc_library (dataplane_cc_grpc).
-bazel_dep(name = "grpc-java", version = "1.78.0")
+bazel_dep(name = "grpc-java", version = "1.78.0.bcr.1")
 bazel_dep(name = "grpc_kotlin", version = "1.5.0")
 
 # WORKAROUND for strict-deps issues in grpc_kotlin@1.5.0 — see
@@ -48,8 +48,8 @@ bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
 # Transitively pulled by @p4runtime; declared directly so our BUILD
 # files can reference it by apparent name under strict deps.
 # googleapis-java enables //google/rpc:rpc_java_proto.
-bazel_dep(name = "googleapis", version = "0.0.0-20260223-edfe7983")
-bazel_dep(name = "googleapis-java", version = "1.0.0")
+bazel_dep(name = "googleapis", version = "0.0.0-20260402-c8ca5bce")
+bazel_dep(name = "googleapis-java", version = "1.1.5")
 
 # p4c provides the compiler frontend and midend that our backend builds on.
 # BCR consumers get p4c 1.2.5.11.bcr.1 (which has //p4include, testdata
@@ -143,7 +143,7 @@ use_repo(pip, "pip")
 
 # --- Dev tools ---
 
-bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
 
 # Runs clang-tidy as a Bazel aspect — no compile_commands.json needed.
 # Usage: bazel build //p4c_backend/... --config=clang-tidy


### PR DESCRIPTION
## Summary

Routine upkeep. Surveyed every \`bazel_dep\` against its BCR
\`metadata.json\` and bumped each one that had a newer version and
built+tested clean:

| Dep | Before | After |
|---|---|---|
| rules_kotlin | 2.3.0 | 2.3.20 |
| rules_java | 9.3.0 | 9.6.1 |
| rules_python | 1.7.0 | 1.9.0 |
| grpc-java | 1.78.0 | 1.78.0.bcr.1 |
| googleapis | 0.0.0-20260223-edfe7983 | 0.0.0-20260402-c8ca5bce |
| googleapis-java | 1.0.0 | 1.1.5 |
| buildifier_prebuilt | 8.2.1.2 | 8.5.1.2 |

### Why not protobuf 33.5 → 34.1

34.1 removes \`@protobuf//bazel:upb_proto_library.bzl\` but grpc@1.80.0
(our current pin) still tries to load it, so the tree fails to analyze.
Waiting for a grpc release that's protobuf-34 compatible before doing
that bump on its own.

## Test plan

- [x] \`bazel build //...\` — green
- [x] \`bazel test //... --test_tag_filters=-heavy\` — 63/63 pass
- [x] bcr_test_module consumer build — green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)