### PR TITLE
Remove done architecture-helper extraction entry from REFACTORING.md

### DIFF
--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -43,19 +43,6 @@ BCR consumers; `p4c` and `grpc` affect BCR consumers too.
 
 ---
 
-## Extract shared architecture helpers
-
-`PSAArchitecture.kt` and `PNAArchitecture.kt` duplicate ~350 lines of
-architecture-agnostic code: `BlockParam`, `buildBlockParamsMap`,
-`createDefaultValues`, `buildExternInstancesMap`, `bindStageParams`,
-`runParserStage`, `runControlStage`, `handleActionSelectorFork`,
-`buildForkTree`, `evalGetHash`, `hashDataArg`, `sumWords`, `IO_TYPES`,
-`MAX_RECIRCULATIONS`, and the entire Register/Hash/Counter/Meter/Checksum
-extern method dispatch. Extract into shared files (e.g.
-`ArchitectureHelpers.kt`, extend `TraceHelpers.kt` and `Hash.kt`).
-
----
-
 ## Establish user-facing documentation
 
 `docs/` currently serves developers working on 4ward. As the project


### PR DESCRIPTION
## Summary

`docs/REFACTORING.md` still listed "Extract shared architecture
helpers" as open tech debt, but that work has already shipped:
`simulator/ArchitectureHelpers.kt` (252 lines) now carries the items
the entry named (`buildBlockParamsMap`, `createDefaultValues`,
`buildExternInstancesMap`, `bindStageParams`, `runParserStage`,
`runControlStage`, `handleActionSelectorFork`,
`handleCommonExternMethod`), and `TraceHelpers.kt` / `Hash.kt` cover
the rest.

The ~130 lines that still look like duplication between PSA and PNA
are load-bearing (per-architecture metadata semantics, free-function
extern handlers dispatching on architecture-specific state) — unifying
them would obscure spec differences without shrinking the code. V1Model
is correctly divergent (fork-as-exception execution model).

Per the file's own rule (*"Remove entries once they are resolved"*),
this one goes.

## Test plan

- [x] `mkdocs build --strict` still clean (REFACTORING.md isn't in nav)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)