### PR TITLE
web: split PlaygroundServer into its own kt_jvm_library

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -28,15 +28,11 @@ kt_jvm_library(
     ],
 )
 
-kt_jvm_binary(
-    name = "playground",
+# Kept separate from `web_lib` so the heavy server deps (grpc-netty, etc.) don't propagate
+# to the test targets that only need the lighter graph-extractor logic in `web_lib`.
+kt_jvm_library(
+    name = "playground_lib",
     srcs = ["PlaygroundServer.kt"],
-    data = [
-        "//p4c_backend:p4c-4ward",
-        "@p4c//p4include",
-    ] + glob(["frontend/**"]),
-    main_class = "fourward.web.PlaygroundServerKt",
-    visibility = ["//visibility:public"],
     deps = [
         ":web_lib",
         "//p4runtime:p4runtime_lib",
@@ -47,6 +43,17 @@ kt_jvm_binary(
         "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
         "@grpc-java//api",
     ],
+)
+
+kt_jvm_binary(
+    name = "playground",
+    data = [
+        "//p4c_backend:p4c-4ward",
+        "@p4c//p4include",
+    ] + glob(["frontend/**"]),
+    main_class = "fourward.web.PlaygroundServerKt",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":playground_lib"],
 )
 
 kt_jvm_test(


### PR DESCRIPTION
## Summary

The `web/playground` binary was the only `kt_jvm_binary` in the repo using \`srcs\` instead of the standard \`runtime_deps = [\":X_lib\"]\` pattern (compare cli/4ward, p4runtime/p4runtime_server). The original split was deliberate — keeping grpc-netty and friends out of \`web_lib\` so the lighter graph-extractor tests don't pull them in — but \`srcs\` on a \`kt_jvm_binary\` causes downstream sync issues in google3.

## What this does

Adds a new \`playground_lib\` \`kt_jvm_library\` target that carries \`PlaygroundServer.kt\` plus the heavy server deps (\`grpc-netty\`, \`grpc-java/api\`, \`p4info\`, etc.). The \`playground\` binary now uses \`runtime_deps = [\":playground_lib\"]\` and only carries \`data\` + \`main_class\`.

\`web_lib\` is unchanged; the test targets remain lean.

## Test plan

- [x] \`bazel build //web:playground //web:playground_lib\` clean
- [ ] CI heavy tests (running)