### PR TITLE
Enable C++ exceptions for p4c_backend targets

### DIFF
--- a/p4c_backend/BUILD.bazel
+++ b/p4c_backend/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 package(
     default_applicable_licenses = ["//:license"],
+    features = ["exceptions"],  # p4c uses C++ exceptions throughout.
     licenses = ["notice"],
 )
 


### PR DESCRIPTION
## Summary

p4c uses C++ exceptions throughout. google3/blaze defaults to \`-fno-exceptions\`, breaking our \`main.cpp\` catch block. Add \`features = [\"exceptions\"]\` to all p4c_backend targets.

This also fixes the boost link error from google3 — with exceptions enabled, the boost \`throw_exception\` symbol is resolved from p4c's pre-compiled libraries (which are also built with exceptions).

No-op on OSS Bazel (exceptions already enabled by default).

## Test plan

- [x] \`bazel build //p4c_backend:p4c-4ward\`
- [ ] CI