### PR TITLE
Publish Stardoc reference for fourward_pipeline rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,17 @@ jobs:
       # TODO(buf-edition-2024): Re-enable buf lint/breaking once buf supports
       # edition 2024. Tracked in https://github.com/smolkaj/4ward/pull/4.
 
+      # Regenerate Stardoc-based reference pages and fail if the
+      # committed copy is stale. Same run-and-diff pattern as
+      # format.sh above.
+      - run: ./tools/gen-docs.sh
+      - name: Check generated docs are up to date
+        run: |
+          if changed=$(git diff-index --name-only HEAD --) && [[ -n "$changed" ]]; then
+            echo -e "Generated docs are stale. Please run ./tools/gen-docs.sh:\n$changed"
+            exit 1
+          fi
+
       # On PRs, skip clang-tidy when no C++ files were modified — most PRs
       # only touch Kotlin or proto files.  Always run on pushes to main.
       - name: Detect C++ changes

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -146,6 +146,10 @@ use_repo(pip, "pip")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
 
+# Stardoc generates Markdown API docs from Starlark rules. Used by
+# tools/gen-docs.sh to refresh userdocs/reference/bazel.md.
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
+
 # Runs clang-tidy as a Bazel aspect — no compile_commands.json needed.
 # Usage: bazel build //p4c_backend/... --config=clang-tidy
 bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -12,6 +13,16 @@ bzl_library(
     name = "fourward_pipeline_bzl",
     srcs = ["fourward_pipeline.bzl"],
     visibility = ["//visibility:public"],
+)
+
+# Markdown API docs for fourward_pipeline.bzl. The committed copy at
+# userdocs/reference/bazel.md is refreshed by tools/gen-docs.sh and
+# kept in sync by a CI staleness check.
+stardoc(
+    name = "fourward_pipeline_docs",
+    out = "fourward_pipeline.md",
+    input = "fourward_pipeline.bzl",
+    deps = [":fourward_pipeline_bzl"],
 )
 
 # `experimental_report_unused_deps` is intentionally not enabled: it

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,8 @@ nav:
   - gRPC API:
       - Getting Started: getting-started/grpc.md
       - Reference: reference/grpc.md
+  - Bazel Integration:
+      - Reference: reference/bazel.md
   - Concepts:
       - Trace Trees: concepts/traces.md
       - Type Translation: concepts/type-translation.md

--- a/tools/gen-docs.sh
+++ b/tools/gen-docs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Regenerates documentation markdown that is auto-generated from source
+# (Stardoc for Bazel rules, etc.) and writes it into userdocs/reference/.
+# Committing the output keeps the docs site free of a Bazel build step
+# at publish time, and the staleness check in CI keeps it honest.
+#
+# Usage:
+#   ./tools/gen-docs.sh
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+bazel build //bazel:fourward_pipeline_docs
+
+# Prepend mkdocs-Material frontmatter + an H1 to the raw Stardoc output.
+# Existing reference/*.md files use the same shape, so the generated
+# page slots into the nav without special casing.
+OUT=userdocs/reference/bazel.md
+{
+  cat <<'EOF'
+---
+description: "Bazel rule reference for fourward_pipeline — compile P4 programs with p4c-4ward from a Bazel build."
+---
+
+# Bazel Rule Reference
+
+EOF
+  cat bazel-bin/bazel/fourward_pipeline.md
+} > "$OUT"
+
+echo "Wrote $OUT"

--- a/userdocs/reference/bazel.md
+++ b/userdocs/reference/bazel.md
@@ -1,0 +1,54 @@
+---
+description: "Bazel rule reference for fourward_pipeline — compile P4 programs with p4c-4ward from a Bazel build."
+---
+
+# Bazel Rule Reference
+
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Bazel rule for compiling P4 programs using p4c-4ward.
+
+Usage:
+
+    load("@fourward//bazel:fourward_pipeline.bzl", "fourward_pipeline")
+
+    fourward_pipeline(
+        name = "sai_middleblock",
+        src = "//sai_p4/instantiations/google:middleblock.p4",
+        out = "sai_middleblock.binpb",
+        out_format = "p4runtime",
+    )
+
+Output formats (`out_format`):
+  - `"native"` (default): `fourward.ir.PipelineConfig`
+  - `"p4runtime"`: `p4.v1.ForwardingPipelineConfig` (for `SetForwardingPipelineConfig`)
+
+File extension of `out` determines serialization: `.txtpb` for text proto,
+`.binpb` for binary proto.
+
+<a id="fourward_pipeline"></a>
+
+## fourward_pipeline
+
+<pre>
+load("@fourward//bazel:fourward_pipeline.bzl", "fourward_pipeline")
+
+fourward_pipeline(<a href="#fourward_pipeline-name">name</a>, <a href="#fourward_pipeline-src">src</a>, <a href="#fourward_pipeline-out">out</a>, <a href="#fourward_pipeline-defines">defines</a>, <a href="#fourward_pipeline-extra_srcs">extra_srcs</a>, <a href="#fourward_pipeline-includes">includes</a>, <a href="#fourward_pipeline-out_format">out_format</a>)
+</pre>
+
+Compiles a P4 source file using p4c-4ward.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="fourward_pipeline-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="fourward_pipeline-src"></a>src |  P4 source file.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="fourward_pipeline-out"></a>out |  Output file. Extension determines serialization: `.txtpb` for text proto, `.binpb` for binary proto. The proto message type is determined by `out_format`.   | <a href="https://bazel.build/concepts/labels">Label</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | required |  |
+| <a id="fourward_pipeline-defines"></a>defines |  Preprocessor defines passed to p4c via -D.   | List of strings | optional |  `[]`  |
+| <a id="fourward_pipeline-extra_srcs"></a>extra_srcs |  Additional file dependencies (e.g. filegroups) that don't need -I flags. Useful when the P4 source uses relative #include paths.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="fourward_pipeline-includes"></a>includes |  P4 files whose directories are added to the include path via -I. Useful for shadowing standard library files (e.g. a modified v1model.p4).   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="fourward_pipeline-out_format"></a>out_format |  Output proto message type. `"native"` (default): `fourward.ir.PipelineConfig`. `"p4runtime"`: `p4.v1.ForwardingPipelineConfig` (suitable for `SetForwardingPipelineConfig`).   | String | optional |  `"native"`  |
+
+


### PR DESCRIPTION
## Summary

BCR consumers load `@fourward//bazel:fourward_pipeline.bzl` to compile
P4 from a Bazel build, but until now the only reference for its
attributes was the rule's docstring in source. This wires up Stardoc
to render the rule into Markdown and surfaces it on the docs site
under a new **Bazel Integration** nav section.

The generated page lives at `userdocs/reference/bazel.md` and is
refreshed by `tools/gen-docs.sh`. A CI staleness check (same
run-and-diff pattern as `format.sh`) keeps it honest, so the
published reference can't silently rot when the rule evolves.

Stardoc is added as `dev_dependency` — BCR consumers never pay for it.

## Design notes

- **Committed markdown over dynamic render at docs-build time**: the
  existing `docs` CI job installs mkdocs only, with no Bazel. Shipping
  the rendered output avoids a Bazel install on the docs builder and
  matches the repo's pattern of "run tool, commit output, CI diffs."
- **Frontmatter/H1 added in gen-docs.sh**: Stardoc emits raw content
  without mkdocs-Material frontmatter, so the script prepends both to
  match the shape of sibling `reference/*.md` pages.

## Test plan

- [x] `bazel build //bazel:fourward_pipeline_docs`
- [x] `./tools/gen-docs.sh` produces the committed file byte-for-byte
- [x] `mkdocs build --strict` clean with the new nav entry
- [x] CI staleness check fires locally when the docstring is edited but gen-docs.sh not rerun
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)