### PR TITLE
CI: run ./tools/lint.sh instead of inlining lint steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,8 @@ jobs:
           fi
 
       # Restore-only: the build-and-test job owns the authoritative cache for
-      # this key.  Lint builds a subset (p4c_backend + formatting tools), so
-      # letting it save would evict simulator/e2e artifacts that build-and-test
-      # needs.
+      # this key.  Lint builds a subset of targets, so letting it save would
+      # evict simulator/e2e artifacts that build-and-test needs.
       - name: Restore Bazel cache
         uses: actions/cache/restore@v5
         with:
@@ -104,24 +103,9 @@ jobs:
       - name: Install clang tools
         run: sudo apt install -y clang-format clang-tidy
 
-      # format.sh modifies files in-place; the diff check below catches any
-      # changes, so we use a single "run and diff" pattern for both clang-format
-      # and buildifier rather than separate --dry-run/--check invocations.
-      - run: ./tools/format.sh
-      - name: Check formatting diff
-        run: |
-          if changed=$(git diff-index --name-only HEAD --) && [[ -n "$changed" ]]; then
-            echo -e "Please run ./tools/format.sh. Files needing formatting:\n$changed"
-            exit 1
-          fi
-
-      # TODO(buf-edition-2024): Re-enable buf lint/breaking once buf supports
-      # edition 2024. Tracked in https://github.com/smolkaj/4ward/pull/4.
-
       # On PRs, skip clang-tidy when no C++ files were modified — most PRs
       # only touch Kotlin or proto files.  Always run on pushes to main.
       - name: Detect C++ changes
-        id: cpp
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -129,12 +113,10 @@ jobs:
           FILES=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only)
           if ! printf '%s\n' "$FILES" | grep -qE '\.(cpp|cc|h)$|\.clang-tidy$'; then
             echo "No C++ files changed; skipping clang-tidy."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "SKIP_CLANG_TIDY=1" >> "$GITHUB_ENV"
           fi
 
-      - name: Run clang-tidy
-        if: steps.cpp.outputs.skip != 'true'
-        run: bazel build //p4c_backend/... --config=clang-tidy
+      - run: ./tools/lint.sh
 
 
   build-and-test:

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -18,11 +18,46 @@
 # Formats source files according to Google's style guide. Requires clang-format.
 # Uses `git ls-files` to respect .gitignore as the single source of truth for
 # which files belong to the project — no manual excludes needed.
+#
+# With --check, reports unformatted files and exits non-zero instead of
+# modifying them.
+#
+# Usage:
+#   ./tools/format.sh          # fix formatting in-place
+#   ./tools/format.sh --check  # check only (used by lint.sh)
 
 set -euo pipefail
 
+CHECK=0
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK=1
+fi
+
 cd "$(git rev-parse --show-toplevel)" || exit 1
 REPO_ROOT=$(pwd)
+
+if [[ "$CHECK" == "1" ]]; then
+  rc=0
+
+  git ls-files '*.cpp' '*.h' '*.proto' \
+    | xargs clang-format --style=google --dry-run -Werror || rc=1
+
+  BZL_SOURCES=()
+  while IFS= read -r f; do BZL_SOURCES+=("$f"); done < <(git ls-files '*.bazel' '*.bzl')
+  if [[ ${#BZL_SOURCES[@]} -gt 0 ]]; then
+    bazel run -- @buildifier_prebuilt//:buildifier --mode=check --lint=warn \
+      "${BZL_SOURCES[@]/#/$REPO_ROOT/}" || rc=1
+  fi
+
+  KT_SOURCES=()
+  while IFS= read -r f; do KT_SOURCES+=("$f"); done < <(git ls-files '*.kt')
+  if [[ ${#KT_SOURCES[@]} -gt 0 ]]; then
+    bazel run //:ktfmt -- --google-style --dry-run --set-exit-if-changed \
+      "${KT_SOURCES[@]/#/$REPO_ROOT/}" || rc=1
+  fi
+
+  exit $rc
+fi
 
 # Run clang-format.
 git ls-files '*.cpp' '*.h' '*.proto' | xargs clang-format --verbose -style=google -i

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,23 +1,36 @@
 #!/usr/bin/env bash
 # Runs all linters:
+#   - formatting check (clang-format, buildifier, ktfmt)
 #   - clang-tidy on C++ sources (via Bazel aspect)
 #   - duplicate-srcs check across kt_jvm_library targets
 #   - detekt on Kotlin sources
 #
 # Runs all checks even if an earlier one fails, so you see all issues at once.
 #
+# Set SKIP_CLANG_TIDY=1 to skip the clang-tidy step (CI sets this when no C++
+# files were modified).
+#
 # Usage:
-#   ./lint.sh
+#   ./tools/lint.sh
 
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-# Both commands go through Bazel, which serializes them via its server lock.
 rc=0
 
-echo "Running clang-tidy..."
-bazel build //p4c_backend/... --config=clang-tidy || rc=1
+echo "Checking formatting..."
+"${REPO_ROOT}/tools/format.sh" --check || rc=1
+
+if [[ "${SKIP_CLANG_TIDY:-}" == "1" ]]; then
+  echo "Skipping clang-tidy (SKIP_CLANG_TIDY=1)."
+else
+  echo "Running clang-tidy..."
+  bazel build //p4c_backend/... --config=clang-tidy || rc=1
+fi
+
+# TODO(buf-edition-2024): Re-enable buf lint/breaking once buf supports
+# edition 2024. Tracked in https://github.com/smolkaj/4ward/pull/4.
 
 echo "Checking for source files compiled into multiple kt_jvm_library targets..."
 if targets=$(bazel query 'kind("kt_jvm_library", //...)' 2>/dev/null); then


### PR DESCRIPTION
## Summary
- CI's lint job was reimplementing clang-tidy and format checks inline while `tools/lint.sh` had its own copy of clang-tidy plus detekt and the duplicate-srcs check (#549). Any new check had to be added in two places.
- Now CI calls `./tools/lint.sh` directly — single source of truth for all lint checks.
- Adds `--check` flag to `format.sh` (dry-run mode for clang-format, buildifier, ktfmt) so `lint.sh` can check formatting without modifying files.
- **Net effect:** detekt and the duplicate-srcs check now run in CI for the first time.

## Test plan
- [ ] CI lint job passes (formatting + clang-tidy + duplicate-srcs + detekt all run)
- [ ] On a Kotlin-only PR, clang-tidy is skipped via `SKIP_CLANG_TIDY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)