### PR TITLE
p4c_backend: disable header modules to fix google3 PCM mismatch

### DIFF
--- a/p4c_backend/BUILD.bazel
+++ b/p4c_backend/BUILD.bazel
@@ -5,6 +5,10 @@ _P4C_COPTS = ["-fexceptions"]
 
 package(
     default_applicable_licenses = ["//:license"],
+    # -use_header_modules: precompiled modules in google3 are built with
+    # -fno-exceptions; our -fexceptions flag creates a configuration mismatch
+    # that prevents loading them. Disable header modules for this package.
+    features = ["-use_header_modules"],
     licenses = ["notice"],
 )
 


### PR DESCRIPTION
Follow-up to #558. google3's precompiled modules are built with `-fno-exceptions`; our `-fexceptions` copt creates a config mismatch. `features = ["-use_header_modules"]` disables PCM loading for this package.