### PR TITLE
Enable layering_check for 4ward's C++ code

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -4,7 +4,14 @@ Applies the Apache-2.0 license in //:license as default package metadata
 for every target and lists directories Bazel should ignore when globbing.
 """
 
-repo(default_package_metadata = ["//:license"])
+repo(
+    default_package_metadata = ["//:license"],
+    # Layering check enforces that a target only #includes headers from its
+    # direct `deps`, not transitive ones. Clang-only (GCC ignores it silently).
+    # Scoped to our repo via REPO.bazel so external deps (e.g. @p4c) aren't
+    # affected.
+    features = ["layering_check"],
+)
 
 ignore_directories([
     # Bazel output symlinks. The last component depends on the workspace

--- a/e2e_tests/bmv2_diff/BUILD.bazel
+++ b/e2e_tests/bmv2_diff/BUILD.bazel
@@ -17,7 +17,10 @@ cc_binary(
         "@platforms//os:linux": ["-latomic"],
         "//conditions:default": [],
     }),
-    deps = ["@behavioral_model//:simple_switch_lib"],
+    deps = [
+        "@behavioral_model//:bm_sim",
+        "@behavioral_model//:simple_switch_lib",
+    ],
 )
 
 kt_jvm_test(

--- a/p4c_backend/BUILD.bazel
+++ b/p4c_backend/BUILD.bazel
@@ -22,6 +22,8 @@ cc_library(
         "@p4c//:ir_frontend_midend_control_plane",
         "@p4c//:lib",
         "@p4c//:p4c_backends_common_lib",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+        "@protobuf",
     ],
 )
 

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -45,6 +45,9 @@ cc_proto_library(
 cc_grpc_library(
     name = "dataplane_cc_grpc",
     srcs = [":dataplane_proto"],
+    # cc_grpc_library's generated code #includes many grpcpp headers without
+    # declaring them as deps on the generated target — out of our control.
+    features = ["-layering_check"],
     grpc_only = True,
     visibility = ["//visibility:public"],
     deps = [":dataplane_cc_proto"],


### PR DESCRIPTION
## Summary

Enables clang's `layering_check` feature repo-wide via `REPO.bazel` so a `cc_*` target only `#include`s headers from its direct `deps`, not transitive ones. Catches hidden dependencies at build time — silent transitive `#include`s now become compile errors.

## Scope

`REPO.bazel` applies the feature to targets in **our repo only**. External deps (`@p4c`, `@behavioral_model`, `@protobuf`, …) are untouched — their own layering issues don't cascade in.

## What fired

**Three real violations, fixed by adding direct deps:**

| Target | Violation | Added dep |
|---|---|---|
| `//p4c_backend:p4c_backend_lib` | `p4/v1/p4runtime.pb.h`, `google/protobuf/text_format.h` | `@p4runtime//proto/p4/v1:p4runtime_cc_proto`, `@protobuf//:protobuf` |
| `//e2e_tests/bmv2_diff:bmv2_driver` | `bm/bm_sim/{options_parse,simple_pre,simple_pre_lag,switch}.h` (via `simple_switch_lib`) | `@behavioral_model//:bm_sim` |

**One opt-out on generated code:**

- `//p4runtime:dataplane_cc_grpc` — generated stubs `#include` ~15 `grpcpp` headers that `cc_grpc_library` doesn't declare on the generated target. Macro limitation, not our code; `features = ["-layering_check"]` on just that target.

## Test plan

- [x] `bazel build //...` — clean.
- [x] `bazel test //... --test_tag_filters=-heavy` — 64/64 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)