### PR TITLE
Exclude InterpreterTestDsl.kt from simulator_lib

### DIFF
--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -96,7 +96,10 @@ kt_jvm_library(
     name = "simulator_lib",
     srcs = glob(
         ["*.kt"],
-        exclude = ["*Test.kt"],
+        exclude = [
+            "*Test.kt",
+            "InterpreterTestDsl.kt",
+        ],
     ),
     visibility = ["//visibility:public"],
     deps = [
@@ -324,6 +327,7 @@ kt_jvm_test(
     srcs = ["SimulatorTest.kt"],
     test_class = "fourward.simulator.SimulatorTest",
     deps = [
+        ":interpreter_test_dsl",
         ":ir_java_proto",
         ":p4info_java_proto",
         ":p4runtime_java_proto",
@@ -339,6 +343,7 @@ kt_jvm_test(
     srcs = ["SimulatorTest.kt"],
     test_class = "fourward.simulator.CollectPossibleOutcomesTest",
     deps = [
+        ":interpreter_test_dsl",
         ":ir_java_proto",
         ":p4info_java_proto",
         ":p4runtime_java_proto",


### PR DESCRIPTION
## Summary
- The `simulator_lib` glob (`*.kt`, excluding only `*Test.kt`) was pulling `InterpreterTestDsl.kt` into the production library, making the `testonly` flag on the dedicated `interpreter_test_dsl` target ineffective.
- Added `InterpreterTestDsl.kt` to the exclude list so it only compiles via the testonly target.

## Test plan
- [ ] CI builds `//simulator/...` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)