### PR TITLE
docs/REFACTORING.md: refresh Pinned dependencies inventory

### DIFF
--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -15,23 +15,29 @@ Blocked on buf support for proto edition 2024.
 
 The `smolkaj/p4c` fork adds the PNA STF backend for p4testgen and a
 PNA drop-by-default fix. Upstream PRs:
-- https://github.com/p4lang/p4c/pull/5570 (PNA STF backend)
-- https://github.com/p4lang/p4c/issues/5569 (drop-by-default)
+- https://github.com/p4lang/p4c/pull/5570 (PNA STF backend) — merged
+  2026-04-06; waiting for a new BCR release to pick it up.
+- https://github.com/p4lang/p4c/issues/5569 (drop-by-default) — open.
 
 The `//p4include` and macOS fixes (p4lang/p4c#5533) already landed and
-are available in BCR as p4c 1.2.5.11.bcr.1. Once the remaining changes
-are merged and released, drop the `git_override` in `MODULE.bazel`.
+are available in BCR as p4c 1.2.5.11.bcr.1. Once the remaining change
+is merged and a BCR release ships both fixes, drop the `git_override`
+in `MODULE.bazel`.
 
 ---
 
 ## Pinned dependencies inventory
 
-Three deps use `git_override` with pinned commits. `behavioral_model` and
+Four deps use `git_override` with pinned commits. `behavioral_model` and
 `bazel_clang_tidy` are dev-only (`dev_dependency = True`) and invisible to
-BCR consumers.
+BCR consumers; `p4c` and `grpc` are honored only when fourward is the
+root module, so BCR consumers see the upstream BCR versions.
 
-- **p4c** (`smolkaj/p4c` fork, `2a38af8`): adds `//p4include` package,
-  testdata exports, macOS build fix. See "Drop p4c fork" above.
+- **p4c** (`smolkaj/p4c` fork, `c7e38ae`): PNA STF backend + drop-by-default
+  fix for p4testgen. See "Drop p4c fork" above.
+- **grpc** (`smolkaj/grpc` fork, `a09a3af`): Bazel 9 compatibility patches
+  (`native.objc_library` and friends) on top of upstream 1.80.0. Drop once
+  grpc publishes a Bazel-9-compatible release to BCR.
 - **bazel_clang_tidy** (`9e54bbb`): pinned before a commit (`c4d35e0`) that
   broke `-isystem` include ordering. Upstream bug never fixed — permanent
   workaround. Re-check if upstream ever resolves the issue.


### PR DESCRIPTION
## Summary

Reconciling \`docs/REFACTORING.md\` against the actual state of
\`MODULE.bazel\`. Three items had drifted:

- **p4c fork commit** was listed as \`2a38af8\`; the override now
  points at \`c7e38ae\`.
- **grpc git_override** was missing from the inventory entirely, so
  the preamble under-counted (\"Three deps\" → \"Four deps\"). Added
  the entry with its Bazel-9-compat rationale.
- **p4lang/p4c#5570** (PNA STF backend) merged upstream on
  2026-04-06 — the \"Drop p4c fork\" entry still flagged it as
  pending. Now reads: merged, waiting on the next BCR release.

Pure doc update — no rule logic or build changes.

## Test plan

- [x] MODULE.bazel cross-check: every \`git_override\` now has a
  matching inventory entry with the correct commit hash.
- [x] \`gh api\` confirmed p4lang/p4c#5570 merged, #5569 still open.
- [ ] CI (docs-only change; only lint really matters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)