### PR TITLE
Narrow visibility on two internal-only targets

### DIFF
--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -378,7 +378,6 @@ cc_binary(
     name = "constraint_validator",
     srcs = ["constraint_validator.cpp"],
     copts = ["-std=c++20"],
-    visibility = ["//visibility:public"],
     deps = [
         ":constraint_validator_cc_proto",
         "@p4_constraints//p4_constraints/backend:constraint_info",

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -14,7 +14,6 @@ kt_jvm_library(
             "PlaygroundServer.kt",
         ],
     ),
-    visibility = ["//visibility:public"],
     deps = [
         "//p4runtime:p4runtime_lib",
         "//simulator:ir_java_proto",


### PR DESCRIPTION
## Summary

A \`bazel query\` for \`attr(visibility, "//visibility:public", //...)\`
crossed against \`rdeps(//..., <target>)\` found two targets whose
reverse deps are confined to their own package but that were
nevertheless marked public:

- \`//web:web_lib\` — only \`//web:playground\` and the web tests use
  it.
- \`//p4runtime:constraint_validator\` — only \`//p4runtime\`'s four
  constraint-related tests use it as a \`data\` dep.

Dropped the explicit \`visibility\` on both so they fall back to
package-private. Prevents accidental cross-package coupling; nothing
else changes.

The other public targets stay public — they're either binaries
(servers, CLIs), proto/gRPC stubs on the public API, or truly
wide-reach shared libs (\`simulator_lib\`, \`stf\`).

## Test plan

- [x] \`bazel build //...\` — green
- [x] \`bazel test //... --test_tag_filters=-heavy\` — 63/63 pass
- [ ] CI (including BCR consumer check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)