### PR TITLE
Perf: reduce fork-copy allocation + cheaper BitVector ops (+50% parallel)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,14 @@ Before submitting:
    checks are needed, fail loudly (`error()`, `require()`, gRPC
    `UNIMPLEMENTED`). Never let unhandled inputs fall through to a default path.
 
+   **Proto oneofs: always switch on the case enum.** When dispatching on a
+   proto `oneof`, use `when (msg.kindCase) { KindCase.FOO -> ... }`, never
+   `when { msg.hasFoo() -> ... msg.hasBar() -> ... }`. The enum-based form
+   is exhaustive at compile time — adding a new oneof variant produces a
+   compiler warning rather than silently falling through to `else`. This
+   applies everywhere: the interpreter's `evalExpr`, `evalLiteral`,
+   `execStmt`, statement/expression visitors, type dispatchers, etc.
+
 3. **The proto IR uses names, not IDs.** All cross-references in `ir.proto` and
    `simulator.proto` use string names. Numeric IDs belong to p4info (the
    control-plane API) only.

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -766,6 +766,167 @@ raises both single-thread and parallel pps proportionally and
 leaves efficiency unchanged). Phase 2.5 evidence says hitting 80%
 likely needs candidates (1)+(2)+(3) stacked — no single lever gets
 there on its own.
+## Phase 3: structural candidates
+
+Phase 2.5's incremental work (Long-backed `BitVector`,
+`CompactFieldMap`, proto builder pooling, map preallocation) moved
+wcmp×128 efficiency from 45% to ~60% — a +15 pp gain from ~360
+lines of code. But the profile is now diffuse: no single method
+exceeds 7% of CPU. Further gains require structural changes to how
+the interpreter executes fork branches, not more micro-optimization
+of individual methods.
+
+Three observations motivate the candidates below:
+
+1. **The interpreter re-executes the full pipeline per fork branch.**
+   128 branches × full ingress+egress pipeline walk. But branches
+   share >95% of their state — only the selected action's ~5 field
+   writes diverge. We pay full interpretation cost for a small delta.
+
+2. **Fork-copy allocates a new value tree even though most values
+   are never written.** Each branch copies ~200 field values; ~5
+   actually change. `CompactFieldMap` made the copy cheaper (array
+   copy vs HashMap node allocation), but it's still copying 200
+   values when only 5 will diverge.
+
+3. **Proto trace events are constructed 128× for mostly-identical
+   content.** The pre-fork prefix events are deterministic replays;
+   post-fork events differ only in the selected action's trace. Full
+   proto messages are built for all of them.
+
+### Candidates
+
+| | Candidate | Ceiling | Effort | Best for |
+|---|---|---|---|---|
+| **A** | Fork-on-write overlay | ~5-7% CPU, several pp efficiency | Medium | Next incremental step toward 80% |
+| **B** | Skip trace construction during fork prefix replay | ~6% CPU | Medium | Quick standalone win |
+| **C** | Compiled instruction sequence (flatten the AST walk) | ~15-20% CPU | Very high | "One big bet" choice |
+| **D** | Thread-local fork state pool | ~5-7% CPU | Medium | Alternative to A |
+| **E** | Deferred trace serialization (lightweight internal events) | ~8-10% CPU | High | Stacks after A or D |
+| **F** | Reactive / dataflow evaluation (re-evaluate only changed dependencies) | Huge (theoretical) | Very high | Research project |
+
+### A. Fork-on-write overlay
+
+Instead of deep-copying headers/structs at fork time, share the base
+value tree across all branches. Each branch gets a lightweight
+overlay map that intercepts writes. Reads check the overlay first,
+then fall through to the shared base.
+
+For SAI wcmp×128: each branch writes ~5 fields (nexthop, egress
+port, MAC rewrites, TTL decrement) out of ~200 total. The overlay
+per branch is ~5 entries vs ~200 copied values today. Fork-copy
+becomes O(mutations) instead of O(total fields).
+
+Implementation: a two-layer `OverlayFieldMap` wrapping the base
+`CompactFieldMap`. The interpreter's mutation pattern
+(`target.fields[name] = value`) stays unchanged; only the map
+implementation underneath changes. `deepCopy` creates a new empty
+overlay sharing the same base — no per-entry work.
+
+This is architecturally simpler than persistent collections (no
+trie, no structural sharing) while capturing the same fundamental
+win: don't copy state that won't be written.
+
+### B. Skip trace construction during fork prefix replay
+
+Fork branch re-executions replay the first `prefixLength` events
+deterministically (same control flow, same table results, same
+trace output), then drop them via `levelEvents.drop(prefixLength)`.
+Those events are constructed-then-discarded — pure waste.
+
+Add a skip counter to `PacketContext`. Guard each
+`addTraceEvent` / `addLightEvent` call site with a
+`packetCtx.isTracing` check that returns false while the counter
+is positive. When skipping, the event isn't constructed at all —
+saves the proto builder + message allocation.
+
+Requires changing the trace tree format: branch subtrees would
+start at the fork point, not at event 0. Consumers (STF runner,
+CLI formatter, web playground) need to handle the stripped format.
+The pre-fork events are already in the outer-level trace; including
+them again in each branch subtree is redundant information.
+
+### C. Compiled instruction sequence
+
+At pipeline load: walk the proto AST once and compile each
+expression / statement into a flat `Array<Instruction>` where each
+`Instruction` is a sealed class with pre-resolved field indices,
+pre-computed literal values, and direct function references.
+Runtime: iterate the array and dispatch on the instruction type.
+No proto field access, no `evalExpr` recursion, no `hasFieldAccess`
+checks, no `env.lookup` for known variables.
+
+Eliminates the ~10% interpreter-dispatch cost AND the HashMap /
+String.equals cost from field-name lookups (field accesses become
+`fieldValues[precomputedIndex]`). Highest single-change ceiling of
+any candidate.
+
+Also the largest refactor — essentially rewriting the interpreter.
+The existing interpreter (proto-walking, HashMap-backed) would
+remain as a reference / fallback; the compiled path runs when the
+pipeline's IR is fully resolvable.
+
+### D. Thread-local fork state pool
+
+Pre-allocate one complete value tree (Environment + all
+HeaderVal / StructVal / CompactFieldMap instances) per worker
+thread. At fork time: `System.arraycopy` the snapshot's field
+values into the pool's arrays, rebind scope variables. No object
+allocation per fork — just array copies and pointer reassignments.
+After the branch completes: return the state to the pool.
+
+Similar ceiling to (A) but a different tradeoff: no overlay-
+dispatch overhead per read, but requires lifecycle management
+(borrow / return protocol, reset between uses).
+
+### E. Deferred trace serialization
+
+Store trace events as lightweight Kotlin sealed classes
+(`LightBranch`, `LightTableLookup`, etc.) throughout the fork path.
+Convert to proto only at the final API boundary (gRPC
+`InjectPacketResponse`, CLI trace output).
+
+Differs from the experiment-B attempt (which regressed -10%)
+because experiment B converted per-branch via `getEvents()`. This
+candidate defers conversion to once-per-packet at the outermost
+`buildTraceTree` call — 128× less conversion work.
+
+Requires refactoring the internal `TraceTree` representation to
+carry lightweight events, converting to proto only at serialization
+time.
+
+### F. Reactive / dataflow evaluation
+
+Instead of re-executing the full pipeline per fork branch, track
+which fields the selected action modifies and only re-evaluate
+expressions that depend on those fields. Tables whose keys are
+unchanged reuse the first execution's result; if-conditions on
+unchanged values don't re-evaluate.
+
+Highest theoretical ceiling (could make 128 branches nearly as
+cheap as 1), but extremely complex — requires full dependency
+tracking across the P4 program. Research-project scope.
+
+### Recommended sequencing
+
+If pursuing Phase 3:
+
+1. **(A) Fork-on-write overlay** — most natural next step. Attacks
+   the structural inefficiency (copying unmodified state) rather than
+   optimizing the copy mechanics. Build the overlay, measure, decide
+   whether to stack more.
+2. **(B) Skip prefix events** — independent of A, can stack in any
+   order. Well-scoped.
+3. **Reassess.** If A+B together reach ~70% efficiency, evaluate
+   whether the remaining 10 pp to 80% justifies (C) or (E). If not,
+   declare victory and move on.
+
+**Oracle-first rule still applies.** For each candidate, build a
+"what if this were free?" stub before committing to the full
+implementation. A+B have obvious stubs (make deepCopy return `this`;
+make addTraceEvent a no-op during replay). C and E are harder to
+stub but the methodology holds.
+
 
 ## Non-goals
 

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -153,6 +153,16 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "CompactFieldMapTest",
+    srcs = ["CompactFieldMapTest.kt"],
+    test_class = "fourward.simulator.CompactFieldMapTest",
+    deps = [
+        ":simulator",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "MatchesFieldMatchTest",
     srcs = ["MatchesFieldMatchTest.kt"],
     test_class = "fourward.simulator.MatchesFieldMatchTest",

--- a/simulator/BitVector.kt
+++ b/simulator/BitVector.kt
@@ -16,12 +16,9 @@ data class BitVector(val value: BigInteger, val width: Int) {
   init {
     // Width 0 is valid for varbit fields with no runtime data (e.g. IPv4 options when IHL=5).
     require(width >= 0) { "width must be non-negative, got $width" }
-    require(value >= BigInteger.ZERO) { "value must be non-negative, got $value" }
-    if (width > 0) {
-      require(value < BigInteger.TWO.pow(width)) { "value $value does not fit in $width bits" }
-    } else {
-      require(value == BigInteger.ZERO) { "zero-width BitVector must have value 0" }
-    }
+    require(value.signum() >= 0) { "value must be non-negative, got $value" }
+    // Equivalent to `value < 2^width` without allocating a BigInteger from `TWO.pow(width)`.
+    require(value.bitLength() <= width) { "value $value does not fit in $width bits" }
   }
 
   /** Cached Long representation for fast comparison. Valid when width ≤ 63. */
@@ -62,11 +59,11 @@ data class BitVector(val value: BigInteger, val width: Int) {
 
   infix fun xor(other: BitVector): BitVector = binaryOp(other) { a, b -> a xor b }
 
-  fun inv(): BitVector = BitVector(value.not() and mask, width)
+  fun inv(): BitVector = BitVector(value.not() and maskFor(width), width)
 
   // Shifts — the shift amount is an arbitrary non-negative integer.
 
-  fun shl(amount: Int): BitVector = BitVector((value shl amount) and mask, width)
+  fun shl(amount: Int): BitVector = BitVector((value shl amount) and maskFor(width), width)
 
   fun shr(amount: Int): BitVector = BitVector(value shr amount, width) // logical shift
 
@@ -86,10 +83,7 @@ data class BitVector(val value: BigInteger, val width: Int) {
     require(hi >= lo) { "hi ($hi) must be >= lo ($lo)" }
     require(hi < width) { "hi ($hi) out of range for width $width" }
     val newWidth = hi - lo + 1
-    return BitVector(
-      (value shr lo) and BigInteger.TWO.pow(newWidth).minus(BigInteger.ONE),
-      newWidth,
-    )
+    return BitVector((value shr lo) and maskFor(newWidth), newWidth)
   }
 
   /**
@@ -118,15 +112,14 @@ data class BitVector(val value: BigInteger, val width: Int) {
 
   override fun toString(): String = "0x${value.toString(16)} : bit<$width>"
 
-  private val mask: BigInteger
-    get() = BigInteger.TWO.pow(width).minus(BigInteger.ONE)
-
   private val max: BigInteger
-    get() = mask
+    get() = maskFor(width)
 
   private fun binaryOp(other: BitVector, op: (BigInteger, BigInteger) -> BigInteger): BitVector {
     requireSameWidth(other)
-    return BitVector(op(value, other.value).mod(BigInteger.TWO.pow(width)), width)
+    // `and mask` truncates to width bits. Safe even when op produces a negative intermediate
+    // (e.g., minus underflow): BigInteger.and sign-extends, so (-1).and(0xFF) = 255.
+    return BitVector(op(value, other.value) and maskFor(width), width)
   }
 
   private fun requireSameWidth(other: BitVector) {
@@ -137,6 +130,16 @@ data class BitVector(val value: BigInteger, val width: Int) {
     const val BITS_PER_BYTE = 8
     // 63 not 64: Java Long is signed, so we reserve bit 63 to keep unsigned comparisons simple.
     const val LONG_WIDTH = 63
+
+    /**
+     * Cache of `2^width - 1` by width. Eliminates repeated `TWO.pow(width)` allocations in
+     * arithmetic, slice, shift, and inv — a few dozen distinct widths per pipeline.
+     */
+    private val maskByWidth = java.util.concurrent.ConcurrentHashMap<Int, BigInteger>()
+
+    /** Returns `2^width - 1`, cached. */
+    fun maskFor(width: Int): BigInteger =
+      maskByWidth.computeIfAbsent(width) { BigInteger.TWO.pow(it).minus(BigInteger.ONE) }
 
     fun ofInt(value: Int, width: Int): BitVector =
       BitVector(BigInteger.valueOf(value.toLong()), width)

--- a/simulator/CompactFieldMap.kt
+++ b/simulator/CompactFieldMap.kt
@@ -1,0 +1,100 @@
+package fourward.simulator
+
+/**
+ * A [MutableMap] backed by parallel arrays of field names and values, for the small, static-key P4
+ * header field maps.
+ *
+ * [fieldNames] is shared across all copies of the same header type; [fieldValues] is per-instance.
+ * [copy] is a single `fieldValues.copyOf()` — no per-entry allocation, unlike [LinkedHashMap] which
+ * allocates a `Node` per entry. Lookup is linear scan on [fieldNames], competitive with [HashMap]
+ * for N ≤ ~20 entries.
+ */
+class CompactFieldMap
+private constructor(private val fieldNames: Array<String>, private val fieldValues: Array<Value?>) :
+  AbstractMutableMap<String, Value>() {
+
+  init {
+    require(fieldNames.size == fieldValues.size) {
+      "fieldNames/fieldValues size mismatch: ${fieldNames.size} vs ${fieldValues.size}"
+    }
+  }
+
+  override val size: Int
+    get() = fieldNames.size
+
+  private fun indexOf(key: String): Int {
+    for (i in fieldNames.indices) if (fieldNames[i] == key) return i
+    return -1
+  }
+
+  override fun containsKey(key: String): Boolean = indexOf(key) >= 0
+
+  override fun get(key: String): Value? {
+    val i = indexOf(key)
+    return if (i >= 0) fieldValues[i] else null
+  }
+
+  override fun put(key: String, value: Value): Value? {
+    val i = indexOf(key)
+    require(i >= 0) { "no such field: '$key' (available: ${fieldNames.toList()})" }
+    val old = fieldValues[i]
+    fieldValues[i] = value
+    return old
+  }
+
+  override fun clear() {
+    fieldValues.fill(null)
+  }
+
+  /** Shallow copy: shared field names, independent values array. */
+  fun copy(): CompactFieldMap = CompactFieldMap(fieldNames, fieldValues.copyOf())
+
+  override val entries: MutableSet<MutableMap.MutableEntry<String, Value>>
+    get() =
+      object : AbstractMutableSet<MutableMap.MutableEntry<String, Value>>() {
+        override val size: Int
+          get() = fieldNames.size
+
+        override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, Value>> {
+          var idx = 0
+          return object : MutableIterator<MutableMap.MutableEntry<String, Value>> {
+            override fun hasNext(): Boolean = idx < fieldNames.size
+
+            override fun next(): MutableMap.MutableEntry<String, Value> {
+              val i = idx++
+              return object : MutableMap.MutableEntry<String, Value> {
+                override val key: String
+                  get() = fieldNames[i]
+
+                override val value: Value
+                  get() = fieldValues[i]!!
+
+                override fun setValue(newValue: Value): Value {
+                  val old = fieldValues[i]!!
+                  fieldValues[i] = newValue
+                  return old
+                }
+              }
+            }
+
+            override fun remove() {
+              throw UnsupportedOperationException("cannot remove keys from a compact field map")
+            }
+          }
+        }
+
+        override fun add(element: MutableMap.MutableEntry<String, Value>): Boolean {
+          put(element.key, element.value)
+          return true
+        }
+      }
+
+  companion object {
+    /** Creates from a list of (name, value) pairs. Field order is preserved. */
+    fun of(entries: List<Pair<String, Value>>): CompactFieldMap {
+      val keys = Array(entries.size) { i -> entries[i].first }
+      val values = Array<Value?>(entries.size) { i -> entries[i].second }
+      return CompactFieldMap(keys, values)
+    }
+  }
+}

--- a/simulator/CompactFieldMapTest.kt
+++ b/simulator/CompactFieldMapTest.kt
@@ -1,0 +1,113 @@
+package fourward.simulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompactFieldMapTest {
+
+  private fun bit(value: Long, width: Int): Value = BitVal(value, width)
+
+  private fun sample() =
+    CompactFieldMap.of(
+      listOf(
+        "srcAddr" to bit(0xAABBCCDD, 32),
+        "dstAddr" to bit(0x11223344, 32),
+        "ttl" to bit(64, 8),
+      )
+    )
+
+  @Test
+  fun `get returns values by field name`() {
+    val map = sample()
+    assertEquals(bit(0xAABBCCDD, 32), map["srcAddr"])
+    assertEquals(bit(64, 8), map["ttl"])
+  }
+
+  @Test
+  fun `get returns null for unknown field`() {
+    assertNull(sample()["nonexistent"])
+  }
+
+  @Test
+  fun `put updates existing field`() {
+    val map = sample()
+    map["ttl"] = bit(63, 8)
+    assertEquals(bit(63, 8), map["ttl"])
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `put rejects unknown field`() {
+    sample()["newField"] = bit(0, 8)
+  }
+
+  @Test
+  fun `size matches field count`() {
+    assertEquals(3, sample().size)
+  }
+
+  @Test
+  fun `containsKey for present and absent keys`() {
+    val map = sample()
+    assertTrue(map.containsKey("srcAddr"))
+    assertFalse(map.containsKey("nonexistent"))
+  }
+
+  @Test
+  fun `iteration preserves declaration order`() {
+    val keys = sample().entries.map { it.key }
+    assertEquals(listOf("srcAddr", "dstAddr", "ttl"), keys)
+  }
+
+  @Test
+  fun `copy produces independent mutations`() {
+    val original = sample()
+    val copy = original.copy()
+
+    copy["ttl"] = bit(1, 8)
+
+    assertEquals(bit(64, 8), original["ttl"])
+    assertEquals(bit(1, 8), copy["ttl"])
+  }
+
+  @Test
+  fun `copy shares field names array`() {
+    val original = sample()
+    val copy = original.copy()
+    // Both should report the same keys — structural, not identity, check.
+    assertEquals(original.keys, copy.keys)
+  }
+
+  @Test
+  fun `clear nulls all values then putAll restores`() {
+    // This is the pattern used by HeaderVal.setValid: clear() then putAll(newFields).
+    val map = sample()
+    map.clear()
+
+    // All values are null after clear (get returns null for present keys).
+    assertNull(map["srcAddr"])
+    assertNull(map["ttl"])
+    // But keys are still present (containsKey still true — the key set is fixed).
+    assertTrue(map.containsKey("srcAddr"))
+
+    map.putAll(mapOf("srcAddr" to bit(1, 32), "dstAddr" to bit(2, 32), "ttl" to bit(3, 8)))
+    assertEquals(bit(1, 32), map["srcAddr"])
+    assertEquals(bit(3, 8), map["ttl"])
+  }
+
+  @Test
+  fun `replaceAll transforms values in place`() {
+    // This is the pattern used by HeaderVal.setInvalid.
+    val map = sample()
+    map.replaceAll { _, v ->
+      when (v) {
+        is BitVal -> BitVal(0L, v.bits.width)
+        else -> v
+      }
+    }
+    assertEquals(bit(0, 32), map["srcAddr"])
+    assertEquals(bit(0, 8), map["ttl"])
+  }
+}

--- a/simulator/DefaultValues.kt
+++ b/simulator/DefaultValues.kt
@@ -54,9 +54,9 @@ internal fun defaultValue(typeName: String, types: Map<String, TypeDecl>): Value
       HeaderVal(
         typeName = typeName,
         fields =
-          typeDecl.header.fieldsList.associateTo(mutableMapOf()) { f ->
-            f.name to defaultValue(f.type, types)
-          },
+          CompactFieldMap.of(
+            typeDecl.header.fieldsList.map { f -> f.name to defaultValue(f.type, types) }
+          ),
         valid = false,
       )
     typeDecl.hasStruct() -> defaultStruct(typeName, typeDecl.struct.fieldsList, types)

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -65,7 +65,10 @@ class Environment {
     val copy = Environment()
     copy.scopes.clear()
     for (scope in scopes) {
-      copy.scopes.addLast(scope.mapValuesTo(mutableMapOf()) { it.value.deepCopy() })
+      // Pre-size to skip HashMap.resize on the fork-copy hot path (load factor 0.75).
+      copy.scopes.addLast(
+        scope.mapValuesTo(LinkedHashMap(scope.size * 4 / 3 + 1)) { it.value.deepCopy() }
+      )
     }
     return copy
   }

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -132,11 +132,18 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       return if (loc.isNotEmpty()) " (at $loc)" else ""
     }
 
+    // Pooled proto builders: reused across events within the same single-threaded Execution
+    // to avoid per-event allocation of builder objects and their internal byte arrays.
+    private val traceEventPool = TraceEvent.newBuilder()
+    private val branchEventPool = BranchEvent.newBuilder()
+    private val tableLookupPool = TableLookupEvent.newBuilder()
+    private val actionExecPool = ActionExecutionEvent.newBuilder()
+
     /** Builds a TraceEvent with source info attached, if available. */
     private fun traceEventBuilder(sourceInfo: SourceInfo? = currentSourceInfo): TraceEvent.Builder {
-      val b = TraceEvent.newBuilder()
-      sourceInfo?.let { b.sourceInfo = it }
-      return b
+      traceEventPool.clear()
+      sourceInfo?.let { traceEventPool.sourceInfo = it }
+      return traceEventPool
     }
 
     // -------------------------------------------------------------------------
@@ -357,7 +364,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       packetCtx?.addTraceEvent(
         traceEventBuilder()
           .setBranch(
-            BranchEvent.newBuilder().setControlName(currentControlName ?: "").setTaken(condition)
+            branchEventPool.clear().setControlName(currentControlName ?: "").setTaken(condition)
           )
           .build()
       )
@@ -383,23 +390,24 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     // Expressions
     // -------------------------------------------------------------------------
 
+    // Dispatch on kindCase for exhaustive matching (compiler-enforced coverage of all oneof arms).
     fun evalExpr(expr: Expr, env: Environment): Value =
-      when {
-        expr.hasLiteral() -> evalLiteral(expr.literal, expr.type)
-        expr.hasNameRef() ->
+      when (expr.kindCase) {
+        Expr.KindCase.LITERAL -> evalLiteral(expr.literal, expr.type)
+        Expr.KindCase.NAME_REF ->
           env.lookup(expr.nameRef.name)
             ?: error("undefined variable: ${expr.nameRef.name}${sourceContext()}")
-        expr.hasFieldAccess() -> evalFieldAccess(expr.fieldAccess, env)
-        expr.hasArrayIndex() -> evalArrayIndex(expr.arrayIndex, env)
-        expr.hasSlice() -> evalSlice(expr.slice, env)
-        expr.hasConcat() -> evalConcat(expr.concat, env)
-        expr.hasCast() -> evalCast(expr.cast, env)
-        expr.hasBinaryOp() -> evalBinaryOp(expr.binaryOp, env)
-        expr.hasUnaryOp() -> evalUnaryOp(expr.unaryOp, env)
-        expr.hasMethodCall() -> evalMethodCall(expr.methodCall, expr.type, env)
-        expr.hasMux() -> evalMux(expr.mux, env)
-        expr.hasStructExpr() -> evalStructExpr(expr.structExpr, expr.type, env)
-        expr.hasTableApply() -> {
+        Expr.KindCase.FIELD_ACCESS -> evalFieldAccess(expr.fieldAccess, env)
+        Expr.KindCase.ARRAY_INDEX -> evalArrayIndex(expr.arrayIndex, env)
+        Expr.KindCase.SLICE -> evalSlice(expr.slice, env)
+        Expr.KindCase.CONCAT -> evalConcat(expr.concat, env)
+        Expr.KindCase.CAST -> evalCast(expr.cast, env)
+        Expr.KindCase.BINARY_OP -> evalBinaryOp(expr.binaryOp, env)
+        Expr.KindCase.UNARY_OP -> evalUnaryOp(expr.unaryOp, env)
+        Expr.KindCase.METHOD_CALL -> evalMethodCall(expr.methodCall, expr.type, env)
+        Expr.KindCase.MUX -> evalMux(expr.mux, env)
+        Expr.KindCase.STRUCT_EXPR -> evalStructExpr(expr.structExpr, expr.type, env)
+        Expr.KindCase.TABLE_APPLY -> {
           val result = applyTable(expr.tableApply.tableName, env)
           when (expr.tableApply.accessKind) {
             TableApplyExpr.AccessKind.HIT -> BoolVal(result.hit)
@@ -407,7 +415,8 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             else -> UnitVal // RESULT / default: switch context
           }
         }
-        else -> error("unhandled expression kind: $expr${sourceContext()}")
+        Expr.KindCase.KIND_NOT_SET,
+        null -> error("unhandled expression kind: $expr${sourceContext()}")
       }
 
     private fun evalLiteral(lit: Literal, type: fourward.ir.Type): Value =
@@ -805,7 +814,8 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       packetCtx?.addTraceEvent(
         traceEventBuilder()
           .setTableLookup(
-            TableLookupEvent.newBuilder()
+            tableLookupPool
+              .clear()
               .setTableName(tableStore.tableDisplayName(tableName))
               .setHit(result.hit)
               .setActionName(tableStore.actionDisplayName(result.actionName))
@@ -857,7 +867,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       if (actionName == "NoAction") {
         packetCtx?.addTraceEvent(
           traceEventBuilder()
-            .setActionExecution(ActionExecutionEvent.newBuilder().setActionName(actionName))
+            .setActionExecution(actionExecPool.clear().setActionName(actionName))
             .build()
         )
         return
@@ -888,7 +898,8 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         packetCtx?.addTraceEvent(
           traceEventBuilder()
             .setActionExecution(
-              ActionExecutionEvent.newBuilder()
+              actionExecPool
+                .clear()
                 .setActionName(displayName)
                 .putAllParams(paramMap.mapValues { it.value })
             )
@@ -1313,11 +1324,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           val src = value as BitVal
           val hi = lhs.slice.hi
           val lo = lhs.slice.lo
-          val mask =
-            BitVector(
-              BigInteger.TWO.pow(hi - lo + 1).minus(BigInteger.ONE).shiftLeft(lo),
-              target.bits.width,
-            )
+          val mask = BitVector(BitVector.maskFor(hi - lo + 1).shiftLeft(lo), target.bits.width)
           val shifted = BitVector(src.bits.value.shiftLeft(lo), target.bits.width)
           val result = (target.bits and mask.inv()) or (shifted and mask)
           setLValue(lhs.slice.expr, BitVal(result), env)

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -93,10 +93,18 @@ data class HeaderVal(
     }
   }
 
-  fun copy(): HeaderVal = HeaderVal(typeName, fields.toMutableMap(), valid)
+  fun copy(): HeaderVal = HeaderVal(typeName, copyFields(), valid)
 
-  override fun deepCopy(): HeaderVal =
-    HeaderVal(typeName, fields.mapValuesTo(mutableMapOf()) { it.value.deepCopy() }, valid)
+  /**
+   * P4 headers contain only primitive fields (`bit<N>`, `int<N>`, `bool`, `varbit`), whose
+   * [Value.deepCopy] returns `this`. So deep-copy is equivalent to a shallow map copy — no
+   * per-entry recursion needed. For [CompactFieldMap]-backed headers (the common path via
+   * [defaultValue]), this is a single [Array.copyOf] with no per-entry allocation.
+   */
+  override fun deepCopy(): HeaderVal = HeaderVal(typeName, copyFields(), valid)
+
+  private fun copyFields(): MutableMap<String, Value> =
+    if (fields is CompactFieldMap) fields.copy() else LinkedHashMap(fields)
 }
 
 /**
@@ -105,10 +113,14 @@ data class HeaderVal(
  */
 data class StructVal(val typeName: String, val fields: MutableMap<String, Value> = mutableMapOf()) :
   Value() {
-  fun copy(): StructVal = StructVal(typeName, fields.toMutableMap())
+  fun copy(): StructVal = StructVal(typeName, LinkedHashMap(fields))
 
   override fun deepCopy(): StructVal =
-    StructVal(typeName, fields.mapValuesTo(mutableMapOf()) { it.value.deepCopy() })
+    StructVal(
+      typeName,
+      // Pre-size to avoid HashMap.resize on the fork-copy hot path (load factor 0.75).
+      fields.mapValuesTo(LinkedHashMap(fields.size * 4 / 3 + 1)) { it.value.deepCopy() },
+    )
 
   /** P4 spec §8.20: a header union is valid if any member header is valid. */
   fun isUnionValid(): Boolean = fields.values.any { it is HeaderVal && it.valid }


### PR DESCRIPTION
## Summary

Profile-driven optimizations for parallel throughput and scaling
efficiency on fork-heavy workloads. Seven code changes + AGENTS.md
convention + Phase 3 roadmap in the scaling doc.

BitVector stays a data class — the full Long-backed dual-storage
refactor is deferred to a follow-up for separate review.

## Measured (AMD Ryzen 9 7950X3D, SAI middleblock, 5-run medians)

| Workload | Main | This PR | Δ | Main Eff | PR Eff |
|---|---|---|---|---|---|
| direct parallel | 38,449 | **39,442** | +3% | 94% | ~96% |
| wcmp×16+mirr parallel | 5,624 | **8,087** | **+44%** | 53% | **~72%** |
| wcmp×128 parallel | 1,501 | **2,169** | **+44%** | 45% | **62%** |
| wcmp×128 sequential | 209 | **220** | +5% | | |

## Changes

1. **BitVector.\<init\>**: \`bitLength() <= width\` instead of
   \`TWO.pow(width)\` bounds check. Clearer AND faster.
2. **BitVector mask cache**: \`maskFor(width)\` eliminates repeated
   \`TWO.pow(width)\` allocations in arithmetic.
3. **CompactFieldMap**: array-backed map for header fields. Fork-copy
   is one \`Array.copyOf\` vs per-entry HashMap Node allocation.
4. **HeaderVal.deepCopy**: shallow copy (headers are primitives-only).
5. **Pre-sized fork-copy LinkedHashMaps**: avoid \`HashMap.resize\`.
6. **Proto builder pooling**: reuse event builders within each
   single-threaded Execution.
7. **evalExpr enum dispatch**: \`when(expr.kindCase)\` for exhaustive
   matching per AGENTS.md convention.
8. **AGENTS.md**: proto oneof dispatch convention.
9. **Scaling doc**: Phase 3 structural candidates.

## Test plan

- [x] \`bazel test //... --test_tag_filters=-heavy\` — 65/65 pass
- [x] \`./tools/format.sh\` clean
- [x] \`./tools/lint.sh\` clean
- [x] Benchmarked 5 runs × 3 workloads on quiet system
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)