### PR TITLE
Narrow cram_bzl's rules_python dep to py_test

### DIFF
--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -18,7 +18,7 @@ bzl_library(
         "//cli:__subpackages__",
         "//examples:__subpackages__",
     ],
-    deps = ["@rules_python//python:defs_bzl"],
+    deps = ["@rules_python//python:py_test_bzl"],
 )
 
 kt_jvm_library(


### PR DESCRIPTION
## Summary

`cli/cram.bzl` only loads `py_test` from `@rules_python//python:defs.bzl`,
so the `bzl_library` dep doesn't need the umbrella `:defs_bzl` target
(which covers nine `py_*` siblings). Narrowing to `:py_test_bzl` makes
the declared Starlark dep graph mirror the actual `load()` statement.

## Test plan

- [x] `bazel build //cli:cram_bzl`
- [x] `bazel build //...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)