### PR TITLE
Declare bzl_library targets for all .bzl files

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,10 +1,17 @@
 # Build rules and patches for third-party dependencies.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 
 package(
     default_applicable_licenses = ["//:license"],
     licenses = ["notice"],
+)
+
+bzl_library(
+    name = "fourward_pipeline_bzl",
+    srcs = ["fourward_pipeline.bzl"],
+    visibility = ["//visibility:public"],
 )
 
 # `experimental_report_unused_deps` is intentionally not enabled: it

--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm_test")
 
 package(
@@ -8,6 +9,16 @@ package(
 exports_files(
     ["run_cram.py"],
     visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "cram_bzl",
+    srcs = ["cram.bzl"],
+    visibility = [
+        "//cli:__subpackages__",
+        "//examples:__subpackages__",
+    ],
+    deps = ["@rules_python//python:defs_bzl"],
 )
 
 kt_jvm_library(

--- a/e2e_tests/BUILD.bazel
+++ b/e2e_tests/BUILD.bazel
@@ -8,9 +8,37 @@ package(
 )
 
 bzl_library(
+    name = "bmv2_diff_bzl",
+    srcs = ["bmv2_diff.bzl"],
+    visibility = ["//e2e_tests:__subpackages__"],
+    deps = ["//bazel:fourward_pipeline_bzl"],
+)
+
+bzl_library(
+    name = "compile_test_bzl",
+    srcs = ["compile_test.bzl"],
+    visibility = ["//e2e_tests:__subpackages__"],
+    deps = [
+        "//bazel:fourward_pipeline_bzl",
+        "@bazel_skylib//rules:build_test",
+    ],
+)
+
+bzl_library(
     name = "corpus_bzl",
     srcs = ["corpus.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//e2e_tests:__subpackages__"],
+    deps = ["//bazel:fourward_pipeline_bzl"],
+)
+
+bzl_library(
+    name = "p4testgen_bzl",
+    srcs = ["p4testgen.bzl"],
+    visibility = ["//e2e_tests:__subpackages__"],
+    deps = [
+        "//bazel:fourward_pipeline_bzl",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
+    ],
 )
 
 kt_jvm_library(


### PR DESCRIPTION
## Summary

Adopts the google3 convention for Starlark code: every `.bzl` file now
has a `bzl_library` target with `deps` mirroring its `load()` graph and
a `visibility` declaring intended scope. The Starlark dependency graph
is now explicit in BUILD files, and the tree is Stardoc-ready.

`fourward_pipeline.bzl` stays public (BCR consumers load it from
`@fourward//bazel:fourward_pipeline.bzl`); the rest are scoped to
`//e2e_tests:__subpackages__` (or `//cli` + `//examples` for `cram.bzl`).

## Design notes

Considered adding in-file `visibility(...)` declarations as a hard
load-gate — stock Bazel does not enforce `bzl_library.visibility` on
`load()` in the way google3 does. Opted against it: a single source of
truth in BUILD files is cleaner, and for a small OSS project the value
here is *declared intent* + a correct deps graph, not adversarial
enforcement.

## Test plan

- [x] `bazel build //...` passes
- [x] `./tools/format.sh` + `./tools/lint.sh` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)