### PR TITLE
ci: loosen BCR remote_timeout from 3s to 30s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
               --remote_header=x-buildbuddy-api-key="${BUILDBUDDY_API_KEY}"
               --remote_download_toplevel
               --remote_upload_local_results
-              --remote_timeout=3s
+              --remote_timeout=30s
               --remote_cache_compression
             )
           fi


### PR DESCRIPTION
## Summary
Follow-up to #526. Bumps `--remote_timeout` in the BCR consumer check from **3s → 30s**.

3s is well below Bazel's default of 60s and tight enough that any jittery CAS blob transfer (a multi-MB p4c object file over grpcs from a GitHub runner) gets treated as a cache miss and falls back to local rebuild. 30s stays conservative vs. the upstream default but gives a struggling RPC room to complete on the happy path.

Together with the disk cache from #526, the intent is that transient BuildBuddy latency stops cascading into 10–60 min tail runs.

## Test plan
- [ ] Watch this PR's BCR job — should stay in the usual 2–3 min band with no regression on the happy path.
- [ ] Longer-term: no more multi-10-minute outliers on BUILD-touching PRs.