### PR TITLE
Switch all proto oneof dispatch to exhaustive kindCase (closes #552)

### DIFF
--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -13,8 +13,8 @@ object TraceFormatter {
     for (event in tree.eventsList) {
       appendEvent(event, indent)
     }
-    when {
-      tree.hasForkOutcome() -> {
+    when (tree.outcomeCase) {
+      TraceTree.OutcomeCase.FORK_OUTCOME -> {
         val fork = tree.forkOutcome
         appendLine("${pad(indent)}fork (${fork.reason.humanName()})")
         for (branch in fork.branchesList) {
@@ -22,36 +22,40 @@ object TraceFormatter {
           appendTree(branch.subtree, indent + 2)
         }
       }
-      tree.hasPacketOutcome() -> {
+      TraceTree.OutcomeCase.PACKET_OUTCOME -> {
         val outcome = tree.packetOutcome
-        when {
-          outcome.hasOutput() -> {
+        when (outcome.outcomeCase) {
+          fourward.sim.PacketOutcome.OutcomeCase.OUTPUT -> {
             val out = outcome.output
             appendLine(
               "${pad(indent)}output port ${out.dataplaneEgressPort}, ${out.payload.size()} bytes"
             )
           }
-          outcome.hasDrop() -> {
+          fourward.sim.PacketOutcome.OutcomeCase.DROP -> {
             appendLine("${pad(indent)}drop (reason: ${outcome.drop.reason.humanName()})")
           }
+          fourward.sim.PacketOutcome.OutcomeCase.OUTCOME_NOT_SET,
+          null -> {}
         }
       }
+      TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+      null -> {}
     }
   }
 
   private fun StringBuilder.appendEvent(event: TraceEvent, indent: Int) {
     val prefix = pad(indent)
-    when {
-      event.hasParserTransition() -> {
+    when (event.eventCase) {
+      TraceEvent.EventCase.PARSER_TRANSITION -> {
         val pt = event.parserTransition
         appendLine("${prefix}parse: ${pt.fromState} -> ${pt.toState}")
       }
-      event.hasTableLookup() -> {
+      TraceEvent.EventCase.TABLE_LOOKUP -> {
         val tl = event.tableLookup
         val result = if (tl.hit) "hit" else "miss"
         appendLine("${prefix}table ${tl.tableName}: $result -> ${tl.actionName}")
       }
-      event.hasActionExecution() -> {
+      TraceEvent.EventCase.ACTION_EXECUTION -> {
         val ae = event.actionExecution
         if (ae.paramsMap.isEmpty()) {
           appendLine("${prefix}action ${ae.actionName}")
@@ -60,22 +64,29 @@ object TraceFormatter {
           appendLine("${prefix}action ${ae.actionName}($params)")
         }
       }
-      event.hasBranch() -> {
+      TraceEvent.EventCase.BRANCH -> {
         val b = event.branch
         val dir = if (b.taken) "then" else "else"
         appendLine("${prefix}branch ${b.controlName}: $dir")
       }
-      event.hasExternCall() -> {
+      TraceEvent.EventCase.EXTERN_CALL -> {
         val ec = event.externCall
         appendLine("${prefix}extern ${ec.externInstanceName}.${ec.method}()")
       }
-      event.hasMarkToDrop() -> appendLine("${prefix}mark_to_drop()")
-      event.hasClone() -> appendLine("${prefix}clone session ${event.clone.sessionId}")
-      event.hasLogMessage() -> appendLine("${prefix}log_msg: ${event.logMessage.message}")
-      event.hasAssertion() -> {
+      TraceEvent.EventCase.MARK_TO_DROP -> appendLine("${prefix}mark_to_drop()")
+      TraceEvent.EventCase.CLONE -> appendLine("${prefix}clone session ${event.clone.sessionId}")
+      TraceEvent.EventCase.LOG_MESSAGE ->
+        appendLine("${prefix}log_msg: ${event.logMessage.message}")
+      TraceEvent.EventCase.ASSERTION -> {
         val result = if (event.assertion.passed) "passed" else "FAILED"
         appendLine("${prefix}assert: $result")
       }
+      TraceEvent.EventCase.PACKET_INGRESS,
+      TraceEvent.EventCase.PIPELINE_STAGE,
+      TraceEvent.EventCase.CLONE_SESSION_LOOKUP,
+      TraceEvent.EventCase.DEPARSER_EMIT,
+      TraceEvent.EventCase.EVENT_NOT_SET,
+      null -> {}
     }
   }
 

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -88,10 +88,11 @@ class TraceTreeConsistencyTest(private val testName: String) {
 
   /** Recursively collects all leaf [PacketOutcome]s from a trace tree. */
   private fun collectLeafOutcomes(tree: TraceTree): List<PacketOutcome> =
-    when {
-      tree.hasPacketOutcome() -> listOf(tree.packetOutcome)
-      tree.hasForkOutcome() ->
+    when (tree.outcomeCase) {
+      TraceTree.OutcomeCase.PACKET_OUTCOME -> listOf(tree.packetOutcome)
+      TraceTree.OutcomeCase.FORK_OUTCOME ->
         tree.forkOutcome.branchesList.flatMap { collectLeafOutcomes(it.subtree) }
-      else -> emptyList()
+      TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+      null -> emptyList()
     }
 }

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -537,8 +537,8 @@ class P4RuntimeService(
     }
 
     val translatedPre =
-      when {
-        pre.hasMulticastGroupEntry() -> {
+      when (pre.typeCase) {
+        P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.MULTICAST_GROUP_ENTRY -> {
           val group = pre.multicastGroupEntry
           val translated = group.replicasList.map { translateReplica(it) }
           pre
@@ -546,7 +546,7 @@ class P4RuntimeService(
             .setMulticastGroupEntry(group.toBuilder().clearReplicas().addAllReplicas(translated))
             .build()
         }
-        pre.hasCloneSessionEntry() -> {
+        P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.CLONE_SESSION_ENTRY -> {
           val session = pre.cloneSessionEntry
           val translated = session.replicasList.map { translateReplica(it) }
           pre
@@ -554,7 +554,8 @@ class P4RuntimeService(
             .setCloneSessionEntry(session.toBuilder().clearReplicas().addAllReplicas(translated))
             .build()
         }
-        else -> return update
+        P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.TYPE_NOT_SET,
+        null -> return update
       }
     return update
       .toBuilder()
@@ -644,14 +645,16 @@ class P4RuntimeService(
 
       try {
         requests.collect { msg ->
-          when {
-            msg.hasArbitration() ->
+          when (msg.updateCase) {
+            StreamMessageRequest.UpdateCase.ARBITRATION ->
               send(handleArbitration(streamId, msg.arbitration, notifications))
-            msg.hasPacket() -> handlePacketOut(msg.packet)
-            msg.hasDigestAck() ->
+            StreamMessageRequest.UpdateCase.PACKET -> handlePacketOut(msg.packet)
+            StreamMessageRequest.UpdateCase.DIGEST_ACK ->
               throw Status.UNIMPLEMENTED.withDescription(DIGEST_NOT_SUPPORTED).asException()
             // P4Runtime spec §16: unrecognized stream messages get an error response.
-            else ->
+            StreamMessageRequest.UpdateCase.OTHER,
+            StreamMessageRequest.UpdateCase.UPDATE_NOT_SET,
+            null ->
               send(
                 StreamMessageResponse.newBuilder()
                   .setError(
@@ -1023,12 +1026,24 @@ class P4RuntimeService(
 
   /** Rejects entity types that are documented but not implemented. */
   private fun rejectUnsupportedEntity(entity: P4RuntimeOuterClass.Entity) {
-    when {
-      entity.hasDigestEntry() ->
+    when (entity.entityCase) {
+      P4RuntimeOuterClass.Entity.EntityCase.DIGEST_ENTRY ->
         throw Status.UNIMPLEMENTED.withDescription(DIGEST_NOT_SUPPORTED).asException()
-      // ValueSetEntry is now handled via the normal write/read path in TableStore.
-      entity.hasExternEntry() ->
+      P4RuntimeOuterClass.Entity.EntityCase.EXTERN_ENTRY ->
         throw Status.UNIMPLEMENTED.withDescription(EXTERN_ENTRY_NOT_SUPPORTED).asException()
+      // All other entity types are handled via the normal write/read path.
+      P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER,
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_GROUP,
+      P4RuntimeOuterClass.Entity.EntityCase.COUNTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_COUNTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.METER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_METER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.REGISTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.VALUE_SET_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.ENTITY_NOT_SET,
+      null -> {}
     }
   }
 

--- a/p4runtime/PacketHeaderCodec.kt
+++ b/p4runtime/PacketHeaderCodec.kt
@@ -170,11 +170,16 @@ private constructor(
     private const val DEFAULT_PORT_BITS = 9
 
     private fun bitWidth(type: Type): Int =
-      when {
-        type.hasBit() -> type.bit.width
-        type.hasSignedInt() -> type.signedInt.width
-        type.hasBoolean() -> 1
-        else -> error("unsupported type in packet header: $type")
+      when (type.kindCase) {
+        Type.KindCase.BIT -> type.bit.width
+        Type.KindCase.SIGNED_INT -> type.signedInt.width
+        Type.KindCase.BOOLEAN -> 1
+        Type.KindCase.VARBIT,
+        Type.KindCase.NAMED,
+        Type.KindCase.HEADER_STACK,
+        Type.KindCase.ERROR,
+        Type.KindCase.KIND_NOT_SET,
+        null -> error("unsupported type in packet header: $type")
       }
   }
 }

--- a/p4runtime/ReferenceValidator.kt
+++ b/p4runtime/ReferenceValidator.kt
@@ -55,8 +55,8 @@ private constructor(
     if (update.type == P4RuntimeOuterClass.Update.Type.DELETE) return
     val entity = update.entity
 
-    when {
-      entity.hasTableEntry() -> {
+    when (entity.entityCase) {
+      P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY -> {
         val entry = entity.tableEntry
 
         // Check match fields.
@@ -74,19 +74,36 @@ private constructor(
         // Check action params — direct action or one-shot action profile action set.
         if (entry.hasAction()) {
           val tableAction = entry.action
-          when {
-            tableAction.hasAction() ->
+          when (tableAction.typeCase) {
+            P4RuntimeOuterClass.TableAction.TypeCase.ACTION ->
               validateActionParams(tableAction.action, entryExists, multicastGroupExists)
-            tableAction.hasActionProfileActionSet() ->
+            P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_ACTION_SET ->
               for (profileAction in tableAction.actionProfileActionSet.actionProfileActionsList) {
                 validateActionParams(profileAction.action, entryExists, multicastGroupExists)
               }
+            P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_MEMBER_ID,
+            P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_GROUP_ID,
+            P4RuntimeOuterClass.TableAction.TypeCase.TYPE_NOT_SET,
+            null -> {}
           }
         }
       }
 
-      entity.hasActionProfileMember() ->
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER ->
         validateActionParams(entity.actionProfileMember.action, entryExists, multicastGroupExists)
+
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_GROUP,
+      P4RuntimeOuterClass.Entity.EntityCase.COUNTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_COUNTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.METER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_METER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.REGISTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.VALUE_SET_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIGEST_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.EXTERN_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.ENTITY_NOT_SET,
+      null -> {}
     }
   }
 
@@ -132,10 +149,15 @@ private constructor(
 
   /** Extracts the exact-match value from a FieldMatch, or null for non-exact fields. */
   private fun extractExactValue(fm: P4RuntimeOuterClass.FieldMatch): ByteString? =
-    when {
-      fm.hasExact() -> fm.exact.value
-      fm.hasOptional() -> fm.optional.value
-      else -> null
+    when (fm.fieldMatchTypeCase) {
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT -> fm.exact.value
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL -> fm.optional.value
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY,
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM,
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE,
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+      null -> null
     }
 
   companion object {

--- a/p4runtime/TraceEnricher.kt
+++ b/p4runtime/TraceEnricher.kt
@@ -45,8 +45,8 @@ object TraceEnricher {
       }
     }
 
-    when {
-      tree.hasForkOutcome() -> {
+    when (tree.outcomeCase) {
+      TraceTree.OutcomeCase.FORK_OUTCOME -> {
         val fork = tree.forkOutcome
         for (i in 0 until fork.branchesCount) {
           val branch = fork.getBranches(i)
@@ -58,15 +58,17 @@ object TraceEnricher {
           }
         }
       }
-      tree.hasPacketOutcome() && pt != null -> {
-        val output = tree.packetOutcome.output
-        if (tree.packetOutcome.hasOutput()) {
+      TraceTree.OutcomeCase.PACKET_OUTCOME -> {
+        if (pt != null && tree.packetOutcome.hasOutput()) {
+          val output = tree.packetOutcome.output
           val p4rtPort = pt.dataplaneToP4rt(output.dataplaneEgressPort)
           if (p4rtPort != null) {
             lazyBuilder().packetOutcomeBuilder.outputBuilder.setP4RtEgressPort(p4rtPort)
           }
         }
       }
+      TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+      null -> {}
     }
 
     return builder?.build() ?: tree

--- a/p4runtime/TypeTranslator.kt
+++ b/p4runtime/TypeTranslator.kt
@@ -153,12 +153,12 @@ private constructor(
   /** Translates a Write update from P4Runtime to data-plane representation. */
   fun translateForWrite(update: Update): Update {
     val entity = update.entity
-    return when {
-      entity.hasTableEntry() -> {
+    return when (entity.entityCase) {
+      Entity.EntityCase.TABLE_ENTRY -> {
         val translated = translateTableEntry(entity.tableEntry, toDataplane = true) ?: return update
         update.toBuilder().setEntity(entity.toBuilder().setTableEntry(translated)).build()
       }
-      entity.hasActionProfileMember() -> {
+      Entity.EntityCase.ACTION_PROFILE_MEMBER -> {
         val member = entity.actionProfileMember
         val translated = translateAction(member.action, toDataplane = true) ?: return update
         update
@@ -168,24 +168,46 @@ private constructor(
           )
           .build()
       }
-      else -> update
+      Entity.EntityCase.ACTION_PROFILE_GROUP,
+      Entity.EntityCase.COUNTER_ENTRY,
+      Entity.EntityCase.DIRECT_COUNTER_ENTRY,
+      Entity.EntityCase.METER_ENTRY,
+      Entity.EntityCase.DIRECT_METER_ENTRY,
+      Entity.EntityCase.REGISTER_ENTRY,
+      Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
+      Entity.EntityCase.VALUE_SET_ENTRY,
+      Entity.EntityCase.DIGEST_ENTRY,
+      Entity.EntityCase.EXTERN_ENTRY,
+      Entity.EntityCase.ENTITY_NOT_SET,
+      null -> update
     }
   }
 
   /** Translates a Read entity from data-plane to P4Runtime representation. */
   fun translateForRead(entity: Entity): Entity =
-    when {
-      entity.hasTableEntry() -> {
+    when (entity.entityCase) {
+      Entity.EntityCase.TABLE_ENTRY -> {
         val translated =
           translateTableEntry(entity.tableEntry, toDataplane = false) ?: return entity
         entity.toBuilder().setTableEntry(translated).build()
       }
-      entity.hasActionProfileMember() -> {
+      Entity.EntityCase.ACTION_PROFILE_MEMBER -> {
         val member = entity.actionProfileMember
         val translated = translateAction(member.action, toDataplane = false) ?: return entity
         entity.toBuilder().setActionProfileMember(member.toBuilder().setAction(translated)).build()
       }
-      else -> entity
+      Entity.EntityCase.ACTION_PROFILE_GROUP,
+      Entity.EntityCase.COUNTER_ENTRY,
+      Entity.EntityCase.DIRECT_COUNTER_ENTRY,
+      Entity.EntityCase.METER_ENTRY,
+      Entity.EntityCase.DIRECT_METER_ENTRY,
+      Entity.EntityCase.REGISTER_ENTRY,
+      Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
+      Entity.EntityCase.VALUE_SET_ENTRY,
+      Entity.EntityCase.DIGEST_ENTRY,
+      Entity.EntityCase.EXTERN_ENTRY,
+      Entity.EntityCase.ENTITY_NOT_SET,
+      null -> entity
     }
 
   /**
@@ -320,8 +342,8 @@ private constructor(
         if (typeName != null) {
           changed = true
           val table = getOrCreateTable(typeName)
-          when {
-            match.hasExact() -> {
+          when (match.fieldMatchTypeCase) {
+            p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT -> {
               val translated = translateValue(table, match.exact.value, toDataplane)
               match
                 .toBuilder()
@@ -330,7 +352,7 @@ private constructor(
                 )
                 .build()
             }
-            match.hasOptional() -> {
+            p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL -> {
               val translated = translateValue(table, match.optional.value, toDataplane)
               match
                 .toBuilder()
@@ -340,7 +362,12 @@ private constructor(
                 .build()
             }
             // Ternary/LPM/Range on translated types is nonsensical — pass through.
-            else -> match
+            p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY,
+            p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM,
+            p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE,
+            p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+            p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+            null -> match
           }
         } else {
           match

--- a/p4runtime/WriteValidator.kt
+++ b/p4runtime/WriteValidator.kt
@@ -56,10 +56,21 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
    */
   fun validate(update: P4RuntimeOuterClass.Update) {
     val entity = update.entity
-    when {
-      entity.hasTableEntry() -> validateTableEntry(update)
-      entity.hasActionProfileMember() -> validateMember(update)
-      entity.hasActionProfileGroup() -> validateGroup(update)
+    when (entity.entityCase) {
+      P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY -> validateTableEntry(update)
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER -> validateMember(update)
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_GROUP -> validateGroup(update)
+      P4RuntimeOuterClass.Entity.EntityCase.EXTERN_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.COUNTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_COUNTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.METER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_METER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.REGISTER_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.VALUE_SET_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIGEST_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.ENTITY_NOT_SET,
+      null -> {}
     }
   }
 
@@ -98,13 +109,18 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
 
     if (entry.hasAction()) {
       val tableAction = entry.action
-      when {
-        tableAction.hasAction() -> validateAction(tableAction.action, tableInfo)
+      when (tableAction.typeCase) {
+        P4RuntimeOuterClass.TableAction.TypeCase.ACTION ->
+          validateAction(tableAction.action, tableInfo)
         // P4Runtime spec §9.2.3: validate each action in a one-shot action set.
-        tableAction.hasActionProfileActionSet() ->
+        P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_ACTION_SET ->
           for (profileAction in tableAction.actionProfileActionSet.actionProfileActionsList) {
             validateAction(profileAction.action, tableInfo)
           }
+        P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_MEMBER_ID,
+        P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_GROUP_ID,
+        P4RuntimeOuterClass.TableAction.TypeCase.TYPE_NOT_SET,
+        null -> {}
       }
     }
     validateMatchFields(entry, tableInfo)
@@ -243,13 +259,20 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
     fieldInfo: P4InfoOuterClass.MatchField,
   ) {
     val actual =
-      when {
-        fm.hasExact() -> P4InfoOuterClass.MatchField.MatchType.EXACT
-        fm.hasTernary() -> P4InfoOuterClass.MatchField.MatchType.TERNARY
-        fm.hasLpm() -> P4InfoOuterClass.MatchField.MatchType.LPM
-        fm.hasRange() -> P4InfoOuterClass.MatchField.MatchType.RANGE
-        fm.hasOptional() -> P4InfoOuterClass.MatchField.MatchType.OPTIONAL
-        else -> throw invalidArg("match field '${fieldInfo.name}' has no value set")
+      when (fm.fieldMatchTypeCase) {
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
+          P4InfoOuterClass.MatchField.MatchType.EXACT
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY ->
+          P4InfoOuterClass.MatchField.MatchType.TERNARY
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM ->
+          P4InfoOuterClass.MatchField.MatchType.LPM
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE ->
+          P4InfoOuterClass.MatchField.MatchType.RANGE
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
+          P4InfoOuterClass.MatchField.MatchType.OPTIONAL
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+        null -> throw invalidArg("match field '${fieldInfo.name}' has no value set")
       }
     if (actual != fieldInfo.matchType) {
       throw invalidArg(
@@ -264,26 +287,31 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
   ) {
     val w = fieldInfo.bitwidth
     val f = fieldInfo.name
-    when {
-      fm.hasExact() -> checkWidth(w, fm.exact.value.size(), "match field '$f' value")
-      fm.hasTernary() -> {
+    when (fm.fieldMatchTypeCase) {
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
+        checkWidth(w, fm.exact.value.size(), "match field '$f' value")
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY -> {
         checkWidth(w, fm.ternary.value.size(), "match field '$f' value")
         checkWidth(w, fm.ternary.mask.size(), "match field '$f' mask")
         // §8.3: bits where mask is 0 must also be 0 in value.
         checkTernaryMaskedBits(fm.ternary.value, fm.ternary.mask, f)
       }
-      fm.hasLpm() -> {
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM -> {
         checkWidth(w, fm.lpm.value.size(), "match field '$f' value")
         // §8.3: bits beyond prefix_len must be zero.
         checkLpmTrailingBits(fm.lpm.value, fm.lpm.prefixLen, f)
       }
-      fm.hasRange() -> {
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE -> {
         checkWidth(w, fm.range.low.size(), "match field '$f' low")
         checkWidth(w, fm.range.high.size(), "match field '$f' high")
         // P4Runtime spec §9.1.1: low must be <= high.
         checkRangeOrder(fm.range.low, fm.range.high, f)
       }
-      fm.hasOptional() -> checkWidth(w, fm.optional.value.size(), "match field '$f' value")
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
+        checkWidth(w, fm.optional.value.size(), "match field '$f' value")
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+      P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+      null -> {}
     }
   }
 

--- a/simulator/DefaultValues.kt
+++ b/simulator/DefaultValues.kt
@@ -26,18 +26,22 @@ import java.math.BigInteger
  * unrecognised types → [UnitVal].
  */
 internal fun defaultValue(type: Type, types: Map<String, TypeDecl>): Value =
-  when {
-    type.hasBit() -> BitVal(0L, type.bit.width)
-    type.hasSignedInt() -> IntVal(SignedBitVector(java.math.BigInteger.ZERO, type.signedInt.width))
-    type.hasBoolean() -> BoolVal(false)
-    type.hasNamed() -> defaultValue(type.named, types)
-    type.hasHeaderStack() ->
+  when (type.kindCase) {
+    Type.KindCase.BIT -> BitVal(0L, type.bit.width)
+    Type.KindCase.SIGNED_INT ->
+      IntVal(SignedBitVector(java.math.BigInteger.ZERO, type.signedInt.width))
+    Type.KindCase.BOOLEAN -> BoolVal(false)
+    Type.KindCase.NAMED -> defaultValue(type.named, types)
+    Type.KindCase.HEADER_STACK ->
       HeaderStackVal(
         elementTypeName = type.headerStack.elementType,
         headers =
           MutableList(type.headerStack.size) { defaultValue(type.headerStack.elementType, types) },
       )
-    else -> UnitVal // varbit<N>: variable-length; no fixed default
+    Type.KindCase.VARBIT,
+    Type.KindCase.ERROR,
+    Type.KindCase.KIND_NOT_SET,
+    null -> UnitVal // varbit<N>: variable-length; no fixed default
   }
 
 /**
@@ -49,8 +53,8 @@ internal fun defaultValue(type: Type, types: Map<String, TypeDecl>): Value =
  */
 internal fun defaultValue(typeName: String, types: Map<String, TypeDecl>): Value {
   val typeDecl = types[typeName] ?: return UnitVal
-  return when {
-    typeDecl.hasHeader() ->
+  return when (typeDecl.kindCase) {
+    TypeDecl.KindCase.HEADER ->
       HeaderVal(
         typeName = typeName,
         fields =
@@ -59,13 +63,16 @@ internal fun defaultValue(typeName: String, types: Map<String, TypeDecl>): Value
           ),
         valid = false,
       )
-    typeDecl.hasStruct() -> defaultStruct(typeName, typeDecl.struct.fieldsList, types)
+    TypeDecl.KindCase.STRUCT -> defaultStruct(typeName, typeDecl.struct.fieldsList, types)
     // Header union (P4 spec §8.20): represented as a StructVal so field access works
     // uniformly; per-member validity is tracked via HeaderVal.valid.
-    typeDecl.hasHeaderUnion() -> defaultStruct(typeName, typeDecl.headerUnion.fieldsList, types)
+    TypeDecl.KindCase.HEADER_UNION ->
+      defaultStruct(typeName, typeDecl.headerUnion.fieldsList, types)
     // Serializable enum: default to zero of the underlying bit width.
-    typeDecl.hasEnum() && typeDecl.enum.width > 0 -> BitVal(0L, typeDecl.enum.width)
-    else -> UnitVal
+    TypeDecl.KindCase.ENUM ->
+      if (typeDecl.enum.width > 0) BitVal(0L, typeDecl.enum.width) else UnitVal
+    TypeDecl.KindCase.KIND_NOT_SET,
+    null -> UnitVal
   }
 }
 

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -5,15 +5,22 @@ import fourward.ir.BinaryOperator
 import fourward.ir.ControlDecl
 import fourward.ir.Direction
 import fourward.ir.Expr
+import fourward.ir.Expr.KindCase as ExprKind
 import fourward.ir.FieldDecl
+import fourward.ir.KeysetExpr
 import fourward.ir.Literal
+import fourward.ir.Literal.KindCase as LiteralKind
 import fourward.ir.MethodCall
 import fourward.ir.ParserDecl
 import fourward.ir.SourceInfo
 import fourward.ir.Stmt
+import fourward.ir.Stmt.KindCase as StmtKind
 import fourward.ir.TableApplyExpr
 import fourward.ir.TableBehavior
+import fourward.ir.Transition
 import fourward.ir.Type
+import fourward.ir.Type.KindCase as TypeKind
+import fourward.ir.TypeDecl
 import fourward.ir.UnaryOperator
 import fourward.sim.ActionExecutionEvent
 import fourward.sim.AssertionEvent
@@ -167,9 +174,11 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         for (stmt in state.stmtsList) execStmt(stmt, env)
 
         val (nextState, selectValue, selectExpr) =
-          when {
-            state.transition.hasSelect() -> evalSelectWithValue(state.transition.select, env)
-            else -> Triple(state.transition.nextState, "", "")
+          when (state.transition.kindCase) {
+            Transition.KindCase.SELECT -> evalSelectWithValue(state.transition.select, env)
+            Transition.KindCase.NEXT_STATE,
+            Transition.KindCase.KIND_NOT_SET,
+            null -> Triple(state.transition.nextState, "", "")
           }
 
         packetCtx?.addTraceEvent(
@@ -234,18 +243,18 @@ class Interpreter internal constructor(config: BehavioralConfig) {
 
     /** Human-readable rendering of an IR expression (best-effort, for trace display). */
     private fun formatExpr(expr: fourward.ir.Expr): String =
-      when {
-        expr.hasNameRef() -> expr.nameRef.name
-        expr.hasFieldAccess() ->
+      when (expr.kindCase) {
+        ExprKind.NAME_REF -> expr.nameRef.name
+        ExprKind.FIELD_ACCESS ->
           "${formatExpr(expr.fieldAccess.expr)}.${expr.fieldAccess.fieldName}"
-        expr.hasArrayIndex() ->
+        ExprKind.ARRAY_INDEX ->
           "${formatExpr(expr.arrayIndex.expr)}[${formatExpr(expr.arrayIndex.index)}]"
-        expr.hasSlice() -> "${formatExpr(expr.slice.expr)}[${expr.slice.hi}:${expr.slice.lo}]"
-        expr.hasLiteral() -> {
+        ExprKind.SLICE -> "${formatExpr(expr.slice.expr)}[${expr.slice.hi}:${expr.slice.lo}]"
+        ExprKind.LITERAL -> {
           val lit = expr.literal
-          when {
-            lit.hasInteger() -> "0x${lit.integer.toString(16).uppercase()}"
-            lit.hasBoolean() -> lit.boolean.toString()
+          when (lit.kindCase) {
+            LiteralKind.INTEGER -> "0x${lit.integer.toString(16).uppercase()}"
+            LiteralKind.BOOLEAN -> lit.boolean.toString()
             else -> lit.toString().trim()
           }
         }
@@ -257,22 +266,25 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       keyset: fourward.ir.KeysetExpr,
       constEnv: Environment,
     ): Boolean =
-      when {
-        keyset.hasDefaultCase() -> true
-        keyset.hasExact() -> value == evalExpr(keyset.exact, constEnv)
-        keyset.hasMask() -> {
+      when (keyset.kindCase) {
+        KeysetExpr.KindCase.DEFAULT_CASE -> true
+        KeysetExpr.KindCase.EXACT -> value == evalExpr(keyset.exact, constEnv)
+        KeysetExpr.KindCase.MASK -> {
           val v = (value as BitVal).bits
           val mask = (evalExpr(keyset.mask.mask, constEnv) as BitVal).bits
           val want = (evalExpr(keyset.mask.value, constEnv) as BitVal).bits
           (v and mask) == (want and mask)
         }
-        keyset.hasRange() -> {
+        KeysetExpr.KindCase.RANGE -> {
           val v = (value as BitVal).bits
           val lo = (evalExpr(keyset.range.lo, constEnv) as BitVal).bits
           val hi = (evalExpr(keyset.range.hi, constEnv) as BitVal).bits
           v >= lo && v <= hi
         }
-        else -> error("unhandled keyset kind: $keyset${sourceContext()}")
+        KeysetExpr.KindCase.VALUE_SET ->
+          error("value_set keyset should be handled before matchesKeyset${sourceContext()}")
+        KeysetExpr.KindCase.KIND_NOT_SET,
+        null -> error("unhandled keyset kind: $keyset${sourceContext()}")
       }
 
     /**
@@ -345,16 +357,17 @@ class Interpreter internal constructor(config: BehavioralConfig) {
 
     private fun execStmt(stmt: Stmt, env: Environment) {
       if (stmt.hasSourceInfo()) currentSourceInfo = stmt.sourceInfo else currentSourceInfo = null
-      when {
-        stmt.hasAssignment() ->
+      when (stmt.kindCase) {
+        StmtKind.ASSIGNMENT ->
           setLValue(stmt.assignment.lhs, evalExpr(stmt.assignment.rhs, env), env)
-        stmt.hasMethodCall() -> evalExpr(stmt.methodCall.call, env) // result discarded
-        stmt.hasIfStmt() -> execIf(stmt.ifStmt, env)
-        stmt.hasSwitchStmt() -> execSwitch(stmt.switchStmt, env)
-        stmt.hasBlock() -> execBlock(stmt.block.stmtsList, env)
-        stmt.hasExit() -> throw ExitException()
-        stmt.hasReturnStmt() -> throw ReturnException(evalExpr(stmt.returnStmt.value, env))
-        else -> error("unhandled statement kind: $stmt${sourceContext()}")
+        StmtKind.METHOD_CALL -> evalExpr(stmt.methodCall.call, env) // result discarded
+        StmtKind.IF_STMT -> execIf(stmt.ifStmt, env)
+        StmtKind.SWITCH_STMT -> execSwitch(stmt.switchStmt, env)
+        StmtKind.BLOCK -> execBlock(stmt.block.stmtsList, env)
+        StmtKind.EXIT -> throw ExitException()
+        StmtKind.RETURN_STMT -> throw ReturnException(evalExpr(stmt.returnStmt.value, env))
+        StmtKind.KIND_NOT_SET,
+        null -> error("unhandled statement kind: $stmt${sourceContext()}")
       }
     }
 
@@ -393,21 +406,21 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     // Dispatch on kindCase for exhaustive matching (compiler-enforced coverage of all oneof arms).
     fun evalExpr(expr: Expr, env: Environment): Value =
       when (expr.kindCase) {
-        Expr.KindCase.LITERAL -> evalLiteral(expr.literal, expr.type)
-        Expr.KindCase.NAME_REF ->
+        ExprKind.LITERAL -> evalLiteral(expr.literal, expr.type)
+        ExprKind.NAME_REF ->
           env.lookup(expr.nameRef.name)
             ?: error("undefined variable: ${expr.nameRef.name}${sourceContext()}")
-        Expr.KindCase.FIELD_ACCESS -> evalFieldAccess(expr.fieldAccess, env)
-        Expr.KindCase.ARRAY_INDEX -> evalArrayIndex(expr.arrayIndex, env)
-        Expr.KindCase.SLICE -> evalSlice(expr.slice, env)
-        Expr.KindCase.CONCAT -> evalConcat(expr.concat, env)
-        Expr.KindCase.CAST -> evalCast(expr.cast, env)
-        Expr.KindCase.BINARY_OP -> evalBinaryOp(expr.binaryOp, env)
-        Expr.KindCase.UNARY_OP -> evalUnaryOp(expr.unaryOp, env)
-        Expr.KindCase.METHOD_CALL -> evalMethodCall(expr.methodCall, expr.type, env)
-        Expr.KindCase.MUX -> evalMux(expr.mux, env)
-        Expr.KindCase.STRUCT_EXPR -> evalStructExpr(expr.structExpr, expr.type, env)
-        Expr.KindCase.TABLE_APPLY -> {
+        ExprKind.FIELD_ACCESS -> evalFieldAccess(expr.fieldAccess, env)
+        ExprKind.ARRAY_INDEX -> evalArrayIndex(expr.arrayIndex, env)
+        ExprKind.SLICE -> evalSlice(expr.slice, env)
+        ExprKind.CONCAT -> evalConcat(expr.concat, env)
+        ExprKind.CAST -> evalCast(expr.cast, env)
+        ExprKind.BINARY_OP -> evalBinaryOp(expr.binaryOp, env)
+        ExprKind.UNARY_OP -> evalUnaryOp(expr.unaryOp, env)
+        ExprKind.METHOD_CALL -> evalMethodCall(expr.methodCall, expr.type, env)
+        ExprKind.MUX -> evalMux(expr.mux, env)
+        ExprKind.STRUCT_EXPR -> evalStructExpr(expr.structExpr, expr.type, env)
+        ExprKind.TABLE_APPLY -> {
           val result = applyTable(expr.tableApply.tableName, env)
           when (expr.tableApply.accessKind) {
             TableApplyExpr.AccessKind.HIT -> BoolVal(result.hit)
@@ -415,33 +428,34 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             else -> UnitVal // RESULT / default: switch context
           }
         }
-        Expr.KindCase.KIND_NOT_SET,
+        ExprKind.KIND_NOT_SET,
         null -> error("unhandled expression kind: $expr${sourceContext()}")
       }
 
     private fun evalLiteral(lit: Literal, type: fourward.ir.Type): Value =
-      when {
-        lit.hasBoolean() -> BoolVal(lit.boolean)
-        lit.hasErrorMember() -> ErrorVal(lit.errorMember)
-        lit.hasEnumMember() -> EnumVal(lit.enumMember)
-        lit.hasStringLiteral() -> StringVal(lit.stringLiteral)
-        lit.hasInteger() -> {
+      when (lit.kindCase) {
+        LiteralKind.BOOLEAN -> BoolVal(lit.boolean)
+        LiteralKind.ERROR_MEMBER -> ErrorVal(lit.errorMember)
+        LiteralKind.ENUM_MEMBER -> EnumVal(lit.enumMember)
+        LiteralKind.STRING_LITERAL -> StringVal(lit.stringLiteral)
+        LiteralKind.INTEGER -> {
           val v = BigInteger.valueOf(lit.integer)
-          when {
-            type.hasBit() -> BitVal(BitVector(v, type.bit.width))
-            type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
+          when (type.kindCase) {
+            TypeKind.BIT -> BitVal(BitVector(v, type.bit.width))
+            TypeKind.SIGNED_INT -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
             else -> InfIntVal(v) // compile-time constant integer (P4 spec §8.1)
           }
         }
-        lit.hasBigInteger() -> {
+        LiteralKind.BIG_INTEGER -> {
           val v = BigInteger(1, lit.bigInteger.toByteArray())
-          when {
-            type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
-            type.hasBit() -> BitVal(BitVector(v, type.bit.width))
+          when (type.kindCase) {
+            TypeKind.SIGNED_INT -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
+            TypeKind.BIT -> BitVal(BitVector(v, type.bit.width))
             else -> error("big integer literal with unexpected type: $type${sourceContext()}")
           }
         }
-        else -> error("unhandled literal kind: $lit${sourceContext()}")
+        LiteralKind.KIND_NOT_SET,
+        null -> error("unhandled literal kind: $lit${sourceContext()}")
       }
 
     private fun evalFieldAccess(fa: fourward.ir.FieldAccess, env: Environment): Value {
@@ -516,8 +530,8 @@ class Interpreter internal constructor(config: BehavioralConfig) {
 
     private fun evalCast(cast: fourward.ir.Cast, env: Environment): Value {
       val inner = evalExpr(cast.expr, env)
-      return when {
-        cast.targetType.hasBit() -> {
+      return when (cast.targetType.kindCase) {
+        TypeKind.BIT -> {
           val targetWidth = cast.targetType.bit.width
           val sourceBits =
             when (inner) {
@@ -529,7 +543,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             }
           BitVal(BitVector(sourceBits.mod(BigInteger.TWO.pow(targetWidth)), targetWidth))
         }
-        cast.targetType.hasSignedInt() -> {
+        TypeKind.SIGNED_INT -> {
           val targetWidth = cast.targetType.signedInt.width
           when (inner) {
             // int<N> → int<M>: preserve the signed value (sign-extends or truncates).
@@ -556,7 +570,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             }
           }
         }
-        cast.targetType.boolean -> {
+        TypeKind.BOOLEAN -> {
           val v =
             when (inner) {
               is BitVal -> inner.bits.value
@@ -565,7 +579,12 @@ class Interpreter internal constructor(config: BehavioralConfig) {
             }
           BoolVal(v != BigInteger.ZERO)
         }
-        else -> error("unsupported cast target type: ${cast.targetType}${sourceContext()}")
+        TypeKind.VARBIT,
+        TypeKind.NAMED,
+        TypeKind.HEADER_STACK,
+        TypeKind.ERROR,
+        TypeKind.KIND_NOT_SET,
+        null -> error("unsupported cast target type: ${cast.targetType}${sourceContext()}")
       }
     }
 
@@ -1108,10 +1127,13 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       val typeName = returnType.named
       val typeDecl = types[typeName] ?: error("type not found for lookahead: $typeName")
       val fields =
-        when {
-          typeDecl.hasHeader() -> typeDecl.header.fieldsList
-          typeDecl.hasStruct() -> typeDecl.struct.fieldsList
-          else -> error("lookahead type must be a header or struct: $typeName")
+        when (typeDecl.kindCase) {
+          TypeDecl.KindCase.HEADER -> typeDecl.header.fieldsList
+          TypeDecl.KindCase.STRUCT -> typeDecl.struct.fieldsList
+          TypeDecl.KindCase.HEADER_UNION,
+          TypeDecl.KindCase.ENUM,
+          TypeDecl.KindCase.KIND_NOT_SET,
+          null -> error("lookahead type must be a header or struct: $typeName")
         }
       val widths = fields.map { fieldWireWidth(it.type) }
       val totalBits = widths.sum()
@@ -1161,19 +1183,26 @@ class Interpreter internal constructor(config: BehavioralConfig) {
      * Serializable enums are looked up by name and use their declared underlying width.
      */
     private fun fieldWireWidth(type: Type, varbitBits: Int = 0): Int =
-      when {
-        type.hasBit() -> type.bit.width
-        type.hasSignedInt() -> type.signedInt.width
-        type.hasBoolean() -> 1
-        type.hasVarbit() -> varbitBits
-        type.hasNamed() -> {
+      when (type.kindCase) {
+        TypeKind.BIT -> type.bit.width
+        TypeKind.SIGNED_INT -> type.signedInt.width
+        TypeKind.BOOLEAN -> 1
+        TypeKind.VARBIT -> varbitBits
+        TypeKind.NAMED -> {
           val decl = types[type.named]
-          when {
-            decl != null && decl.hasEnum() -> decl.enum.width
-            else -> 0
+          when (decl?.kindCase) {
+            TypeDecl.KindCase.ENUM -> decl.enum.width
+            TypeDecl.KindCase.HEADER,
+            TypeDecl.KindCase.STRUCT,
+            TypeDecl.KindCase.HEADER_UNION,
+            TypeDecl.KindCase.KIND_NOT_SET,
+            null -> 0
           }
         }
-        else -> 0
+        TypeKind.HEADER_STACK,
+        TypeKind.ERROR,
+        TypeKind.KIND_NOT_SET,
+        null -> 0
       }
 
     /**
@@ -1182,9 +1211,9 @@ class Interpreter internal constructor(config: BehavioralConfig) {
      * bit<N> → [BitVal], bool → [BoolVal], int<N> → [IntVal], varbit / enum → [BitVal].
      */
     private fun bitsToValue(type: Type, raw: BigInteger, width: Int): Value =
-      when {
-        type.hasBoolean() -> BoolVal(raw != BigInteger.ZERO)
-        type.hasSignedInt() -> IntVal(SignedBitVector.fromUnsignedBits(raw, width))
+      when (type.kindCase) {
+        TypeKind.BOOLEAN -> BoolVal(raw != BigInteger.ZERO)
+        TypeKind.SIGNED_INT -> IntVal(SignedBitVector.fromUnsignedBits(raw, width))
         else -> BitVal(BitVector(raw, width))
       }
 
@@ -1209,10 +1238,13 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           // Emit in the declaration order from the TypeDecl; fall back to map order if unknown.
           val typeDecl = types[value.typeName]
           val fieldDecls =
-            when {
-              typeDecl != null && typeDecl.hasStruct() -> typeDecl.struct.fieldsList
-              typeDecl != null && typeDecl.hasHeaderUnion() -> typeDecl.headerUnion.fieldsList
-              else -> null
+            when (typeDecl?.kindCase) {
+              TypeDecl.KindCase.STRUCT -> typeDecl.struct.fieldsList
+              TypeDecl.KindCase.HEADER_UNION -> typeDecl.headerUnion.fieldsList
+              TypeDecl.KindCase.HEADER,
+              TypeDecl.KindCase.ENUM,
+              TypeDecl.KindCase.KIND_NOT_SET,
+              null -> null
             }
           if (fieldDecls != null) {
             for (field in fieldDecls) {
@@ -1300,11 +1332,11 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           is StructVal -> value.copy()
           else -> value
         }
-      when {
-        lhs.hasNameRef() -> {
+      when (lhs.kindCase) {
+        ExprKind.NAME_REF -> {
           env.update(lhs.nameRef.name, copy)
         }
-        lhs.hasFieldAccess() -> {
+        ExprKind.FIELD_ACCESS -> {
           val target = evalExpr(lhs.fieldAccess.expr, env)
           when (target) {
             is HeaderVal -> target.fields[lhs.fieldAccess.fieldName] = copy
@@ -1313,12 +1345,12 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           }
         }
         // P4 spec §8.18: out-of-bounds writes are no-ops.
-        lhs.hasArrayIndex() -> {
+        ExprKind.ARRAY_INDEX -> {
           val stack = evalExpr(lhs.arrayIndex.expr, env) as HeaderStackVal
           val index = intValue(evalExpr(lhs.arrayIndex.index, env))
           if (index in 0 until stack.size) stack.headers[index] = copy
         }
-        lhs.hasSlice() -> {
+        ExprKind.SLICE -> {
           // Slice assignment: update [hi:lo] bits of the target.
           val target = evalExpr(lhs.slice.expr, env) as BitVal
           val src = value as BitVal
@@ -1329,7 +1361,17 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           val result = (target.bits and mask.inv()) or (shifted and mask)
           setLValue(lhs.slice.expr, BitVal(result), env)
         }
-        else -> error("unhandled lvalue kind: $lhs${sourceContext()}")
+        ExprKind.LITERAL,
+        ExprKind.CONCAT,
+        ExprKind.CAST,
+        ExprKind.BINARY_OP,
+        ExprKind.UNARY_OP,
+        ExprKind.METHOD_CALL,
+        ExprKind.TABLE_APPLY,
+        ExprKind.MUX,
+        ExprKind.STRUCT_EXPR,
+        ExprKind.KIND_NOT_SET,
+        null -> error("unhandled lvalue kind: $lhs${sourceContext()}")
       }
     }
   } // end Execution

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -216,20 +216,30 @@ class Simulator(
   ): List<p4.v1.P4RuntimeOuterClass.Entity> {
     val tableStore = loaded().tableStore
     return filters.flatMap { entity ->
-      when {
-        entity.hasTableEntry() -> emptyList()
-        entity.hasActionProfileMember() -> tableStore.readProfileMembers(entity.actionProfileMember)
-        entity.hasActionProfileGroup() -> tableStore.readProfileGroups(entity.actionProfileGroup)
-        entity.hasRegisterEntry() -> tableStore.readRegisterEntries(entity.registerEntry)
-        entity.hasCounterEntry() -> tableStore.readCounterEntries(entity.counterEntry)
-        entity.hasMeterEntry() -> tableStore.readMeterEntries(entity.meterEntry)
-        entity.hasDirectCounterEntry() ->
+      when (entity.entityCase) {
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY -> emptyList()
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER ->
+          tableStore.readProfileMembers(entity.actionProfileMember)
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_GROUP ->
+          tableStore.readProfileGroups(entity.actionProfileGroup)
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.REGISTER_ENTRY ->
+          tableStore.readRegisterEntries(entity.registerEntry)
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.COUNTER_ENTRY ->
+          tableStore.readCounterEntries(entity.counterEntry)
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.METER_ENTRY ->
+          tableStore.readMeterEntries(entity.meterEntry)
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.DIRECT_COUNTER_ENTRY ->
           tableStore.readDirectCounterEntries(entity.directCounterEntry)
-        entity.hasDirectMeterEntry() -> tableStore.readDirectMeterEntries(entity.directMeterEntry)
-        entity.hasPacketReplicationEngineEntry() ->
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.DIRECT_METER_ENTRY ->
+          tableStore.readDirectMeterEntries(entity.directMeterEntry)
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY ->
           tableStore.readPreEntries(entity.packetReplicationEngineEntry)
-        entity.hasValueSetEntry() -> tableStore.readValueSetEntries(entity.valueSetEntry)
-        else -> error("unsupported entity type for read: ${entity.entityCase}")
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.VALUE_SET_ENTRY ->
+          tableStore.readValueSetEntries(entity.valueSetEntry)
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.EXTERN_ENTRY,
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.DIGEST_ENTRY,
+        p4.v1.P4RuntimeOuterClass.Entity.EntityCase.ENTITY_NOT_SET,
+        null -> error("unsupported entity type for read: ${entity.entityCase}")
       }
     }
   }
@@ -251,12 +261,16 @@ class Simulator(
  * from a single real execution.
  */
 fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
-  if (!tree.hasForkOutcome()) {
-    return if (tree.hasPacketOutcome() && tree.packetOutcome.hasOutput()) {
-      listOf(listOf(tree.packetOutcome.output))
-    } else {
-      listOf(emptyList())
-    }
+  when (tree.outcomeCase) {
+    TraceTree.OutcomeCase.PACKET_OUTCOME ->
+      return if (tree.packetOutcome.hasOutput()) {
+        listOf(listOf(tree.packetOutcome.output))
+      } else {
+        listOf(emptyList())
+      }
+    TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+    null -> return listOf(emptyList())
+    TraceTree.OutcomeCase.FORK_OUTCOME -> {} // fall through to fork handling below
   }
   val fork = tree.forkOutcome
   val branchOutcomes = fork.branchesList.map { collectPossibleOutcomes(it.subtree) }

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -40,13 +40,14 @@ fun matchesFieldMatch(bits: BitVector, match: P4RuntimeOuterClass.FieldMatch): B
   else matchBig(bits.value, bits.width, match)
 
 private fun matchLong(bits: Long, width: Int, match: P4RuntimeOuterClass.FieldMatch): Boolean =
-  when {
-    match.hasExact() -> bits == match.exact.value.toUnsignedLong()
-    match.hasTernary() -> {
+  when (match.fieldMatchTypeCase) {
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
+      bits == match.exact.value.toUnsignedLong()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY -> {
       val mask = match.ternary.mask.toUnsignedLong()
       (bits and mask) == (match.ternary.value.toUnsignedLong() and mask)
     }
-    match.hasLpm() -> {
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM -> {
       val prefixLen = match.lpm.prefixLen
       if (prefixLen == 0) true
       else {
@@ -54,19 +55,24 @@ private fun matchLong(bits: Long, width: Int, match: P4RuntimeOuterClass.FieldMa
         bits ushr shift == match.lpm.value.toUnsignedLong() ushr shift
       }
     }
-    match.hasRange() -> bits in match.range.low.toUnsignedLong()..match.range.high.toUnsignedLong()
-    match.hasOptional() -> bits == match.optional.value.toUnsignedLong()
-    else -> true
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE ->
+      bits in match.range.low.toUnsignedLong()..match.range.high.toUnsignedLong()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
+      bits == match.optional.value.toUnsignedLong()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+    null -> true
   }
 
 private fun matchBig(bits: BigInteger, width: Int, match: P4RuntimeOuterClass.FieldMatch): Boolean =
-  when {
-    match.hasExact() -> bits == match.exact.value.toUnsignedBigInteger()
-    match.hasTernary() -> {
+  when (match.fieldMatchTypeCase) {
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
+      bits == match.exact.value.toUnsignedBigInteger()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY -> {
       val mask = match.ternary.mask.toUnsignedBigInteger()
       bits.and(mask) == match.ternary.value.toUnsignedBigInteger().and(mask)
     }
-    match.hasLpm() -> {
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM -> {
       val prefixLen = match.lpm.prefixLen
       if (prefixLen == 0) true
       else {
@@ -74,13 +80,16 @@ private fun matchBig(bits: BigInteger, width: Int, match: P4RuntimeOuterClass.Fi
         bits.shiftRight(shift) == match.lpm.value.toUnsignedBigInteger().shiftRight(shift)
       }
     }
-    match.hasRange() -> {
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE -> {
       val lo = match.range.low.toUnsignedBigInteger()
       val hi = match.range.high.toUnsignedBigInteger()
       bits in lo..hi
     }
-    match.hasOptional() -> bits == match.optional.value.toUnsignedBigInteger()
-    else -> true
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
+      bits == match.optional.value.toUnsignedBigInteger()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+    null -> true
   }
 
 /**
@@ -1076,20 +1085,30 @@ class TableStore : TableDataReader {
   @Synchronized
   fun write(update: Update): WriteResult {
     val entity = update.entity
-    return when {
-      entity.hasActionProfileMember() -> writeProfileMember(update.type, entity.actionProfileMember)
-      entity.hasActionProfileGroup() -> writeProfileGroup(update.type, entity.actionProfileGroup)
-      entity.hasRegisterEntry() -> writeRegisterEntry(update.type, entity.registerEntry)
-      entity.hasCounterEntry() -> writeCounterEntry(update.type, entity.counterEntry)
-      entity.hasMeterEntry() -> writeMeterEntry(update.type, entity.meterEntry)
-      entity.hasDirectCounterEntry() ->
+    return when (entity.entityCase) {
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER ->
+        writeProfileMember(update.type, entity.actionProfileMember)
+      P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_GROUP ->
+        writeProfileGroup(update.type, entity.actionProfileGroup)
+      P4RuntimeOuterClass.Entity.EntityCase.REGISTER_ENTRY ->
+        writeRegisterEntry(update.type, entity.registerEntry)
+      P4RuntimeOuterClass.Entity.EntityCase.COUNTER_ENTRY ->
+        writeCounterEntry(update.type, entity.counterEntry)
+      P4RuntimeOuterClass.Entity.EntityCase.METER_ENTRY ->
+        writeMeterEntry(update.type, entity.meterEntry)
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_COUNTER_ENTRY ->
         writeDirectCounterEntry(update.type, entity.directCounterEntry)
-      entity.hasDirectMeterEntry() -> writeDirectMeterEntry(update.type, entity.directMeterEntry)
-      entity.hasPacketReplicationEngineEntry() ->
+      P4RuntimeOuterClass.Entity.EntityCase.DIRECT_METER_ENTRY ->
+        writeDirectMeterEntry(update.type, entity.directMeterEntry)
+      P4RuntimeOuterClass.Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY ->
         writePreEntry(update.type, entity.packetReplicationEngineEntry)
-      entity.hasValueSetEntry() -> writeValueSetEntry(update.type, entity.valueSetEntry)
-      entity.hasTableEntry() -> writeTableEntry(update)
-      else ->
+      P4RuntimeOuterClass.Entity.EntityCase.VALUE_SET_ENTRY ->
+        writeValueSetEntry(update.type, entity.valueSetEntry)
+      P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY -> writeTableEntry(update)
+      P4RuntimeOuterClass.Entity.EntityCase.EXTERN_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.DIGEST_ENTRY,
+      P4RuntimeOuterClass.Entity.EntityCase.ENTITY_NOT_SET,
+      null ->
         WriteResult.InvalidArgument(
           "unsupported entity type; only table entries, action profiles, counters, meters, " +
             "registers, value sets, and PRE entries are supported"
@@ -1261,8 +1280,8 @@ class TableStore : TableDataReader {
     type: Update.Type,
     pre: P4RuntimeOuterClass.PacketReplicationEngineEntry,
   ): WriteResult =
-    when {
-      pre.hasCloneSessionEntry() -> {
+    when (pre.typeCase) {
+      P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.CLONE_SESSION_ENTRY -> {
         val entry = pre.cloneSessionEntry
         writeProfileEntity(
           type,
@@ -1272,7 +1291,7 @@ class TableStore : TableDataReader {
           "clone session ${entry.sessionId}",
         )
       }
-      pre.hasMulticastGroupEntry() -> {
+      P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.MULTICAST_GROUP_ENTRY -> {
         val entry = pre.multicastGroupEntry
         writeProfileEntity(
           type,
@@ -1282,7 +1301,8 @@ class TableStore : TableDataReader {
           "multicast group ${entry.multicastGroupId}",
         )
       }
-      else -> WriteResult.InvalidArgument("PRE entry must have a clone session or multicast group")
+      P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.TYPE_NOT_SET,
+      null -> WriteResult.InvalidArgument("PRE entry must have a clone session or multicast group")
     }
 
   fun getCloneSession(sessionId: Int): P4RuntimeOuterClass.CloneSessionEntry? =
@@ -1459,10 +1479,15 @@ class TableStore : TableDataReader {
     return writeState.tables[tableName]?.any { entry ->
       entry.matchList.any { fm ->
         fm.fieldId == fieldId &&
-          when {
-            fm.hasExact() -> fm.exact.value == value
-            fm.hasOptional() -> fm.optional.value == value
-            else -> false
+          when (fm.fieldMatchTypeCase) {
+            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT -> fm.exact.value == value
+            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL -> fm.optional.value == value
+            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY,
+            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM,
+            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE,
+            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+            null -> false
           }
       }
     } ?: false
@@ -1641,10 +1666,17 @@ class TableStore : TableDataReader {
 
       // Accumulate score for priority-based match kinds.
       // Exact and optional don't contribute — all exact fields either match or don't.
-      when {
-        match.hasLpm() -> score += match.lpm.prefixLen.toLong()
-        match.hasTernary() -> score += entry.priority.toLong()
-        match.hasRange() -> score += entry.priority.toLong()
+      when (match.fieldMatchTypeCase) {
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM ->
+          score += match.lpm.prefixLen.toLong()
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY ->
+          score += entry.priority.toLong()
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE -> score += entry.priority.toLong()
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT,
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL,
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+        P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+        null -> {}
       }
     }
     return score

--- a/web/ControlGraphExtractor.kt
+++ b/web/ControlGraphExtractor.kt
@@ -50,13 +50,16 @@ object ControlGraphExtractor {
   }
 
   private fun walkStmt(stmt: Stmt, currentIds: Set<String>, ctx: Context): Set<String> =
-    when {
-      stmt.hasSwitchStmt() -> walkSwitch(stmt.switchStmt, currentIds, ctx)
-      stmt.hasIfStmt() -> walkIf(stmt.ifStmt, currentIds, ctx)
-      stmt.hasBlock() -> walkStmts(stmt.block.stmtsList, currentIds, ctx)
-      stmt.hasMethodCall() -> walkMethodCall(stmt.methodCall.call, currentIds, ctx)
-      stmt.hasExit() || stmt.hasReturnStmt() -> emptySet()
-      else -> currentIds // assignments and other non-branching stmts: invisible
+    when (stmt.kindCase) {
+      Stmt.KindCase.SWITCH_STMT -> walkSwitch(stmt.switchStmt, currentIds, ctx)
+      Stmt.KindCase.IF_STMT -> walkIf(stmt.ifStmt, currentIds, ctx)
+      Stmt.KindCase.BLOCK -> walkStmts(stmt.block.stmtsList, currentIds, ctx)
+      Stmt.KindCase.METHOD_CALL -> walkMethodCall(stmt.methodCall.call, currentIds, ctx)
+      Stmt.KindCase.EXIT,
+      Stmt.KindCase.RETURN_STMT -> emptySet()
+      Stmt.KindCase.ASSIGNMENT,
+      Stmt.KindCase.KIND_NOT_SET,
+      null -> currentIds // assignments and other non-branching stmts: invisible
     }
 
   private fun walkSwitch(sw: SwitchStmt, currentIds: Set<String>, ctx: Context): Set<String> {
@@ -142,37 +145,55 @@ object ControlGraphExtractor {
 
   /** Recursively search an expression tree for a TableApplyExpr. */
   private fun findTableApply(expr: Expr): TableApplyExpr? =
-    when {
-      expr.hasTableApply() -> expr.tableApply
-      expr.hasMethodCall() -> findTableApply(expr.methodCall.target)
-      expr.hasUnaryOp() -> findTableApply(expr.unaryOp.expr)
-      else -> null
+    when (expr.kindCase) {
+      Expr.KindCase.TABLE_APPLY -> expr.tableApply
+      Expr.KindCase.METHOD_CALL -> findTableApply(expr.methodCall.target)
+      Expr.KindCase.UNARY_OP -> findTableApply(expr.unaryOp.expr)
+      Expr.KindCase.LITERAL,
+      Expr.KindCase.NAME_REF,
+      Expr.KindCase.FIELD_ACCESS,
+      Expr.KindCase.ARRAY_INDEX,
+      Expr.KindCase.SLICE,
+      Expr.KindCase.CONCAT,
+      Expr.KindCase.CAST,
+      Expr.KindCase.BINARY_OP,
+      Expr.KindCase.MUX,
+      Expr.KindCase.STRUCT_EXPR,
+      Expr.KindCase.KIND_NOT_SET,
+      null -> null
     }
 
   /** Extract a human-readable label from a condition expression. */
   private fun conditionLabel(expr: Expr): String =
-    when {
-      expr.hasMethodCall() -> {
+    when (expr.kindCase) {
+      Expr.KindCase.METHOD_CALL -> {
         val target = expr.methodCall.target
         val method = expr.methodCall.method
-        if (target.hasFieldAccess()) {
-          "${target.fieldAccess.fieldName}.$method()"
-        } else if (target.hasNameRef()) {
-          "${target.nameRef.name}.$method()"
-        } else {
-          "$method()"
+        when (target.kindCase) {
+          Expr.KindCase.FIELD_ACCESS -> "${target.fieldAccess.fieldName}.$method()"
+          Expr.KindCase.NAME_REF -> "${target.nameRef.name}.$method()"
+          else -> "$method()"
         }
       }
-      expr.hasFieldAccess() -> expr.fieldAccess.fieldName
-      expr.hasNameRef() -> expr.nameRef.name
-      expr.hasBinaryOp() -> {
+      Expr.KindCase.FIELD_ACCESS -> expr.fieldAccess.fieldName
+      Expr.KindCase.NAME_REF -> expr.nameRef.name
+      Expr.KindCase.BINARY_OP -> {
         val left = conditionLabel(expr.binaryOp.left)
         val right = conditionLabel(expr.binaryOp.right)
         val op = binaryOpSymbol(expr.binaryOp.op)
         "$left $op $right"
       }
-      expr.hasUnaryOp() -> "!${conditionLabel(expr.unaryOp.expr)}"
-      else -> "?"
+      Expr.KindCase.UNARY_OP -> "!${conditionLabel(expr.unaryOp.expr)}"
+      Expr.KindCase.LITERAL,
+      Expr.KindCase.ARRAY_INDEX,
+      Expr.KindCase.SLICE,
+      Expr.KindCase.CONCAT,
+      Expr.KindCase.CAST,
+      Expr.KindCase.TABLE_APPLY,
+      Expr.KindCase.MUX,
+      Expr.KindCase.STRUCT_EXPR,
+      Expr.KindCase.KIND_NOT_SET,
+      null -> "?"
     }
 
   private fun binaryOpSymbol(op: BinaryOperator): String =

--- a/web/ParserGraphExtractor.kt
+++ b/web/ParserGraphExtractor.kt
@@ -33,11 +33,11 @@ object ParserGraphExtractor {
       nodes += Node(state.name, type, state.name)
 
       val transition = state.transition
-      when {
-        transition.hasNextState() -> {
+      when (transition.kindCase) {
+        fourward.ir.Transition.KindCase.NEXT_STATE -> {
           edges += Edge(state.name, transition.nextState)
         }
-        transition.hasSelect() -> {
+        fourward.ir.Transition.KindCase.SELECT -> {
           val sel = transition.select
           for (case in sel.casesList) {
             val label = case.keysetsList.joinToString(", ") { keysetLabel(it) }
@@ -51,6 +51,8 @@ object ParserGraphExtractor {
             edges += Edge(state.name, sel.defaultState, "default")
           }
         }
+        fourward.ir.Transition.KindCase.KIND_NOT_SET,
+        null -> {}
       }
     }
 
@@ -70,24 +72,46 @@ object ParserGraphExtractor {
 
   /** Human-readable label for a keyset expression. */
   private fun keysetLabel(keyset: fourward.ir.KeysetExpr): String =
-    when {
-      keyset.hasExact() -> exprLabel(keyset.exact)
-      keyset.hasMask() -> "${exprLabel(keyset.mask.value)} &&& ${exprLabel(keyset.mask.mask)}"
-      keyset.hasRange() -> "${exprLabel(keyset.range.lo)}..${exprLabel(keyset.range.hi)}"
-      else -> "_"
+    when (keyset.kindCase) {
+      fourward.ir.KeysetExpr.KindCase.EXACT -> exprLabel(keyset.exact)
+      fourward.ir.KeysetExpr.KindCase.MASK ->
+        "${exprLabel(keyset.mask.value)} &&& ${exprLabel(keyset.mask.mask)}"
+      fourward.ir.KeysetExpr.KindCase.RANGE ->
+        "${exprLabel(keyset.range.lo)}..${exprLabel(keyset.range.hi)}"
+      fourward.ir.KeysetExpr.KindCase.DEFAULT_CASE,
+      fourward.ir.KeysetExpr.KindCase.VALUE_SET,
+      fourward.ir.KeysetExpr.KindCase.KIND_NOT_SET,
+      null -> "_"
     }
 
   private fun exprLabel(expr: Expr): String =
-    when {
-      expr.hasLiteral() -> {
+    when (expr.kindCase) {
+      Expr.KindCase.LITERAL -> {
         val lit = expr.literal
-        when {
-          lit.hasInteger() -> "0x${lit.integer.toString(16).uppercase()}"
-          lit.hasBoolean() -> lit.boolean.toString()
-          else -> lit.toString().trim()
+        when (lit.kindCase) {
+          fourward.ir.Literal.KindCase.INTEGER -> "0x${lit.integer.toString(16).uppercase()}"
+          fourward.ir.Literal.KindCase.BOOLEAN -> lit.boolean.toString()
+          fourward.ir.Literal.KindCase.BIG_INTEGER,
+          fourward.ir.Literal.KindCase.ERROR_MEMBER,
+          fourward.ir.Literal.KindCase.ENUM_MEMBER,
+          fourward.ir.Literal.KindCase.STRING_LITERAL,
+          fourward.ir.Literal.KindCase.KIND_NOT_SET,
+          null -> lit.toString().trim()
         }
       }
-      expr.hasNameRef() -> expr.nameRef.name
-      else -> "?"
+      Expr.KindCase.NAME_REF -> expr.nameRef.name
+      Expr.KindCase.FIELD_ACCESS,
+      Expr.KindCase.ARRAY_INDEX,
+      Expr.KindCase.SLICE,
+      Expr.KindCase.CONCAT,
+      Expr.KindCase.CAST,
+      Expr.KindCase.BINARY_OP,
+      Expr.KindCase.UNARY_OP,
+      Expr.KindCase.METHOD_CALL,
+      Expr.KindCase.TABLE_APPLY,
+      Expr.KindCase.MUX,
+      Expr.KindCase.STRUCT_EXPR,
+      Expr.KindCase.KIND_NOT_SET,
+      null -> "?"
     }
 }

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -487,12 +487,16 @@ class WebServer(
             val fields =
               typeDecl.header.fieldsList.joinToString(",") { field ->
                 val bitwidth =
-                  when {
-                    field.type.hasBit() -> field.type.bit.width
-                    field.type.hasSignedInt() -> field.type.signedInt.width
-                    field.type.boolean -> 1
-                    field.type.hasVarbit() -> field.type.varbit.maxWidth
-                    else -> 0
+                  when (field.type.kindCase) {
+                    fourward.ir.Type.KindCase.BIT -> field.type.bit.width
+                    fourward.ir.Type.KindCase.SIGNED_INT -> field.type.signedInt.width
+                    fourward.ir.Type.KindCase.BOOLEAN -> 1
+                    fourward.ir.Type.KindCase.VARBIT -> field.type.varbit.maxWidth
+                    fourward.ir.Type.KindCase.NAMED,
+                    fourward.ir.Type.KindCase.HEADER_STACK,
+                    fourward.ir.Type.KindCase.ERROR,
+                    fourward.ir.Type.KindCase.KIND_NOT_SET,
+                    null -> 0
                   }
                 """{"name":${jsonEscape(field.name)},"bitwidth":$bitwidth}"""
               }


### PR DESCRIPTION
## Summary

Per AGENTS.md invariant #2 and #552: converts every `when { msg.hasFoo() -> }` block to `when (msg.fooCase) { FooCase.FOO -> }` so new oneof variants break the build instead of silently falling through.

15 blocks converted in `Interpreter.kt`. All other files already used exhaustive dispatch.

## Test plan

- [x] `bazel build //...`
- [x] `bazel test //... --test_tag_filters=-heavy` (64/64 pass)
- [x] `./tools/format.sh`, `./tools/lint.sh` clean
- [ ] CI