### PR TITLE
Swap bespoke BMv2 genrule for upstream p4_library rule

### DIFF
--- a/e2e_tests/sai_p4/BUILD.bazel
+++ b/e2e_tests/sai_p4/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@p4c//bazel:p4_library.bzl", "p4_library")
 load("//bazel:fourward_pipeline.bzl", "fourward_pipeline")
 
 package(
@@ -39,26 +40,14 @@ fourward_pipeline(
 )
 
 # BMv2 JSON (for head-to-head benchmarking against the 4ward simulator).
-genrule(
+p4_library(
     name = "sai_middleblock_bmv2_json",
-    srcs = [
-        "instantiations/google/middleblock.p4",
-        ":sai_p4_srcs",
-    ],
-    outs = ["sai_middleblock.json"],
-    cmd = " ".join([
-        "$(execpath @p4c//:p4c_bmv2)",
-        "-I $$(dirname $(execpath @p4c//p4include:core.p4))",
-        "-DPLATFORM_BMV2",
-        "-o $@",
-        "$(execpath instantiations/google/middleblock.p4)",
-    ]),
-    tools = [
-        "@p4c//:p4c_bmv2",
-        "@p4c//p4include",
-        "@p4c//p4include:core.p4",
-    ],
+    src = "instantiations/google/middleblock.p4",
+    extra_args = "-DPLATFORM_BMV2",
+    target = "bmv2",
+    target_out = "sai_middleblock.json",
     visibility = ["//e2e_tests/bmv2_diff:__pkg__"],
+    deps = [":sai_p4_srcs"],
 )
 
 # 4ward PipelineConfig with BMv2 defines (for P4Info used by BMv2 benchmark).


### PR DESCRIPTION
## Summary

One P4→BMv2 JSON genrule in the repo — the one that feeds `//e2e_tests/bmv2_diff` — was rolling its own invocation of `p4c_bmv2` via shell. Swap it for `@p4c//bazel:p4_library.bzl`, which p4c already ships and which we already transitively depend on.

## Why

- **Hermetic CC toolchain.** p4c shells out to `cc` internally for preprocessing. The old genrule relied on `use_default_shell_env` picking up whatever `cc` is on PATH. `p4_library` wires p4c to Bazel's `CC_TOOLCHAIN_TYPE` properly — same correctness today, fewer surprises tomorrow.
- **-11 lines of bespoke shell plumbing** (include-dir juggling, tools list, output-path wiring). The rule already encodes all of that.
- **No new dependency.** `p4_library.bzl` is already available via our existing `bazel_dep(name = "p4c")`.

## Scope

One call site: `//e2e_tests/sai_p4:sai_middleblock_bmv2_json`. It's the only genrule of its kind — everything else goes through our own `fourward_pipeline` rule, which emits `.txtpb`, not BMv2 JSON.

Output path (`sai_middleblock.json`) is unchanged, so the downstream runfile lookup in `Bmv2Benchmark.kt` keeps working as-is.

## Test plan

- [x] `bazel build //e2e_tests/sai_p4:sai_middleblock_bmv2_json` — succeeds; output byte-identical path.
- [x] `bazel test //e2e_tests/bmv2_diff/... --test_tag_filters=-heavy` — `bmv2_diff_test` PASSED.
- [x] `./tools/format.sh` and `./tools/lint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)