### PR TITLE
ci: cache the BCR consumer check — kill the CI straggler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Separate cache namespace (`bazel-bcr-*`) from the main
+      # build-and-test job: this workspace pins Bazel 8.x, uses a
+      # different `.bazelrc`, and resolves its own dependency graph via
+      # `bcr_test_module/MODULE.bazel`, so sharing a key would cause
+      # constant eviction churn. The key folds in root MODULE files
+      # because fourward is pulled in via `local_path_override`.
+      - name: Restore Bazel cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/bazel
+          key: bazel-bcr-${{ hashFiles('bcr_test_module/MODULE.bazel', 'bcr_test_module/.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}
+          restore-keys: bazel-bcr-
+
+      - name: Save start time
+        run: echo "START_TIME=$(date +%s)" >> "$GITHUB_ENV"
+
       # Build flags live in `bcr_test_module/.bazelrc` so local
       # invocations reproduce this job exactly — CI only adds the
       # BuildBuddy remote cache and target-pattern exclusions on top.
@@ -251,6 +267,20 @@ jobs:
             @fourward//... \
             -@fourward//e2e_tests/... \
             -@fourward//examples/...
+
+      - name: Calculate build duration
+        if: always()
+        run: echo "DURATION=$(( $(date +%s) - START_TIME ))" >> "$GITHUB_ENV"
+
+      # Mirror build-and-test: save on main (authoritative cache) or
+      # when the build was slow enough (>5 min) that persisting is
+      # worthwhile despite the PR-branch scoping.
+      - name: Save Bazel cache
+        uses: actions/cache/save@v5
+        if: always() && (github.ref_name == 'main' || env.DURATION > 300)
+        with:
+          path: ~/.cache/bazel
+          key: bazel-bcr-${{ hashFiles('bcr_test_module/MODULE.bazel', 'bcr_test_module/.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock', 'bazel/*.patch') }}-${{ github.run_id }}
 
 
   coverage:


### PR DESCRIPTION
## Summary
The **BCR consumer check** has been the CI tail for the past week — spiking from a baseline of ~2 min to 10, 15, 47, even 62 minutes on PRs that touched Bazel BUILD files. Every other job in those runs still finished in 1–3 min; this one sat alone rebuilding p4c from C++ source for the better part of an hour.

Root cause: it was the only cache-backed job with **no local disk cache**. It relied 100% on BuildBuddy with a 3s remote_timeout — any miss on that path turns into a from-scratch p4c rebuild (700+ C++ actions, 18× the critical path in wall time on the worst observed run).

This PR gives the job the same disk-cache treatment as `lint` / `build-and-test` / `coverage`.

## Design notes
- **Separate key namespace** (`bazel-bcr-*`). `bcr_test_module` pins Bazel 8.x, uses its own `.bazelrc`, and resolves its own dep graph — sharing a key with the main `bazel-ubuntu-24.04-*` namespace would just cause eviction churn under GitHub's 10 GB per-repo cap.
- **Key folds in root MODULE files** because fourward is pulled in via `local_path_override` — a bump to the root `MODULE.bazel.lock` should invalidate this cache too.
- **Save policy mirrors build-and-test**: main pushes always, PRs only when the build was slow enough (>5 min) that persisting is worthwhile despite PR-branch scoping.
- Not touching `--remote_timeout=3s` in this PR — separate concern, easier to evaluate in isolation.

## Test plan
- [ ] Watch this PR's own BCR job — first run is still a cache miss (no `bazel-bcr-*` entry exists yet), so the *second* run on this branch should show the speedup.
- [ ] After merge, confirm the next main push seeds the authoritative cache, and that a subsequent PR's BCR job restores from it.