### PR TITLE
Disambiguate InjectPacket p4rt_ingress_port rejection

### DIFF
--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -221,6 +221,7 @@ kt_jvm_test(
         "//e2e_tests/golden_errors:stateful",
         "//e2e_tests/golden_errors:value_set",
         "//e2e_tests/lpm_routing",
+        "//e2e_tests/passthrough",
         "//e2e_tests/ternary_acl",
         "//e2e_tests/trace_tree:action_selector_3",
         "//e2e_tests/trace_tree:clone_with_egress",

--- a/p4runtime/DataplaneService.kt
+++ b/p4runtime/DataplaneService.kt
@@ -41,11 +41,11 @@ class DataplaneService(
 
   override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse {
     val translator = typeTranslator()
-    val pt = translator?.portTranslator
     val ingressPort = resolveIngressPort(request, translator)
     val payload = request.payload.toByteArray()
     val result = broker.processPacket(ingressPort, payload)
     try {
+      val pt = translator?.portTranslator
       val possibleOutcomes =
         result.possibleOutcomes.map { world ->
           PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
@@ -154,23 +154,21 @@ class DataplaneService(
     when (request.ingressPortCase) {
       InjectPacketRequest.IngressPortCase.DATAPLANE_INGRESS_PORT -> request.dataplaneIngressPort
       InjectPacketRequest.IngressPortCase.P4RT_INGRESS_PORT ->
-        (translator?.portTranslator ?: throw missingPortTranslation(request, translator))
+        (translator?.portTranslator
+            ?: throw missingPortTranslation(request.p4RtIngressPort, translator))
           .p4rtToDataplane(request.p4RtIngressPort)
       InjectPacketRequest.IngressPortCase.INGRESSPORT_NOT_SET,
       null -> 0
     }
 }
 
-// Distinguishes the two reasons InjectPacket can reject a p4rt_ingress_port:
-// no pipeline loaded at all vs. a pipeline whose port type lacks
-// @p4runtime_translation. Same status code, different remediation — the
-// caller needs to know which one they hit.
+// Same FAILED_PRECONDITION covers two distinct remediations — "load a pipeline"
+// vs. "use a pipeline whose port type has @p4runtime_translation" — so the
+// message has to say which branch the caller is on.
 private fun missingPortTranslation(
-  request: InjectPacketRequest,
+  requestedPort: ByteString,
   translator: TypeTranslator?,
 ): StatusException {
-  val requested =
-    request.p4RtIngressPort.toByteArray().joinToString("") { "%02x".format(it.toInt() and 0xFF) }
   val reason =
     if (translator == null) {
       "no pipeline is loaded — call SetForwardingPipelineConfig first"
@@ -179,7 +177,7 @@ private fun missingPortTranslation(
         "with a port type that carries the annotation (e.g. via v1model_sai.p4)"
     }
   return Status.FAILED_PRECONDITION.withDescription(
-      "InjectPacket uses p4rt_ingress_port (0x$requested), but $reason. " +
+      "InjectPacket uses p4rt_ingress_port (0x${requestedPort.toHex()}), but $reason. " +
         "Alternatively, use dataplane_ingress_port (numeric) to bypass P4Runtime port translation."
     )
     .asException()

--- a/p4runtime/DataplaneService.kt
+++ b/p4runtime/DataplaneService.kt
@@ -16,6 +16,7 @@ import fourward.dataplane.SubscribeResultsResponse
 import fourward.dataplane.SubscriptionActive
 import fourward.sim.TraceTree
 import io.grpc.Status
+import io.grpc.StatusException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -41,7 +42,7 @@ class DataplaneService(
   override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse {
     val translator = typeTranslator()
     val pt = translator?.portTranslator
-    val ingressPort = resolveIngressPort(request, pt)
+    val ingressPort = resolveIngressPort(request, translator)
     val payload = request.payload.toByteArray()
     val result = broker.processPacket(ingressPort, payload)
     try {
@@ -59,12 +60,12 @@ class DataplaneService(
   }
 
   override suspend fun injectPackets(requests: Flow<InjectPacketRequest>): InjectPacketsResponse {
-    val pt = typeTranslator()?.portTranslator
+    val translator = typeTranslator()
     broker.withHookOnce { processPacket ->
       val futures = mutableListOf<java.util.concurrent.ForkJoinTask<*>>()
       kotlinx.coroutines.runBlocking {
         requests.collect { request ->
-          val port = resolveIngressPort(request, pt)
+          val port = resolveIngressPort(request, translator)
           val payload = request.payload.toByteArray()
           futures.add(
             java.util.concurrent.ForkJoinPool.commonPool().submit { processPacket(port, payload) }
@@ -149,22 +150,39 @@ class DataplaneService(
     }
   }
 
-  private fun resolveIngressPort(request: InjectPacketRequest, pt: PortTranslator?): Int =
+  private fun resolveIngressPort(request: InjectPacketRequest, translator: TypeTranslator?): Int =
     when (request.ingressPortCase) {
       InjectPacketRequest.IngressPortCase.DATAPLANE_INGRESS_PORT -> request.dataplaneIngressPort
-      InjectPacketRequest.IngressPortCase.P4RT_INGRESS_PORT -> {
-        val translator =
-          pt
-            ?: throw Status.FAILED_PRECONDITION.withDescription(
-                "P4Runtime port translation requires a loaded pipeline with " +
-                  "@p4runtime_translation on the port type"
-              )
-              .asException()
-        translator.p4rtToDataplane(request.p4RtIngressPort)
-      }
+      InjectPacketRequest.IngressPortCase.P4RT_INGRESS_PORT ->
+        (translator?.portTranslator ?: throw missingPortTranslation(request, translator))
+          .p4rtToDataplane(request.p4RtIngressPort)
       InjectPacketRequest.IngressPortCase.INGRESSPORT_NOT_SET,
       null -> 0
     }
+}
+
+// Distinguishes the two reasons InjectPacket can reject a p4rt_ingress_port:
+// no pipeline loaded at all vs. a pipeline whose port type lacks
+// @p4runtime_translation. Same status code, different remediation — the
+// caller needs to know which one they hit.
+private fun missingPortTranslation(
+  request: InjectPacketRequest,
+  translator: TypeTranslator?,
+): StatusException {
+  val requested =
+    request.p4RtIngressPort.toByteArray().joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+  val reason =
+    if (translator == null) {
+      "no pipeline is loaded — call SetForwardingPipelineConfig first"
+    } else {
+      "the loaded pipeline's port type has no @p4runtime_translation — compile " +
+        "with a port type that carries the annotation (e.g. via v1model_sai.p4)"
+    }
+  return Status.FAILED_PRECONDITION.withDescription(
+      "InjectPacket uses p4rt_ingress_port (0x$requested), but $reason. " +
+        "Alternatively, use dataplane_ingress_port (numeric) to bypass P4Runtime port translation."
+    )
+    .asException()
 }
 
 private fun enrichTrace(trace: TraceTree, translator: TypeTranslator?): TraceTree =

--- a/p4runtime/DataplaneServiceTest.kt
+++ b/p4runtime/DataplaneServiceTest.kt
@@ -249,7 +249,22 @@ class DataplaneServiceTest {
   @Test
   fun `InjectPacket with P4RT port fails without pipeline`() {
     val p4rtPort = ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))
-    assertGrpcError(Status.Code.FAILED_PRECONDITION) {
+    assertGrpcError(Status.Code.FAILED_PRECONDITION, messageContains = "no pipeline is loaded") {
+      harness.injectPacketP4rt(p4rtPort, byteArrayOf(0x01))
+    }
+  }
+
+  @Test
+  fun `InjectPacket with P4RT port fails when pipeline has no port translation`() {
+    // Passthrough's port type has no @p4runtime_translation, so p4rt_ingress_port
+    // cannot be translated. The error must name the offending request field and
+    // point at the fix, not just report a generic FAILED_PRECONDITION.
+    harness.loadPipeline(loadPassthroughConfig())
+    val p4rtPort = ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))
+    assertGrpcError(
+      Status.Code.FAILED_PRECONDITION,
+      messageContains = "no @p4runtime_translation",
+    ) {
       harness.injectPacketP4rt(p4rtPort, byteArrayOf(0x01))
     }
   }

--- a/p4runtime/DataplaneServiceTest.kt
+++ b/p4runtime/DataplaneServiceTest.kt
@@ -249,22 +249,7 @@ class DataplaneServiceTest {
   @Test
   fun `InjectPacket with P4RT port fails without pipeline`() {
     val p4rtPort = ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))
-    assertGrpcError(Status.Code.FAILED_PRECONDITION, messageContains = "no pipeline is loaded") {
-      harness.injectPacketP4rt(p4rtPort, byteArrayOf(0x01))
-    }
-  }
-
-  @Test
-  fun `InjectPacket with P4RT port fails when pipeline has no port translation`() {
-    // Passthrough's port type has no @p4runtime_translation, so p4rt_ingress_port
-    // cannot be translated. The error must name the offending request field and
-    // point at the fix, not just report a generic FAILED_PRECONDITION.
-    harness.loadPipeline(loadPassthroughConfig())
-    val p4rtPort = ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))
-    assertGrpcError(
-      Status.Code.FAILED_PRECONDITION,
-      messageContains = "no @p4runtime_translation",
-    ) {
+    assertGrpcError(Status.Code.FAILED_PRECONDITION) {
       harness.injectPacketP4rt(p4rtPort, byteArrayOf(0x01))
     }
   }

--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -168,6 +168,8 @@ class GoldenErrorTest(private val testName: String) {
       "refers-to-violation-no-multicast" -> triggerRefersToViolationNoMulticast()
       "type-translation-failed" -> triggerTypeTranslationFailed()
       "wrong-role-write" -> triggerWrongRoleWrite()
+      "inject-packet-no-pipeline" -> triggerInjectPacketNoPipeline()
+      "inject-packet-no-port-translation" -> triggerInjectPacketNoPortTranslation()
       else -> error("unknown test: $name")
     }
   }
@@ -175,6 +177,20 @@ class GoldenErrorTest(private val testName: String) {
   private fun triggerNoPipelineLoaded() {
     val entity = Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(1)).build()
     harness.installEntry(entity)
+  }
+
+  private fun triggerInjectPacketNoPipeline() {
+    val p4rtPort = ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))
+    harness.injectPacketP4rt(p4rtPort, byteArrayOf(0x01))
+  }
+
+  private fun triggerInjectPacketNoPortTranslation() {
+    // Passthrough's port type has no @p4runtime_translation, so p4rt_ingress_port
+    // hits the "pipeline loaded but no translation" branch — distinct from the
+    // no-pipeline branch above.
+    harness.loadPipeline(loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    val p4rtPort = ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))
+    harness.injectPacketP4rt(p4rtPort, byteArrayOf(0x01))
   }
 
   private fun triggerUnknownTableId() {
@@ -1664,6 +1680,8 @@ class GoldenErrorTest(private val testName: String) {
         "refers-to-violation-no-multicast",
         "type-translation-failed",
         "wrong-role-write",
+        "inject-packet-no-pipeline",
+        "inject-packet-no-port-translation",
       )
 
     private val VALIDATOR_BINARY: Path =

--- a/p4runtime/golden_errors/inject-packet-no-pipeline.golden.txt
+++ b/p4runtime/golden_errors/inject-packet-no-pipeline.golden.txt
@@ -1,0 +1,1 @@
+FAILED_PRECONDITION: InjectPacket uses p4rt_ingress_port (0x00000001), but no pipeline is loaded — call SetForwardingPipelineConfig first. Alternatively, use dataplane_ingress_port (numeric) to bypass P4Runtime port translation.

--- a/p4runtime/golden_errors/inject-packet-no-port-translation.golden.txt
+++ b/p4runtime/golden_errors/inject-packet-no-port-translation.golden.txt
@@ -1,0 +1,1 @@
+FAILED_PRECONDITION: InjectPacket uses p4rt_ingress_port (0x00000001), but the loaded pipeline's port type has no @p4runtime_translation — compile with a port type that carries the annotation (e.g. via v1model_sai.p4). Alternatively, use dataplane_ingress_port (numeric) to bypass P4Runtime port translation.


### PR DESCRIPTION
## Summary

Closes #470.

The `InjectPacket` rejection for `p4rt_ingress_port` without port
translation conflated *"no pipeline loaded"* with *"pipeline loaded
but the port type has no `@p4runtime_translation`"* — same status
code, very different remediation. Callers reading the old message had
to guess which situation they were in.

The rewritten error names the offending field, quotes the exact port
bytes the caller sent, and states which of the two situations they're
in along with the fix. It also surfaces the `dataplane_ingress_port`
escape hatch, since many callers don't actually need P4Runtime port
translation and just want to get unstuck.

### Before
```
FAILED_PRECONDITION: P4Runtime port translation requires a loaded
pipeline with @p4runtime_translation on the port type
```

### After (no pipeline)
```
FAILED_PRECONDITION: InjectPacket uses p4rt_ingress_port (0x00000001),
but no pipeline is loaded — call SetForwardingPipelineConfig first.
Alternatively, use dataplane_ingress_port (numeric) to bypass
P4Runtime port translation.
```

### After (pipeline loaded, no translation)
```
FAILED_PRECONDITION: InjectPacket uses p4rt_ingress_port (0x00000001),
but the loaded pipeline's port type has no @p4runtime_translation —
compile with a port type that carries the annotation (e.g. via
v1model_sai.p4). Alternatively, use dataplane_ingress_port (numeric)
to bypass P4Runtime port translation.
```

## Test plan

- [x] New tests cover both paths (no pipeline / pipeline w/o translation)
- [x] Existing tests pass (all 19 `//p4runtime/...` tests green)
- [x] `./tools/format.sh` + `./tools/lint.sh` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)