### PR TITLE
Use Runfiles library for portable runfile path resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ obvious approach, works around a non-obvious constraint, or implements a
 subtle spec requirement. Include spec references (section numbers, GitHub
 issues) where helpful. Do not add comments that merely restate the code.
 
+**Never use deprecated APIs.** When a library marks a function deprecated,
+find and use the successor immediately — don't suppress the warning. A
+deprecated call that works today is a broken call on the next upgrade.
+
 If you take a shortcut or skip a corner case, note it in
 [LIMITATIONS.md](docs/LIMITATIONS.md) with a `TODO` comment at the site.
 Mark workarounds with a prominent `WORKAROUND` comment explaining what is

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -25,6 +25,7 @@ kt_jvm_library(
         "@fourward_maven//:com_google_protobuf_protobuf_java_util",
         "@fourward_maven//:io_grpc_grpc_api",
         "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@rules_java//java/runfiles",
     ],
 )
 

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -1,5 +1,6 @@
 package fourward.web
 
+import com.google.devtools.build.runfiles.Runfiles
 import com.google.protobuf.TextFormat
 import com.google.protobuf.util.JsonFormat
 import com.sun.net.httpserver.HttpExchange
@@ -43,6 +44,34 @@ class WebServer(
     JsonFormat.printer().preservingProtoFieldNames().alwaysPrintFieldsWithNoPresence()
   private val jsonParser: JsonFormat.Parser = JsonFormat.parser().ignoringUnknownFields()
   private val textPrinter: TextFormat.Printer = TextFormat.printer().escapingNonAscii(false)
+
+  // Resolves runfiles paths portably across OSS Bazel and google3/blaze.
+  private val runfiles: Runfiles? =
+    try {
+      Runfiles.preload().withSourceRepository("_main")
+    } catch (_: Exception) {
+      null
+    }
+
+  /** Resolves a repo-relative path (e.g. "web/frontend/index.html") via the Runfiles library. */
+  private fun rlocation(repoRelativePath: String): Path? {
+    val r = runfiles ?: return null
+    // bzlmod: main repo is "_main"; WORKSPACE: may use the workspace name or empty.
+    for (prefix in listOf("_main", "fourward")) {
+      val resolved = r.rlocation("$prefix/$repoRelativePath")
+      if (resolved != null) {
+        val path = Path.of(resolved)
+        if (Files.exists(path)) return path
+      }
+    }
+    // External repos (e.g. p4c+/p4include) — try the path as-is.
+    val resolved = r.rlocation(repoRelativePath)
+    if (resolved != null) {
+      val path = Path.of(resolved)
+      if (Files.exists(path)) return path
+    }
+    return null
+  }
 
   @Volatile private var loadedP4Info: p4.config.v1.P4InfoOuterClass.P4Info? = null
 
@@ -297,10 +326,8 @@ class WebServer(
       }
     }
 
-    // 2. Bazel runfiles.
-    val runfiles = System.getenv("JAVA_RUNFILES")
-    if (runfiles != null) {
-      val file = Path.of(runfiles, "_main/web/frontend", relativePath)
+    // 2. Bazel runfiles (works across OSS Bazel and google3/blaze).
+    rlocation("web/frontend/$relativePath")?.let { file ->
       if (Files.isRegularFile(file)) return Files.readAllBytes(file)
     }
 
@@ -320,9 +347,7 @@ class WebServer(
     val cmd = mutableListOf(p4c.toString())
 
     // Add standard includes (core.p4, v1model.p4) from runfiles.
-    val runfiles = System.getenv("JAVA_RUNFILES")
-    if (runfiles != null) {
-      val p4include = Path.of(runfiles, "p4c+/p4include")
+    rlocation("p4c+/p4include/core.p4")?.parent?.let { p4include ->
       if (Files.isDirectory(p4include)) cmd += listOf("-I", p4include.toString())
     }
 
@@ -336,9 +361,7 @@ class WebServer(
   }
 
   private fun findP4c(): Path? {
-    val runfiles = System.getenv("JAVA_RUNFILES")
-    if (runfiles != null) {
-      val candidate = Path.of(runfiles, "_main/p4c_backend/p4c-4ward")
+    rlocation("p4c_backend/p4c-4ward")?.let { candidate ->
       if (Files.isExecutable(candidate)) return candidate
     }
     val pathDirs = System.getenv("PATH")?.split(":") ?: emptyList()


### PR DESCRIPTION
Fixes 404s on `blaze run web:playground` in google3. Replaces hardcoded `_main/...` paths with the Bazel Runfiles library.