### PR TITLE
Enforce bzl_library coverage for every .bzl file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       # TODO(buf-edition-2024): Re-enable buf lint/breaking once buf supports
       # edition 2024. Tracked in https://github.com/smolkaj/4ward/pull/4.
 
+      - name: Check bzl_library coverage
+        run: ./tools/check-bzl-library.sh
+
       # On PRs, skip clang-tidy when no C++ files were modified — most PRs
       # only touch Kotlin or proto files.  Always run on pushes to main.
       - name: Detect C++ changes

--- a/tools/check-bzl-library.sh
+++ b/tools/check-bzl-library.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Verifies that every checked-in .bzl file is declared as a src of some
+# bzl_library target. Catches the common mistake of adding a new .bzl
+# without a matching BUILD entry.
+#
+# Running `bzl_library` targets for every .bzl file is the google3
+# convention; it makes the Starlark dep graph explicit and is a
+# prerequisite for Stardoc. Without this check the convention silently
+# erodes over time.
+#
+# Exits 1 if any .bzl file is uncovered.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+tracked=$(git ls-files '*.bzl' | sort)
+# bzl_library srcs come back as labels (//pkg:file.bzl); strip the "//"
+# and colon to match `git ls-files` paths.
+covered=$(
+  bazel query 'labels("srcs", kind(bzl_library, //...))' --output=label 2>/dev/null \
+    | sed 's|^//||; s|:|/|' \
+    | sort
+)
+
+missing=$(comm -23 <(echo "$tracked") <(echo "$covered"))
+if [[ -n "$missing" ]]; then
+  echo "ERROR: .bzl files not covered by any bzl_library target:" >&2
+  printf '  %s\n' $missing >&2
+  echo >&2
+  echo "Add a bzl_library target in the file's package. See" >&2
+  echo "bazel/BUILD.bazel for an example." >&2
+  exit 1
+fi

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Runs all linters:
+#   - bzl_library coverage check (every .bzl file has a bzl_library target)
 #   - clang-tidy on C++ sources (via Bazel aspect)
 #   - detekt on Kotlin sources
 #
-# Runs both even if the first fails, so you see all issues at once.
+# Runs all checks even if one fails, so you see all issues at once.
 #
 # Usage:
 #   ./lint.sh
@@ -12,8 +13,11 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-# Both commands go through Bazel, which serializes them via its server lock.
+# All commands go through Bazel, which serializes them via its server lock.
 rc=0
+
+echo "Checking bzl_library coverage..."
+"${REPO_ROOT}/tools/check-bzl-library.sh" || rc=1
 
 echo "Running clang-tidy..."
 bazel build //p4c_backend/... --config=clang-tidy || rc=1


### PR DESCRIPTION
## Summary

Guards the google3-style `bzl_library` convention adopted in #530 with a
CI check, so it doesn't silently erode when new `.bzl` files get added.

The check is a small set-diff between `git ls-files '*.bzl'` and the
`srcs` of every `bzl_library` target — no new tooling, no Starlark
parsing. Wired into `tools/lint.sh` and the `lint` CI job.

## Test plan

- [x] Check passes on clean tree
- [x] Check fails when a `bzl_library` target is removed (validated locally)
- [x] `./tools/lint.sh` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)