### PR TITLE
Fix setInvalid() to zero IntVal and ErrorVal fields (closes #539)

### DIFF
--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -133,6 +133,16 @@ kt_jvm_library(
 # =============================================================================
 
 kt_jvm_test(
+    name = "HeaderValTest",
+    srcs = ["HeaderValTest.kt"],
+    test_class = "fourward.simulator.HeaderValTest",
+    deps = [
+        ":simulator",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "HashTest",
     srcs = ["HashTest.kt"],
     test_class = "fourward.simulator.HashTest",

--- a/simulator/HeaderValTest.kt
+++ b/simulator/HeaderValTest.kt
@@ -1,0 +1,31 @@
+package fourward.simulator
+
+import java.math.BigInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/** Unit tests for [HeaderVal], focusing on setInvalid() field zeroing (P4 §8.17). */
+class HeaderValTest {
+
+  @Test
+  fun `setInvalid zeros all field types`() {
+    val hdr =
+      HeaderVal(
+        "test_t",
+        mutableMapOf(
+          "addr" to BitVal(0xFFL, 8),
+          "offset" to IntVal(SignedBitVector(BigInteger.valueOf(-3), 16)),
+          "flag" to BoolVal(true),
+          "err" to ErrorVal("PacketTooShort"),
+        ),
+        valid = true,
+      )
+    hdr.setInvalid()
+    assertFalse(hdr.valid)
+    assertEquals(BitVal(0L, 8), hdr.fields["addr"])
+    assertEquals(IntVal(SignedBitVector(BigInteger.ZERO, 16)), hdr.fields["offset"])
+    assertEquals(BoolVal(false), hdr.fields["flag"])
+    assertEquals(ErrorVal.NO_ERROR, hdr.fields["err"])
+  }
+}

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -252,7 +252,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     (values["pna_pre_input_metadata_t"] as? StructVal)?.let {
       it.setBitField("input_port", portLong)
-      it.fields["parser_error"] = ErrorVal("NoError")
+      it.fields["parser_error"] = ErrorVal.NO_ERROR
       it.fields["direction"] = EnumVal(direction)
       if (it.fields.containsKey("pass")) it.setBitField("pass", passTruncated)
       it.fields["loopedback"] = BoolVal(loopedback)
@@ -271,7 +271,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       if (it.fields.containsKey("pass")) it.setBitField("pass", passTruncated)
       it.fields["loopedback"] = BoolVal(loopedback)
       if (it.fields.containsKey("timestamp")) it.setBitField("timestamp", 0L)
-      it.fields["parser_error"] = ErrorVal("NoError")
+      it.fields["parser_error"] = ErrorVal.NO_ERROR
       if (it.fields.containsKey("class_of_service")) it.setBitField("class_of_service", 0L)
       it.setBitField("input_port", portLong)
     }

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -587,7 +587,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     (values["psa_ingress_input_metadata_t"] as? StructVal)?.let {
       it.setBitField("ingress_port", ingressPort.toLong())
       it.fields["packet_path"] = EnumVal(packetPath)
-      it.fields["parser_error"] = ErrorVal("NoError")
+      it.fields["parser_error"] = ErrorVal.NO_ERROR
     }
     // PSA spec: ingress output metadata defaults to drop=true.
     (values["psa_ingress_output_metadata_t"] as? StructVal)?.let {
@@ -617,7 +617,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       // PSA spec §6.5: instance identifies the replica within a multicast group.
       // Only set if the program declares the field (not all PSA programs use it).
       if (it.fields.containsKey("instance")) it.setBitField("instance", instance.toLong())
-      it.fields["parser_error"] = ErrorVal("NoError")
+      it.fields["parser_error"] = ErrorVal.NO_ERROR
     }
     // PSA spec: egress output metadata defaults to drop=false.
     (values["psa_egress_output_metadata_t"] as? StructVal)?.let {

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -312,7 +312,7 @@ class V1ModelArchitecture(
     }
     standardMetadata.setBitField("ingress_port", ctx.ingressPort.toLong())
     standardMetadata.setBitField("packet_length", ctx.payload.size.toLong())
-    standardMetadata.fields["parser_error"] = ErrorVal("NoError")
+    standardMetadata.fields["parser_error"] = ErrorVal.NO_ERROR
     if (decisions.instanceTypeOverride != null) {
       standardMetadata.setBitField("instance_type", decisions.instanceTypeOverride)
     }

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -55,7 +55,12 @@ data class BoolVal(val value: Boolean) : Value() {
 }
 
 /** A P4 error value (one of the named error members, e.g. "NoError"). */
-data class ErrorVal(val member: String) : Value()
+data class ErrorVal(val member: String) : Value() {
+  companion object {
+    /** P4 spec §7.1.4: the default error value. */
+    val NO_ERROR = ErrorVal("NoError")
+  }
+}
 
 /** A plain (non-serializable) P4 enum value, e.g. HashAlgorithm.crc16. */
 data class EnumVal(val member: String) : Value()
@@ -93,8 +98,11 @@ data class HeaderVal(
     fields.replaceAll { _, v ->
       when (v) {
         is BitVal -> BitVal(0L, v.bits.width)
+        is IntVal -> IntVal(SignedBitVector(java.math.BigInteger.ZERO, v.bits.width))
         is BoolVal -> BoolVal(false)
-        else -> v
+        is ErrorVal -> ErrorVal.NO_ERROR
+        is UnitVal -> v
+        else -> error("unexpected header field type: ${v::class.simpleName}")
       }
     }
   }


### PR DESCRIPTION
## Summary
- P4 §8.17 requires `setInvalid()` to reset all header fields. `BitVal` and `BoolVal` were zeroed but `IntVal` and `ErrorVal` fell through unchanged.
- Extracts `ErrorVal.NO_ERROR` constant — was a raw `"NoError"` string scattered across 8 sites.
- Makes the `else` branch in `setInvalid` crash loudly per the "never fail silently" invariant, instead of silently retaining stale values.

## Test plan
- [x] `HeaderValTest`: one test covering all 4 field types (BitVal, IntVal, BoolVal, ErrorVal)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)