### PR TITLE
Drop stale boost reference from big-integer serialization comment

### DIFF
--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -122,7 +122,7 @@ fourward::ir::Expr FourWardBackend::emitExpr(const IR::Expression* expr) {
     if (cnst->fitsUint64()) {
       lit->set_integer(cnst->asUint64());
     } else {
-      // Serialise as big-endian bytes using boost::multiprecision::export_bits.
+      // Serialise as big-endian bytes.
       std::string bytes;
       auto v = cnst->value;
       while (v != 0) {


### PR DESCRIPTION
One-word comment fix — the code doesn't use boost.