### PR TITLE
lint: detect duplicate srcs across kt_jvm_library targets

### DIFF
--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Runs all linters:
 #   - clang-tidy on C++ sources (via Bazel aspect)
+#   - duplicate-srcs check across kt_jvm_library targets
 #   - detekt on Kotlin sources
 #
-# Runs both even if the first fails, so you see all issues at once.
+# Runs all checks even if an earlier one fails, so you see all issues at once.
 #
 # Usage:
 #   ./lint.sh
@@ -17,6 +18,24 @@ rc=0
 
 echo "Running clang-tidy..."
 bazel build //p4c_backend/... --config=clang-tidy || rc=1
+
+echo "Checking for source files compiled into multiple kt_jvm_library targets..."
+if targets=$(bazel query 'kind("kt_jvm_library", //...)' 2>/dev/null); then
+  duplicates=$(
+    echo "$targets" | while read -r t; do
+      bazel query "labels(srcs, $t)" 2>/dev/null
+    done | sort | uniq -d
+  )
+  if [[ -n "$duplicates" ]]; then
+    echo "ERROR: Source files compiled into multiple kt_jvm_library targets:"
+    echo "$duplicates"
+    rc=1
+  fi
+else
+  echo "WARNING: could not enumerate kt_jvm_library targets; skipping duplicate-srcs check"
+  echo "$targets"
+  rc=1
+fi
 
 echo "Running detekt..."
 bazel run //:detekt -- \


### PR DESCRIPTION
## Summary
- Adds a lint check that catches source files compiled into multiple `kt_jvm_library` targets — the class of bug fixed in #548.
- Uses `bazel query labels(srcs, ...)` to expand globs and detect overlap across all 10 `kt_jvm_library` targets in the repo.
- Runs before detekt, adds a few seconds to `./tools/lint.sh`.

## Test plan
- [ ] CI passes (no false positives on the clean repo)
- Verified locally that it catches the #548 bug when re-introduced, and produces no output on the fixed repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)