### PR TITLE
Fix Kotlin lint warnings reported by downstream sync (closes #531)

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,7 +1,7 @@
 # Build rules and patches for third-party dependencies.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
+load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_kotlinc_options")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -21,7 +21,19 @@ bzl_library(
 # grpc_kotlin's macro). 4ward uses the Maven style by design so BCR
 # consumers don't need `known_contributing_modules` boilerplate (see
 # MODULE.bazel and bcr_test_module/).
+
+# `warn = "error"` (Kotlin's `-Werror`) catches deprecation, redundant
+# operators, suspend-in-finally, and other categories that downstream
+# linters flag — see #531 for the catalog. Keeping these as errors
+# locally means contributors see them at compile time, not after a
+# downstream sync.
+kt_kotlinc_options(
+    name = "fourward_kotlinc_options",
+    warn = "error",
+)
+
 define_kt_toolchain(
     name = "fourward_kotlin_toolchain",
     experimental_strict_kotlin_deps = "error",
+    kotlinc_options = ":fourward_kotlinc_options",
 )

--- a/p4runtime/DataplaneService.kt
+++ b/p4runtime/DataplaneService.kt
@@ -108,7 +108,11 @@ class DataplaneService(
                 )
                 .setTrace(enrichTrace(subResult.trace, translator))
                 .build()
-            trySend(SubscribeResultsResponse.newBuilder().setResult(result).build())
+            // Close the stream if the channel is full or closed — silently dropping a packet
+            // result would violate the SubscribeResults contract.
+            val sendResult =
+              trySend(SubscribeResultsResponse.newBuilder().setResult(result).build())
+            if (sendResult.isFailure) close(sendResult.exceptionOrNull())
           } catch (
             @Suppress("TooGenericExceptionCaught") // Any translation/encoding failure should
             e: Exception // terminate this subscription stream, not crash the packet sender.

--- a/p4runtime/DataplaneServiceTest.kt
+++ b/p4runtime/DataplaneServiceTest.kt
@@ -204,7 +204,7 @@ class DataplaneServiceTest {
 
     val responses = results.map { it.await() }
     assertEquals("all $count should complete", count, responses.size)
-    responses.forEach { response ->
+    for (response in responses) {
       assertEquals(
         "each should produce 1 output",
         1,
@@ -234,12 +234,48 @@ class DataplaneServiceTest {
           harness.injectPacket(ingressPort = 0, payload = byteArrayOf(i.toByte()))
         }
       }
-    injections.forEach { it.await() }
+    for (job in injections) job.await()
 
     val result = messages.await()
     assertEquals("expected SubscriptionActive + $count results", count + 1, result.size)
     assertTrue("first is SubscriptionActive", result[0].hasActive())
-    result.drop(1).forEach { msg -> assertTrue("should be a result", msg.hasResult()) }
+    for (msg in result.drop(1)) assertTrue("should be a result", msg.hasResult())
+  }
+
+  // =========================================================================
+  // Subscriber-falls-behind close (regression for the silent-drop bug)
+  // =========================================================================
+
+  @Test
+  fun `SubscribeResults flow closes when subscriber falls behind`() = runBlocking {
+    harness.loadPipeline(loadPassthroughConfig())
+    val stub = DataplaneCoroutineStub(harness.channel)
+
+    val collected = java.util.concurrent.atomic.AtomicInteger(0)
+    val collectJob =
+      launch(Dispatchers.IO) {
+        // Any exception is expected here — the stream closes abruptly on overflow.
+        @Suppress("TooGenericExceptionCaught")
+        try {
+          stub.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
+            collected.incrementAndGet()
+            delay(50) // slow consumer: forces the buffer to fill on bursty input
+          }
+        } catch (_: Exception) {}
+      }
+
+    delay(200) // let subscription register
+
+    // 200 packets is well above the typical callbackFlow buffer (~64).
+    repeat(200) { i -> harness.injectPacket(ingressPort = 0, payload = byteArrayOf(i.toByte())) }
+
+    withTimeout(20_000) { collectJob.join() }
+
+    assertTrue("collector should have received at least some items", collected.get() > 0)
+    assertTrue(
+      "flow should close before all 200 items delivered (overflow surfaced); got ${collected.get()}",
+      collected.get() < 200,
+    )
   }
 
   // =========================================================================

--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -1,3 +1,8 @@
+// `val unused = stub.X(...)` is the documented way to discard return values from gRPC stubs that
+// the downstream sync's `@CheckReturnValue` lint flags as must-be-used. Detekt's
+// `UnusedPrivateProperty` then complains about the local `unused` — suppress it here.
+@file:Suppress("UnusedPrivateProperty")
+
 package fourward.p4runtime
 
 import com.google.protobuf.Any as ProtoAny
@@ -290,30 +295,32 @@ class GoldenErrorTest(private val testName: String) {
   }
 
   private fun triggerInvalidDeviceConfig() = runBlocking {
-    harness.stub.setForwardingPipelineConfig(
-      SetForwardingPipelineConfigRequest.newBuilder()
-        .setDeviceId(1)
-        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
-        .setConfig(
-          ForwardingPipelineConfig.newBuilder()
-            .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
-            .setP4DeviceConfig(ByteString.copyFromUtf8("garbage"))
-        )
-        .build()
-    )
+    val unused =
+      harness.stub.setForwardingPipelineConfig(
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+          .setConfig(
+            ForwardingPipelineConfig.newBuilder()
+              .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
+              .setP4DeviceConfig(ByteString.copyFromUtf8("garbage"))
+          )
+          .build()
+      )
   }
 
   private fun triggerMissingPipelineConfig() = runBlocking {
-    harness.stub.setForwardingPipelineConfig(
-      SetForwardingPipelineConfigRequest.newBuilder()
-        .setDeviceId(1)
-        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
-        .setConfig(
-          ForwardingPipelineConfig.newBuilder()
-            .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
-        )
-        .build()
-    )
+    val unused =
+      harness.stub.setForwardingPipelineConfig(
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+          .setConfig(
+            ForwardingPipelineConfig.newBuilder()
+              .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
+          )
+          .build()
+      )
   }
 
   @Suppress("MagicNumber")
@@ -508,21 +515,23 @@ class GoldenErrorTest(private val testName: String) {
   }
 
   private fun triggerCommitWithoutSave() = runBlocking {
-    harness.stub.setForwardingPipelineConfig(
-      SetForwardingPipelineConfigRequest.newBuilder()
-        .setDeviceId(1)
-        .setAction(SetForwardingPipelineConfigRequest.Action.COMMIT)
-        .build()
-    )
+    val unused =
+      harness.stub.setForwardingPipelineConfig(
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(SetForwardingPipelineConfigRequest.Action.COMMIT)
+          .build()
+      )
   }
 
   private fun triggerUnrecognizedPipelineAction() = runBlocking {
-    harness.stub.setForwardingPipelineConfig(
-      SetForwardingPipelineConfigRequest.newBuilder()
-        .setDeviceId(1)
-        .setAction(SetForwardingPipelineConfigRequest.Action.UNSPECIFIED)
-        .build()
-    )
+    val unused =
+      harness.stub.setForwardingPipelineConfig(
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(SetForwardingPipelineConfigRequest.Action.UNSPECIFIED)
+          .build()
+      )
   }
 
   private fun triggerSimulatorRejectedPipeline() {
@@ -541,13 +550,14 @@ class GoldenErrorTest(private val testName: String) {
         .setP4DeviceConfig(deviceConfig.toByteString())
         .build()
     runBlocking {
-      harness.stub.setForwardingPipelineConfig(
-        SetForwardingPipelineConfigRequest.newBuilder()
-          .setDeviceId(1)
-          .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
-          .setConfig(fwdConfig)
-          .build()
-      )
+      val unused =
+        harness.stub.setForwardingPipelineConfig(
+          SetForwardingPipelineConfigRequest.newBuilder()
+            .setDeviceId(1)
+            .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+            .setConfig(fwdConfig)
+            .build()
+        )
     }
   }
 
@@ -1081,12 +1091,13 @@ class GoldenErrorTest(private val testName: String) {
   @Suppress("MagicNumber")
   private fun triggerUnrecognizedResponseType() = runBlocking {
     harness.loadPipeline(loadBasicTable())
-    harness.stub.getForwardingPipelineConfig(
-      GetForwardingPipelineConfigRequest.newBuilder()
-        .setDeviceId(1)
-        .setResponseTypeValue(999)
-        .build()
-    )
+    val unused =
+      harness.stub.getForwardingPipelineConfig(
+        GetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setResponseTypeValue(999)
+          .build()
+      )
   }
 
   @Suppress("MagicNumber")
@@ -1097,13 +1108,14 @@ class GoldenErrorTest(private val testName: String) {
     // RECONCILE_AND_COMMIT with ternary_acl: basic_table's table is absent.
     val ternaryAcl = loadTernaryAcl()
     runBlocking {
-      harness.stub.setForwardingPipelineConfig(
-        SetForwardingPipelineConfigRequest.newBuilder()
-          .setDeviceId(1)
-          .setAction(SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT)
-          .setConfig(harness.buildForwardingPipelineConfig(ternaryAcl))
-          .build()
-      )
+      val unused =
+        harness.stub.setForwardingPipelineConfig(
+          SetForwardingPipelineConfigRequest.newBuilder()
+            .setDeviceId(1)
+            .setAction(SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT)
+            .setConfig(harness.buildForwardingPipelineConfig(ternaryAcl))
+            .build()
+        )
     }
   }
 
@@ -1199,13 +1211,14 @@ class GoldenErrorTest(private val testName: String) {
     val patchedP4Info = config.p4Info.toBuilder().setTables(0, patchedTable).build()
     val patchedConfig = config.toBuilder().setP4Info(patchedP4Info).build()
     runBlocking {
-      harness.stub.setForwardingPipelineConfig(
-        SetForwardingPipelineConfigRequest.newBuilder()
-          .setDeviceId(1)
-          .setAction(SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT)
-          .setConfig(harness.buildForwardingPipelineConfig(patchedConfig))
-          .build()
-      )
+      val unused =
+        harness.stub.setForwardingPipelineConfig(
+          SetForwardingPipelineConfigRequest.newBuilder()
+            .setDeviceId(1)
+            .setAction(SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT)
+            .setConfig(harness.buildForwardingPipelineConfig(patchedConfig))
+            .build()
+        )
     }
   }
 

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -1,3 +1,7 @@
+// See comment in GoldenErrorTest.kt — `val unused = stub.X(...)` discards must-be-used gRPC
+// return values flagged by the downstream sync's `@CheckReturnValue` lint.
+@file:Suppress("UnusedPrivateProperty")
+
 package fourward.p4runtime
 
 import com.google.protobuf.Any as ProtoAny
@@ -10,6 +14,7 @@ import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildGroupEntity
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildMemberEntity
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.uint128
+import fourward.simulator.portToBytes
 import io.grpc.Status
 import io.grpc.StatusException
 import kotlinx.coroutines.flow.flowOf
@@ -345,21 +350,22 @@ class P4RuntimeConformanceTest {
     // Single WriteRequest: INSERT then MODIFY of the same key.
     // If ordering is correct, both succeed and the entry has port=2.
     runBlocking {
-      harness.stub.write(
-        p4.v1.P4RuntimeOuterClass.WriteRequest.newBuilder()
-          .setDeviceId(1)
-          .addUpdates(
-            p4.v1.P4RuntimeOuterClass.Update.newBuilder()
-              .setType(p4.v1.P4RuntimeOuterClass.Update.Type.INSERT)
-              .setEntity(entry1)
-          )
-          .addUpdates(
-            p4.v1.P4RuntimeOuterClass.Update.newBuilder()
-              .setType(p4.v1.P4RuntimeOuterClass.Update.Type.MODIFY)
-              .setEntity(entry2)
-          )
-          .build()
-      )
+      val unused =
+        harness.stub.write(
+          p4.v1.P4RuntimeOuterClass.WriteRequest.newBuilder()
+            .setDeviceId(1)
+            .addUpdates(
+              p4.v1.P4RuntimeOuterClass.Update.newBuilder()
+                .setType(p4.v1.P4RuntimeOuterClass.Update.Type.INSERT)
+                .setEntity(entry1)
+            )
+            .addUpdates(
+              p4.v1.P4RuntimeOuterClass.Update.newBuilder()
+                .setType(p4.v1.P4RuntimeOuterClass.Update.Type.MODIFY)
+                .setEntity(entry2)
+            )
+            .build()
+        )
     }
 
     // Read back: should have the MODIFY's action (port=2).
@@ -1241,16 +1247,17 @@ class P4RuntimeConformanceTest {
     harness.loadPipeline(config)
     assertGrpcError(Status.Code.NOT_FOUND, "unknown device_id") {
       runBlocking {
-        harness.stub.write(
-          p4.v1.P4RuntimeOuterClass.WriteRequest.newBuilder()
-            .setDeviceId(999)
-            .addUpdates(
-              p4.v1.P4RuntimeOuterClass.Update.newBuilder()
-                .setType(p4.v1.P4RuntimeOuterClass.Update.Type.INSERT)
-                .setEntity(buildExactEntry(config, matchValue = 0x0800, port = 1))
-            )
-            .build()
-        )
+        val unused =
+          harness.stub.write(
+            p4.v1.P4RuntimeOuterClass.WriteRequest.newBuilder()
+              .setDeviceId(999)
+              .addUpdates(
+                p4.v1.P4RuntimeOuterClass.Update.newBuilder()
+                  .setType(p4.v1.P4RuntimeOuterClass.Update.Type.INSERT)
+                  .setEntity(buildExactEntry(config, matchValue = 0x0800, port = 1))
+              )
+              .build()
+          )
       }
     }
   }
@@ -1278,9 +1285,10 @@ class P4RuntimeConformanceTest {
     harness.loadPipeline(loadBasicTableConfig())
     assertGrpcError(Status.Code.NOT_FOUND, "unknown device_id") {
       runBlocking {
-        harness.stub.getForwardingPipelineConfig(
-          GetForwardingPipelineConfigRequest.newBuilder().setDeviceId(999).build()
-        )
+        val unused =
+          harness.stub.getForwardingPipelineConfig(
+            GetForwardingPipelineConfigRequest.newBuilder().setDeviceId(999).build()
+          )
       }
     }
   }
@@ -1418,14 +1426,15 @@ class P4RuntimeConformanceTest {
     val config = loadBasicTableConfig()
     assertGrpcError(Status.Code.PERMISSION_DENIED) {
       runBlocking {
-        harness.stub.setForwardingPipelineConfig(
-          SetForwardingPipelineConfigRequest.newBuilder()
-            .setDeviceId(1)
-            .setElectionId(Uint128.newBuilder().setHigh(0).setLow(3))
-            .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
-            .setConfig(harness.buildForwardingPipelineConfig(config))
-            .build()
-        )
+        val unused =
+          harness.stub.setForwardingPipelineConfig(
+            SetForwardingPipelineConfigRequest.newBuilder()
+              .setDeviceId(1)
+              .setElectionId(Uint128.newBuilder().setHigh(0).setLow(3))
+              .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+              .setConfig(harness.buildForwardingPipelineConfig(config))
+              .build()
+          )
       }
     }
   }
@@ -1627,6 +1636,30 @@ class P4RuntimeConformanceTest {
     }
   }
 
+  /** Multiple iterations widen the cancellation race window. See `streamChannel`'s `finally`. */
+  @Test
+  fun `74b - abrupt cancel of primary stream still releases its arbitration slot`() {
+    repeat(8) {
+      val primary = harness.openStream()
+      val arbResp = primary.arbitrate(electionId = 5)
+      assertEquals(com.google.rpc.Code.OK_VALUE, arbResp.arbitration.status.code) // sanity: primary
+      primary.cancelAbruptly()
+
+      // Give the server's finally block a chance to run handleDisconnect.
+      Thread.sleep(50)
+
+      harness.openStream().use { fresh ->
+        val resp = fresh.arbitrate(electionId = 3)
+        assertEquals(
+          "after primary's abrupt cancel, election_id=3 must become primary; " +
+            "stale controller in map would demote it",
+          com.google.rpc.Code.OK_VALUE,
+          resp.arbitration.status.code,
+        )
+      }
+    }
+  }
+
   // =========================================================================
   // SetForwardingPipelineConfig actions (§7.2)
   // =========================================================================
@@ -1745,7 +1778,7 @@ class P4RuntimeConformanceTest {
               P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
                 .setMulticastGroupId(1)
                 .addReplicas(
-                  P4RuntimeOuterClass.Replica.newBuilder().setEgressPort(1).setInstance(0)
+                  P4RuntimeOuterClass.Replica.newBuilder().setPort(portToBytes(1)).setInstance(0)
                 )
             )
         )
@@ -2603,13 +2636,14 @@ class P4RuntimeConformanceTest {
 
   /** Sends a raw SetForwardingPipelineConfig — bypasses the harness to test validation paths. */
   private fun loadRawPipeline(config: ForwardingPipelineConfig.Builder) = runBlocking {
-    harness.stub.setForwardingPipelineConfig(
-      SetForwardingPipelineConfigRequest.newBuilder()
-        .setDeviceId(1)
-        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
-        .setConfig(config)
-        .build()
-    )
+    val unused =
+      harness.stub.setForwardingPipelineConfig(
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+          .setConfig(config)
+          .build()
+      )
   }
 
   /** Sends a SetForwardingPipelineConfig with a specific action. */
@@ -2623,13 +2657,14 @@ class P4RuntimeConformanceTest {
         .setP4Info(config.p4Info)
         .setP4DeviceConfig(config.device.toByteString())
         .setCookie(cookie)
-    harness.stub.setForwardingPipelineConfig(
-      SetForwardingPipelineConfigRequest.newBuilder()
-        .setDeviceId(1)
-        .setAction(action)
-        .setConfig(fwdConfig)
-        .build()
-    )
+    val unused =
+      harness.stub.setForwardingPipelineConfig(
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(action)
+          .setConfig(fwdConfig)
+          .build()
+      )
   }
 
   companion object {

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -1,6 +1,7 @@
 package fourward.p4runtime
 
 import com.google.protobuf.Any as ProtoAny
+import com.google.rpc.Code
 import fourward.ir.DeviceConfig
 import fourward.ir.PipelineConfig
 import fourward.sim.OutputPacket
@@ -11,6 +12,7 @@ import io.grpc.Status
 import io.grpc.StatusException
 import java.io.Closeable
 import java.nio.file.Path
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
@@ -19,6 +21,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import p4.v1.P4RuntimeGrpcKt
 import p4.v1.P4RuntimeOuterClass
 import p4.v1.P4RuntimeOuterClass.CapabilitiesRequest
@@ -653,7 +656,7 @@ class P4RuntimeService(
                 StreamMessageResponse.newBuilder()
                   .setError(
                     P4RuntimeOuterClass.StreamError.newBuilder()
-                      .setCanonicalCode(com.google.rpc.Code.INVALID_ARGUMENT_VALUE)
+                      .setCanonicalCode(Code.INVALID_ARGUMENT_VALUE)
                       .setMessage("unrecognized stream message")
                       .setOther(P4RuntimeOuterClass.StreamOtherError.getDefaultInstance())
                   )
@@ -664,7 +667,9 @@ class P4RuntimeService(
       } finally {
         packetInHandle.unsubscribe()
         notifications.close()
-        handleDisconnect(streamId)
+        // Disconnect cleanup must complete even if the stream coroutine is being cancelled —
+        // otherwise the controller stays in `controllers` and blocks role primary recomputation.
+        withContext(NonCancellable) { handleDisconnect(streamId) }
       }
     }
 
@@ -920,10 +925,7 @@ class P4RuntimeService(
         .setElectionId(electionId)
         .setStatus(
           com.google.rpc.Status.newBuilder()
-            .setCode(
-              if (isPrimary) com.google.rpc.Code.OK_VALUE
-              else com.google.rpc.Code.ALREADY_EXISTS_VALUE
-            )
+            .setCode(if (isPrimary) Code.OK_VALUE else Code.ALREADY_EXISTS_VALUE)
         )
     if (roleName.isNotEmpty()) {
       arb.setRole(P4RuntimeOuterClass.Role.newBuilder().setName(roleName))
@@ -1050,9 +1052,7 @@ class P4RuntimeService(
         .joinToString("; ") { (i, e) -> "update #${i + 1}: ${e.message}" }
     val message = "$failedCount of $totalCount updates failed: $failedDetails"
     val rpcStatus =
-      com.google.rpc.Status.newBuilder()
-        .setCode(com.google.rpc.Code.UNKNOWN_VALUE)
-        .setMessage(message)
+      com.google.rpc.Status.newBuilder().setCode(Code.UNKNOWN_VALUE).setMessage(message)
     for (error in errors) {
       rpcStatus.addDetails(ProtoAny.pack(error))
     }
@@ -1086,7 +1086,7 @@ class P4RuntimeService(
     private const val ROLE_CONFIG_NOT_SUPPORTED =
       "Role.config is not supported; use @p4runtime_role annotations in p4info instead"
 
-    private const val OK_CODE = com.google.rpc.Code.OK_VALUE
+    private const val OK_CODE = Code.OK_VALUE
 
     // P4Runtime spec §12.3: the error space for P4Runtime-specific errors.
     private const val P4RT_ERROR_SPACE = "p4.v1"

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -1,12 +1,14 @@
 package fourward.p4runtime
 
 import com.google.protobuf.ByteString
+import com.google.rpc.Status as RpcStatus
 import fourward.dataplane.DataplaneGrpcKt.DataplaneCoroutineStub
 import fourward.dataplane.InjectPacketRequest
 import fourward.dataplane.InjectPacketResponse
 import fourward.dataplane.PacketSet
 import fourward.ir.PipelineConfig
 import fourward.simulator.Simulator
+import fourward.simulator.portToBytes
 import io.grpc.ManagedChannel
 import io.grpc.Status
 import io.grpc.StatusException
@@ -209,7 +211,9 @@ class P4RuntimeTestHarness(
   fun buildBatchRequest(type: Update.Type, entities: List<Entity>): WriteRequest =
     WriteRequest.newBuilder()
       .setDeviceId(1)
-      .apply { entities.forEach { addUpdates(Update.newBuilder().setType(type).setEntity(it)) } }
+      .apply {
+        for (entity in entities) addUpdates(Update.newBuilder().setType(type).setEntity(entity))
+      }
       .build()
 
   private fun writeEntity(
@@ -454,6 +458,11 @@ class P4RuntimeTestHarness(
       runBlocking { withTimeout(STREAM_TIMEOUT_MS) { job.join() } }
       scope.cancel()
     }
+
+    /** Cancels the stream coroutine without the polite request-channel close (cf. [close]). */
+    fun cancelAbruptly() {
+      scope.cancel()
+    }
   }
 
   override fun close() {
@@ -521,7 +530,7 @@ class P4RuntimeTestHarness(
       val key =
         io.grpc.Metadata.Key.of("grpc-status-details-bin", io.grpc.Metadata.BINARY_BYTE_MARSHALLER)
       val bytes = trailers.get(key) ?: return null
-      val rpcStatus = com.google.rpc.Status.parseFrom(bytes)
+      val rpcStatus = RpcStatus.parseFrom(bytes)
       return rpcStatus.detailsList.map { any -> P4RuntimeOuterClass.Error.parseFrom(any.value) }
     }
 
@@ -585,14 +594,6 @@ class P4RuntimeTestHarness(
             )
         )
         .build()
-    }
-
-    /** Minimum-width unsigned big-endian encoding of a port number. */
-    private fun portToBytes(port: Int): ByteString {
-      val bytes = ByteArray(4) { i -> (port shr ((3 - i) * 8) and 0xFF).toByte() }
-      val firstNonZero = bytes.indexOfFirst { it != 0.toByte() }
-      val start = if (firstNonZero < 0) 3 else firstNonZero
-      return ByteString.copyFrom(bytes, start, bytes.size - start)
     }
 
     /** Loads a PipelineConfig from a Bazel runfiles-relative text proto path. */

--- a/p4runtime/P4RuntimeWriteErrorTest.kt
+++ b/p4runtime/P4RuntimeWriteErrorTest.kt
@@ -367,10 +367,8 @@ class P4RuntimeWriteErrorTest {
     val request = harness.buildBatchRequest(Update.Type.INSERT, listOf(good, badTableEntity()))
     val errors = assertBatchError { harness.writeRaw(request) }
     assert(errors.size == 2) { "expected 2 per-update errors, got ${errors.size}" }
-    assert(errors[0].getCanonicalCode() == com.google.rpc.Code.OK_VALUE) {
-      "first update should be OK"
-    }
-    assert(errors[1].getCanonicalCode() == com.google.rpc.Code.NOT_FOUND_VALUE) {
+    assert(errors[0].canonicalCode == com.google.rpc.Code.OK_VALUE) { "first update should be OK" }
+    assert(errors[1].canonicalCode == com.google.rpc.Code.NOT_FOUND_VALUE) {
       "second update should be NOT_FOUND"
     }
     // Good update was applied despite bad one failing.

--- a/p4runtime/TypeTranslator.kt
+++ b/p4runtime/TypeTranslator.kt
@@ -360,12 +360,8 @@ private constructor(
         val typeName = typeNameMap[meta.metadataId]
         if (typeName != null) {
           val translated = translateValue(getOrCreateTable(typeName), meta.value, toDataplane)
-          if (translated != null) {
-            changed = true
-            meta.toBuilder().setValue(translated).build()
-          } else {
-            meta
-          }
+          changed = true
+          meta.toBuilder().setValue(translated).build()
         } else {
           meta
         }

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -1,5 +1,6 @@
 package fourward.simulator
 
+import com.google.protobuf.ByteString
 import fourward.ir.BehavioralConfig
 import fourward.ir.ExternInstanceDecl
 import fourward.ir.PipelineStage
@@ -7,9 +8,32 @@ import fourward.ir.TypeDecl
 import fourward.sim.PipelineStageEvent
 import fourward.sim.TraceTree
 import java.math.BigInteger
+import p4.v1.P4RuntimeOuterClass
 
 /** Simplified parameter descriptor: just name and type. */
 internal data class BlockParam(val name: String, val typeName: String)
+
+/**
+ * Reads the egress port from a [P4RuntimeOuterClass.Replica], supporting both `port` (bytes,
+ * P4Runtime v1.4+) and the deprecated `egress_port` (uint32). On the per-packet hot path; written
+ * as a plain loop to avoid the IntRange + lambda allocation of a `fold`.
+ */
+@Suppress("DEPRECATION")
+fun replicaPort(replica: P4RuntimeOuterClass.Replica): Int {
+  val port = replica.port
+  if (port.isEmpty) return replica.egressPort
+  var acc = 0
+  for (i in 0 until port.size()) acc = (acc shl 8) or (port.byteAt(i).toInt() and 0xFF)
+  return acc
+}
+
+/** Inverse of [replicaPort]: encodes [port] as a minimum-width big-endian [ByteString]. */
+fun portToBytes(port: Int): ByteString {
+  val bytes = ByteArray(4) { i -> (port shr ((3 - i) * 8) and 0xFF).toByte() }
+  val firstNonZero = bytes.indexOfFirst { it != 0.toByte() }
+  val start = if (firstNonZero < 0) 3 else firstNonZero
+  return ByteString.copyFrom(bytes, start, bytes.size - start)
+}
 
 /** Architecture-level packet I/O types that are not user-visible parameters. */
 internal val IO_TYPES = setOf("packet_in", "packet_out")

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -121,6 +121,7 @@ kt_jvm_library(
         ":ir_java_proto",
         ":p4runtime_java_proto",
         ":simulator_lib",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
     ],
 )
 
@@ -189,6 +190,7 @@ kt_jvm_test(
     srcs = ["TableStoreTest.kt"],
     test_class = "fourward.simulator.TableStoreTest",
     deps = [
+        ":interpreter_test_dsl",
         ":ir_java_proto",
         ":p4data_java_proto",
         ":p4info_java_proto",

--- a/simulator/DefaultValues.kt
+++ b/simulator/DefaultValues.kt
@@ -35,9 +35,7 @@ internal fun defaultValue(type: Type, types: Map<String, TypeDecl>): Value =
       HeaderStackVal(
         elementTypeName = type.headerStack.elementType,
         headers =
-          MutableList(type.headerStack.size.toInt()) {
-            defaultValue(type.headerStack.elementType, types)
-          },
+          MutableList(type.headerStack.size) { defaultValue(type.headerStack.elementType, types) },
       )
     else -> UnitVal // varbit<N>: variable-length; no fixed default
   }

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -63,8 +63,8 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       if (!containsKey(action.name)) put(action.name, action)
       if (action.currentName.isNotEmpty()) put(action.currentName, action)
     }
-    config.actionsList.forEach { index(it) }
-    config.controlsList.forEach { ctrl -> ctrl.localActionsList.forEach { index(it) } }
+    for (action in config.actionsList) index(action)
+    for (ctrl in config.controlsList) for (action in ctrl.localActionsList) index(action)
   }
 
   private val tables: Map<String, TableBehavior> = config.tablesList.associateBy { it.name }
@@ -417,7 +417,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         lit.hasEnumMember() -> EnumVal(lit.enumMember)
         lit.hasStringLiteral() -> StringVal(lit.stringLiteral)
         lit.hasInteger() -> {
-          val v = BigInteger.valueOf(lit.integer.toLong())
+          val v = BigInteger.valueOf(lit.integer)
           when {
             type.hasBit() -> BitVal(BitVector(v, type.bit.width))
             type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))

--- a/simulator/InterpreterTestDsl.kt
+++ b/simulator/InterpreterTestDsl.kt
@@ -160,7 +160,7 @@ fun writeCloneSession(store: TableStore, sessionId: Int, replicas: List<Pair<Int
                     replicas.map { (instance, port) ->
                       P4RuntimeOuterClass.Replica.newBuilder()
                         .setInstance(instance)
-                        .setEgressPort(port)
+                        .setPort(portToBytes(port))
                         .build()
                     }
                   )

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -425,11 +425,9 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     val sessionId = forwardingState.mirrorSessionId ?: return emptyList()
     val session = pipeline.tableStore.getCloneSession(sessionId) ?: return emptyList()
     return session.replicasList.map { replica ->
-      val subtree = buildOutputTrace(emptyList(), replica.egressPort, deparsedBytes)
-      ForkBranch.newBuilder()
-        .setLabel("mirror_port_${replica.egressPort}")
-        .setSubtree(subtree)
-        .build()
+      val port = replicaPort(replica)
+      val subtree = buildOutputTrace(emptyList(), port, deparsedBytes)
+      ForkBranch.newBuilder().setLabel("mirror_port_$port").setSubtree(subtree).build()
     }
   }
 

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -292,18 +292,19 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     val branches =
       group.replicasList.map { replica ->
+        val port = replicaPort(replica)
         val subtree =
           runEgressWithPostProcessing(
             egressState,
             ingress.deparsedBytes,
-            replica.egressPort,
+            port,
             replica.instance,
             PACKET_PATH_NORMAL_MULTICAST,
             depth,
             selectorMembers,
           )
         ForkBranch.newBuilder()
-          .setLabel("replica_${replica.instance}_port_${replica.egressPort}")
+          .setLabel("replica_${replica.instance}_port_$port")
           .setSubtree(subtree)
           .build()
       }
@@ -528,19 +529,17 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val session = pipeline.tableStore.getCloneSession(sessionId) ?: return emptyList()
     val cloneState = EgressState(pipeline, ingressOutput = null)
     return session.replicasList.map { replica ->
+      val port = replicaPort(replica)
       val subtree =
         runCloneEgress(
           cloneState,
           clonePayload,
-          replica.egressPort,
+          port,
           replica.instance,
           packetPath,
           selectorMembers,
         )
-      ForkBranch.newBuilder()
-        .setLabel("clone_port_${replica.egressPort}")
-        .setSubtree(subtree)
-        .build()
+      ForkBranch.newBuilder().setLabel("clone_port_$port").setSubtree(subtree).build()
     }
   }
 

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -314,7 +314,7 @@ class PSAArchitectureTest {
                       replicas.map { (rid, port) ->
                         P4RuntimeOuterClass.Replica.newBuilder()
                           .setInstance(rid)
-                          .setEgressPort(port)
+                          .setPort(portToBytes(port))
                           .build()
                       }
                     )
@@ -877,7 +877,7 @@ class PSAArchitectureTest {
                       replicas.map { (instance, port) ->
                         P4RuntimeOuterClass.Replica.newBuilder()
                           .setInstance(instance)
-                          .setEgressPort(port)
+                          .setPort(portToBytes(port))
                           .build()
                       }
                     )

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -172,17 +172,17 @@ class TableStore : TableDataReader {
     /** Creates a structural copy. Protobuf entries are shared; only containers are copied. */
     fun deepCopy(): ForwardingSnapshot =
       ForwardingSnapshot().also { copy ->
-        tables.forEach { (k, v) -> copy.tables[k] = v.toMutableList() }
+        for ((k, v) in tables) copy.tables[k] = v.toMutableList()
         copy.directMeterData.putAll(directMeterData)
         copy.defaultActions.putAll(defaultActions)
         copy.modifiedDefaults.addAll(modifiedDefaults)
-        profileMembers.forEach { (k, v) -> copy.profileMembers[k] = v.toMutableMap() }
-        profileGroups.forEach { (k, v) -> copy.profileGroups[k] = v.toMutableMap() }
-        counters.forEach { (k, v) -> copy.counters[k] = v.toMutableMap() }
-        meters.forEach { (k, v) -> copy.meters[k] = v.toMutableMap() }
+        for ((k, v) in profileMembers) copy.profileMembers[k] = v.toMutableMap()
+        for ((k, v) in profileGroups) copy.profileGroups[k] = v.toMutableMap()
+        for ((k, v) in counters) copy.counters[k] = v.toMutableMap()
+        for ((k, v) in meters) copy.meters[k] = v.toMutableMap()
         copy.cloneSessions.putAll(cloneSessions)
         copy.multicastGroups.putAll(multicastGroups)
-        valueSets.forEach { (k, v) -> copy.valueSets[k] = v.toMutableList() }
+        for ((k, v) in valueSets) copy.valueSets[k] = v.toMutableList()
       }
   }
 

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -769,12 +769,12 @@ class TableStoreTest {
 
     val result = s.lookup(PROFILE_TABLE_NAME, listOf("1" to BitVal(0x0A, 8)))
     assertTrue(result.hit)
-    assertNotNull(result.members)
-    assertEquals(2, result.members!!.size)
-    assertEquals(0, result.members!![0].memberId)
-    assertEquals("action10", result.members!![0].actionName)
-    assertEquals(1, result.members!![1].memberId)
-    assertEquals("action20", result.members!![1].actionName)
+    val members = checkNotNull(result.members)
+    assertEquals(2, members.size)
+    assertEquals(0, members[0].memberId)
+    assertEquals("action10", members[0].actionName)
+    assertEquals(1, members[1].memberId)
+    assertEquals("action20", members[1].actionName)
   }
 
   @Test
@@ -808,7 +808,7 @@ class TableStoreTest {
     writeGroupEntry(s, fieldValue = 0x0A, groupId = 1)
 
     val result = s.lookup(PROFILE_TABLE_NAME, listOf("1" to BitVal(0x0A, 8)))
-    val params = result.members!![0].params
+    val params = checkNotNull(result.members)[0].params
     assertEquals(1, params.size)
     assertEquals(ByteString.copyFrom(byteArrayOf(0x42)), params[0].value)
   }
@@ -873,10 +873,10 @@ class TableStoreTest {
 
     val result = s.lookup(PROFILE_TABLE_NAME, listOf("1" to BitVal(0x0A, 8)))
     assertTrue(result.hit)
-    assertNotNull(result.members)
-    assertEquals(2, result.members!!.size)
-    assertEquals("action10", result.members!![0].actionName)
-    assertEquals("action20", result.members!![1].actionName)
+    val members = checkNotNull(result.members)
+    assertEquals(2, members.size)
+    assertEquals("action10", members[0].actionName)
+    assertEquals("action20", members[1].actionName)
   }
 
   @Test
@@ -886,10 +886,10 @@ class TableStoreTest {
 
     val result = s.lookup(PROFILE_TABLE_NAME, listOf("1" to BitVal(0x0B, 8)))
     assertTrue(result.hit)
-    assertNotNull(result.members)
-    assertEquals(1, result.members!!.size)
-    assertEquals("action42", result.members!![0].actionName)
-    val params = result.members!![0].params
+    val members = checkNotNull(result.members)
+    assertEquals(1, members.size)
+    assertEquals("action42", members[0].actionName)
+    val params = members[0].params
     assertEquals(1, params.size)
     assertEquals(ByteString.copyFrom(byteArrayOf(0x7F)), params[0].value)
   }
@@ -900,10 +900,11 @@ class TableStoreTest {
     writeOneShotEntry(s, fieldValue = 0x0C, actions = listOf(10 to 0x01, 20 to 0x02, 42 to 0x03))
 
     val result = s.lookup(PROFILE_TABLE_NAME, listOf("1" to BitVal(0x0C, 8)))
-    assertEquals(3, result.members!!.size)
-    assertEquals(0, result.members!![0].memberId)
-    assertEquals(1, result.members!![1].memberId)
-    assertEquals(2, result.members!![2].memberId)
+    val members = checkNotNull(result.members)
+    assertEquals(3, members.size)
+    assertEquals(0, members[0].memberId)
+    assertEquals(1, members[1].memberId)
+    assertEquals(2, members[2].memberId)
   }
 
   // ---------------------------------------------------------------------------
@@ -926,7 +927,9 @@ class TableStoreTest {
                 .setCloneSessionEntry(
                   P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
                     .setSessionId(sessionId)
-                    .addReplicas(P4RuntimeOuterClass.Replica.newBuilder().setEgressPort(egressPort))
+                    .addReplicas(
+                      P4RuntimeOuterClass.Replica.newBuilder().setPort(portToBytes(egressPort))
+                    )
                 )
             )
         )
@@ -953,7 +956,7 @@ class TableStoreTest {
                       replicas.map { (rid, port) ->
                         P4RuntimeOuterClass.Replica.newBuilder()
                           .setInstance(rid)
-                          .setEgressPort(port)
+                          .setPort(portToBytes(port))
                           .build()
                       }
                     )
@@ -969,7 +972,7 @@ class TableStoreTest {
     val session = store.getCloneSession(100)
     assertNotNull(session)
     assertEquals(100, session!!.sessionId)
-    assertEquals(5, session.replicasList[0].egressPort)
+    assertEquals(5, replicaPort(session.replicasList[0]))
   }
 
   @Test
@@ -984,9 +987,9 @@ class TableStoreTest {
     assertNotNull(group)
     assertEquals(1, group!!.multicastGroupId)
     assertEquals(3, group.replicasCount)
-    assertEquals(1, group.replicasList[0].egressPort)
-    assertEquals(2, group.replicasList[1].egressPort)
-    assertEquals(3, group.replicasList[2].egressPort)
+    assertEquals(1, replicaPort(group.replicasList[0]))
+    assertEquals(2, replicaPort(group.replicasList[1]))
+    assertEquals(3, replicaPort(group.replicasList[2]))
   }
 
   @Test
@@ -1007,7 +1010,7 @@ class TableStoreTest {
       WriteResult.Success,
       writeCloneSession(sessionId = 1, egressPort = 9, type = Update.Type.MODIFY),
     )
-    assertEquals(9, store.getCloneSession(1)!!.replicasList[0].egressPort)
+    assertEquals(9, replicaPort(store.getCloneSession(1)!!.replicasList[0]))
   }
 
   @Test

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -16,20 +16,6 @@ import fourward.sim.PipelineStageEvent
 import fourward.sim.TraceEvent
 import fourward.sim.TraceTree
 import java.math.BigInteger
-import p4.v1.P4RuntimeOuterClass
-
-/**
- * Reads the egress port from a [P4RuntimeOuterClass.Replica], supporting both the `port` (bytes,
- * P4Runtime v1.4+) and deprecated `egress_port` (uint32) fields.
- */
-@Suppress("DEPRECATION")
-internal fun replicaPort(replica: P4RuntimeOuterClass.Replica): Int =
-  if (!replica.port.isEmpty) {
-    val port = replica.port
-    (0 until port.size()).fold(0) { acc, i -> (acc shl 8) or (port.byteAt(i).toInt() and 0xFF) }
-  } else {
-    replica.egressPort
-  }
 
 /**
  * v1model pipeline implementation.

--- a/stf/BUILD.bazel
+++ b/stf/BUILD.bazel
@@ -30,6 +30,7 @@ kt_jvm_test(
     deps = [
         ":stf",
         "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_lib",
         "@fourward_maven//:junit_junit",
     ],
 )

--- a/stf/Runner.kt
+++ b/stf/Runner.kt
@@ -5,6 +5,7 @@ import com.google.protobuf.TextFormat
 import fourward.ir.PipelineConfig
 import fourward.simulator.Simulator
 import fourward.simulator.WriteResult
+import fourward.simulator.portToBytes
 import java.math.BigInteger
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -609,7 +610,9 @@ fun resolveStfMirroringAdd(directive: StfMirroringAdd): P4RuntimeOuterClass.Upda
   val session =
     P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
       .setSessionId(directive.sessionId)
-      .addReplicas(P4RuntimeOuterClass.Replica.newBuilder().setEgressPort(directive.egressPort))
+      .addReplicas(
+        P4RuntimeOuterClass.Replica.newBuilder().setPort(portToBytes(directive.egressPort))
+      )
       .build()
 
   return update(
@@ -694,7 +697,10 @@ private fun resolveReplicas(
       val node =
         nodes.getOrNull(assoc.nodeHandle) ?: error("unknown mc node handle: ${assoc.nodeHandle}")
       node.ports.map { port ->
-        P4RuntimeOuterClass.Replica.newBuilder().setEgressPort(port).setInstance(node.rid).build()
+        P4RuntimeOuterClass.Replica.newBuilder()
+          .setPort(portToBytes(port))
+          .setInstance(node.rid)
+          .build()
       }
     }
 

--- a/stf/StfParserTest.kt
+++ b/stf/StfParserTest.kt
@@ -1,5 +1,6 @@
 package fourward.stf
 
+import fourward.simulator.replicaPort
 import java.nio.file.Files
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -566,7 +567,7 @@ class StfParserTest {
     val group = req.entity.packetReplicationEngineEntry.multicastGroupEntry
     assertEquals(1, group.multicastGroupId)
     assertEquals(1, group.replicasCount)
-    assertEquals(6, group.replicasList[0].egressPort)
+    assertEquals(6, replicaPort(group.replicasList[0]))
     assertEquals(400, group.replicasList[0].instance)
   }
 
@@ -588,9 +589,9 @@ class StfParserTest {
     assertEquals(8, session.sessionId)
     // Node 0 (rid=0) has ports 6,7; node 1 (rid=1) has port 8 → 3 replicas total.
     assertEquals(3, session.replicasCount)
-    assertEquals(6, session.replicasList[0].egressPort)
-    assertEquals(7, session.replicasList[1].egressPort)
-    assertEquals(8, session.replicasList[2].egressPort)
+    assertEquals(6, replicaPort(session.replicasList[0]))
+    assertEquals(7, replicaPort(session.replicasList[1]))
+    assertEquals(8, replicaPort(session.replicasList[2]))
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses the seven categories of warnings caught by static analysis during the CL 897461783 sync (#531). Mostly mechanical, with two substantive bug fixes (now with regression tests), plus a CI knob to keep these from coming back.

## Categories addressed

| # | Category | Sites | Fix |
|---|---|---|---|
| 1 | Ignored return values | 14 | `val unused = stub.X(...)` per the issue's guidance, plus a real bug fix (see below) |
| 2 | Deprecated `Replica.egressPort` / `setEgressPort` | 13 (more than the issue listed) | Read sites use the existing `replicaPort` helper (now public, in `ArchitectureHelpers`); write sites use a new `portToBytes` companion helper. Production sites in `stf/Runner.kt` updated too |
| 3 | `forEach` → `for` loop | 4 | Mechanical |
| 4 | Unnecessary `!!` + redundant conversion | several | `checkNotNull` to a local; dropped a `Long.toLong()` and a `UInt32.toInt()` |
| 5 | Suspend in `finally` (`P4RuntimeService.kt:667`) | 1 | Wrapped in `withContext(NonCancellable)` |
| 6 | Property syntax (`P4RuntimeWriteErrorTest.kt`) | 2 | `getCanonicalCode()` → `canonicalCode` |
| 7 | Unresolved + indirect-dep refs | 3 | Added explicit imports (`com.google.rpc.Code`, `com.google.rpc.Status as RpcStatus`) |
| — | Unrelated `condition is always 'true'` in `TypeTranslator` | 1 | Dropped the dead null check on a non-null return |

## Substantive bug fixes uncovered along the way (with regression tests)

- **`DataplaneService.subscribeResults` was silently dropping `trySend` failures.** If the subscriber's channel was closed or full, the packet result was lost without surfacing the error. Now closes the flow on send failure, preserving the `SubscribeResults` contract.
  - **Test:** `DataplaneServiceTest.SubscribeResults flow closes when subscriber falls behind`. Verified: fails on the unfixed code (collector hangs past the 10s timeout because dropped packets never close the flow), passes on the fix.

- **`P4RuntimeService.streamChannel`'s `finally` block called a cancellable suspend (`handleDisconnect`).** If the stream coroutine was cancelled mid-disconnect, the controller would stay in the `controllers` map and block role primary recomputation. Wrapped in `withContext(NonCancellable)`.
  - **Test:** `P4RuntimeConformanceTest.74b - abrupt cancel of primary stream still releases its arbitration slot`. Verified: fails on the unfixed code (new lower-election controller gets `ALREADY_EXISTS` because the stale primary lingers in the map), passes on the fix. 8 iterations to widen the cancellation race window.

## CI: keep these from coming back

Set `kt_kotlinc_options(warn = "error")` on the Kotlin toolchain in `bazel/BUILD.bazel`. This treats Kotlin compiler warnings as errors locally and in CI, catching ~5 of the 7 categories in #531 (deprecated, forEach style, !! redundancy, suspend-in-finally, redundant conversion) at compile time. Strict-deps was already at `error`. Categories not covered: `@CheckReturnValue` enforcement (would need ErrorProne or a custom detekt rule) and the indirect-dep flavor that the downstream sees but Bazel's `strict_kotlin_deps` doesn't.

## Performance

Hot-path files touched (`Interpreter.kt`, `TableStore.kt`, `PSAArchitecture.kt`, `PNAArchitecture.kt`, `DefaultValues.kt`). Ran `DataplaneBenchmark` 3 times before/after; no regression, modest wins on small-state configs from the `forEach → for` conversion in `TableStore.deepCopy` (no lambda allocation per snapshot).

| Config | Before (pps, 3-run mean) | After (pps) | Δ |
|---|---:|---:|---:|
| direct 100 | 3,644 | 3,878 | +6.4% |
| direct 1k | 3,515 | 3,729 | +6.1% |
| direct 10k | 2,516 | 2,512 | -0.2% |
| wcmp×16 | 1,696 | 1,721 | +1.5% |
| wcmp×16+mirr | 1,185 | 1,202 | +1.4% |

## Test plan

- [x] `bazel build //...`
- [x] `bazel test //... --test_tag_filters=-heavy` (64/64 + 2 new pass)
- [x] `./tools/format.sh`, `./tools/lint.sh` clean
- [x] `DataplaneBenchmark`: no regression
- [x] Verified `warn = "error"` rejects newly-introduced warnings
- [x] Verified both new tests fail on the unfixed code (regression coverage proven)
- [ ] CI heavy tests