### PR TITLE
Lift pipeline-invariant state to architecture constructor (closes #516)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,15 @@ Before submitting:
    P4Runtime server (`p4runtime/`) is a thin adapter that forwards requests;
    it holds no P4 state of its own.
 
+6. **When changing concurrency assumptions, audit every site that depended on
+   the old assumption.** Code written under "single-threaded" can hide caches,
+   shared mutable state, and lazy initialisation that becomes racy the moment
+   multiple threads enter. Update both the code and any docs that asserted the
+   old contract — a stale "single-threaded" comment is how the next
+   maintainer assumes a guarantee the code no longer provides. Document the
+   new contract per-method, not just at the class level, so it shows up at the
+   call site.
+
 ## P4 language notes
 
 The authoritative source for language semantics is the

--- a/p4runtime/DataplaneServiceTest.kt
+++ b/p4runtime/DataplaneServiceTest.kt
@@ -189,7 +189,11 @@ class DataplaneServiceTest {
   @Test
   fun `concurrent InjectPacket calls all produce correct results`() = runBlocking {
     harness.loadPipeline(loadPassthroughConfig())
-    val count = 10
+    // Demonstrates concurrent processing is a supported use case. Cannot deterministically
+    // catch JMM races on x86 (TSO hides most reordering), so this is documentation-by-test,
+    // not a regression test for the underlying race fixed in the PR — that lives in the
+    // architecture-level invariants, audited at review time.
+    val count = 100
 
     val results =
       (0 until count).map { i ->

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -1,6 +1,5 @@
 package fourward.simulator
 
-import fourward.ir.BehavioralConfig
 import fourward.sim.OutputPacket
 import fourward.sim.TraceTree
 
@@ -29,12 +28,7 @@ interface Architecture {
    * - Handling architecture-specific operations (clone, resubmit, etc.).
    * - Returning the trace tree (with packet outcomes at leaves).
    */
-  fun processPacket(
-    ingressPort: UInt,
-    payload: ByteArray,
-    config: BehavioralConfig,
-    tableStore: TableStore,
-  ): PipelineResult
+  fun processPacket(ingressPort: UInt, payload: ByteArray, tableStore: TableStore): PipelineResult
 }
 
 /**

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -17,6 +17,21 @@ internal val IO_TYPES = setOf("packet_in", "packet_out")
 /** Guard against infinite recirculation loops. */
 internal const val MAX_RECIRCULATIONS = 16
 
+/**
+ * Resolves a named pipeline stage; throws with [archName] context if missing or has no block name.
+ * Used by architecture constructors to fail fast on misconfigured pipelines.
+ */
+internal fun resolveStage(
+  config: BehavioralConfig,
+  archName: String,
+  stageName: String,
+): PipelineStage =
+  config.architecture.stagesList
+    .first { it.name == stageName }
+    .also {
+      require(it.blockName.isNotEmpty()) { "$archName stage '$stageName' has no block name" }
+    }
+
 /** Builds a map from block name to parameter list across all parsers and controls. */
 internal fun buildBlockParamsMap(config: BehavioralConfig): Map<String, List<BlockParam>> {
   val result = mutableMapOf<String, List<BlockParam>>()

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -308,6 +308,16 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "NetworkSimulatorTest",
+    srcs = ["NetworkSimulatorTest.kt"],
+    test_class = "fourward.simulator.NetworkSimulatorTest",
+    deps = [
+        ":simulator_lib",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "SimulatorTest",
     srcs = ["SimulatorTest.kt"],
     test_class = "fourward.simulator.SimulatorTest",

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -36,6 +36,11 @@ import java.math.BigInteger
  * The interpreter is deliberately simple: it pattern-matches on proto oneof fields and dispatches
  * to focused methods. There is no bytecode compilation or optimisation — correctness and
  * readability are the goals.
+ *
+ * Thread safety: all fields are `val`s holding immutable proto messages and Kotlin Maps populated
+ * during construction. JMM final-field publication makes the [Interpreter] safe to share across any
+ * number of [Execution] threads after construction. Mutable per-run state lives in [Execution],
+ * which is created fresh for each call.
  */
 class Interpreter internal constructor(config: BehavioralConfig) {
   private val parsers: Map<String, ParserDecl> = config.parsersList.associateBy { it.name }
@@ -1321,20 +1326,6 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       }
     }
   } // end Execution
-
-  /** Holds one [Interpreter] per [BehavioralConfig], rebuilding only when the config changes. */
-  class Cache {
-    private var cached: Interpreter? = null
-    private var cachedConfig: BehavioralConfig? = null
-
-    fun get(config: BehavioralConfig): Interpreter {
-      if (config === cachedConfig) return cached!!
-      return Interpreter(config).also {
-        cached = it
-        cachedConfig = config
-      }
-    }
-  }
 
   companion object {
     // P4 spec §8.18: header stack lastIndex/size are bit<32>.

--- a/simulator/NetworkSimulator.kt
+++ b/simulator/NetworkSimulator.kt
@@ -11,12 +11,17 @@ import fourward.sim.TraceTree
  * layer is purely additive.
  *
  * Packet delivery is instant. A [MAX_HOP_COUNT] limit prevents infinite loops from routing
- * misconfigurations. Single-threaded — callers must serialise concurrent requests (inherited from
- * [Simulator]).
+ * misconfigurations.
+ *
+ * **Concurrency:** [addSwitch] is single-writer (callers must serialize against other [addSwitch]
+ * calls and against [processPacket]). [processPacket] is safe to call concurrently from any number
+ * of threads once topology setup is complete, inheriting [Simulator.processPacket]'s concurrency
+ * contract. The switch map uses [java.util.concurrent.ConcurrentHashMap] so that the read path is
+ * JMM-safe even if a future refactor relaxes the setup ordering.
  */
 class NetworkSimulator(topology: NetworkTopology) {
 
-  private val simulators = mutableMapOf<String, Simulator>()
+  private val simulators = java.util.concurrent.ConcurrentHashMap<String, Simulator>()
 
   /** Bidirectional link lookup: endpoint → endpoint. */
   private val linkMap: Map<Endpoint, Endpoint> = buildMap {
@@ -33,8 +38,9 @@ class NetworkSimulator(topology: NetworkTopology) {
    * installing table entries).
    */
   fun addSwitch(id: String): Simulator {
-    require(id !in simulators) { "switch '$id' already exists" }
-    return Simulator().also { simulators[id] = it }
+    val sim = Simulator()
+    require(simulators.putIfAbsent(id, sim) == null) { "switch '$id' already exists" }
+    return sim
   }
 
   /**

--- a/simulator/NetworkSimulatorTest.kt
+++ b/simulator/NetworkSimulatorTest.kt
@@ -1,0 +1,94 @@
+// Copyright 2026 4ward Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fourward.simulator
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Concurrency tests for [NetworkSimulator]. The switch map was changed from `mutableMapOf` to
+ * `ConcurrentHashMap` and `addSwitch` to `putIfAbsent`; these tests verify the contract.
+ */
+class NetworkSimulatorTest {
+
+  @Test
+  fun `concurrent addSwitch with distinct ids all succeed`() {
+    val network = NetworkSimulator(NetworkTopology(links = emptyList()))
+    val errors = ConcurrentLinkedQueue<Throwable>()
+    val latch = CountDownLatch(1)
+    val n = 32
+
+    val workers =
+      (0 until n).map { i ->
+        Thread {
+            try {
+              latch.await()
+              val sim = network.addSwitch("s$i")
+              assertNotNull(sim)
+            } catch (
+              @Suppress("TooGenericExceptionCaught")
+              t: Throwable) { // any failure is a race symptom
+              errors.add(t)
+            }
+          }
+          .also { it.start() }
+      }
+    latch.countDown()
+    workers.forEach { it.join() }
+
+    assertTrue("no errors expected: ${errors.firstOrNull()}", errors.isEmpty())
+  }
+
+  @Test
+  fun `concurrent addSwitch with duplicate id elects exactly one winner`() {
+    val network = NetworkSimulator(NetworkTopology(links = emptyList()))
+    val n = 32
+    val successes = ConcurrentLinkedQueue<Simulator>()
+    val rejections = ConcurrentLinkedQueue<Throwable>()
+    val unexpected = ConcurrentLinkedQueue<Throwable>()
+    val latch = CountDownLatch(1)
+
+    val workers =
+      (0 until n).map {
+        Thread {
+            try {
+              latch.await()
+              successes.add(network.addSwitch("dup"))
+            } catch (e: IllegalArgumentException) {
+              rejections.add(e)
+            } catch (
+              @Suppress("TooGenericExceptionCaught")
+              t: Throwable) { // any other failure is a race symptom
+              unexpected.add(t)
+            }
+          }
+          .also { it.start() }
+      }
+    latch.countDown()
+    workers.forEach { it.join() }
+
+    assertTrue("unexpected exceptions: ${unexpected.firstOrNull()}", unexpected.isEmpty())
+    assertEquals("exactly one addSwitch should succeed", 1, successes.size)
+    assertEquals("the rest should be rejected as duplicate", n - 1, rejections.size)
+    // A subsequent addSwitch must also fail — the slot is permanently taken by the winner.
+    assertTrue(
+      runCatching { network.addSwitch("dup") }.exceptionOrNull() is IllegalArgumentException
+    )
+  }
+}

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -28,11 +28,24 @@ import java.math.BigInteger
  * - PNA spec: https://p4.org/p4-spec/docs/PNA.html
  * - p4c pna.p4: https://github.com/p4lang/p4c/blob/main/p4include/pna.p4
  */
-class PNAArchitecture : Architecture {
+class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
 
-  private val interpreterCache = Interpreter.Cache()
+  // Pipeline-invariant state derived from [config], built once per loaded pipeline. All vals are
+  // immutable after publication, so safe to read concurrently from any number of [processPacket]
+  // threads without synchronization. Pre-resolving the pipeline stages here also fails fast on
+  // misconfigured pipelines.
+  private val interpreter: Interpreter = Interpreter(config)
+  private val blockParams: Map<String, List<BlockParam>> = buildBlockParamsMap(config)
+  private val typesByName: Map<String, TypeDecl> = config.typesList.associateBy { it.name }
+  private val externInstances: Map<String, ExternInstanceDecl> = buildExternInstancesMap(config)
+  private val mainParser: PipelineStage = resolveStage(config, "PNA", "main_parser")
+  private val preControl: PipelineStage = resolveStage(config, "PNA", "pre_control")
+  private val mainControl: PipelineStage = resolveStage(config, "PNA", "main_control")
+  private val mainDeparser: PipelineStage = resolveStage(config, "PNA", "main_deparser")
 
-  /** Pipeline-invariant state derived from the [BehavioralConfig]. */
+  /**
+   * Per-call binding: pipeline invariants (held by the architecture) plus the live [TableStore].
+   */
   @Suppress("LongParameterList")
   private class PipelineConfig(
     val config: BehavioralConfig,
@@ -66,26 +79,20 @@ class PNAArchitecture : Architecture {
   override fun processPacket(
     ingressPort: UInt,
     payload: ByteArray,
-    config: BehavioralConfig,
     tableStore: TableStore,
   ): PipelineResult {
-    val stages = config.architecture.stagesList
-    fun stage(name: String) =
-      stages
-        .first { it.name == name }
-        .also { require(it.blockName.isNotEmpty()) { "PNA stage '$name' has no block name" } }
     val pipeline =
       PipelineConfig(
         config,
         tableStore,
-        blockParams = buildBlockParamsMap(config),
-        typesByName = config.typesList.associateBy { it.name },
-        externInstances = buildExternInstancesMap(config),
-        interpreter = interpreterCache.get(config),
-        mainParser = stage("main_parser"),
-        preControl = stage("pre_control"),
-        mainControl = stage("main_control"),
-        mainDeparser = stage("main_deparser"),
+        blockParams,
+        typesByName,
+        externInstances,
+        interpreter,
+        mainParser,
+        preControl,
+        mainControl,
+        mainDeparser,
       )
 
     val tree =

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -254,7 +254,7 @@ class PNAArchitectureTest {
   @Test
   fun `PNA drops by default without send_to_port`() {
     val config = pnaConfig()
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -264,7 +264,7 @@ class PNAArchitectureTest {
   fun `send_to_port forwards packet`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(5)))
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = PNAArchitecture().processPacket(0u, payload, config, TableStore())
+    val result = PNAArchitecture(config).processPacket(0u, payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -276,7 +276,7 @@ class PNAArchitectureTest {
   fun `drop_packet explicitly drops`() {
     // send_to_port then drop_packet — last writer wins, packet drops.
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(5), dropPacket()))
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -286,7 +286,7 @@ class PNAArchitectureTest {
   fun `send_to_port overrides drop_packet`() {
     // drop_packet then send_to_port — last writer wins, packet forwards.
     val config = pnaConfig(mainControlStmts = listOf(dropPacket(), sendToPort(5)))
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -296,7 +296,7 @@ class PNAArchitectureTest {
   @Test
   fun `trace has enter-exit pairs for all 4 PNA stages`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(1)))
-    val result = PNAArchitecture().processPacket(7u, byteArrayOf(0x01), config, TableStore())
+    val result = PNAArchitecture(config).processPacket(7u, byteArrayOf(0x01), TableStore())
     val events = result.trace.eventsList.filter { it.hasPacketIngress() || it.hasPipelineStage() }
 
     // First event: packet ingress.
@@ -338,7 +338,7 @@ class PNAArchitectureTest {
           )
       )
     val tableStore = TableStore()
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     // Packet should forward (register write doesn't affect drop).
     val outputs = result.possibleOutcomes.single()
@@ -356,7 +356,7 @@ class PNAArchitectureTest {
     // This should hit the MAX_RECIRCULATIONS guard.
     val config = pnaConfig(mainControlStmts = listOf(recirculate()))
     try {
-      PNAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, TableStore())
+      PNAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), TableStore())
       fail("expected recirculation depth exceeded")
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("recirculation depth exceeded"))
@@ -366,7 +366,7 @@ class PNAArchitectureTest {
   @Test
   fun `assertion failure drops packet`() {
     val config = pnaConfig(mainControlStmts = listOf(externCall("assert", boolLit(false))))
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -387,7 +387,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, store)
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -402,7 +402,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 7))
 
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0xBB.toByte()), config, store)
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0xBB.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -415,7 +415,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -426,7 +426,7 @@ class PNAArchitectureTest {
   @Test
   fun `mirror_packet with unknown session silently ignores mirror`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(2), mirrorPacket(0, 999)))
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -439,7 +439,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5, 1 to 6, 2 to 7))
 
-    val result = PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
     val outputs = result.possibleOutcomes.single()
 
     // Original + 3 mirror replicas = 4 outputs.
@@ -461,7 +461,7 @@ class PNAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 5))
 
     try {
-      PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+      PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
       fail("expected recirculation depth exceeded")
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("recirculation depth exceeded"))
@@ -476,7 +476,7 @@ class PNAArchitectureTest {
   fun `drop_packet in pre_control is rejected`() {
     val config = pnaConfig(preControlStmts = listOf(dropPacket()))
     try {
-      PNAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+      PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
       fail("expected drop_packet to be rejected in pre_control")
     } catch (e: IllegalArgumentException) {
       assertTrue(e.message!!.contains("main_control"))

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -32,11 +32,26 @@ import java.math.BigInteger
  * - PSA spec: https://p4.org/p4-spec/docs/PSA.html
  * - BMv2 psa.p4: https://github.com/p4lang/p4c/blob/main/p4include/bmv2/psa.p4
  */
-class PSAArchitecture : Architecture {
+class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
-  private val interpreterCache = Interpreter.Cache()
+  // Pipeline-invariant state derived from [config], built once per loaded pipeline. All vals are
+  // immutable after publication, so safe to read concurrently from any number of [processPacket]
+  // threads without synchronization. Pre-resolving the pipeline stages here also fails fast on
+  // misconfigured pipelines.
+  private val interpreter: Interpreter = Interpreter(config)
+  private val blockParams: Map<String, List<BlockParam>> = buildBlockParamsMap(config)
+  private val typesByName: Map<String, TypeDecl> = config.typesList.associateBy { it.name }
+  private val externInstances: Map<String, ExternInstanceDecl> = buildExternInstancesMap(config)
+  private val ingressParser: PipelineStage = resolveStage(config, "PSA", "ingress_parser")
+  private val ingress: PipelineStage = resolveStage(config, "PSA", "ingress")
+  private val ingressDeparser: PipelineStage = resolveStage(config, "PSA", "ingress_deparser")
+  private val egressParser: PipelineStage = resolveStage(config, "PSA", "egress_parser")
+  private val egress: PipelineStage = resolveStage(config, "PSA", "egress")
+  private val egressDeparser: PipelineStage = resolveStage(config, "PSA", "egress_deparser")
 
-  /** Pipeline-invariant state derived from the [BehavioralConfig]. */
+  /**
+   * Per-call binding: pipeline invariants (held by the architecture) plus the live [TableStore].
+   */
   @Suppress("LongParameterList")
   private class PipelineConfig(
     val config: BehavioralConfig,
@@ -45,7 +60,6 @@ class PSAArchitecture : Architecture {
     val typesByName: Map<String, TypeDecl>,
     val externInstances: Map<String, ExternInstanceDecl>,
     val interpreter: Interpreter,
-    // Pre-resolved PSA pipeline stages (fail fast on misconfigured pipelines).
     val ingressParser: PipelineStage,
     val ingress: PipelineStage,
     val ingressDeparser: PipelineStage,
@@ -57,28 +71,22 @@ class PSAArchitecture : Architecture {
   override fun processPacket(
     ingressPort: UInt,
     payload: ByteArray,
-    config: BehavioralConfig,
     tableStore: TableStore,
   ): PipelineResult {
-    val stages = config.architecture.stagesList
-    fun stage(name: String) =
-      stages
-        .first { it.name == name }
-        .also { require(it.blockName.isNotEmpty()) { "PSA stage '$name' has no block name" } }
     val pipeline =
       PipelineConfig(
         config,
         tableStore,
-        blockParams = buildBlockParamsMap(config),
-        typesByName = config.typesList.associateBy { it.name },
-        externInstances = buildExternInstancesMap(config),
-        interpreter = interpreterCache.get(config),
-        ingressParser = stage("ingress_parser"),
-        ingress = stage("ingress"),
-        ingressDeparser = stage("ingress_deparser"),
-        egressParser = stage("egress_parser"),
-        egress = stage("egress"),
-        egressDeparser = stage("egress_deparser"),
+        blockParams,
+        typesByName,
+        externInstances,
+        interpreter,
+        ingressParser,
+        ingress,
+        ingressDeparser,
+        egressParser,
+        egress,
+        egressDeparser,
       )
 
     val tree = processPacketRecursive(pipeline, payload, ingressPort, PACKET_PATH_NORMAL, depth = 0)

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -345,7 +345,7 @@ class PSAArchitectureTest {
   @Test
   fun `PSA drops by default without send_to_port`() {
     val config = psaConfig()
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -356,7 +356,7 @@ class PSAArchitectureTest {
   fun `send_to_port forwards packet`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(5)))
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = PSAArchitecture().processPacket(0u, payload, config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -367,7 +367,7 @@ class PSAArchitectureTest {
   @Test
   fun `trace has enter-exit pairs for all 6 PSA stages`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(1)))
-    val result = PSAArchitecture().processPacket(7u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(7u, byteArrayOf(0x01), TableStore())
     val events = result.trace.eventsList.filter { it.hasPacketIngress() || it.hasPipelineStage() }
 
     // First event: packet ingress.
@@ -415,7 +415,7 @@ class PSAArchitectureTest {
           )
       )
     val tableStore = TableStore()
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     // Packet should forward (register write doesn't affect drop).
     val outputs = result.possibleOutcomes.single()
@@ -442,7 +442,7 @@ class PSAArchitectureTest {
             sendToPort(1),
           )
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     // Should not crash — the read returns a default zero value.
     val outputs = result.possibleOutcomes.single()
@@ -456,7 +456,7 @@ class PSAArchitectureTest {
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 5, 1 to 6, 2 to 7))
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = PSAArchitecture().processPacket(0u, payload, config, tableStore)
+    val result = PSAArchitecture(config).processPacket(0u, payload, tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(3, outputs.size)
@@ -475,7 +475,7 @@ class PSAArchitectureTest {
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 1 to 3))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
@@ -488,7 +488,7 @@ class PSAArchitectureTest {
   fun `multicast with unknown group drops packet`() {
     // multicast(group=99) but no group 99 is configured — should drop.
     val config = psaConfig(ingressStmts = listOf(multicast(99)))
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -578,7 +578,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(hashGetHash1Arg("h_0", 0x456, 12), sendToPort(1)),
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -592,8 +592,8 @@ class PSAArchitectureTest {
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
     // Run twice — should get the same result (deterministic hash).
-    val result1 = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
-    val result2 = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result1 = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result2 = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val out1 = result1.possibleOutcomes.single()
     val out2 = result2.possibleOutcomes.single()
     assertEquals(out1[0].payload, out2[0].payload)
@@ -694,7 +694,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(hashGetHash1ArgBareBit("h_0", 0xAABBCCDD, 32), sendToPort(1)),
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -709,7 +709,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(hashGetHash1ArgBareBit("h_0", 0xAABBCCDD, 32), sendToPort(1)),
         ingressExterns = listOf(hashInstance("h_0", "IDENTITY")),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -722,7 +722,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(hashGetHash3Arg("h_0", 0, 0x456, 12, 1000, 16), sendToPort(1)),
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -736,7 +736,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(randomRead("rng_0", 16), sendToPort(1)),
         ingressExterns = listOf(randomInstance("rng_0", 0, 100)),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -750,7 +750,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(digestPack("digest_0", 0xBEEF, 16), sendToPort(1)),
         ingressExterns = listOf(digestInstance("digest_0")),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -763,7 +763,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(meterExecute("meter0", 1), sendToPort(1)),
         ingressExterns = listOf(meterInstance("meter0")),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -831,7 +831,7 @@ class PSAArchitectureTest {
           ),
         ingressExterns = listOf(checksumInstance("ck_0")),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -895,7 +895,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -911,7 +911,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 7))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0xBB.toByte()), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xBB.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     // Original dropped, clone emitted.
@@ -925,7 +925,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -939,7 +939,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5, 1 to 6, 2 to 7))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
     val outputs = result.possibleOutcomes.single()
 
     // Original + 3 clones = 4 outputs.
@@ -956,7 +956,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 200, listOf(0 to 8))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0xCC.toByte()), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xCC.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -978,7 +978,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 200, listOf(0 to 9))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0xDD.toByte()), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xDD.toByte()), store)
 
     // Clone fork exists even though original drops — E2E clone is processed independently.
     assertTrue(result.trace.hasForkOutcome())
@@ -992,7 +992,7 @@ class PSAArchitectureTest {
   @Test
   fun `E2E clone with unknown session silently drops clone`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(2)), egressStmts = cloneStmts(999))
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // No clone session 999 → clone silently ignored, original output normally.
@@ -1006,7 +1006,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 200, listOf(0 to 8))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
     // E2E clone fork is in the egress subtree, flattened into the top-level trace since
     // there's no I2E clone.
@@ -1020,7 +1020,7 @@ class PSAArchitectureTest {
   @Test
   fun `I2E clone with unknown session silently drops clone`() {
     val config = psaConfig(ingressStmts = cloneStmts(999) + listOf(sendToPort(2)))
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // No clone session 999 → clone silently ignored, original output normally.
@@ -1035,7 +1035,7 @@ class PSAArchitectureTest {
     // PSA_PORT_RECIRCULATE = 32w0xfffffffa (psa.p4).
     val config = psaConfig(ingressStmts = listOf(sendToPort(0xFFFFFFFAL)))
     try {
-      PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+      PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
       fail("expected recirculation depth exception")
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("PSA recirculation depth exceeded"))
@@ -1075,8 +1075,7 @@ class PSAArchitectureTest {
             )
           )
       )
-    val result =
-      PSAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // Packet recirculates once, then forwards on port 5.
@@ -1092,7 +1091,7 @@ class PSAArchitectureTest {
   fun `egress drop without clone produces drop trace`() {
     // Egress drops the original packet, no clone — pure egress drop path.
     val config = psaConfig(ingressStmts = listOf(sendToPort(2)), egressStmts = listOf(egressDrop()))
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1104,7 +1103,7 @@ class PSAArchitectureTest {
     // send_to_port sets drop=false, then ingress_drop sets drop=true — last writer wins.
     val config =
       psaConfig(ingressStmts = listOf(sendToPort(2), externCall("ingress_drop", nameRef("ostd"))))
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1115,7 +1114,7 @@ class PSAArchitectureTest {
     // Set clone=true but leave clone_session_id at default (0). No session 0 exists.
     val config =
       psaConfig(ingressStmts = listOf(assignField("ostd", "clone", boolLit(true)), sendToPort(2)))
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // No clone session 0 → clone silently ignored, original output normally.
@@ -1146,8 +1145,7 @@ class PSAArchitectureTest {
             )
           )
       )
-    val result =
-      PSAArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1173,8 +1171,7 @@ class PSAArchitectureTest {
             )
           )
       )
-    val result =
-      PSAArchitecture().processPacket(0u, byteArrayOf(0xBB.toByte()), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xBB.toByte()), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // Resubmitted packet exits on port 1 with original bytes.
@@ -1187,7 +1184,7 @@ class PSAArchitectureTest {
     // PSA spec §6.2: drop has highest priority. resubmit=true with drop=true → dropped.
     val config =
       psaConfig(ingressStmts = listOf(resubmitStmt())) // drop=true by default, resubmit=true
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1211,7 +1208,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 9))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
     val outputs = result.possibleOutcomes.single()
 
     // Resubmit wins: packet loops back, then exits on port 5. No clone on port 9.
@@ -1225,7 +1222,7 @@ class PSAArchitectureTest {
     // Unconditional resubmit causes infinite loop — simulator must enforce depth limit.
     val config = psaConfig(ingressStmts = listOf(resubmitStmt(), sendToPort(1)))
     try {
-      PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+      PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
       fail("expected recirculation depth exception")
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("PSA recirculation depth exceeded"))
@@ -1441,7 +1438,7 @@ class PSAArchitectureTest {
     writeActionProfileGroup(store, groupId = 1, memberIds = listOf(0, 1))
     writeGroupTableEntry(store, keyValue = 0x0A, groupId = 1)
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
     // Should produce an ACTION_SELECTOR fork with 2 member branches.
     assertTrue("expected fork outcome", result.trace.hasForkOutcome())
@@ -1463,7 +1460,7 @@ class PSAArchitectureTest {
     val config = psaConfigWithTable(postTableStmts = emptyList())
     val store = storeWithActionProfile()
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
     // No fork — table miss falls through to default action, packet dropped by PSA default.
     assertTrue("expected drop (no fork)", result.trace.hasPacketOutcome())
@@ -1478,7 +1475,7 @@ class PSAArchitectureTest {
     writeActionProfileGroup(store, groupId = 1, memberIds = listOf(0))
     writeGroupTableEntry(store, keyValue = 0x0A, groupId = 1)
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
     assertTrue("expected fork outcome", result.trace.hasForkOutcome())
     assertEquals(ForkReason.ACTION_SELECTOR, result.trace.forkOutcome.reason)
@@ -1502,7 +1499,7 @@ class PSAArchitectureTest {
     writeActionProfileGroup(store, groupId = 1, memberIds = listOf(0, 1))
     writeGroupTableEntry(store, keyValue = 0x0A, groupId = 1)
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
     // Egress fork: ACTION_SELECTOR with 2 member branches.
     assertTrue("expected fork outcome", result.trace.hasForkOutcome())
@@ -1529,7 +1526,7 @@ class PSAArchitectureTest {
     writeGroupTableEntry(store, keyValue = 0x0A, groupId = 1)
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, store)
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
     // Top-level fork is CLONE (I2E clone) — parallel.
     assertTrue("expected clone fork", result.trace.hasForkOutcome())
@@ -1570,7 +1567,7 @@ class PSAArchitectureTest {
           ),
         ingressExterns = listOf(checksumInstance("ck_0")),
       )
-    val result = PSAArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -3,6 +3,7 @@ package fourward.simulator
 import fourward.ir.PipelineConfig
 import fourward.sim.OutputPacket
 import fourward.sim.TraceTree
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Result of processing a single packet through the pipeline.
@@ -31,8 +32,11 @@ data class ProcessPacketResult(val trace: TraceTree, val possibleOutcomes: List<
  * Public methods: [loadPipeline], [processPacket], [writeEntry], [readEntries]. These use natural
  * Kotlin error handling (exceptions, sealed results).
  *
- * One [Simulator] instance runs for the lifetime of the process; it is single-threaded (callers
- * must serialise concurrent requests).
+ * One [Simulator] instance runs for the lifetime of the process. [processPacket] is safe to call
+ * concurrently from any number of threads — it reads the loaded pipeline atomically (one snapshot,
+ * no tearing across reload) and the published forwarding snapshot from [TableStore]. Control-plane
+ * mutations ([loadPipeline], [writeEntry]) must be serialized by the caller (the P4Runtime layer
+ * does this via its write mutex), but they do not require packet processing to be quiesced.
  */
 class Simulator(
   /**
@@ -42,61 +46,87 @@ class Simulator(
   private val dropPortOverride: Int? = null
 ) : TableDataReader {
 
-  private var pipeline: PipelineConfig? = null
-  private var architecture: Architecture? = null
-  private val tableStore = TableStore()
+  /**
+   * Atomically published bundle of "the currently loaded pipeline". Includes the [TableStore] so
+   * `(architecture, tableStore)` publish as one snapshot — no torn pair across reload.
+   */
+  private data class LoadedPipeline(
+    val config: PipelineConfig,
+    val architecture: Architecture,
+    val tableStore: TableStore,
+  )
+
+  // Single source of truth for "the loaded pipeline". Published via AtomicReference so all
+  // readers (processPacket, writeEntry, snapshot, ...) observe the architecture and tableStore
+  // as one consistent pair, even mid-reload. JMM happens-before across the .set() carries the
+  // prior tableStore.loadMappings writes along with the publish.
+  private val current = AtomicReference<LoadedPipeline?>(null)
+
+  /** Throws if no pipeline is loaded; otherwise returns the current snapshot. */
+  private fun loaded(): LoadedPipeline = checkNotNull(current.get()) { "no pipeline loaded" }
 
   /**
    * Installs a compiled P4 program. Must be called before [processPacket].
    *
    * Replaces the current program and clears all table entries.
    *
+   * **Concurrency:** single-writer. Callers must serialize this against other [loadPipeline],
+   * [loadPipelinePreservingEntries], and [writeEntry] calls (P4Runtime does this via its write
+   * mutex). Concurrent [processPacket] callers are safe — they observe either the old or the new
+   * pipeline as one atomic `(architecture, tableStore)` snapshot, never a torn mix.
+   *
    * @throws IllegalArgumentException if the architecture is unsupported.
    */
   fun loadPipeline(config: PipelineConfig) {
-    pipeline = config
-
+    val tableStore = TableStore()
     tableStore.loadMappings(config.p4Info, config.device)
-
-    architecture =
-      when (val archName = config.device.behavioral.architecture.name) {
-        "v1model" -> V1ModelArchitecture(dropPortOverride)
-        "psa" -> PSAArchitecture()
-        "pna" -> PNAArchitecture()
+    val behavioral = config.device.behavioral
+    val architecture =
+      when (val archName = behavioral.architecture.name) {
+        "v1model" -> V1ModelArchitecture(behavioral, dropPortOverride)
+        "psa" -> PSAArchitecture(behavioral)
+        "pna" -> PNAArchitecture(behavioral)
         else -> throw IllegalArgumentException("unsupported architecture: $archName")
       }
+    current.set(LoadedPipeline(config, architecture, tableStore))
   }
 
   /**
    * Like [loadPipeline], but preserves forwarding state for tables whose schema is unchanged.
    *
    * Used by RECONCILE_AND_COMMIT. Snapshots the current write-state, loads the new pipeline (which
-   * clears all state), then restores entries for tables that exist in both pipelines. The caller
-   * must verify schema compatibility before calling this.
+   * starts with a fresh [TableStore]), then restores entries for tables that exist in both
+   * pipelines. The caller must verify schema compatibility before calling this.
+   *
+   * **Concurrency:** same as [loadPipeline] — single-writer.
    */
   fun loadPipelinePreservingEntries(config: PipelineConfig) {
-    val snapshot = tableStore.snapshot()
-    val oldAliasByName = tableStore.tableAliasByName
+    val old = loaded()
+    val oldSnapshot = old.tableStore.snapshot()
+    val oldAliasByName = old.tableStore.tableAliasByName
     loadPipeline(config)
-    tableStore.restoreTableEntries(snapshot.forwarding, oldAliasByName)
-    tableStore.publishSnapshot()
+    val newTableStore = loaded().tableStore
+    newTableStore.restoreTableEntries(oldSnapshot.forwarding, oldAliasByName)
+    newTableStore.publishSnapshot()
   }
 
   /**
    * Processes a single packet through the pipeline.
    *
+   * **Concurrency:** safe to call concurrently from any number of threads. Reads the loaded
+   * pipeline as one atomic snapshot; reads forwarding state from [TableStore]'s published snapshot.
+   * No locks on the hot path.
+   *
    * @throws IllegalStateException if no pipeline is loaded.
    */
   fun processPacket(ingressPort: Int, payload: ByteArray): ProcessPacketResult {
-    val config = checkNotNull(pipeline) { "no pipeline loaded" }
-    val arch = checkNotNull(architecture) { "no pipeline loaded" }
+    val loaded = loaded()
 
     val result =
-      arch.processPacket(
+      loaded.architecture.processPacket(
         ingressPort = ingressPort.toUInt(),
         payload = payload,
-        config = config.device.behavioral,
-        tableStore = tableStore,
+        tableStore = loaded.tableStore,
       )
 
     // Output packets are extracted from trace tree leaves — the tree is the single source
@@ -109,21 +139,23 @@ class Simulator(
   /**
    * Writes a table entry (insert, modify, or delete).
    *
+   * **Concurrency:** single-writer. Callers must serialize this against other [writeEntry] and
+   * [loadPipeline] calls (P4Runtime does this via its write mutex). [TableStore.write] mutates
+   * write-state; visibility to [processPacket] requires a subsequent [publishSnapshot].
+   *
    * @throws IllegalStateException if no pipeline is loaded.
    */
-  fun writeEntry(update: p4.v1.P4RuntimeOuterClass.Update): WriteResult {
-    checkNotNull(pipeline) { "no pipeline loaded" }
-    return tableStore.write(update)
-  }
+  fun writeEntry(update: p4.v1.P4RuntimeOuterClass.Update): WriteResult =
+    loaded().tableStore.write(update)
 
   /** Captures a checkpoint of all mutable state for rollback. */
-  fun snapshot(): TableStore.RollbackCheckpoint = tableStore.snapshot()
+  fun snapshot(): TableStore.RollbackCheckpoint = loaded().tableStore.snapshot()
 
   /** Restores all mutable state to a previously captured checkpoint. */
-  fun restore(checkpoint: TableStore.RollbackCheckpoint) = tableStore.restore(checkpoint)
+  fun restore(checkpoint: TableStore.RollbackCheckpoint) = loaded().tableStore.restore(checkpoint)
 
   /** Publishes the current write-state as a new immutable snapshot for data-plane threads. */
-  fun publishSnapshot() = tableStore.publishSnapshot()
+  fun publishSnapshot() = loaded().tableStore.publishSnapshot()
 
   /**
    * Returns true if the table with p4info [tableId] has an entry with match field [fieldId] equal
@@ -135,10 +167,11 @@ class Simulator(
     tableId: Int,
     fieldId: Int,
     value: com.google.protobuf.ByteString,
-  ): Boolean = tableStore.hasEntryWithFieldValue(tableId, fieldId, value)
+  ): Boolean = loaded().tableStore.hasEntryWithFieldValue(tableId, fieldId, value)
 
   /** Returns true if a multicast group with [groupId] exists in the PRE. */
-  fun hasMulticastGroup(groupId: Int): Boolean = tableStore.getMulticastGroup(groupId) != null
+  fun hasMulticastGroup(groupId: Int): Boolean =
+    loaded().tableStore.getMulticastGroup(groupId) != null
 
   // -------------------------------------------------------------------------
   // Raw data accessors (used by the P4Runtime layer's EntityReader)
@@ -146,30 +179,31 @@ class Simulator(
 
   /** ID→name maps populated by [loadPipeline], for building P4Runtime Entity protos. */
   val tableNameById: Map<Int, String>
-    get() = tableStore.tableNameById
+    get() = loaded().tableStore.tableNameById
 
   val actionNameById: Map<Int, String>
-    get() = tableStore.actionNameById
+    get() = loaded().tableStore.actionNameById
 
   /** P4info alias names of tables that have at least one installed entry. */
   val populatedTableAliases: Set<String>
-    get() = tableStore.populatedTableAliases()
+    get() = loaded().tableStore.populatedTableAliases()
 
-  override fun getTableEntries(tableName: String) = tableStore.getTableEntries(tableName)
+  override fun getTableEntries(tableName: String) = loaded().tableStore.getTableEntries(tableName)
 
-  override fun getDefaultAction(tableName: String) = tableStore.getDefaultAction(tableName)
+  override fun getDefaultAction(tableName: String) = loaded().tableStore.getDefaultAction(tableName)
 
-  override fun isDefaultModified(tableName: String) = tableStore.isDefaultModified(tableName)
+  override fun isDefaultModified(tableName: String) =
+    loaded().tableStore.isDefaultModified(tableName)
 
   override fun getDirectCounterData(entry: p4.v1.P4RuntimeOuterClass.TableEntry) =
-    tableStore.getDirectCounterData(entry)
+    loaded().tableStore.getDirectCounterData(entry)
 
   override fun getDirectMeterData(entry: p4.v1.P4RuntimeOuterClass.TableEntry) =
-    tableStore.getDirectMeterData(entry)
+    loaded().tableStore.getDirectMeterData(entry)
 
-  override fun hasDirectCounter(tableName: String) = tableStore.hasDirectCounter(tableName)
+  override fun hasDirectCounter(tableName: String) = loaded().tableStore.hasDirectCounter(tableName)
 
-  override fun hasDirectMeter(tableName: String) = tableStore.hasDirectMeter(tableName)
+  override fun hasDirectMeter(tableName: String) = loaded().tableStore.hasDirectMeter(tableName)
 
   /**
    * Reads non-table entities matching the given filters.
@@ -179,8 +213,9 @@ class Simulator(
    */
   fun readEntries(
     filters: List<p4.v1.P4RuntimeOuterClass.Entity>
-  ): List<p4.v1.P4RuntimeOuterClass.Entity> =
-    filters.flatMap { entity ->
+  ): List<p4.v1.P4RuntimeOuterClass.Entity> {
+    val tableStore = loaded().tableStore
+    return filters.flatMap { entity ->
       when {
         entity.hasTableEntry() -> emptyList()
         entity.hasActionProfileMember() -> tableStore.readProfileMembers(entity.actionProfileMember)
@@ -197,9 +232,10 @@ class Simulator(
         else -> error("unsupported entity type for read: ${entity.entityCase}")
       }
     }
+  }
 
   /** Returns the short p4info alias for a behavioral name (table or action), or the name itself. */
-  fun displayName(behavioralName: String): String = tableStore.displayName(behavioralName)
+  fun displayName(behavioralName: String): String = loaded().tableStore.displayName(behavioralName)
 }
 
 /**

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -281,6 +281,101 @@ class SimulatorTest {
     assertEquals(1, outputs.size)
     assertEquals(V1ModelArchitecture.DEFAULT_DROP_PORT, outputs[0].dataplaneEgressPort)
   }
+
+  // ---------------------------------------------------------------------------
+  // Concurrency: atomic loadPipeline publish
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `concurrent loadPipeline and processPacket never observe a torn snapshot`() {
+    // Two pipelines with distinguishable outputs: a torn (architecture, tableStore) snapshot
+    // would throw or yield a port outside {1, 2}. Because tableStore now lives inside
+    // LoadedPipeline, both fields publish via the same AtomicReference — atomic by structure.
+    val configA = v1modelPipelineConfig(egressPort = 1)
+    val configB = v1modelPipelineConfig(egressPort = 2)
+
+    val sim = Simulator()
+    sim.loadPipeline(configA)
+
+    val errors = java.util.concurrent.ConcurrentLinkedQueue<Throwable>()
+    val stop = java.util.concurrent.atomic.AtomicBoolean(false)
+    val processed = java.util.concurrent.atomic.AtomicInteger(0)
+
+    val readers =
+      (0 until 8).map {
+        Thread {
+            try {
+              while (!stop.get()) {
+                val result = sim.processPacket(ingressPort = 0, payload = byteArrayOf(0x01))
+                val port = result.possibleOutcomes.single().singleOrNull()?.dataplaneEgressPort
+                require(port == 1 || port == 2) { "torn snapshot: got port=$port" }
+                processed.incrementAndGet()
+              }
+            } catch (
+              @Suppress("TooGenericExceptionCaught")
+              t: Throwable) { // any failure is a race symptom
+              errors.add(t)
+            }
+          }
+          .also { it.start() }
+      }
+
+    repeat(200) { sim.loadPipeline(if (it % 2 == 0) configB else configA) }
+
+    Thread.sleep(50) // let readers run a bit longer to expose any final race
+    stop.set(true)
+    readers.forEach { it.join() }
+
+    assertEquals(
+      "expected no errors during concurrent reload (processed ${processed.get()} packets); " +
+        "first: ${errors.firstOrNull()}",
+      0,
+      errors.size,
+    )
+  }
+
+  @Test
+  fun `concurrent loadPipelinePreservingEntries and processPacket never throw`() {
+    // RECONCILE_AND_COMMIT path: snapshots old tableStore, builds new pipeline, restores entries.
+    // The whole sequence happens against a single LoadedPipeline atomic publish, so concurrent
+    // processPacket must never observe a half-restored tableStore.
+    val configA = v1modelPipelineConfig(egressPort = 1)
+    val configB = v1modelPipelineConfig(egressPort = 2)
+
+    val sim = Simulator()
+    sim.loadPipeline(configA)
+
+    val errors = java.util.concurrent.ConcurrentLinkedQueue<Throwable>()
+    val stop = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    val readers =
+      (0 until 4).map {
+        Thread {
+            try {
+              while (!stop.get()) {
+                sim.processPacket(ingressPort = 0, payload = byteArrayOf(0x01))
+              }
+            } catch (
+              @Suppress("TooGenericExceptionCaught")
+              t: Throwable) { // any failure is a race symptom
+              errors.add(t)
+            }
+          }
+          .also { it.start() }
+      }
+
+    repeat(50) { sim.loadPipelinePreservingEntries(if (it % 2 == 0) configB else configA) }
+
+    Thread.sleep(50)
+    stop.set(true)
+    readers.forEach { it.join() }
+
+    assertEquals(
+      "expected no errors during concurrent reconcile reload; first: ${errors.firstOrNull()}",
+      0,
+      errors.size,
+    )
+  }
 }
 
 /** Unit tests for [collectPossibleOutcomes] — the parallel vs alternative fork semantics. */

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -72,12 +72,18 @@ private val INTRA_PACKET_PARALLELISM_ENABLED =
   System.getProperty("fourward.simulator.intraPacketParallelism", "true").toBoolean()
 
 class V1ModelArchitecture(
+  private val config: BehavioralConfig,
   /**
    * Override for the drop port. When null (default), derived from `standard_metadata` port width:
    * `2^N - 1` (511 for 9-bit ports). Applied in [PipelineState] and in the `mark_to_drop` extern.
    */
-  private val dropPortOverride: Int? = null
+  private val dropPortOverride: Int? = null,
 ) : Architecture {
+
+  // Pipeline-invariant state derived from [config], built once per loaded pipeline. Immutable
+  // after publication, so safe to read concurrently from any number of [processPacket] threads
+  // without synchronization.
+  private val interpreter: Interpreter = Interpreter(config)
 
   /**
    * Post-parser snapshot captured during the first [runPipeline] execution of a packet. Read by
@@ -87,7 +93,6 @@ class V1ModelArchitecture(
   // ThreadLocal: parallel fork branches each get their own snapshot, avoiding races when
   // nested forks (clone after selector) write concurrently.
   private val postParserSnapshot = ThreadLocal<PostParserSnapshot?>()
-  private val interpreterCache = Interpreter.Cache()
 
   /** Invariant inputs to the pipeline, shared across fork re-executions. */
   private data class PipelineContext(
@@ -128,12 +133,10 @@ class V1ModelArchitecture(
   override fun processPacket(
     ingressPort: UInt,
     payload: ByteArray,
-    config: BehavioralConfig,
     tableStore: TableStore,
   ): PipelineResult {
     postParserSnapshot.set(null)
-    val ctx =
-      PipelineContext(ingressPort, payload, config, tableStore, interpreterCache.get(config))
+    val ctx = PipelineContext(ingressPort, payload, config, tableStore, interpreter)
     return buildTraceTree(ctx, V1ModelDecisions(), prefixLength = 0)
   }
 

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -301,7 +301,7 @@ class V1ModelArchitectureTest {
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = V1ModelArchitecture().processPacket(0u, payload, config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -317,7 +317,7 @@ class V1ModelArchitectureTest {
     val config =
       v1modelConfig(assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS))
     val payload = byteArrayOf(0x01, 0x02, 0x03)
-    val result = V1ModelArchitecture().processPacket(0u, payload, config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -336,7 +336,7 @@ class V1ModelArchitectureTest {
           V1ModelArchitecture.DEFAULT_PORT_BITS,
         )
       )
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -355,7 +355,7 @@ class V1ModelArchitectureTest {
           V1ModelArchitecture.DEFAULT_PORT_BITS,
         )
       )
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     val stageNames =
       result.trace.eventsList.filter { it.hasPipelineStage() }.map { it.pipelineStage.stageName }
@@ -385,7 +385,7 @@ class V1ModelArchitectureTest {
             assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
           ),
       )
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -398,7 +398,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
@@ -417,7 +417,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
     val payload = byteArrayOf(0xAA.toByte())
-    val result = V1ModelArchitecture().processPacket(0u, payload, config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -445,7 +445,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7, usePortBytes = true)
 
     val result =
-      V1ModelArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, tableStore)
+      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -465,7 +465,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 510, usePortBytes = true)
 
     val result =
-      V1ModelArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, tableStore)
+      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -483,7 +483,7 @@ class V1ModelArchitectureTest {
       usePortBytes = true,
     )
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -503,7 +503,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 8)
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -527,7 +527,7 @@ class V1ModelArchitectureTest {
         ifFieldEquals("sm", "instance_type", 0, 32, externCall("resubmit", intArg(0, 8)))
       )
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
@@ -550,7 +550,7 @@ class V1ModelArchitectureTest {
           ),
       )
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
@@ -569,7 +569,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertFalse(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -587,7 +587,7 @@ class V1ModelArchitectureTest {
         egressStmts = listOf(externCall("clone", enumArg("E2E"), intArg(99, 32))),
       )
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertFalse(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -604,7 +604,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     // No fork — falls through to unicast path.
     val outputs = result.possibleOutcomes.single()
@@ -630,7 +630,7 @@ class V1ModelArchitectureTest {
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))
 
     val result =
-      V1ModelArchitecture().processPacket(0u, byteArrayOf(0xAA.toByte()), config, tableStore)
+      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -646,7 +646,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -680,7 +680,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 8)
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -701,7 +701,7 @@ class V1ModelArchitectureTest {
   fun `trace starts with packet ingress and has enter-exit pairs for all stages`() {
     val config =
       v1modelConfig(assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS))
-    val result = V1ModelArchitecture().processPacket(7u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(7u, byteArrayOf(0x01), TableStore())
     val events = stageEvents(result.trace)
 
     // First event: packet ingress with correct port.
@@ -753,7 +753,7 @@ class V1ModelArchitectureTest {
         .build()
 
     val config = v1modelConfig(parser = exitParser)
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     // Should be a drop.
     assertTrue(result.trace.hasPacketOutcome())
@@ -800,7 +800,7 @@ class V1ModelArchitectureTest {
     val portBits = 16
     val largePort = 1000L // beyond bit<9> range
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", largePort, portBits))
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -812,7 +812,7 @@ class V1ModelArchitectureTest {
     val portBits = 16
     val dropPort = (1L shl portBits) - 1 // 65535, not 511
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", dropPort, portBits))
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -823,7 +823,7 @@ class V1ModelArchitectureTest {
     // Port 511 is NOT the drop port when port width is 16 bits — it's a valid port.
     val portBits = 16
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", 511, portBits))
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -838,7 +838,7 @@ class V1ModelArchitectureTest {
     val portBits = 16
     val markToDrop = externCall("mark_to_drop", nameRef("sm"))
     val config = widePortConfig(portBits, markToDrop)
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -849,7 +849,7 @@ class V1ModelArchitectureTest {
     val portBits = 32
     val largePort = 100_000L
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", largePort, portBits))
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -903,7 +903,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -949,7 +949,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 8)
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -992,7 +992,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
@@ -1037,7 +1037,7 @@ class V1ModelArchitectureTest {
         metaTypeDecl = metaTypeWithFieldList,
       )
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
@@ -1090,7 +1090,7 @@ class V1ModelArchitectureTest {
         metaTypeDecl = metaTypeWithFieldList,
       )
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
@@ -1135,7 +1135,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -1154,7 +1154,7 @@ class V1ModelArchitectureTest {
         externCall("assert", boolLit(true)),
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1166,7 +1166,7 @@ class V1ModelArchitectureTest {
   @Test
   fun `assert false drops packet with ASSERTION_FAILURE reason`() {
     val config = v1modelConfig(externCall("assert", boolLit(false)))
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1178,7 +1178,7 @@ class V1ModelArchitectureTest {
   @Test
   fun `assume false drops packet with ASSERTION_FAILURE reason`() {
     val config = v1modelConfig(externCall("assume", boolLit(false)))
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1196,7 +1196,7 @@ class V1ModelArchitectureTest {
         externCall("log_msg", stringLit("hello world")),
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1212,7 +1212,7 @@ class V1ModelArchitectureTest {
         externCall("log_msg", stringLit("value = {}"), bit(42, 8)),
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1229,7 +1229,7 @@ class V1ModelArchitectureTest {
           listOf(assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS)),
         egressStmts = listOf(externCall("assert", boolLit(false))),
       )
-    val result = V1ModelArchitecture().processPacket(0u, byteArrayOf(0x01), config, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1246,8 +1246,8 @@ class V1ModelArchitectureTest {
     // Sending to port 42 should now be a drop.
     val config = v1modelConfig(assignField("sm", "egress_spec", 42, DEFAULT_PORT_BITS))
     val result =
-      V1ModelArchitecture(dropPortOverride = 42)
-        .processPacket(0u, byteArrayOf(0x01), config, TableStore())
+      V1ModelArchitecture(config, dropPortOverride = 42)
+        .processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1259,8 +1259,8 @@ class V1ModelArchitectureTest {
     val config =
       v1modelConfig(assignField("sm", "egress_spec", DEFAULT_DROP_PORT.toLong(), DEFAULT_PORT_BITS))
     val result =
-      V1ModelArchitecture(dropPortOverride = 42)
-        .processPacket(0u, byteArrayOf(0x01), config, TableStore())
+      V1ModelArchitecture(config, dropPortOverride = 42)
+        .processPacket(0u, byteArrayOf(0x01), TableStore())
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
@@ -1272,8 +1272,8 @@ class V1ModelArchitectureTest {
     // mark_to_drop should set egress_spec to the override value, not the default.
     val config = v1modelConfig(externCall("mark_to_drop", nameRef("sm")))
     val result =
-      V1ModelArchitecture(dropPortOverride = 42)
-        .processPacket(0u, byteArrayOf(0x01), config, TableStore())
+      V1ModelArchitecture(config, dropPortOverride = 42)
+        .processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1285,8 +1285,8 @@ class V1ModelArchitectureTest {
     val config =
       v1modelConfig(assignField("sm", "egress_spec", DEFAULT_DROP_PORT.toLong(), DEFAULT_PORT_BITS))
     val result =
-      V1ModelArchitecture(dropPortOverride = null)
-        .processPacket(0u, byteArrayOf(0x01), config, TableStore())
+      V1ModelArchitecture(config, dropPortOverride = null)
+        .processPacket(0u, byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())

--- a/userdocs/concepts/architecture-modifications.md
+++ b/userdocs/concepts/architecture-modifications.md
@@ -127,9 +127,9 @@ Add your architecture to the dispatcher in [`Simulator.kt`](https://github.com/s
 
 ```kotlin
 architecture = when (archName) {
-  "v1model" -> V1ModelArchitecture(dropPort)
-  "psa" -> PSAArchitecture()
-  "pna" -> PnaArchitecture()       // ← add here
+  "v1model" -> V1ModelArchitecture(behavioral, dropPort)
+  "psa" -> PSAArchitecture(behavioral)
+  "pna" -> PnaArchitecture(behavioral)   // ← add here
   else -> throw IllegalArgumentException("unsupported architecture: $archName")
 }
 ```


### PR DESCRIPTION
## The win

Removes a JMM data race on the simulator's hot path — silently — by deleting the `Interpreter.Cache` class entirely instead of locking it. While auditing for related races, picked up the same anti-pattern in PSA/PNA, made `Simulator`'s pipeline reload publish atomically (architecture *and* table store as one snapshot), and made `NetworkSimulator` thread-safe-by-design. Net: simpler code, `@Synchronized`-free, no locks added on the per-packet path, and the per-method concurrency contracts of `Simulator` are now actually documented and tested. Benchmarks confirm no regression.

## What was wrong

`Interpreter.Cache` (introduced in #400 as a perf optimization back when the simulator was still single-threaded) held two unsynchronized vars and was hit on the lock-free packet hot path enabled by #406 / #409. ThreadSanitizer caught it; #516 proposed a `@Synchronized` patch.

The deeper issue was a design smell, not just a missing lock:

- `BehavioralConfig` is set once by `loadPipeline` and never mutated. So the "cache" was effectively a lazy-init disguise — the identity check `config === cachedConfig` was trivially true after the first packet.
- `processPacket` accepted `config` as a per-call parameter, when it's actually a property of the loaded pipeline.
- PSA and PNA had the same shape for `blockParams`, `typesByName`, `externInstances`, and pipeline-stage lookups — recomputed per packet from immutable config.
- `Simulator.loadPipeline` itself wrote the architecture and table-store mappings non-atomically — a separate latent torn-snapshot race surfaced by the audit.
- `NetworkSimulator` carried the same stale "single-threaded" assumption with a non-thread-safe mutable map.

## What this does

**Per-pipeline state moved to constructor:**
- Each architecture (`V1ModelArchitecture`, `PSAArchitecture`, `PNAArchitecture`) takes `BehavioralConfig` as a constructor parameter and builds its `Interpreter` and other config-derived state as immutable `val`s at load time.
- PSA/PNA also pre-resolve their pipeline stages (fail fast on misconfigured pipelines) via a shared `resolveStage` helper in `ArchitectureHelpers`.
- `Architecture.processPacket` drops the `config` parameter.
- `Interpreter.Cache` is deleted.

**Truly atomic `loadPipeline`:**
- New private `LoadedPipeline(config, architecture, tableStore)` data class published via a single `AtomicReference`.
- A fresh `TableStore` is built per pipeline load and goes inside the snapshot, so `(architecture, tableStore)` publish as one atomic pair — no possible window where a reader sees the new architecture against the old table store (or vice versa).
- Pipeline reload no longer requires quiescing data-plane traffic.
- `loadPipelinePreservingEntries` snapshots the old table store before swap, then restores entries to the new one (RECONCILE_AND_COMMIT path, unchanged externally).

**`NetworkSimulator` made consistent:**
- Switched its switch map from `mutableMapOf` to `ConcurrentHashMap`, with `addSwitch` now using `putIfAbsent` for atomic duplicate detection.
- Documented the actual concurrency contract.

**Contracts written down where they belong:**
- Per-method KDoc on `Simulator.loadPipeline` / `processPacket` / `writeEntry` (single-writer vs. concurrent-safe).
- Inline thread-safety notes on `Interpreter`, `V1ModelArchitecture`, `PSAArchitecture`, `PNAArchitecture`.
- Updated `Simulator.kt:34` class doc.
- Added an AGENTS.md invariant: when changing concurrency assumptions, audit every site that depended on the old assumption — both code and docs.

## Tests

- `SimulatorTest.concurrent loadPipeline and processPacket never observe a torn snapshot` — 8 reader threads hammer `processPacket` while a writer alternates `loadPipeline` between two configs with distinguishable outputs.
- `SimulatorTest.concurrent loadPipelinePreservingEntries and processPacket never throw` — same pattern for the RECONCILE path.
- `NetworkSimulatorTest.concurrent addSwitch with distinct ids all succeed` — 32 threads concurrently add unique switches; all must succeed.
- `NetworkSimulatorTest.concurrent addSwitch with duplicate id elects exactly one winner` — 32 threads race on the same id; exactly one succeeds, n-1 are rejected with `IllegalArgumentException`. Directly exercises `putIfAbsent`.
- `DataplaneServiceTest.concurrent InjectPacket calls all produce correct results` — bumped from 10 → 100 iterations.

JMM races are TSO-hidden on x86 so none of these will deterministically fail on the *unfixed* code. They directly exercise the new code paths and would catch any regression that breaks the publish/atomicity properties.

## Performance

Ran `DataplaneBenchmark` (SAI middleblock) 3 times before and 3 times after the table-store-into-LoadedPipeline refactor on a 32-core machine. Mean throughput (sequential mode):

| Config | Before (pps) | After (pps) | Δ |
|---|---:|---:|---:|
| direct 100 routes | 3,644 | 3,699 | +1.5% |
| direct 1k | 3,515 | 3,704 | +5.4% |
| direct 4k | 3,203 | 3,342 | +4.3% |
| direct 10k | 2,516 | 2,441 | -3.0% |
| wcmp×4 10k | 1,818 | 1,846 | +1.5% |
| wcmp×16 10k | 1,696 | 1,697 | +0.1% |
| wcmp×16+mirr 10k | 1,185 | 1,191 | +0.5% |

All within run-to-run noise. No meaningful regression.

## Considered and rejected

| Option | Why rejected |
|---|---|
| **A: `@Synchronized` on `Cache.get`** (#516) | Patches the symptom. Adds a lock on every packet's hot path (against the throughput goal of #409). Leaves the cache for the next maintainer to mishandle. |
| **B: `AtomicReference` inside `Cache`** | Lock-free and JMM-correct, but still keeps a cache that exists to solve a non-problem. |
| **C: this PR — delete the cache, lift Interpreter to load time, atomically publish (architecture, tableStore)** | Eliminates the bug class. Matches `PacketBroker`'s published-immutable-snapshot idiom. |

## Audit

Walked every cross-packet field on `Interpreter`, `V1ModelArchitecture`, `PSAArchitecture`, `PNAArchitecture`. All are `val` + immutable, `ThreadLocal`, or per-call. The original TSan trace pointed at `Interpreter.kt:1331`; that line and its class no longer exist.

## Replaces

Closes #516 in spirit — same bug, deeper fix.

## Test plan

- [x] `bazel build //...`
- [x] `bazel test //... --test_tag_filters=-heavy` (64/64 pass, including 4 new concurrency tests)
- [x] `./tools/format.sh`, `./tools/lint.sh` clean
- [x] `DataplaneBenchmark`: no regression vs. baseline (3-run means within ±5% noise)
- [ ] CI heavy tests