### PR TITLE
Fork-point resume for all pipeline fork types (+47% parallel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ enough for production test workloads.
 | Architecture customization | no | [**first-class support**](docs/ROADMAP.md#track-5-architecture-customization) |
 | Interactive playground | no | [**browser-based IDE**](#web-playground) with trace playback & packet decoding |
 | Error messages | opaque | [**actionable, with valid options**](docs/ROADMAP.md#track-11-error-quality) — [75 golden-tested](p4runtime/golden_errors/) |
-| Throughput (16-way selector) | [~4,500 pps ÷ 16 paths](docs/PERFORMANCE.md#bmv2-comparison) | [**~1,400 pps, all 16 paths**](docs/PERFORMANCE.md) ([head-to-head on SAI P4](docs/PERFORMANCE.md#bmv2-comparison)) |
-| Parallelism (16-way selector) | single-threaded | [**10,000 pps on 16 cores**](docs/PERFORMANCE.md) — parallel across packets and forks |
+| Throughput (16-way selector) | [~4,500 pps ÷ 16 paths](docs/PERFORMANCE.md#bmv2-comparison) | [**~1,900 pps, all 16 paths**](docs/PERFORMANCE.md) ([head-to-head on SAI P4](docs/PERFORMANCE.md#bmv2-comparison)) |
+| Parallelism (16-way selector) | single-threaded | [**12,000 pps on 16 cores**](docs/PERFORMANCE.md) — parallel across packets and forks |
 | Extensibility | limited | [**AI-friendly codebase**](docs/ROADMAP.md#why-4ward-is-easier-to-extend) — if AI can extend it, anyone can |
 | CI | slow | **[~2 min](https://4ward.buildbuddy.io/trends/)**, rigorous |
 | Development pace | slow | **[AI-fast](docs/AI_WORKFLOW.md)** |

--- a/designs/parallel_packet_scaling.md
+++ b/designs/parallel_packet_scaling.md
@@ -1,14 +1,10 @@
 # Parallel Packet Scaling
 
-**Status: Phase 2.5 + sequential/parallel diff complete. Flat-buffer
-attempt (#522 / `designs/flat_packet_buffer.md`) refuted the
-working-set-bytes hypothesis. Follow-up profile + seq/par diff
-isolates ~35% of parallel CPU as *scaling-specific* excess (mostly
-`BigInteger` + `HashMap` allocation + proto trace-event builders);
-the rest scales cleanly. Candidates are now scored on two axes —
-efficiency lever (the north-star concern) vs sequential speedup —
-because a uniform CPU-time reduction improves throughput without
-changing the scaling ratio. See "Phase 2.5: empirical profile" below.**
+**Status: Phase 3 complete (PRs #554, #562, #567). wcmp×128 parallel
+throughput improved +120% from baseline (1,501 → 3,393 pps), efficiency
+from 45% to ~59%. The three main wins: Long-backed BitVector (#562),
+CompactFieldMap + proto builder pooling (#554), and fork-point resume
+(#567). See "Phase 3 results" below for measurements.**
 
 ## North star
 
@@ -907,25 +903,35 @@ Highest theoretical ceiling (could make 128 branches nearly as
 cheap as 1), but extremely complex — requires full dependency
 tracking across the P4 program. Research-project scope.
 
-### Recommended sequencing
+### What we actually shipped (Phase 3 results)
 
-If pursuing Phase 3:
+**Fork-point resume (#567)** superseded both Candidate A (fork-on-write
+overlay) and Candidate B (skip prefix events). Instead of optimizing
+the deep copy (A) or skipping trace construction during replay (B), it
+eliminates prefix replay entirely — each branch continues from the fork
+point, producing only its own events. No prefix stripping, no replay
+infrastructure, no `BranchMode` dispatch.
 
-1. **(A) Fork-on-write overlay** — most natural next step. Attacks
-   the structural inefficiency (copying unmodified state) rather than
-   optimizing the copy mechanics. Build the overlay, measure, decide
-   whether to stack more.
-2. **(B) Skip prefix events** — independent of A, can stack in any
-   order. Well-scoped.
-3. **Reassess.** If A+B together reach ~70% efficiency, evaluate
-   whether the remaining 10 pp to 80% justifies (C) or (E). If not,
-   declare victory and move on.
+Measured on the same hardware (AMD Ryzen 9 7950X3D), same workload
+(SAI P4, 10k routes, intra-packet parallelism off):
 
-**Oracle-first rule still applies.** For each candidate, build a
-"what if this were free?" stub before committing to the full
-implementation. A+B have obvious stubs (make deepCopy return `this`;
-make addTraceEvent a no-op during replay). C and E are harder to
-stub but the methodology holds.
+| Workload | Baseline | After Phase 3 | Sequential Δ | Parallel Δ |
+|----------|----------|---------------|-------------|------------|
+| wcmp×128 seq | 207 pps | 345 pps | **+67%** | — |
+| wcmp×128 par | 1,501 pps | 3,393 pps | — | **+126%** |
+| direct seq | 2,568 pps | ~2,500 pps | ≈0% | — |
+| direct par | 38,449 pps | ~38,000 pps | — | ≈0% |
+
+Direct L3 is unaffected (no forks, nothing to optimize). wcmp×128
+sees the full benefit: +67% sequential, +126% parallel. Efficiency
+improved from 45% to ~59%.
+
+**Remaining candidates.** C (compiled instruction sequence) and E
+(deferred trace serialization) are still viable for further gains but
+are higher effort. The fork-point resume design also opens a path for
+Candidate A (copy-on-write `Environment`) which would stack on top by
+reducing the per-branch `env.deepCopy()` cost — currently the
+dominant remaining cost on the fork hot path.
 
 
 ## Non-goals

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -81,6 +81,12 @@ guilt — just write it down so someone can find it later.
 
 ## Simulator
 
+- **Fork-point resume is v1model only.** When the trace tree forks (action
+  selectors, clone, multicast), v1model continues each branch from the fork
+  point instead of replaying the pipeline. PSA and PNA still use the
+  replay-based approach (`handleActionSelectorFork` in `ArchitectureHelpers.kt`).
+  Other v1model-specific optimizations (Long-backed `BitVector`, `CompactFieldMap`,
+  proto builder pooling) benefit all architectures.
 - **Multicast: basic replication only.** Multicast group replication works
   for the trace tree (forking per replica). PRE entries are installed via
   P4Runtime `PacketReplicationEngineEntry`.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -42,8 +42,8 @@ ternary ACL entries.
 | Workload | Sequential, 1 core | Sequential, 16 cores | Batch, 1 core | Batch, 16 cores |
 |----------|--------------------|----------------------|---------------|-----------------|
 | L3 forwarding | 2,500 | 2,600 | 2,600 | 29,000 |
-| WCMP ×16 | 1,400 | 1,700 | 1,200 | 10,000 |
-| WCMP ×16 + mirror | 970 | 1,200 | 710 | 5,200 |
+| WCMP ×16 | 1,900 | 2,200 | 1,600 | 12,000 |
+| WCMP ×16 + mirror | 1,300 | 1,600 | 1,000 | 8,000 |
 
 - **Sequential** = `InjectPacket` (one packet at a time, wait for result).
 - **Batch** = `InjectPackets` (1000 packets streamed concurrently).
@@ -64,7 +64,7 @@ with the same table entries: 10k LPM routes + 500 ternary ACL entries.
 | Workload | BMv2 | 4ward, 1 core | 4ward, 16 cores |
 |----------|------|---------------|-----------------|
 | L3 forwarding | 4,500 | 2,500 | 29,000 |
-| WCMP ×16 | 4,400 | 1,400 | 10,000 |
+| WCMP ×16 | 4,400 | 1,900 | 12,000 |
 
 (packets/sec; higher is better)
 
@@ -122,15 +122,15 @@ bazel test //p4runtime:DataplaneBenchmark --test_output=streamed
 
 ## Optimizations
 
-Starting from an unoptimized baseline, eight optimizations delivered a
-**127× improvement** on the hardest workload (WCMP ×16 + mirror, batch,
-16 cores) and **29× single-core sequential**.
+Starting from an unoptimized baseline, eleven optimizations delivered a
+**195× improvement** on the hardest workload (WCMP ×16 + mirror, batch,
+16 cores) and **32× single-core sequential**.
 
 | Workload | Baseline | Current (1 core) | Current (16 cores) |
 |----------|----------|-------------------|--------------------|
 | L3 forwarding | 1,400 | 2,500 | 29,000 |
-| WCMP ×16 | 83 | 1,400 | 10,000 |
-| WCMP ×16 + mirror | 41 | 970 | 5,200 |
+| WCMP ×16 | 83 | 1,900 | 12,000 |
+| WCMP ×16 + mirror | 41 | 1,300 | 8,000 |
 
 (sequential packets/sec, except "16 cores" column which uses batch mode)
 
@@ -152,6 +152,17 @@ Starting from an unoptimized baseline, eight optimizations delivered a
 8. **Array-indexed field lookup** (PR #430): field ID array replaces
    HashMap + String conversion in scoreEntry. Zero allocation per
    match field.
+9. **Long-backed BitVector** (PR #562): fields ≤ 63 bits use a `Long`
+   instead of `BigInteger`. Eliminates heap allocation for the
+   majority of field operations.
+10. **CompactFieldMap + proto builder pooling** (PR #554):
+    array-backed header field map (copy = `Array.copyOf`) and reused
+    `TraceEvent.Builder` per execution.
+11. **Fork-point resume** (PR #567): instead of replaying the pipeline
+    for each fork branch, captures state at the fork point and
+    continues each branch from there. Eliminates prefix re-execution,
+    prefix event stripping, and the entire replay infrastructure.
+    v1model only — PSA/PNA still use replay.
 
 **What didn't help** (tried and reverted):
 - Caching `defaultValue()` templates — negligible impact.

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -38,6 +38,9 @@ _GOLDEN = [
     "multicast_drop_replica",
     "multicast_selector",
     "selector_exit",
+    "e2e_clone",
+    "resubmit",
+    "recirculate",
 ]
 
 # Programs without golden files — tested via STF expect directives only.

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -84,6 +84,13 @@ fork_outcome {
         pipeline_stage {
           stage_name: "egress"
           stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
           direction: EXIT
         }
       }

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -95,6 +95,13 @@ fork_outcome {
         pipeline_stage {
           stage_name: "egress"
           stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
           direction: EXIT
         }
       }

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -129,6 +129,13 @@ fork_outcome {
               pipeline_stage {
                 stage_name: "egress"
                 stage_kind: CONTROL
+                direction: ENTER
+              }
+            }
+            events {
+              pipeline_stage {
+                stage_name: "egress"
+                stage_kind: CONTROL
                 direction: EXIT
               }
             }
@@ -273,6 +280,13 @@ fork_outcome {
         branches {
           label: "original"
           subtree {
+            events {
+              pipeline_stage {
+                stage_name: "egress"
+                stage_kind: CONTROL
+                direction: ENTER
+              }
+            }
             events {
               pipeline_stage {
                 stage_name: "egress"

--- a/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
@@ -81,6 +81,13 @@ fork_outcome {
     label: "original"
     subtree {
       events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
         branch {
           control_name: "MyEgress"
           taken: false

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -81,6 +81,13 @@ fork_outcome {
     label: "original"
     subtree {
       events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
         table_lookup {
           table_name: "egress_classify"
           hit: true

--- a/e2e_tests/trace_tree/e2e_clone.golden.txtpb
+++ b/e2e_tests/trace_tree/e2e_clone.golden.txtpb
@@ -1,0 +1,300 @@
+events {
+  packet_ingress {
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "parser"
+    stage_kind: PARSER
+    direction: ENTER
+  }
+}
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/e2e_clone.p4"
+    line: 23
+    column: 10
+    source_fragment: "start"
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "parser"
+    stage_kind: PARSER
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "verify_checksum"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "verify_checksum"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "ingress"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "ingress"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "egress"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  branch {
+    control_name: "MyEgress"
+    taken: true
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/e2e_clone.p4"
+    line: 53
+    column: 12
+    source_fragment: "smeta.instance_type == 0"
+  }
+}
+events {
+  clone {
+    session_id: 100
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/e2e_clone.p4"
+    line: 54
+    column: 12
+    source_fragment: "clone3(CloneType.E2E, 32w100, {})"
+  }
+}
+events {
+  table_lookup {
+    table_name: "egress_classify"
+    hit: true
+    matched_entry {
+      table_id: 43808281
+      match {
+        field_id: 1
+        exact {
+          value: "\000\000\000\000"
+        }
+      }
+      action {
+        action {
+          action_id: 23337001
+        }
+      }
+      is_const: true
+    }
+    action_name: "tag_original"
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/e2e_clone.p4"
+    line: 56
+    column: 8
+    source_fragment: "egress_classify.apply()"
+  }
+}
+events {
+  action_execution {
+    action_name: "tag_original"
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/e2e_clone.p4"
+    line: 56
+    column: 8
+    source_fragment: "egress_classify.apply()"
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "egress"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "compute_checksum"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "compute_checksum"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  clone_session_lookup {
+    session_id: 100
+    session_found: true
+    dataplane_egress_port: 5
+  }
+}
+fork_outcome {
+  reason: CLONE
+  branches {
+    label: "original"
+    subtree {
+      events {
+        pipeline_stage {
+          stage_name: "deparser"
+          stage_kind: DEPARSER
+          direction: ENTER
+        }
+      }
+      events {
+        deparser_emit {
+          header_type: "ethernet_t"
+          byte_length: 14
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "deparser"
+          stage_kind: DEPARSER
+          direction: EXIT
+        }
+      }
+      packet_outcome {
+        output {
+          dataplane_egress_port: 2
+          payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
+        }
+      }
+    }
+  }
+  branches {
+    label: "clone"
+    subtree {
+      events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        branch {
+          control_name: "MyEgress"
+          taken: false
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/e2e_clone.p4"
+          line: 53
+          column: 12
+          source_fragment: "smeta.instance_type == 0"
+        }
+      }
+      events {
+        table_lookup {
+          table_name: "egress_classify"
+          hit: true
+          matched_entry {
+            table_id: 43808281
+            match {
+              field_id: 1
+              exact {
+                value: "\000\000\000\002"
+              }
+            }
+            action {
+              action {
+                action_id: 20863306
+              }
+            }
+            is_const: true
+          }
+          action_name: "tag_clone"
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/e2e_clone.p4"
+          line: 56
+          column: 8
+          source_fragment: "egress_classify.apply()"
+        }
+      }
+      events {
+        action_execution {
+          action_name: "tag_clone"
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/e2e_clone.p4"
+          line: 56
+          column: 8
+          source_fragment: "egress_classify.apply()"
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "compute_checksum"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "compute_checksum"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "deparser"
+          stage_kind: DEPARSER
+          direction: ENTER
+        }
+      }
+      events {
+        deparser_emit {
+          header_type: "ethernet_t"
+          byte_length: 14
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "deparser"
+          stage_kind: DEPARSER
+          direction: EXIT
+        }
+      }
+      packet_outcome {
+        output {
+          dataplane_egress_port: 5
+          payload: "\252\252\252\252\252\252\273\273\273\273\273\273\b\000"
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/e2e_clone.p4
+++ b/e2e_tests/trace_tree/e2e_clone.p4
@@ -1,0 +1,65 @@
+/* e2e_clone.p4 — E2E clone where egress behavior differs per branch.
+ *
+ * Ingress sets egress_spec = 2. Egress clones the packet (E2E, session 100)
+ * on the first pass (instance_type == 0). Egress reads instance_type: the
+ * original (0) tags dstAddr; the clone (CLONE_E2E = 2) tags srcAddr.
+ * Verifies both branches execute egress with correct metadata.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply { smeta.egress_spec = 2; }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) {
+    action tag_original() { hdr.ethernet.dstAddr = 0xAAAAAAAAAAAA; }
+    action tag_clone()    { hdr.ethernet.srcAddr = 0xBBBBBBBBBBBB; }
+
+    table egress_classify {
+        key = { smeta.instance_type : exact; }
+        actions = { tag_original; tag_clone; }
+        const entries = {
+            0 : tag_original();  // original packet
+            2 : tag_clone();     // E2E clone (CLONE_E2E instance_type)
+        }
+    }
+
+    apply {
+        // Clone on first pass only.
+        if (smeta.instance_type == 0) {
+            clone3(CloneType.E2E, 32w100, {});
+        }
+        egress_classify.apply();
+    }
+}
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/e2e_clone.stf
+++ b/e2e_tests/trace_tree/e2e_clone.stf
@@ -1,0 +1,3 @@
+# E2E clone: egress clones the packet to port 5 via session 100.
+mirroring_add 100 5
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/recirculate.golden.txtpb
+++ b/e2e_tests/trace_tree/recirculate.golden.txtpb
@@ -1,0 +1,252 @@
+events {
+  packet_ingress {
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "parser"
+    stage_kind: PARSER
+    direction: ENTER
+  }
+}
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/recirculate.p4"
+    line: 22
+    column: 10
+    source_fragment: "start"
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "parser"
+    stage_kind: PARSER
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "verify_checksum"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "verify_checksum"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "ingress"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "ingress"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "egress"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  branch {
+    control_name: "MyEgress"
+    taken: true
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/recirculate.p4"
+    line: 39
+    column: 12
+    source_fragment: "smeta.instance_type == 0"
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "egress"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "compute_checksum"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "compute_checksum"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "deparser"
+    stage_kind: DEPARSER
+    direction: ENTER
+  }
+}
+events {
+  deparser_emit {
+    header_type: "ethernet_t"
+    byte_length: 14
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "deparser"
+    stage_kind: DEPARSER
+    direction: EXIT
+  }
+}
+fork_outcome {
+  reason: RECIRCULATE
+  branches {
+    label: "recirculate"
+    subtree {
+      events {
+        packet_ingress {
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "parser"
+          stage_kind: PARSER
+          direction: ENTER
+        }
+      }
+      events {
+        parser_transition {
+          parser_name: "MyParser"
+          from_state: "start"
+          to_state: "accept"
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/recirculate.p4"
+          line: 22
+          column: 10
+          source_fragment: "start"
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "parser"
+          stage_kind: PARSER
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "verify_checksum"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "verify_checksum"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "ingress"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "ingress"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        branch {
+          control_name: "MyEgress"
+          taken: false
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/recirculate.p4"
+          line: 39
+          column: 12
+          source_fragment: "smeta.instance_type == 0"
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "compute_checksum"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "compute_checksum"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "deparser"
+          stage_kind: DEPARSER
+          direction: ENTER
+        }
+      }
+      events {
+        deparser_emit {
+          header_type: "ethernet_t"
+          byte_length: 14
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "deparser"
+          stage_kind: DEPARSER
+          direction: EXIT
+        }
+      }
+      packet_outcome {
+        output {
+          dataplane_egress_port: 1
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/recirculate.p4
+++ b/e2e_tests/trace_tree/recirculate.p4
@@ -1,0 +1,50 @@
+/* recirculate.p4 — recirculate on first egress pass.
+ *
+ * Ingress sets egress_spec = 1. Egress calls recirculate() when
+ * instance_type == 0 (first pass). The recirculated packet gets
+ * instance_type = 4 (RECIRC), so it doesn't recirculate again.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply { smeta.egress_spec = 1; }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) {
+    apply {
+        if (smeta.instance_type == 0) {
+            recirculate<metadata_t>(meta);
+        }
+    }
+}
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/recirculate.stf
+++ b/e2e_tests/trace_tree/recirculate.stf
@@ -1,0 +1,2 @@
+# Recirculate: no table entries needed, just inject a packet.
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/e2e_tests/trace_tree/resubmit.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit.golden.txtpb
@@ -1,0 +1,204 @@
+events {
+  packet_ingress {
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "parser"
+    stage_kind: PARSER
+    direction: ENTER
+  }
+}
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/resubmit.p4"
+    line: 22
+    column: 10
+    source_fragment: "start"
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "parser"
+    stage_kind: PARSER
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "verify_checksum"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "verify_checksum"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "ingress"
+    stage_kind: CONTROL
+    direction: ENTER
+  }
+}
+events {
+  branch {
+    control_name: "MyIngress"
+    taken: true
+  }
+  source_info {
+    file: "e2e_tests/trace_tree/resubmit.p4"
+    line: 35
+    column: 12
+    source_fragment: "smeta.instance_type == 0"
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "ingress"
+    stage_kind: CONTROL
+    direction: EXIT
+  }
+}
+fork_outcome {
+  reason: RESUBMIT
+  branches {
+    label: "resubmit"
+    subtree {
+      events {
+        packet_ingress {
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "parser"
+          stage_kind: PARSER
+          direction: ENTER
+        }
+      }
+      events {
+        parser_transition {
+          parser_name: "MyParser"
+          from_state: "start"
+          to_state: "accept"
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/resubmit.p4"
+          line: 22
+          column: 10
+          source_fragment: "start"
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "parser"
+          stage_kind: PARSER
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "verify_checksum"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "verify_checksum"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "ingress"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        branch {
+          control_name: "MyIngress"
+          taken: false
+        }
+        source_info {
+          file: "e2e_tests/trace_tree/resubmit.p4"
+          line: 35
+          column: 12
+          source_fragment: "smeta.instance_type == 0"
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "ingress"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "egress"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "compute_checksum"
+          stage_kind: CONTROL
+          direction: ENTER
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "compute_checksum"
+          stage_kind: CONTROL
+          direction: EXIT
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "deparser"
+          stage_kind: DEPARSER
+          direction: ENTER
+        }
+      }
+      events {
+        deparser_emit {
+          header_type: "ethernet_t"
+          byte_length: 14
+        }
+      }
+      events {
+        pipeline_stage {
+          stage_name: "deparser"
+          stage_kind: DEPARSER
+          direction: EXIT
+        }
+      }
+      packet_outcome {
+        output {
+          dataplane_egress_port: 1
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
+        }
+      }
+    }
+  }
+}

--- a/e2e_tests/trace_tree/resubmit.p4
+++ b/e2e_tests/trace_tree/resubmit.p4
@@ -1,0 +1,51 @@
+/* resubmit.p4 — resubmit on first ingress pass.
+ *
+ * Ingress calls resubmit() when instance_type == 0 (first pass). The
+ * resubmitted packet gets instance_type = 6 (RESUBMIT), so it doesn't
+ * resubmit again. Both passes set egress_spec = 1.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply {
+        smeta.egress_spec = 1;
+        if (smeta.instance_type == 0) {
+            resubmit<metadata_t>(meta);
+        }
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) {
+    apply {}
+}
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/resubmit.stf
+++ b/e2e_tests/trace_tree/resubmit.stf
@@ -1,0 +1,2 @@
+# Resubmit: no table entries needed, just inject a packet.
+packet 0 FFFFFFFFFFFF 000000000001 0800

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -327,6 +327,25 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       withLocalScope(control.localVarsList, env) { execBlock(control.applyBodyList, env) }
     }
 
+    /**
+     * Resumes from an action selector fork point: executes the selected member's action, then the
+     * continuation (remaining statements captured as the fork propagated through [execBlock]). The
+     * caller must pop the control scope afterwards.
+     */
+    fun resumeFromFork(
+      fork: ActionSelectorFork,
+      member: TableStore.MemberAction,
+      env: Environment,
+    ) {
+      currentSourceInfo = fork.sourceInfo
+      val tableBehavior = tables[fork.tableName] ?: error("unknown table: ${fork.tableName}")
+      val resolvedName = tableBehavior.actionOverridesMap[member.actionName] ?: member.actionName
+      execAction(resolvedName, member.params, env)
+      for (stmts in fork.remainingStmts) {
+        execBlock(stmts, env)
+      }
+    }
+
     /** Pushes a scope, defines [localVars], runs [body], then pops the scope. */
     private inline fun withLocalScope(
       localVars: List<fourward.ir.VarDecl>,
@@ -352,7 +371,15 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     // -------------------------------------------------------------------------
 
     private fun execBlock(stmts: List<Stmt>, env: Environment) {
-      for (stmt in stmts) execStmt(stmt, env)
+      for ((i, stmt) in stmts.withIndex()) {
+        try {
+          execStmt(stmt, env)
+        } catch (fork: ActionSelectorFork) {
+          // Capture the continuation: statements after the fork in this block.
+          fork.remainingStmts.addLast(stmts.subList(i + 1, stmts.size))
+          throw fork
+        }
+      }
     }
 
     private fun execStmt(stmt: Stmt, env: Environment) {
@@ -857,12 +884,14 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           execAction(resolvedMember, member.params, env)
           return TableResult(result.hit, member.actionName)
         }
-        // First encounter: throw to let the architecture build the trace tree.
+        // First encounter: capture state and throw to let the architecture fork.
         throw ActionSelectorFork(
           tableName,
           result.members,
           packetCtx!!.getEvents(),
-          recordedLookups.toMap(),
+          env.deepCopy(),
+          packetCtx!!.bytesConsumed,
+          currentSourceInfo,
         )
       }
 
@@ -1415,11 +1444,25 @@ class ReturnException(val value: Value) : Exception()
  */
 sealed class ForkException(val eventsBeforeFork: List<TraceEvent>) : Exception()
 
-/** Fork at an action selector group hit — one branch per group member. */
+/**
+ * Fork at an action selector group hit — one branch per group member.
+ *
+ * Carries the full interpreter state at the fork point so each branch can continue from there
+ * (fork-on-write) instead of replaying the entire pipeline.
+ */
 class ActionSelectorFork(
   val tableName: String,
   val members: List<TableStore.MemberAction>,
   eventsBeforeFork: List<TraceEvent>,
-  /** Table lookup results from before the fork point, for caching in re-executions. */
-  val preForkLookups: Map<String, TableStore.LookupResult> = emptyMap(),
+  /** Deep copy of the environment at the fork point — each branch restores from this. */
+  val forkPointEnv: Environment,
+  /** Parser buffer position at the fork point. */
+  val bytesConsumed: Int,
+  /** Source info at the fork point (the table apply statement), for trace events in branches. */
+  val sourceInfo: fourward.ir.SourceInfo? = null,
+  /**
+   * Continuation: remaining statements at each block nesting level (innermost first). Populated as
+   * the exception propagates through [Interpreter.Execution.execBlock].
+   */
+  val remainingStmts: ArrayDeque<List<fourward.ir.Stmt>> = ArrayDeque(),
 ) : ForkException(eventsBeforeFork)

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -86,11 +86,10 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     packetCtx: PacketContext? = null,
     selectorOverrides: Map<String, Int> = emptyMap(),
     externHandler: ExternHandler? = null,
-    tableLookupCache: Map<String, TableStore.LookupResult>? = null,
-  ) = Execution(tableStore, packetCtx, selectorOverrides, externHandler, tableLookupCache)
+  ) = Execution(tableStore, packetCtx, selectorOverrides, externHandler)
 
   /**
-   * Per-execution interpreter state. Cheap to create (5 field assignments). Accesses the outer
+   * Per-execution interpreter state. Cheap to create (4 field assignments). Accesses the outer
    * [Interpreter]'s config-derived maps directly via the inner class relationship.
    */
   inner class Execution(
@@ -98,26 +97,11 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     private val packetCtx: PacketContext? = null,
     private val selectorOverrides: Map<String, Int> = emptyMap(),
     private val externHandler: ExternHandler? = null,
-    /**
-     * Cached table lookup results from a prior execution, keyed by table name. When non-null, table
-     * lookups use the cache instead of scanning [tableStore] — avoiding O(n) scans for tables whose
-     * key values haven't changed since the cache was populated (i.e., tables before a fork point).
-     *
-     * The cache is disabled once a table from [selectorOverrides] is hit, since tables after the
-     * fork point may produce different key values due to different selector member actions.
-     */
-    private val tableLookupCache: Map<String, TableStore.LookupResult>? = null,
   ) {
 
     /** Non-null packet context; throws a clear error if packet I/O is attempted without one. */
     private val packet: PacketContext
       get() = packetCtx ?: error("packet I/O requires a PacketContext")
-
-    /** Table lookup results recorded during this execution, for caching in fork re-executions. */
-    private val recordedLookups = mutableMapOf<String, TableStore.LookupResult>()
-
-    /** Set to true once a [selectorOverrides] table is hit, disabling the [tableLookupCache]. */
-    private var pastForkPoint = false
 
     /** Context from the most recent table miss, for PNA's `add_entry` extern. */
     private var lastTableMissCtx: TableMissContext? = null
@@ -838,12 +822,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     private fun applyTable(tableName: String, env: Environment): TableResult {
       val tableBehavior = tables[tableName] ?: error("unknown table: $tableName")
       val keyValues = tableBehavior.keysList.map { key -> key.fieldName to evalExpr(key.expr, env) }
-
-      // On fork re-executions, use cached results for tables before the fork point.
-      val cached =
-        if (!pastForkPoint && tableLookupCache != null) tableLookupCache[tableName] else null
-      val result = cached ?: tableStore.lookup(tableName, keyValues)
-      if (!pastForkPoint) recordedLookups.putIfAbsent(tableName, result)
+      val result = tableStore.lookup(tableName, keyValues)
 
       // Record table miss context so PNA's add_entry extern knows which table to insert into.
       if (!result.hit) lastTableMissCtx = TableMissContext(tableName, keyValues)
@@ -873,9 +852,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       if (result.members != null) {
         val forced = selectorOverrides[tableName]
         if (forced != null) {
-          // Re-execution with a forced member. Disable cache: tables after the fork may
-          // see different key values per branch.
-          pastForkPoint = true
+          // Re-execution with a forced member (replay path for resubmit/recirculate).
           val member =
             result.members.find { it.memberId == forced }
               ?: error("forced member $forced not found in table $tableName")
@@ -1420,10 +1397,8 @@ fun interpreterExecution(
   packetCtx: PacketContext? = null,
   selectorOverrides: Map<String, Int> = emptyMap(),
   externHandler: ExternHandler? = null,
-  tableLookupCache: Map<String, TableStore.LookupResult>? = null,
 ): Interpreter.Execution =
-  Interpreter(config)
-    .execution(tableStore, packetCtx, selectorOverrides, externHandler, tableLookupCache)
+  Interpreter(config).execution(tableStore, packetCtx, selectorOverrides, externHandler)
 
 /**
  * Thrown by an `exit` statement; unwinds the call stack to the top of the current pipeline stage.
@@ -1437,10 +1412,9 @@ class AssertionFailureException(message: String) : Exception(message)
 class ReturnException(val value: Value) : Exception()
 
 /**
- * Thrown at non-deterministic choice points to signal the architecture to fork the trace tree.
- *
- * The architecture catches this and re-executes the pipeline for each branch, building a tree by
- * stripping shared prefix events.
+ * Thrown at non-deterministic choice points to signal the architecture to fork the trace tree. The
+ * architecture catches this and handles each fork type via fork-on-write: continuing each branch
+ * from the fork point instead of replaying the pipeline.
  */
 sealed class ForkException(val eventsBeforeFork: List<TraceEvent>) : Exception()
 

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -355,14 +355,15 @@ class Interpreter internal constructor(config: BehavioralConfig) {
     // -------------------------------------------------------------------------
 
     private fun execBlock(stmts: List<Stmt>, env: Environment) {
-      for ((i, stmt) in stmts.withIndex()) {
-        try {
-          execStmt(stmt, env)
-        } catch (fork: ActionSelectorFork) {
-          // Capture the continuation: statements after the fork in this block.
-          fork.remainingStmts.addLast(stmts.subList(i + 1, stmts.size))
-          throw fork
+      var i = 0
+      try {
+        while (i < stmts.size) {
+          execStmt(stmts[i], env)
+          i++
         }
+      } catch (fork: ActionSelectorFork) {
+        fork.remainingStmts.addLast(stmts.subList(i + 1, stmts.size))
+        throw fork
       }
     }
 
@@ -1413,8 +1414,8 @@ class ReturnException(val value: Value) : Exception()
 
 /**
  * Thrown at non-deterministic choice points to signal the architecture to fork the trace tree. The
- * architecture catches this and handles each fork type via fork-on-write: continuing each branch
- * from the fork point instead of replaying the pipeline.
+ * architecture catches this and continues each branch from the fork point (fork-point resume)
+ * instead of replaying the pipeline.
  */
 sealed class ForkException(val eventsBeforeFork: List<TraceEvent>) : Exception()
 
@@ -1422,7 +1423,7 @@ sealed class ForkException(val eventsBeforeFork: List<TraceEvent>) : Exception()
  * Fork at an action selector group hit — one branch per group member.
  *
  * Carries the full interpreter state at the fork point so each branch can continue from there
- * (fork-on-write) instead of replaying the entire pipeline.
+ * (fork-point resume) instead of replaying the entire pipeline.
  */
 class ActionSelectorFork(
   val tableName: String,

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -114,6 +114,9 @@ class V1ModelArchitecture(
 
     // Derived from the IR's standard_metadata struct definition, not hardcoded.
     val portBits: Int = standardMetadata.bitWidth("ingress_port")
+
+    /** Post-parser env deep copy, for I2E clone branches (BMv2: clone gets pre-ingress state). */
+    var postParserEnv: Environment? = null
   }
 
   override fun processPacket(
@@ -142,6 +145,14 @@ class V1ModelArchitecture(
       return buildSelectorForkTree(ctx, decisions, selectorFork, prefixLength)
     } catch (multicastFork: MulticastFork) {
       return buildMulticastForkTree(ctx, multicastFork, prefixLength)
+    } catch (cloneFork: CloneFork) {
+      return buildCloneForkTree(ctx, cloneFork, prefixLength)
+    } catch (egressCloneFork: EgressCloneFork) {
+      return buildEgressCloneForkTree(ctx, egressCloneFork, prefixLength)
+    } catch (resubmitFork: ResubmitFork) {
+      return buildResubmitForkTree(ctx, resubmitFork, prefixLength)
+    } catch (recirculateFork: RecirculateFork) {
+      return buildRecirculateForkTree(ctx, recirculateFork, prefixLength)
     } catch (fork: ForkException) {
       return buildReplayForkTree(ctx, decisions, fork, prefixLength)
     }
@@ -174,9 +185,8 @@ class V1ModelArchitecture(
       try {
         val trace = continueFromForkPoint(ctx, branchDecisions, selectorFork, member)
         PipelineResult(trace)
-      } catch (_: ForkException) {
-        // Nested fork (clone, multicast, etc.) — fall back to full pipeline replay.
-        buildTraceTree(ctx, branchDecisions, fork.eventsBeforeFork.size)
+      } catch (nestedFork: ForkException) {
+        PipelineResult(handleNestedFork(ctx, nestedFork))
       }
     }
 
@@ -226,6 +236,7 @@ class V1ModelArchitecture(
     val standardMetadata = resolveStandardMetadata(ctx, env)
 
     val s = finishPipelineState(ctx, decisions, packetCtx, env, standardMetadata, pendingOps)
+    s.postParserEnv = selectorFork.postParserEnv
 
     try {
       // Resume: execute the selected action + continuation stmts.
@@ -236,6 +247,16 @@ class V1ModelArchitecture(
         s.interpreter.resumeFromFork(fork, member, s.env)
       } catch (_: ExitException) {
         exitCalled = true
+      } catch (nestedSelector: ActionSelectorFork) {
+        // Nested selector in the continuation — wrap with V1Model pipeline context.
+        throw V1ModelSelectorFork(
+          nestedSelector,
+          s.pendingOps.copy(),
+          selectorFork.stage,
+          selectorFork.remainingStages,
+          selectorFork.duringIngress,
+          s.postParserEnv,
+        )
       } finally {
         s.env.popScope()
         s.packetCtx.addTraceEvent(stageEvent(selectorFork.stage, PipelineStageEvent.Direction.EXIT))
@@ -285,9 +306,8 @@ class V1ModelArchitecture(
         finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
       try {
         runEgressAndDeparser(ctx, s)
-      } catch (nestedFork: V1ModelSelectorFork) {
-        // Nested action selector in egress — handle via fork-on-write.
-        buildSelectorForkTree(ctx, V1ModelDecisions(), nestedFork, 0).trace
+      } catch (nestedFork: ForkException) {
+        handleNestedFork(ctx, nestedFork)
       } catch (_: AssertionFailureException) {
         buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
       }
@@ -320,6 +340,223 @@ class V1ModelArchitecture(
     return env.lookup(parserUserParams[2].name) as? StructVal
       ?: error("standard_metadata not found in environment")
   }
+
+  /**
+   * Handles an I2E clone fork via fork-on-write.
+   *
+   * "Original" branch: uses the post-ingress fork-point state, suppresses the clone, runs the
+   * remaining boundary checks (resubmit, multicast, unicast) then egress + deparser.
+   *
+   * "Clone" branch: uses the post-parser state (BMv2: clone gets parsed-but-not-ingress-modified
+   * headers), applies preserved metadata, sets clone metadata, runs egress + deparser.
+   */
+  private fun buildCloneForkTree(
+    ctx: PipelineContext,
+    fork: CloneFork,
+    prefixLength: Int = 0,
+  ): PipelineResult {
+    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+
+    val buildOriginal = {
+      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
+      val env = fork.forkPointEnv.deepCopy()
+      val pendingOps = fork.forkPointPendingOps.copy()
+      pendingOps.cloneSessionId = null
+      val standardMetadata = resolveStandardMetadata(ctx, env)
+      val s =
+        finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
+
+      try {
+        // Resume boundary: check resubmit, multicast, unicast (clone already handled).
+        ingressEgressBoundary(
+          ctx,
+          s,
+          V1ModelDecisions(branchMode = BranchMode.Normal(suppressI2EClone = true)),
+          0,
+        )
+        if (egressPortIsDropPort(s)) {
+          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        } else {
+          runEgressAndDeparser(ctx, s)
+        }
+      } catch (nestedFork: ForkException) {
+        handleNestedFork(ctx, nestedFork)
+      } catch (_: AssertionFailureException) {
+        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+      }
+    }
+
+    val buildClone = {
+      // BMv2: I2E clone gets the post-parser, pre-ingress state.
+      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
+      val env = fork.postParserEnv.deepCopy()
+      val standardMetadata = resolveStandardMetadata(ctx, env)
+
+      standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
+      standardMetadata.setBitField("egress_port", fork.clonePort)
+
+      // Apply preserved metadata (fields from the post-ingress state).
+      if (fork.preservedMetadata != null) {
+        val parserUserParams =
+          ctx.config.parsersList.first().paramsList.filter {
+            it.type.hasNamed() && it.type.named !in IO_TYPES
+          }
+        val metaVal = env.lookup(parserUserParams[1].name) as? StructVal
+        if (metaVal != null) {
+          for ((name, value) in fork.preservedMetadata) metaVal.fields[name] = value
+        }
+      }
+
+      val s = finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata)
+      try {
+        runEgressAndDeparser(ctx, s)
+      } catch (nestedFork: ForkException) {
+        handleNestedFork(ctx, nestedFork)
+      } catch (_: AssertionFailureException) {
+        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+      }
+    }
+
+    val branches =
+      listOf(
+        ForkBranch.newBuilder().setLabel("original").setSubtree(buildOriginal()).build(),
+        ForkBranch.newBuilder().setLabel("clone").setSubtree(buildClone()).build(),
+      )
+    return PipelineResult(buildForkTree(levelEvents, ForkReason.CLONE, branches))
+  }
+
+  /**
+   * Handles an E2E clone fork via fork-on-write.
+   *
+   * "Original" branch: suppresses E2E clone, runs deparser. "Clone" branch: sets CLONE_E2E
+   * metadata, applies preserved metadata, runs second egress + deparser.
+   */
+  private fun buildEgressCloneForkTree(
+    ctx: PipelineContext,
+    fork: EgressCloneFork,
+    prefixLength: Int = 0,
+  ): PipelineResult {
+    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+
+    val buildOriginal = {
+      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
+      val env = fork.forkPointEnv.deepCopy()
+      val pendingOps = fork.forkPointPendingOps.copy()
+      pendingOps.egressCloneSessionId = null
+      val standardMetadata = resolveStandardMetadata(ctx, env)
+      val s =
+        finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
+
+      try {
+        if (egressSpecIsDropPort(s)) {
+          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        } else {
+          runDeparser(s)
+        }
+      } catch (_: AssertionFailureException) {
+        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+      }
+    }
+
+    val buildClone = {
+      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
+      val env = fork.forkPointEnv.deepCopy()
+      val pendingOps = fork.forkPointPendingOps.copy()
+      pendingOps.egressCloneSessionId = null
+      val standardMetadata = resolveStandardMetadata(ctx, env)
+
+      standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
+      standardMetadata.setBitField("egress_port", fork.clonePort)
+
+      // Apply preserved metadata.
+      if (fork.preservedMetadata != null) {
+        val parserUserParams =
+          ctx.config.parsersList.first().paramsList.filter {
+            it.type.hasNamed() && it.type.named !in IO_TYPES
+          }
+        val metaVal = env.lookup(parserUserParams[1].name) as? StructVal
+        if (metaVal != null) {
+          for ((name, value) in fork.preservedMetadata) metaVal.fields[name] = value
+        }
+      }
+
+      val s =
+        finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
+      try {
+        // E2E clone runs egress again with clone metadata.
+        resetEgressSpec(s)
+        runControlStages(s, s.egressControls)
+        if (egressSpecIsDropPort(s)) {
+          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        } else {
+          runDeparser(s)
+        }
+      } catch (nestedFork: ForkException) {
+        handleNestedFork(ctx, nestedFork)
+      } catch (_: AssertionFailureException) {
+        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+      }
+    }
+
+    val branches =
+      listOf(
+        ForkBranch.newBuilder().setLabel("original").setSubtree(buildOriginal()).build(),
+        ForkBranch.newBuilder().setLabel("clone").setSubtree(buildClone()).build(),
+      )
+    return PipelineResult(buildForkTree(levelEvents, ForkReason.CLONE, branches))
+  }
+
+  /** Handles a resubmit fork: restarts the pipeline with preserved metadata. */
+  private fun buildResubmitForkTree(
+    ctx: PipelineContext,
+    fork: ResubmitFork,
+    prefixLength: Int = 0,
+  ): PipelineResult {
+    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+    val decisions =
+      V1ModelDecisions(
+        pipelineDepth = 1,
+        instanceTypeOverride = RESUBMIT_INSTANCE_TYPE,
+        preservedMetadata = fork.preservedMetadata,
+      )
+    val result = buildTraceTree(ctx, decisions, 0)
+    val branch = ForkBranch.newBuilder().setLabel("resubmit").setSubtree(result.trace).build()
+    return PipelineResult(buildForkTree(levelEvents, ForkReason.RESUBMIT, listOf(branch)))
+  }
+
+  /** Handles a recirculate fork: restarts the pipeline with deparsed bytes. */
+  private fun buildRecirculateForkTree(
+    ctx: PipelineContext,
+    fork: RecirculateFork,
+    prefixLength: Int = 0,
+  ): PipelineResult {
+    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+    val decisions =
+      V1ModelDecisions(
+        pipelineDepth = 1,
+        instanceTypeOverride = RECIRC_INSTANCE_TYPE,
+        preservedMetadata = fork.preservedMetadata,
+      )
+    val recircCtx = ctx.copy(payload = fork.deparsedBytes)
+    val result = buildTraceTree(recircCtx, decisions, 0)
+    val branch = ForkBranch.newBuilder().setLabel("recirculate").setSubtree(result.trace).build()
+    return PipelineResult(buildForkTree(levelEvents, ForkReason.RECIRCULATE, listOf(branch)))
+  }
+
+  /**
+   * Dispatches a nested fork exception to the appropriate fork-on-write handler. Called from within
+   * branch builders when a branch's execution throws a fork.
+   */
+  private fun handleNestedFork(ctx: PipelineContext, fork: ForkException): TraceTree =
+    when (fork) {
+      is V1ModelSelectorFork -> buildSelectorForkTree(ctx, V1ModelDecisions(), fork, 0).trace
+      is MulticastFork -> buildMulticastForkTree(ctx, fork).trace
+      is CloneFork -> buildCloneForkTree(ctx, fork).trace
+      is EgressCloneFork -> buildEgressCloneForkTree(ctx, fork).trace
+      is ResubmitFork -> buildResubmitForkTree(ctx, fork).trace
+      is RecirculateFork -> buildRecirculateForkTree(ctx, fork).trace
+      is ActionSelectorFork -> error("unwrapped ActionSelectorFork — should be V1ModelSelectorFork")
+    }
 
   /** Handles non-selector forks (clone, multicast, resubmit, recirculate) via replay. */
   private fun buildReplayForkTree(
@@ -383,78 +620,11 @@ class V1ModelArchitecture(
           }
         ForkReason.ACTION_SELECTOR to specs
       }
-      is CloneFork -> {
-        // The clone branch skips ingress, so its prefix is only parser events.
-        ForkReason.CLONE to
-          listOf(
-            BranchSpec(
-              "original",
-              ctx,
-              decisions.copy(branchMode = BranchMode.Normal(suppressI2EClone = true)),
-              fork.eventsBeforeFork.size,
-            ),
-            BranchSpec(
-              "clone",
-              ctx,
-              decisions.copy(
-                branchMode = BranchMode.I2EClone(fork.sessionId, fork.clonePort),
-                preservedMetadata = fork.preservedMetadata,
-              ),
-              fork.parserEventCount,
-            ),
-          )
-      }
-      is EgressCloneFork -> {
-        ForkReason.CLONE to
-          listOf(
-            BranchSpec(
-              "original",
-              ctx,
-              decisions.copy(branchMode = BranchMode.Normal(suppressE2EClone = true)),
-              fork.eventsBeforeFork.size,
-            ),
-            BranchSpec(
-              "clone",
-              ctx,
-              decisions.copy(
-                branchMode = BranchMode.E2EClone(fork.sessionId, fork.clonePort),
-                preservedMetadata = fork.preservedMetadata,
-              ),
-              fork.eventsBeforeFork.size,
-            ),
-          )
-      }
-      is MulticastFork -> {
-        val specs =
-          fork.replicas.map { replica ->
-            BranchSpec(
-              "replica_${replica.rid}_port_${replica.port}",
-              ctx,
-              decisions.copy(branchMode = replica),
-              fork.eventsBeforeFork.size,
-            )
-          }
-        ForkReason.MULTICAST to specs
-      }
-      is ResubmitFork -> {
-        val d =
-          V1ModelDecisions(
-            pipelineDepth = decisions.pipelineDepth + 1,
-            instanceTypeOverride = RESUBMIT_INSTANCE_TYPE,
-            preservedMetadata = fork.preservedMetadata,
-          )
-        ForkReason.RESUBMIT to listOf(BranchSpec("resubmit", ctx, d, fork.eventsBeforeFork.size))
-      }
-      is RecirculateFork -> {
-        val d =
-          V1ModelDecisions(
-            pipelineDepth = decisions.pipelineDepth + 1,
-            instanceTypeOverride = RECIRC_INSTANCE_TYPE,
-            preservedMetadata = fork.preservedMetadata,
-          )
-        ForkReason.RECIRCULATE to
-          listOf(BranchSpec("recirculate", ctx.copy(payload = fork.deparsedBytes), d, 0))
-      }
+      is CloneFork -> error("CloneFork handled by buildCloneForkTree")
+      is EgressCloneFork -> error("EgressCloneFork handled by buildEgressCloneForkTree")
+      is MulticastFork -> error("MulticastFork handled by buildMulticastForkTree")
+      is ResubmitFork -> error("ResubmitFork handled by buildResubmitForkTree")
+      is RecirculateFork -> error("RecirculateFork handled by buildRecirculateForkTree")
     }
 
   /**
@@ -599,6 +769,8 @@ class V1ModelArchitecture(
       s = initPipelineState(ctx, decisions)
       s.packetCtx.addTraceEvent(packetIngressEvent(ctx.ingressPort))
       parserExitDrop = runParser(s)
+      // Post-parser env for I2E clone fork-on-write (clone gets pre-ingress state).
+      s.postParserEnv = s.env.deepCopy()
       // Capture snapshot for potential fork re-executions.
       val parserUserParams =
         ctx.config.parsersList.first().paramsList.filter {
@@ -745,6 +917,7 @@ class V1ModelArchitecture(
           stage,
           stages.subList(i + 1, stages.size),
           duringIngress,
+          s.postParserEnv,
         )
       } finally {
         s.packetCtx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
@@ -785,9 +958,12 @@ class V1ModelArchitecture(
             throw CloneFork(
               pendingClone,
               clonePort,
-              parserEventCount,
               s.packetCtx.getEvents(),
               snapshotPreservedMetadata(s, s.pendingOps.cloneFieldListId),
+              s.env.deepCopy(),
+              s.packetCtx.bytesConsumed,
+              s.pendingOps.copy(),
+              s.postParserEnv ?: error("no post-parser env for I2E clone"),
             )
           }
         }
@@ -848,6 +1024,9 @@ class V1ModelArchitecture(
               clonePort,
               s.packetCtx.getEvents(),
               snapshotPreservedMetadata(s, s.pendingOps.egressCloneFieldListId),
+              s.env.deepCopy(),
+              s.packetCtx.bytesConsumed,
+              s.pendingOps.copy(),
             )
           }
         }
@@ -1324,28 +1503,44 @@ internal class V1ModelSelectorFork(
   val remainingStages: List<PipelineStage>,
   /** True if the fork happened during ingress controls (boundary + egress + deparser remain). */
   val duringIngress: Boolean,
+  /** Post-parser env for I2E clone fork-on-write (may be null for egress forks). */
+  val postParserEnv: Environment? = null,
 ) : ForkException(fork.eventsBeforeFork)
 
 /**
  * Fork at the ingress→egress boundary when an I2E clone was requested — "original" and "clone".
- *
- * [parserEventCount] tracks how many trace events came from the parser (before ingress). The clone
- * branch skips ingress, so its prefix length is shorter.
+ * Carries fork-point state so both branches can continue via fork-on-write.
  */
 internal class CloneFork(
   val sessionId: Int,
   val clonePort: Long,
-  val parserEventCount: Int,
   eventsBeforeFork: List<TraceEvent>,
   val preservedMetadata: Map<String, Value>? = null,
+  /** Deep copy of the post-ingress environment (for the "original" branch). */
+  val forkPointEnv: Environment,
+  /** Parser buffer position at the fork point. */
+  val bytesConsumed: Int,
+  /** Pending operations at the fork point. */
+  val forkPointPendingOps: V1ModelPendingOps,
+  /** Post-parser env (for the "clone" branch — BMv2: clone gets pre-ingress state). */
+  val postParserEnv: Environment,
 ) : ForkException(eventsBeforeFork)
 
-/** Fork after egress controls when an E2E clone was requested — "original" and "clone". */
+/**
+ * Fork after egress controls when an E2E clone was requested — "original" and "clone". Carries
+ * fork-point state so both branches can continue via fork-on-write.
+ */
 internal class EgressCloneFork(
   val sessionId: Int,
   val clonePort: Long,
   eventsBeforeFork: List<TraceEvent>,
   val preservedMetadata: Map<String, Value>? = null,
+  /** Deep copy of the post-egress environment (for both branches). */
+  val forkPointEnv: Environment,
+  /** Parser buffer position at the fork point. */
+  val bytesConsumed: Int,
+  /** Pending operations at the fork point. */
+  val forkPointPendingOps: V1ModelPendingOps,
 ) : ForkException(eventsBeforeFork)
 
 /** Fork at the ingress→egress boundary when mcast_grp is set — one branch per replica. */

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -7,7 +7,6 @@ import fourward.ir.StructDecl
 import fourward.sim.CloneEvent
 import fourward.sim.CloneSessionLookupEvent
 import fourward.sim.DropReason
-import fourward.sim.Fork
 import fourward.sim.ForkBranch
 import fourward.sim.ForkReason
 import fourward.sim.LogMessageEvent
@@ -120,55 +119,49 @@ class V1ModelArchitecture(
   }
 
   /**
-   * Builds a trace tree by executing the pipeline and handling forks via fork-on-write. Each fork
-   * type has a dedicated handler that continues branches from the fork point. Only
+   * Builds a trace tree by executing the pipeline and handling forks via fork-point resume. Only
    * resubmit/recirculate call back into this method (they restart the pipeline).
    */
   private fun buildTraceTree(ctx: PipelineContext, decisions: V1ModelDecisions): PipelineResult {
     try {
       return PipelineResult(runPipeline(ctx, decisions))
-    } catch (fork: V1ModelSelectorFork) {
-      return buildSelectorForkTree(ctx, decisions, fork)
-    } catch (fork: MulticastFork) {
-      return buildMulticastForkTree(ctx, fork)
-    } catch (fork: CloneFork) {
-      return buildCloneForkTree(ctx, fork)
-    } catch (fork: EgressCloneFork) {
-      return buildEgressCloneForkTree(ctx, fork)
-    } catch (fork: ResubmitFork) {
-      return buildResubmitForkTree(ctx, fork)
-    } catch (fork: RecirculateFork) {
-      return buildRecirculateForkTree(ctx, fork)
+    } catch (fork: ForkException) {
+      return handleFork(ctx, fork, decisions.pipelineDepth)
     }
   }
 
-  /**
-   * Handles an action selector fork via fork-on-write: each branch continues from the fork point
-   * instead of replaying the entire pipeline. If a branch hits a nested fork (clone, multicast), it
-   * falls back to the replay approach for that branch.
-   */
+  /** Dispatches a fork exception to the appropriate fork-point resume handler. */
+  private fun handleFork(
+    ctx: PipelineContext,
+    fork: ForkException,
+    pipelineDepth: Int = 0,
+  ): PipelineResult =
+    when (fork) {
+      is V1ModelSelectorFork -> buildSelectorForkTree(ctx, fork)
+      is MulticastFork -> buildMulticastForkTree(ctx, fork)
+      is CloneFork -> buildCloneForkTree(ctx, fork)
+      is EgressCloneFork -> buildEgressCloneForkTree(ctx, fork)
+      is ResubmitFork -> buildResubmitForkTree(ctx, fork, pipelineDepth)
+      is RecirculateFork -> buildRecirculateForkTree(ctx, fork, pipelineDepth)
+      is ActionSelectorFork -> error("unwrapped ActionSelectorFork — should be V1ModelSelectorFork")
+    }
+
+  /** Action selector: each member continues from the fork point via [continueFromForkPoint]. */
   private fun buildSelectorForkTree(
     ctx: PipelineContext,
-    decisions: V1ModelDecisions,
     selectorFork: V1ModelSelectorFork,
   ): PipelineResult {
     val fork = selectorFork.fork
-    val levelEvents = fork.eventsBeforeFork
 
     val buildBranch = { member: TableStore.MemberAction ->
-      val branchDecisions =
-        decisions.copy(
-          selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId)
-        )
       try {
-        val trace = continueFromForkPoint(ctx, branchDecisions, selectorFork, member)
-        PipelineResult(trace)
+        continueFromForkPoint(ctx, selectorFork, member)
       } catch (nestedFork: ForkException) {
-        PipelineResult(handleNestedFork(ctx, nestedFork))
+        handleFork(ctx, nestedFork).trace
       }
     }
 
-    val results =
+    val traces: List<TraceTree> =
       if (INTRA_PACKET_PARALLELISM_ENABLED) {
         fork.members.parallelStream().map(buildBranch).toList()
       } else {
@@ -176,57 +169,117 @@ class V1ModelArchitecture(
       }
 
     val branches =
-      fork.members.zip(results).map { (member, result) ->
-        ForkBranch.newBuilder()
-          .setLabel("member_${member.memberId}")
-          .setSubtree(result.trace)
-          .build()
+      fork.members.zip(traces).map { (member, trace) ->
+        ForkBranch.newBuilder().setLabel("member_${member.memberId}").setSubtree(trace).build()
       }
-    val tree =
-      TraceTree.newBuilder()
-        .addAllEvents(levelEvents)
-        .setForkOutcome(
-          Fork.newBuilder().setReason(ForkReason.ACTION_SELECTOR).addAllBranches(branches)
-        )
-        .build()
-    return PipelineResult(tree)
+    return PipelineResult(
+      buildForkTree(fork.eventsBeforeFork, ForkReason.ACTION_SELECTOR, branches)
+    )
+  }
+
+  // -------------------------------------------------------------------------
+  // Fork-on-write branch execution
+  // -------------------------------------------------------------------------
+
+  /**
+   * Creates a [PipelineState] from a fork-point snapshot. Each fork branch gets an independent deep
+   * copy of the environment and pending operations, with a fresh [PacketContext] (empty trace
+   * events, buffer at the parser's extraction position).
+   */
+  private fun createBranchState(
+    ctx: PipelineContext,
+    bytesConsumed: Int,
+    snapshotEnv: Environment,
+    snapshotPendingOps: V1ModelPendingOps? = null,
+    selectorMembers: Map<String, Int> = emptyMap(),
+  ): PipelineState {
+    val packetCtx = PacketContext(ctx.payload, bytesConsumed)
+    val env = snapshotEnv.deepCopy()
+    val pendingOps = snapshotPendingOps?.copy() ?: V1ModelPendingOps()
+    val standardMetadata = resolveStandardMetadata(ctx, env)
+    return finishPipelineState(
+      ctx,
+      V1ModelDecisions(selectorMembers = selectorMembers),
+      packetCtx,
+      env,
+      standardMetadata,
+      pendingOps,
+    )
   }
 
   /**
-   * Continues pipeline execution from an action selector fork point. Restores the interpreter state
-   * captured at the fork, executes the selected member's action and continuation, then runs the
-   * remaining pipeline (boundary, egress, deparser).
+   * Runs a fork branch: creates state from a snapshot, applies branch-specific configuration, then
+   * runs the pipeline tail. Nested forks and assertion failures are handled automatically.
+   */
+  private inline fun runBranch(
+    ctx: PipelineContext,
+    bytesConsumed: Int,
+    snapshotEnv: Environment,
+    snapshotPendingOps: V1ModelPendingOps? = null,
+    configure: (PipelineState) -> Unit = {},
+    pipelineTail: (PipelineContext, PipelineState) -> TraceTree,
+  ): TraceTree {
+    val s = createBranchState(ctx, bytesConsumed, snapshotEnv, snapshotPendingOps)
+    configure(s)
+    return try {
+      pipelineTail(ctx, s)
+    } catch (nestedFork: ForkException) {
+      handleFork(ctx, nestedFork).trace
+    } catch (_: AssertionFailureException) {
+      buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+    }
+  }
+
+  /** Applies preserved metadata fields onto the user metadata struct in [env]. */
+  private fun applyPreservedMetadata(
+    ctx: PipelineContext,
+    env: Environment,
+    preservedMetadata: Map<String, Value>?,
+  ) {
+    if (preservedMetadata == null) return
+    val parserUserParams =
+      ctx.config.parsersList.first().paramsList.filter {
+        it.type.hasNamed() && it.type.named !in IO_TYPES
+      }
+    val metaVal = env.lookup(parserUserParams[1].name) as? StructVal ?: return
+    for ((name, value) in preservedMetadata) metaVal.fields[name] = value
+  }
+
+  /** Resolves standard_metadata from the environment using the config's parser parameter names. */
+  private fun resolveStandardMetadata(ctx: PipelineContext, env: Environment): StructVal {
+    val parserUserParams =
+      ctx.config.parsersList.first().paramsList.filter {
+        it.type.hasNamed() && it.type.named !in IO_TYPES
+      }
+    return env.lookup(parserUserParams[2].name) as? StructVal
+      ?: error("standard_metadata not found in environment")
+  }
+
+  // -------------------------------------------------------------------------
+  // Fork-on-write handlers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Continues from an action selector fork point. Has custom error handling because nested selector
+   * forks must be wrapped in [V1ModelSelectorFork] (not dispatched via [handleNestedFork]).
    */
   @Suppress("ThrowsCount")
   private fun continueFromForkPoint(
     ctx: PipelineContext,
-    decisions: V1ModelDecisions,
     selectorFork: V1ModelSelectorFork,
     member: TableStore.MemberAction,
   ): TraceTree {
     val fork = selectorFork.fork
-
-    // Fresh packet context at the parser's buffer position — trace events start empty.
-    val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
-    val env = fork.forkPointEnv.deepCopy()
-    val pendingOps = selectorFork.pendingOps.copy()
-
-    val standardMetadata = resolveStandardMetadata(ctx, env)
-
-    val s = finishPipelineState(ctx, decisions, packetCtx, env, standardMetadata, pendingOps)
+    val s = createBranchState(ctx, fork.bytesConsumed, fork.forkPointEnv, selectorFork.pendingOps)
     s.postParserEnv = selectorFork.postParserEnv
 
     try {
-      // Resume: execute the selected action + continuation stmts.
-      // An exit statement terminates the current control — catch it, pop scope, skip
-      // remaining stages (same as runControlStages's ExitException handler).
       var exitCalled = false
       try {
         s.interpreter.resumeFromFork(fork, member, s.env)
       } catch (_: ExitException) {
         exitCalled = true
       } catch (nestedSelector: ActionSelectorFork) {
-        // Nested selector in the continuation — wrap with V1Model pipeline context.
         throw V1ModelSelectorFork(
           nestedSelector,
           s.pendingOps.copy(),
@@ -240,64 +293,43 @@ class V1ModelArchitecture(
         s.packetCtx.addTraceEvent(stageEvent(selectorFork.stage, PipelineStageEvent.Direction.EXIT))
       }
 
-      // Remaining stages in the same control group (skipped on exit).
-      if (!exitCalled) {
-        runControlStages(s, selectorFork.remainingStages)
-      }
+      if (!exitCalled) runControlStages(s, selectorFork.remainingStages)
 
       if (selectorFork.duringIngress) {
-        // Fork was in ingress — run boundary + egress + deparser.
         ingressEgressBoundary(ctx, s)
         if (egressPortIsDropPort(s)) {
           return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
         }
         return runEgressAndDeparser(ctx, s)
       }
-      // Fork was in egress — remaining egress stages already ran, just finish.
       return runPostEgressAndDeparser(ctx, s)
     } catch (_: AssertionFailureException) {
       return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
     }
   }
 
-  /**
-   * Handles a multicast fork via fork-on-write: each replica gets a deep copy of the fork-point
-   * state with its metadata (instance_type, egress_port, egress_rid) set, then runs egress +
-   * deparser independently.
-   */
-  private fun buildMulticastForkTree(
-    ctx: PipelineContext,
-    fork: MulticastFork,
-    prefixLength: Int = 0,
-  ): PipelineResult {
+  /** Multicast: each replica sets port/rid metadata, then runs egress + deparser. */
+  private fun buildMulticastForkTree(ctx: PipelineContext, fork: MulticastFork): PipelineResult {
     val buildBranch = { replica: Replica ->
-      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
-      val env = fork.forkPointEnv.deepCopy()
-      val pendingOps = fork.forkPointPendingOps.copy()
-
-      val standardMetadata = resolveStandardMetadata(ctx, env)
-      standardMetadata.setBitField("instance_type", REPLICATION_INSTANCE_TYPE)
-      standardMetadata.setBitField("egress_port", replica.port.toLong())
-      standardMetadata.setBitField("egress_rid", replica.rid.toLong())
-
-      val s =
-        finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
-      try {
-        runEgressAndDeparser(ctx, s)
-      } catch (nestedFork: ForkException) {
-        handleNestedFork(ctx, nestedFork)
-      } catch (_: AssertionFailureException) {
-        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
-      }
+      runBranch(
+        ctx,
+        fork.bytesConsumed,
+        fork.forkPointEnv,
+        fork.forkPointPendingOps,
+        configure = { s ->
+          s.standardMetadata.setBitField("instance_type", REPLICATION_INSTANCE_TYPE)
+          s.standardMetadata.setBitField("egress_port", replica.port.toLong())
+          s.standardMetadata.setBitField("egress_rid", replica.rid.toLong())
+        },
+        pipelineTail = { c, s -> runEgressAndDeparser(c, s) },
+      )
     }
-
     val results =
       if (INTRA_PACKET_PARALLELISM_ENABLED) {
         fork.replicas.parallelStream().map(buildBranch).toList()
       } else {
         fork.replicas.map(buildBranch)
       }
-
     val branches =
       fork.replicas.zip(results).map { (replica, trace) ->
         ForkBranch.newBuilder()
@@ -305,222 +337,138 @@ class V1ModelArchitecture(
           .setSubtree(trace)
           .build()
       }
-    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
-    return PipelineResult(buildForkTree(levelEvents, ForkReason.MULTICAST, branches))
-  }
-
-  /** Resolves standard_metadata from the environment using the config's parser parameter names. */
-  private fun resolveStandardMetadata(ctx: PipelineContext, env: Environment): StructVal {
-    val parserUserParams =
-      ctx.config.parsersList.first().paramsList.filter {
-        it.type.hasNamed() && it.type.named !in IO_TYPES
-      }
-    return env.lookup(parserUserParams[2].name) as? StructVal
-      ?: error("standard_metadata not found in environment")
+    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.MULTICAST, branches))
   }
 
   /**
-   * Handles an I2E clone fork via fork-on-write.
-   *
-   * "Original" branch: uses the post-ingress fork-point state, suppresses the clone, runs the
-   * remaining boundary checks (resubmit, multicast, unicast) then egress + deparser.
-   *
-   * "Clone" branch: uses the post-parser state (BMv2: clone gets parsed-but-not-ingress-modified
-   * headers), applies preserved metadata, sets clone metadata, runs egress + deparser.
+   * I2E clone: "original" continues through boundary + egress; "clone" uses post-parser env (BMv2:
+   * clone gets pre-ingress state) with preserved metadata overlay.
    */
   private fun buildCloneForkTree(ctx: PipelineContext, fork: CloneFork): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork
-
-    val buildOriginal = {
-      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
-      val env = fork.forkPointEnv.deepCopy()
-      val pendingOps = fork.forkPointPendingOps.copy()
-      pendingOps.cloneSessionId = null
-      val standardMetadata = resolveStandardMetadata(ctx, env)
-      val s =
-        finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
-
-      try {
-        // Resume boundary: check resubmit, multicast, unicast (clone already handled).
-        // pendingOps.cloneSessionId already cleared — boundary won't re-clone.
-        ingressEgressBoundary(ctx, s)
-        if (egressPortIsDropPort(s)) {
-          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-        } else {
-          runEgressAndDeparser(ctx, s)
-        }
-      } catch (nestedFork: ForkException) {
-        handleNestedFork(ctx, nestedFork)
-      } catch (_: AssertionFailureException) {
-        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
-      }
-    }
-
-    val buildClone = {
-      // BMv2: I2E clone gets the post-parser, pre-ingress state.
-      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
-      val env = fork.postParserEnv.deepCopy()
-      val standardMetadata = resolveStandardMetadata(ctx, env)
-
-      standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
-      standardMetadata.setBitField("egress_port", fork.clonePort)
-
-      // Apply preserved metadata (fields from the post-ingress state).
-      if (fork.preservedMetadata != null) {
-        val parserUserParams =
-          ctx.config.parsersList.first().paramsList.filter {
-            it.type.hasNamed() && it.type.named !in IO_TYPES
-          }
-        val metaVal = env.lookup(parserUserParams[1].name) as? StructVal
-        if (metaVal != null) {
-          for ((name, value) in fork.preservedMetadata) metaVal.fields[name] = value
-        }
-      }
-
-      val s = finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata)
-      try {
-        runEgressAndDeparser(ctx, s)
-      } catch (nestedFork: ForkException) {
-        handleNestedFork(ctx, nestedFork)
-      } catch (_: AssertionFailureException) {
-        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
-      }
-    }
-
+    val original =
+      runBranch(
+        ctx,
+        fork.bytesConsumed,
+        fork.forkPointEnv,
+        fork.forkPointPendingOps,
+        configure = { s -> s.pendingOps.cloneSessionId = null },
+        pipelineTail = { c, s ->
+          ingressEgressBoundary(c, s)
+          if (egressPortIsDropPort(s))
+            buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+          else runEgressAndDeparser(c, s)
+        },
+      )
+    val clone =
+      runBranch(
+        ctx,
+        fork.bytesConsumed,
+        fork.postParserEnv,
+        configure = { s ->
+          s.standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
+          s.standardMetadata.setBitField("egress_port", fork.clonePort)
+          applyPreservedMetadata(ctx, s.env, fork.preservedMetadata)
+        },
+        pipelineTail = { c, s -> runEgressAndDeparser(c, s) },
+      )
     val branches =
       listOf(
-        ForkBranch.newBuilder().setLabel("original").setSubtree(buildOriginal()).build(),
-        ForkBranch.newBuilder().setLabel("clone").setSubtree(buildClone()).build(),
+        ForkBranch.newBuilder().setLabel("original").setSubtree(original).build(),
+        ForkBranch.newBuilder().setLabel("clone").setSubtree(clone).build(),
       )
-    return PipelineResult(buildForkTree(levelEvents, ForkReason.CLONE, branches))
+    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.CLONE, branches))
   }
 
   /**
-   * Handles an E2E clone fork via fork-on-write.
-   *
-   * "Original" branch: suppresses E2E clone, runs deparser. "Clone" branch: sets CLONE_E2E
-   * metadata, applies preserved metadata, runs second egress + deparser.
+   * E2E clone: "original" suppresses E2E clone and runs deparser; "clone" sets CLONE_E2E metadata,
+   * applies preserved metadata, and re-runs egress + deparser.
    */
   private fun buildEgressCloneForkTree(
     ctx: PipelineContext,
     fork: EgressCloneFork,
   ): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork
-
-    val buildOriginal = {
-      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
-      val env = fork.forkPointEnv.deepCopy()
-      val pendingOps = fork.forkPointPendingOps.copy()
-      pendingOps.egressCloneSessionId = null
-      val standardMetadata = resolveStandardMetadata(ctx, env)
-      val s =
-        finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
-
-      try {
-        if (egressSpecIsDropPort(s)) {
-          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-        } else {
-          runDeparser(s)
-        }
-      } catch (_: AssertionFailureException) {
-        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
-      }
-    }
-
-    val buildClone = {
-      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
-      val env = fork.forkPointEnv.deepCopy()
-      val pendingOps = fork.forkPointPendingOps.copy()
-      pendingOps.egressCloneSessionId = null
-      val standardMetadata = resolveStandardMetadata(ctx, env)
-
-      standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
-      standardMetadata.setBitField("egress_port", fork.clonePort)
-
-      // Apply preserved metadata.
-      if (fork.preservedMetadata != null) {
-        val parserUserParams =
-          ctx.config.parsersList.first().paramsList.filter {
-            it.type.hasNamed() && it.type.named !in IO_TYPES
-          }
-        val metaVal = env.lookup(parserUserParams[1].name) as? StructVal
-        if (metaVal != null) {
-          for ((name, value) in fork.preservedMetadata) metaVal.fields[name] = value
-        }
-      }
-
-      val s =
-        finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
-      try {
-        // E2E clone runs egress again with clone metadata.
-        resetEgressSpec(s)
-        runControlStages(s, s.egressControls)
-        if (egressSpecIsDropPort(s)) {
-          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-        } else {
-          runDeparser(s)
-        }
-      } catch (nestedFork: ForkException) {
-        handleNestedFork(ctx, nestedFork)
-      } catch (_: AssertionFailureException) {
-        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
-      }
-    }
-
+    val original =
+      runBranch(
+        ctx,
+        fork.bytesConsumed,
+        fork.forkPointEnv,
+        fork.forkPointPendingOps,
+        configure = { s -> s.pendingOps.egressCloneSessionId = null },
+        pipelineTail = { _, s ->
+          if (egressSpecIsDropPort(s))
+            buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+          else runDeparser(s)
+        },
+      )
+    val clone =
+      runBranch(
+        ctx,
+        fork.bytesConsumed,
+        fork.forkPointEnv,
+        fork.forkPointPendingOps,
+        configure = { s ->
+          s.pendingOps.egressCloneSessionId = null
+          s.standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
+          s.standardMetadata.setBitField("egress_port", fork.clonePort)
+          applyPreservedMetadata(ctx, s.env, fork.preservedMetadata)
+        },
+        pipelineTail = { _, s ->
+          resetEgressSpec(s)
+          runControlStages(s, s.egressControls)
+          if (egressSpecIsDropPort(s))
+            buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+          else runDeparser(s)
+        },
+      )
     val branches =
       listOf(
-        ForkBranch.newBuilder().setLabel("original").setSubtree(buildOriginal()).build(),
-        ForkBranch.newBuilder().setLabel("clone").setSubtree(buildClone()).build(),
+        ForkBranch.newBuilder().setLabel("original").setSubtree(original).build(),
+        ForkBranch.newBuilder().setLabel("clone").setSubtree(clone).build(),
       )
-    return PipelineResult(buildForkTree(levelEvents, ForkReason.CLONE, branches))
+    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.CLONE, branches))
   }
 
-  /** Handles a resubmit fork: restarts the pipeline with preserved metadata. */
-  private fun buildResubmitForkTree(ctx: PipelineContext, fork: ResubmitFork): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork
+  /** Resubmit: restarts the pipeline with preserved metadata. */
+  private fun buildResubmitForkTree(
+    ctx: PipelineContext,
+    fork: ResubmitFork,
+    pipelineDepth: Int,
+  ): PipelineResult {
     val decisions =
       V1ModelDecisions(
-        pipelineDepth = 1,
+        pipelineDepth = pipelineDepth + 1,
         instanceTypeOverride = RESUBMIT_INSTANCE_TYPE,
         preservedMetadata = fork.preservedMetadata,
       )
-    val result = buildTraceTree(ctx, decisions)
-    val branch = ForkBranch.newBuilder().setLabel("resubmit").setSubtree(result.trace).build()
-    return PipelineResult(buildForkTree(levelEvents, ForkReason.RESUBMIT, listOf(branch)))
+    val branch =
+      ForkBranch.newBuilder()
+        .setLabel("resubmit")
+        .setSubtree(buildTraceTree(ctx, decisions).trace)
+        .build()
+    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.RESUBMIT, listOf(branch)))
   }
 
-  /** Handles a recirculate fork: restarts the pipeline with deparsed bytes. */
+  /** Recirculate: restarts the pipeline with deparsed bytes. */
   private fun buildRecirculateForkTree(
     ctx: PipelineContext,
     fork: RecirculateFork,
+    pipelineDepth: Int,
   ): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork
     val decisions =
       V1ModelDecisions(
-        pipelineDepth = 1,
+        pipelineDepth = pipelineDepth + 1,
         instanceTypeOverride = RECIRC_INSTANCE_TYPE,
         preservedMetadata = fork.preservedMetadata,
       )
-    val recircCtx = ctx.copy(payload = fork.deparsedBytes)
-    val result = buildTraceTree(recircCtx, decisions)
-    val branch = ForkBranch.newBuilder().setLabel("recirculate").setSubtree(result.trace).build()
-    return PipelineResult(buildForkTree(levelEvents, ForkReason.RECIRCULATE, listOf(branch)))
+    val branch =
+      ForkBranch.newBuilder()
+        .setLabel("recirculate")
+        .setSubtree(buildTraceTree(ctx.copy(payload = fork.deparsedBytes), decisions).trace)
+        .build()
+    return PipelineResult(
+      buildForkTree(fork.eventsBeforeFork, ForkReason.RECIRCULATE, listOf(branch))
+    )
   }
-
-  /**
-   * Dispatches a nested fork exception to the appropriate fork-on-write handler. Called from within
-   * branch builders when a branch's execution throws a fork.
-   */
-  private fun handleNestedFork(ctx: PipelineContext, fork: ForkException): TraceTree =
-    when (fork) {
-      is V1ModelSelectorFork -> buildSelectorForkTree(ctx, V1ModelDecisions(), fork).trace
-      is MulticastFork -> buildMulticastForkTree(ctx, fork).trace
-      is CloneFork -> buildCloneForkTree(ctx, fork).trace
-      is EgressCloneFork -> buildEgressCloneForkTree(ctx, fork).trace
-      is ResubmitFork -> buildResubmitForkTree(ctx, fork).trace
-      is RecirculateFork -> buildRecirculateForkTree(ctx, fork).trace
-      is ActionSelectorFork -> error("unwrapped ActionSelectorFork — should be V1ModelSelectorFork")
-    }
 
   /**
    * Creates a fresh [PipelineState] for one pipeline execution.
@@ -757,7 +705,7 @@ class V1ModelArchitecture(
       } catch (_: ExitException) {
         break
       } catch (fork: ActionSelectorFork) {
-        // Wrap with V1Model-specific fork-point state for fork-on-write resume.
+        // Wrap with V1Model-specific fork-point state for fork-point resume.
         // Stage EXIT still fires (via finally) — the fork-point events include it.
         throw V1ModelSelectorFork(
           fork,
@@ -781,7 +729,6 @@ class V1ModelArchitecture(
    */
   @Suppress("ThrowsCount") // one throw per fork type at the boundary
   private fun ingressEgressBoundary(ctx: PipelineContext, s: PipelineState) {
-    // BMv2 priority order: I2E clone > resubmit > multicast > unicast/drop.
     val pendingClone = s.pendingOps.cloneSessionId
     if (pendingClone != null) {
       resolveCloneSession(ctx, s, pendingClone)?.let { clonePort ->
@@ -1199,14 +1146,8 @@ class V1ModelArchitecture(
 internal data class Replica(val rid: Int, val port: Int)
 
 /**
- * v1model-specific policies for pipeline execution.
- *
- * @property selectorMembers Forced member selections per table (action selector branches).
- * @property branchMode The execution mode for this branch (normal, clone, or replica).
- * @property instanceTypeOverride If non-null, override instance_type at pipeline init.
- * @property pipelineDepth Tracks resubmit/recirculate nesting to prevent infinite loops.
- * @property preservedMetadata Pre-filtered metadata fields to restore from
- *   clone/resubmit/recirculate.
+ * Pipeline execution decisions for resubmit/recirculate replays. Fork-on-write branches bypass this
+ * entirely — they restore state from the fork-point snapshot instead.
  */
 internal data class V1ModelDecisions(
   val selectorMembers: Map<String, Int> = emptyMap(),
@@ -1221,44 +1162,16 @@ internal data class V1ModelDecisions(
  * A fresh instance is created per pipeline execution. This keeps v1model state out of the shared
  * [PacketContext], which only carries architecture-agnostic concerns (packet I/O, trace events).
  */
-internal class V1ModelPendingOps {
-  /** Session ID from the last I2E clone() call, or null if no clone was requested. */
-  var cloneSessionId: Int? = null
-
-  /** Field list ID for I2E clone metadata preservation. */
-  var cloneFieldListId: Int? = null
-
-  /** Session ID from the last E2E clone() call, checked after egress controls. */
-  var egressCloneSessionId: Int? = null
-
-  /** Field list ID for E2E clone metadata preservation. */
-  var egressCloneFieldListId: Int? = null
-
-  /** True if resubmit() was called during ingress. */
-  var resubmit: Boolean = false
-
-  /** Field list ID for resubmit metadata preservation. */
-  var resubmitFieldListId: Int? = null
-
-  /** True if recirculate() was called during egress. */
-  var recirculate: Boolean = false
-
-  /** Field list ID for recirculate metadata preservation. */
-  var recirculateFieldListId: Int? = null
-
-  fun copy(): V1ModelPendingOps {
-    val c = V1ModelPendingOps()
-    c.cloneSessionId = cloneSessionId
-    c.cloneFieldListId = cloneFieldListId
-    c.egressCloneSessionId = egressCloneSessionId
-    c.egressCloneFieldListId = egressCloneFieldListId
-    c.resubmit = resubmit
-    c.resubmitFieldListId = resubmitFieldListId
-    c.recirculate = recirculate
-    c.recirculateFieldListId = recirculateFieldListId
-    return c
-  }
-}
+internal data class V1ModelPendingOps(
+  var cloneSessionId: Int? = null,
+  var cloneFieldListId: Int? = null,
+  var egressCloneSessionId: Int? = null,
+  var egressCloneFieldListId: Int? = null,
+  var resubmit: Boolean = false,
+  var resubmitFieldListId: Int? = null,
+  var recirculate: Boolean = false,
+  var recirculateFieldListId: Int? = null,
+)
 
 // -------------------------------------------------------------------------
 // v1model-specific fork exceptions
@@ -1268,8 +1181,8 @@ internal class V1ModelPendingOps {
  * Wraps an [ActionSelectorFork] with v1model-specific pipeline state captured at the fork point.
  *
  * Created by [runControlStages] when it catches the interpreter's fork exception. Carries
- * everything needed to resume each branch from the fork point (fork-on-write) instead of replaying
- * the pipeline.
+ * everything needed to resume each branch from the fork point (fork-point resume) instead of
+ * replaying the pipeline.
  */
 internal class V1ModelSelectorFork(
   val fork: ActionSelectorFork,
@@ -1278,13 +1191,13 @@ internal class V1ModelSelectorFork(
   val remainingStages: List<PipelineStage>,
   /** True if the fork happened during ingress controls (boundary + egress + deparser remain). */
   val duringIngress: Boolean,
-  /** Post-parser env for I2E clone fork-on-write (may be null for egress forks). */
+  /** Post-parser env for I2E clone fork-point resume (may be null for egress forks). */
   val postParserEnv: Environment? = null,
 ) : ForkException(fork.eventsBeforeFork)
 
 /**
  * Fork at the ingress→egress boundary when an I2E clone was requested — "original" and "clone".
- * Carries fork-point state so both branches can continue via fork-on-write.
+ * Carries fork-point state so both branches can continue via fork-point resume.
  */
 internal class CloneFork(
   val sessionId: Int,
@@ -1303,7 +1216,7 @@ internal class CloneFork(
 
 /**
  * Fork after egress controls when an E2E clone was requested — "original" and "clone". Carries
- * fork-point state so both branches can continue via fork-on-write.
+ * fork-point state so both branches can continue via fork-point resume.
  */
 internal class EgressCloneFork(
   val sessionId: Int,

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -138,39 +138,206 @@ class V1ModelArchitecture(
     val trace: TraceTree
     try {
       trace = runPipeline(ctx, decisions)
+    } catch (selectorFork: V1ModelSelectorFork) {
+      // Fork-on-write: continue each branch from the fork point instead of replaying.
+      return buildSelectorForkTree(ctx, decisions, selectorFork, prefixLength)
     } catch (fork: ForkException) {
-      val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
-      val (reason, specs) = forkSpecs(ctx, decisions, fork)
-
-      // Intra-packet parallelism: runs fork branches on ForkJoinPool. Helpful for
-      // single-packet latency (CLI, STF, playground), neutral for throughput under
-      // inter-packet parallelism. See designs/parallel_packet_scaling.md for the
-      // measured trade-off.
-      val subtrees =
-        if (INTRA_PACKET_PARALLELISM_ENABLED) {
-          specs
-            .parallelStream()
-            .map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
-            .toList()
-        } else {
-          specs.map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
-        }
-
-      val branches =
-        specs.zip(subtrees).map { (spec, result) ->
-          ForkBranch.newBuilder().setLabel(spec.label).setSubtree(result.trace).build()
-        }
-      val tree =
-        TraceTree.newBuilder()
-          .addAllEvents(levelEvents)
-          .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
-          .build()
-      return PipelineResult(tree)
+      return buildReplayForkTree(ctx, decisions, fork, prefixLength)
     }
 
     val stripped = TraceTree.newBuilder().addAllEvents(trace.eventsList.drop(prefixLength))
     if (trace.hasPacketOutcome()) stripped.setPacketOutcome(trace.packetOutcome)
     return PipelineResult(stripped.build())
+  }
+
+  /**
+   * Handles an action selector fork via fork-on-write: each branch continues from the fork point
+   * instead of replaying the entire pipeline. If a branch hits a nested fork (clone, multicast), it
+   * falls back to the replay approach for that branch.
+   */
+  private fun buildSelectorForkTree(
+    ctx: PipelineContext,
+    decisions: V1ModelDecisions,
+    selectorFork: V1ModelSelectorFork,
+    prefixLength: Int,
+  ): PipelineResult {
+    val fork = selectorFork.fork
+    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+
+    val buildBranch = { member: TableStore.MemberAction ->
+      val branchDecisions =
+        decisions.copy(
+          selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId),
+          postParserSnapshot = postParserSnapshot.get(),
+        )
+      try {
+        val trace = continueFromForkPoint(ctx, branchDecisions, selectorFork, member)
+        PipelineResult(trace)
+      } catch (_: ForkException) {
+        // Nested fork (clone, multicast, etc.) — fall back to full pipeline replay.
+        buildTraceTree(ctx, branchDecisions, fork.eventsBeforeFork.size)
+      }
+    }
+
+    val results =
+      if (INTRA_PACKET_PARALLELISM_ENABLED) {
+        fork.members.parallelStream().map(buildBranch).toList()
+      } else {
+        fork.members.map(buildBranch)
+      }
+
+    val branches =
+      fork.members.zip(results).map { (member, result) ->
+        ForkBranch.newBuilder()
+          .setLabel("member_${member.memberId}")
+          .setSubtree(result.trace)
+          .build()
+      }
+    val tree =
+      TraceTree.newBuilder()
+        .addAllEvents(levelEvents)
+        .setForkOutcome(
+          Fork.newBuilder().setReason(ForkReason.ACTION_SELECTOR).addAllBranches(branches)
+        )
+        .build()
+    return PipelineResult(tree)
+  }
+
+  /**
+   * Continues pipeline execution from an action selector fork point. Restores the interpreter state
+   * captured at the fork, executes the selected member's action and continuation, then runs the
+   * remaining pipeline (boundary, egress, deparser).
+   */
+  @Suppress("ThrowsCount")
+  private fun continueFromForkPoint(
+    ctx: PipelineContext,
+    decisions: V1ModelDecisions,
+    selectorFork: V1ModelSelectorFork,
+    member: TableStore.MemberAction,
+  ): TraceTree {
+    val fork = selectorFork.fork
+
+    // Fresh packet context at the parser's buffer position — trace events start empty.
+    val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
+    val env = fork.forkPointEnv.deepCopy()
+    val pendingOps = selectorFork.pendingOps.copy()
+
+    // Resolve standard_metadata from the restored environment.
+    val parserUserParams =
+      ctx.config.parsersList.first().paramsList.filter {
+        it.type.hasNamed() && it.type.named !in IO_TYPES
+      }
+    val standardMetaParamName = parserUserParams[2].name
+    val standardMetadata =
+      env.lookup(standardMetaParamName) as? StructVal
+        ?: error("standard_metadata not found in fork-point environment")
+
+    val s = finishPipelineState(ctx, decisions, packetCtx, env, standardMetadata, pendingOps)
+
+    try {
+      // Resume: execute the selected action + continuation stmts.
+      // An exit statement terminates the current control — catch it, pop scope, skip
+      // remaining stages (same as runControlStages's ExitException handler).
+      var exitCalled = false
+      try {
+        s.interpreter.resumeFromFork(fork, member, s.env)
+      } catch (_: ExitException) {
+        exitCalled = true
+      } finally {
+        s.env.popScope()
+        s.packetCtx.addTraceEvent(stageEvent(selectorFork.stage, PipelineStageEvent.Direction.EXIT))
+      }
+
+      // Remaining stages in the same control group (skipped on exit).
+      if (!exitCalled) {
+        runControlStages(s, selectorFork.remainingStages)
+      }
+
+      if (selectorFork.duringIngress) {
+        // Fork was in ingress — run the full post-ingress pipeline.
+        ingressEgressBoundary(ctx, s, decisions, 0)
+        if (egressPortIsDropPort(s)) {
+          return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        }
+
+        resetEgressSpec(s)
+        runControlStages(s, s.egressControls)
+        postEgressBoundary(ctx, s, decisions)
+
+        if (decisions.branchMode is BranchMode.E2EClone) {
+          resetEgressSpec(s)
+          runControlStages(s, s.egressControls)
+        }
+
+        if (egressSpecIsDropPort(s)) {
+          return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        }
+      } else {
+        // Fork was in egress — boundary already ran, just check for E2E clone.
+        postEgressBoundary(ctx, s, decisions)
+
+        if (egressSpecIsDropPort(s)) {
+          return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        }
+      }
+
+      if (s.deparserStage != null) {
+        s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.ENTER))
+        try {
+          s.interpreter.runControl(s.deparserStage.blockName, s.env)
+        } finally {
+          s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.EXIT))
+        }
+      }
+    } catch (_: AssertionFailureException) {
+      return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+    }
+
+    val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
+
+    if (s.pendingOps.recirculate) {
+      throw RecirculateFork(
+        outputBytes,
+        s.packetCtx.getEvents(),
+        snapshotPreservedMetadata(s, s.pendingOps.recirculateFieldListId),
+      )
+    }
+
+    val egressPort =
+      (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
+    return buildOutputTrace(s.packetCtx.getEvents(), egressPort, outputBytes)
+  }
+
+  /** Handles non-selector forks (clone, multicast, resubmit, recirculate) via replay. */
+  private fun buildReplayForkTree(
+    ctx: PipelineContext,
+    decisions: V1ModelDecisions,
+    fork: ForkException,
+    prefixLength: Int,
+  ): PipelineResult {
+    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+    val (reason, specs) = forkSpecs(ctx, decisions, fork)
+
+    val subtrees =
+      if (INTRA_PACKET_PARALLELISM_ENABLED) {
+        specs
+          .parallelStream()
+          .map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
+          .toList()
+      } else {
+        specs.map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
+      }
+
+    val branches =
+      specs.zip(subtrees).map { (spec, result) ->
+        ForkBranch.newBuilder().setLabel(spec.label).setSubtree(result.trace).build()
+      }
+    val tree =
+      TraceTree.newBuilder()
+        .addAllEvents(levelEvents)
+        .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
+        .build()
+    return PipelineResult(tree)
   }
 
   /** A branch specification: everything needed to re-execute one fork branch. */
@@ -188,13 +355,15 @@ class V1ModelArchitecture(
     fork: ForkException,
   ): Pair<ForkReason, List<BranchSpec>> =
     when (fork) {
+      is V1ModelSelectorFork ->
+        error("V1ModelSelectorFork is handled by buildSelectorForkTree, not forkSpecs")
       is ActionSelectorFork -> {
+        // Fallback replay path — used when fork-on-write encounters a nested fork.
         val specs =
           fork.members.map { member ->
             val d =
               decisions.copy(
                 selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId),
-                tableLookupCache = fork.preForkLookups,
                 postParserSnapshot = postParserSnapshot.get(),
               )
             BranchSpec("member_${member.memberId}", ctx, d, fork.eventsBeforeFork.size)
@@ -355,11 +524,12 @@ class V1ModelArchitecture(
     packetCtx: PacketContext,
     env: Environment,
     standardMetadata: StructVal,
+    existingPendingOps: V1ModelPendingOps? = null,
   ): PipelineState {
     val portBits = standardMetadata.bitWidth("ingress_port")
     val dropPort = dropPortOverride?.toLong() ?: ((1L shl portBits) - 1)
 
-    val pendingOps = V1ModelPendingOps()
+    val pendingOps = existingPendingOps ?: V1ModelPendingOps()
     val interpreter =
       ctx.interpreter.execution(
         ctx.tableStore,
@@ -441,7 +611,7 @@ class V1ModelArchitecture(
       // I2E clone branch: skip ingress — the clone gets the original parsed packet,
       // not the version modified by ingress (BMv2 simple_switch semantics).
       if (decisions.branchMode !is BranchMode.I2EClone) {
-        runControlStages(s, s.ingressControls)
+        runControlStages(s, s.ingressControls, duringIngress = true)
       }
 
       // --- Ingress→egress boundary (traffic manager) ---
@@ -521,13 +691,27 @@ class V1ModelArchitecture(
   }
 
   /** Runs a list of control stages, emitting enter/exit events for each. */
-  private fun runControlStages(s: PipelineState, stages: List<PipelineStage>) {
-    for (stage in stages) {
+  private fun runControlStages(
+    s: PipelineState,
+    stages: List<PipelineStage>,
+    duringIngress: Boolean = false,
+  ) {
+    for ((i, stage) in stages.withIndex()) {
       s.packetCtx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.ENTER))
       try {
         s.interpreter.runControl(stage.blockName, s.env)
       } catch (_: ExitException) {
         break
+      } catch (fork: ActionSelectorFork) {
+        // Wrap with V1Model-specific fork-point state for fork-on-write resume.
+        // Stage EXIT still fires (via finally) — the fork-point events include it.
+        throw V1ModelSelectorFork(
+          fork,
+          s.pendingOps.copy(),
+          stage,
+          stages.subList(i + 1, stages.size),
+          duringIngress,
+        )
       } finally {
         s.packetCtx.addTraceEvent(stageEvent(stage, PipelineStageEvent.Direction.EXIT))
       }
@@ -1067,11 +1251,40 @@ internal class V1ModelPendingOps {
 
   /** Field list ID for recirculate metadata preservation. */
   var recirculateFieldListId: Int? = null
+
+  fun copy(): V1ModelPendingOps {
+    val c = V1ModelPendingOps()
+    c.cloneSessionId = cloneSessionId
+    c.cloneFieldListId = cloneFieldListId
+    c.egressCloneSessionId = egressCloneSessionId
+    c.egressCloneFieldListId = egressCloneFieldListId
+    c.resubmit = resubmit
+    c.resubmitFieldListId = resubmitFieldListId
+    c.recirculate = recirculate
+    c.recirculateFieldListId = recirculateFieldListId
+    return c
+  }
 }
 
 // -------------------------------------------------------------------------
 // v1model-specific fork exceptions
 // -------------------------------------------------------------------------
+
+/**
+ * Wraps an [ActionSelectorFork] with v1model-specific pipeline state captured at the fork point.
+ *
+ * Created by [runControlStages] when it catches the interpreter's fork exception. Carries
+ * everything needed to resume each branch from the fork point (fork-on-write) instead of replaying
+ * the pipeline.
+ */
+internal class V1ModelSelectorFork(
+  val fork: ActionSelectorFork,
+  val pendingOps: V1ModelPendingOps,
+  val stage: PipelineStage,
+  val remainingStages: List<PipelineStage>,
+  /** True if the fork happened during ingress controls (boundary + egress + deparser remain). */
+  val duringIngress: Boolean,
+) : ForkException(fork.eventsBeforeFork)
 
 /**
  * Fork at the ingress→egress boundary when an I2E clone was requested — "original" and "clone".

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -71,15 +71,6 @@ class V1ModelArchitecture(
   // without synchronization.
   private val interpreter: Interpreter = Interpreter(config)
 
-  /**
-   * Post-parser snapshot captured during the first [runPipeline] execution of a packet. Read by
-   * [forkSpecs] when an [ActionSelectorFork] is caught, to pass to fork re-executions. Reset at the
-   * start of each [processPacket] to prevent stale state across packets.
-   */
-  // ThreadLocal: parallel fork branches each get their own snapshot, avoiding races when
-  // nested forks (clone after selector) write concurrently.
-  private val postParserSnapshot = ThreadLocal<PostParserSnapshot?>()
-
   /** Invariant inputs to the pipeline, shared across fork re-executions. */
   private data class PipelineContext(
     val ingressPort: UInt,
@@ -124,42 +115,31 @@ class V1ModelArchitecture(
     payload: ByteArray,
     tableStore: TableStore,
   ): PipelineResult {
-    postParserSnapshot.set(null)
     val ctx = PipelineContext(ingressPort, payload, config, tableStore, interpreter)
-    return buildTraceTree(ctx, V1ModelDecisions(), prefixLength = 0)
+    return buildTraceTree(ctx, V1ModelDecisions())
   }
 
   /**
-   * Recursively builds a trace tree by executing the pipeline and forking at non-deterministic
-   * choice points. Fork branches run in parallel on a shared thread pool.
+   * Builds a trace tree by executing the pipeline and handling forks via fork-on-write. Each fork
+   * type has a dedicated handler that continues branches from the fork point. Only
+   * resubmit/recirculate call back into this method (they restart the pipeline).
    */
-  private fun buildTraceTree(
-    ctx: PipelineContext,
-    decisions: V1ModelDecisions,
-    prefixLength: Int,
-  ): PipelineResult {
-    val trace: TraceTree
+  private fun buildTraceTree(ctx: PipelineContext, decisions: V1ModelDecisions): PipelineResult {
     try {
-      trace = runPipeline(ctx, decisions)
-    } catch (selectorFork: V1ModelSelectorFork) {
-      return buildSelectorForkTree(ctx, decisions, selectorFork, prefixLength)
-    } catch (multicastFork: MulticastFork) {
-      return buildMulticastForkTree(ctx, multicastFork, prefixLength)
-    } catch (cloneFork: CloneFork) {
-      return buildCloneForkTree(ctx, cloneFork, prefixLength)
-    } catch (egressCloneFork: EgressCloneFork) {
-      return buildEgressCloneForkTree(ctx, egressCloneFork, prefixLength)
-    } catch (resubmitFork: ResubmitFork) {
-      return buildResubmitForkTree(ctx, resubmitFork, prefixLength)
-    } catch (recirculateFork: RecirculateFork) {
-      return buildRecirculateForkTree(ctx, recirculateFork, prefixLength)
-    } catch (fork: ForkException) {
-      return buildReplayForkTree(ctx, decisions, fork, prefixLength)
+      return PipelineResult(runPipeline(ctx, decisions))
+    } catch (fork: V1ModelSelectorFork) {
+      return buildSelectorForkTree(ctx, decisions, fork)
+    } catch (fork: MulticastFork) {
+      return buildMulticastForkTree(ctx, fork)
+    } catch (fork: CloneFork) {
+      return buildCloneForkTree(ctx, fork)
+    } catch (fork: EgressCloneFork) {
+      return buildEgressCloneForkTree(ctx, fork)
+    } catch (fork: ResubmitFork) {
+      return buildResubmitForkTree(ctx, fork)
+    } catch (fork: RecirculateFork) {
+      return buildRecirculateForkTree(ctx, fork)
     }
-
-    val stripped = TraceTree.newBuilder().addAllEvents(trace.eventsList.drop(prefixLength))
-    if (trace.hasPacketOutcome()) stripped.setPacketOutcome(trace.packetOutcome)
-    return PipelineResult(stripped.build())
   }
 
   /**
@@ -171,16 +151,14 @@ class V1ModelArchitecture(
     ctx: PipelineContext,
     decisions: V1ModelDecisions,
     selectorFork: V1ModelSelectorFork,
-    prefixLength: Int,
   ): PipelineResult {
     val fork = selectorFork.fork
-    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+    val levelEvents = fork.eventsBeforeFork
 
     val buildBranch = { member: TableStore.MemberAction ->
       val branchDecisions =
         decisions.copy(
-          selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId),
-          postParserSnapshot = postParserSnapshot.get(),
+          selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId)
         )
       try {
         val trace = continueFromForkPoint(ctx, branchDecisions, selectorFork, member)
@@ -269,7 +247,7 @@ class V1ModelArchitecture(
 
       if (selectorFork.duringIngress) {
         // Fork was in ingress — run boundary + egress + deparser.
-        ingressEgressBoundary(ctx, s, decisions, 0)
+        ingressEgressBoundary(ctx, s)
         if (egressPortIsDropPort(s)) {
           return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
         }
@@ -292,7 +270,7 @@ class V1ModelArchitecture(
     fork: MulticastFork,
     prefixLength: Int = 0,
   ): PipelineResult {
-    val buildBranch = { replica: BranchMode.Replica ->
+    val buildBranch = { replica: Replica ->
       val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
       val env = fork.forkPointEnv.deepCopy()
       val pendingOps = fork.forkPointPendingOps.copy()
@@ -350,12 +328,8 @@ class V1ModelArchitecture(
    * "Clone" branch: uses the post-parser state (BMv2: clone gets parsed-but-not-ingress-modified
    * headers), applies preserved metadata, sets clone metadata, runs egress + deparser.
    */
-  private fun buildCloneForkTree(
-    ctx: PipelineContext,
-    fork: CloneFork,
-    prefixLength: Int = 0,
-  ): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+  private fun buildCloneForkTree(ctx: PipelineContext, fork: CloneFork): PipelineResult {
+    val levelEvents = fork.eventsBeforeFork
 
     val buildOriginal = {
       val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
@@ -368,12 +342,8 @@ class V1ModelArchitecture(
 
       try {
         // Resume boundary: check resubmit, multicast, unicast (clone already handled).
-        ingressEgressBoundary(
-          ctx,
-          s,
-          V1ModelDecisions(branchMode = BranchMode.Normal(suppressI2EClone = true)),
-          0,
-        )
+        // pendingOps.cloneSessionId already cleared — boundary won't re-clone.
+        ingressEgressBoundary(ctx, s)
         if (egressPortIsDropPort(s)) {
           buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
         } else {
@@ -434,9 +404,8 @@ class V1ModelArchitecture(
   private fun buildEgressCloneForkTree(
     ctx: PipelineContext,
     fork: EgressCloneFork,
-    prefixLength: Int = 0,
   ): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+    val levelEvents = fork.eventsBeforeFork
 
     val buildOriginal = {
       val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
@@ -507,19 +476,15 @@ class V1ModelArchitecture(
   }
 
   /** Handles a resubmit fork: restarts the pipeline with preserved metadata. */
-  private fun buildResubmitForkTree(
-    ctx: PipelineContext,
-    fork: ResubmitFork,
-    prefixLength: Int = 0,
-  ): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+  private fun buildResubmitForkTree(ctx: PipelineContext, fork: ResubmitFork): PipelineResult {
+    val levelEvents = fork.eventsBeforeFork
     val decisions =
       V1ModelDecisions(
         pipelineDepth = 1,
         instanceTypeOverride = RESUBMIT_INSTANCE_TYPE,
         preservedMetadata = fork.preservedMetadata,
       )
-    val result = buildTraceTree(ctx, decisions, 0)
+    val result = buildTraceTree(ctx, decisions)
     val branch = ForkBranch.newBuilder().setLabel("resubmit").setSubtree(result.trace).build()
     return PipelineResult(buildForkTree(levelEvents, ForkReason.RESUBMIT, listOf(branch)))
   }
@@ -528,9 +493,8 @@ class V1ModelArchitecture(
   private fun buildRecirculateForkTree(
     ctx: PipelineContext,
     fork: RecirculateFork,
-    prefixLength: Int = 0,
   ): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+    val levelEvents = fork.eventsBeforeFork
     val decisions =
       V1ModelDecisions(
         pipelineDepth = 1,
@@ -538,7 +502,7 @@ class V1ModelArchitecture(
         preservedMetadata = fork.preservedMetadata,
       )
     val recircCtx = ctx.copy(payload = fork.deparsedBytes)
-    val result = buildTraceTree(recircCtx, decisions, 0)
+    val result = buildTraceTree(recircCtx, decisions)
     val branch = ForkBranch.newBuilder().setLabel("recirculate").setSubtree(result.trace).build()
     return PipelineResult(buildForkTree(levelEvents, ForkReason.RECIRCULATE, listOf(branch)))
   }
@@ -549,82 +513,13 @@ class V1ModelArchitecture(
    */
   private fun handleNestedFork(ctx: PipelineContext, fork: ForkException): TraceTree =
     when (fork) {
-      is V1ModelSelectorFork -> buildSelectorForkTree(ctx, V1ModelDecisions(), fork, 0).trace
+      is V1ModelSelectorFork -> buildSelectorForkTree(ctx, V1ModelDecisions(), fork).trace
       is MulticastFork -> buildMulticastForkTree(ctx, fork).trace
       is CloneFork -> buildCloneForkTree(ctx, fork).trace
       is EgressCloneFork -> buildEgressCloneForkTree(ctx, fork).trace
       is ResubmitFork -> buildResubmitForkTree(ctx, fork).trace
       is RecirculateFork -> buildRecirculateForkTree(ctx, fork).trace
       is ActionSelectorFork -> error("unwrapped ActionSelectorFork — should be V1ModelSelectorFork")
-    }
-
-  /** Handles non-selector forks (clone, multicast, resubmit, recirculate) via replay. */
-  private fun buildReplayForkTree(
-    ctx: PipelineContext,
-    decisions: V1ModelDecisions,
-    fork: ForkException,
-    prefixLength: Int,
-  ): PipelineResult {
-    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
-    val (reason, specs) = forkSpecs(ctx, decisions, fork)
-
-    val subtrees =
-      if (INTRA_PACKET_PARALLELISM_ENABLED) {
-        specs
-          .parallelStream()
-          .map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
-          .toList()
-      } else {
-        specs.map { spec -> buildTraceTree(spec.ctx, spec.decisions, spec.prefixLength) }
-      }
-
-    val branches =
-      specs.zip(subtrees).map { (spec, result) ->
-        ForkBranch.newBuilder().setLabel(spec.label).setSubtree(result.trace).build()
-      }
-    val tree =
-      TraceTree.newBuilder()
-        .addAllEvents(levelEvents)
-        .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
-        .build()
-    return PipelineResult(tree)
-  }
-
-  /** A branch specification: everything needed to re-execute one fork branch. */
-  private data class BranchSpec(
-    val label: String,
-    val ctx: PipelineContext,
-    val decisions: V1ModelDecisions,
-    val prefixLength: Int,
-  )
-
-  /** Maps a [ForkException] to the fork reason and per-branch execution specs. */
-  private fun forkSpecs(
-    ctx: PipelineContext,
-    decisions: V1ModelDecisions,
-    fork: ForkException,
-  ): Pair<ForkReason, List<BranchSpec>> =
-    when (fork) {
-      is V1ModelSelectorFork ->
-        error("V1ModelSelectorFork is handled by buildSelectorForkTree, not forkSpecs")
-      is ActionSelectorFork -> {
-        // Fallback replay path — used when fork-on-write encounters a nested fork.
-        val specs =
-          fork.members.map { member ->
-            val d =
-              decisions.copy(
-                selectorMembers = decisions.selectorMembers + (fork.tableName to member.memberId),
-                postParserSnapshot = postParserSnapshot.get(),
-              )
-            BranchSpec("member_${member.memberId}", ctx, d, fork.eventsBeforeFork.size)
-          }
-        ForkReason.ACTION_SELECTOR to specs
-      }
-      is CloneFork -> error("CloneFork handled by buildCloneForkTree")
-      is EgressCloneFork -> error("EgressCloneFork handled by buildEgressCloneForkTree")
-      is MulticastFork -> error("MulticastFork handled by buildMulticastForkTree")
-      is ResubmitFork -> error("ResubmitFork handled by buildResubmitForkTree")
-      is RecirculateFork -> error("RecirculateFork handled by buildRecirculateForkTree")
     }
 
   /**
@@ -719,7 +614,6 @@ class V1ModelArchitecture(
         packetCtx,
         decisions.selectorMembers,
         createExternHandler(standardMetadata, pendingOps, ctx.tableStore, dropPort),
-        decisions.tableLookupCache,
       )
 
     val config = ctx.config
@@ -750,63 +644,27 @@ class V1ModelArchitecture(
       "max pipeline depth exceeded ($MAX_PIPELINE_DEPTH) — " +
         "possible infinite resubmit/recirculate loop"
     }
-    val snapshot = decisions.postParserSnapshot
 
     // --- Init + Parser ---
-    val s: PipelineState
-    val parserExitDrop: Boolean
-    if (snapshot != null) {
-      // Fork re-execution: restore from post-parser snapshot instead of re-parsing.
-      val packetCtx = PacketContext(ctx.payload, snapshot.bytesConsumed)
-      val env = snapshot.env.deepCopy()
-      val standardMetadata =
-        env.lookup(snapshot.standardMetaParamName) as? StructVal
-          ?: error("standard_metadata not found in snapshot environment")
-      s = finishPipelineState(ctx, decisions, packetCtx, env, standardMetadata)
-      for (event in snapshot.eventsThroughParser) s.packetCtx.addTraceEvent(event)
-      parserExitDrop = snapshot.parserExitDrop
-    } else {
-      s = initPipelineState(ctx, decisions)
-      s.packetCtx.addTraceEvent(packetIngressEvent(ctx.ingressPort))
-      parserExitDrop = runParser(s)
-      // Post-parser env for I2E clone fork-on-write (clone gets pre-ingress state).
-      s.postParserEnv = s.env.deepCopy()
-      // Capture snapshot for potential fork re-executions.
-      val parserUserParams =
-        ctx.config.parsersList.first().paramsList.filter {
-          it.type.hasNamed() && it.type.named !in IO_TYPES
-        }
-      postParserSnapshot.set(
-        PostParserSnapshot(
-          env = s.env.deepCopy(),
-          bytesConsumed = s.packetCtx.bytesConsumed,
-          eventsThroughParser = s.packetCtx.getEvents(),
-          parserExitDrop = parserExitDrop,
-          standardMetaParamName = parserUserParams[2].name,
-        )
-      )
-    }
+    val s = initPipelineState(ctx, decisions)
+    s.packetCtx.addTraceEvent(packetIngressEvent(ctx.ingressPort))
+    val parserExitDrop = runParser(s)
+    s.postParserEnv = s.env.deepCopy()
     if (parserExitDrop) return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-
-    val parserEventCount = s.packetCtx.getEvents().size
 
     // An assert()/assume() failure anywhere in the pipeline drops the packet.
     try {
       // --- Ingress controls (verify checksum, ingress) ---
-      // I2E clone branch: skip ingress — the clone gets the original parsed packet,
-      // not the version modified by ingress (BMv2 simple_switch semantics).
-      if (decisions.branchMode !is BranchMode.I2EClone) {
-        runControlStages(s, s.ingressControls, duringIngress = true)
-      }
+      runControlStages(s, s.ingressControls, duringIngress = true)
 
       // --- Ingress→egress boundary (traffic manager) ---
-      ingressEgressBoundary(ctx, s, decisions, parserEventCount)
+      ingressEgressBoundary(ctx, s)
       if (egressPortIsDropPort(s)) {
         return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
       }
 
       // --- Egress + deparser ---
-      return runEgressAndDeparser(ctx, s, decisions)
+      return runEgressAndDeparser(ctx, s)
     } catch (_: AssertionFailureException) {
       return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
     }
@@ -816,20 +674,10 @@ class V1ModelArchitecture(
    * Runs egress controls, post-egress boundary, deparser, and output. Called after the
    * ingress-egress boundary has set egress_port.
    */
-  private fun runEgressAndDeparser(
-    ctx: PipelineContext,
-    s: PipelineState,
-    decisions: V1ModelDecisions = V1ModelDecisions(),
-  ): TraceTree {
+  private fun runEgressAndDeparser(ctx: PipelineContext, s: PipelineState): TraceTree {
     resetEgressSpec(s)
     runControlStages(s, s.egressControls)
-    postEgressBoundary(ctx, s, decisions)
-
-    // E2E clone branch: postEgressBoundary set up clone metadata — run egress again.
-    if (decisions.branchMode is BranchMode.E2EClone) {
-      resetEgressSpec(s)
-      runControlStages(s, s.egressControls)
-    }
+    postEgressBoundary(ctx, s)
 
     if (egressSpecIsDropPort(s)) {
       return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
@@ -843,7 +691,7 @@ class V1ModelArchitecture(
    * fork inside the egress controls (remaining egress stages already ran).
    */
   private fun runPostEgressAndDeparser(ctx: PipelineContext, s: PipelineState): TraceTree {
-    postEgressBoundary(ctx, s, V1ModelDecisions())
+    postEgressBoundary(ctx, s)
 
     if (egressSpecIsDropPort(s)) {
       return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
@@ -932,69 +780,46 @@ class V1ModelArchitecture(
    * https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md
    */
   @Suppress("ThrowsCount") // one throw per fork type at the boundary
-  private fun ingressEgressBoundary(
-    ctx: PipelineContext,
-    s: PipelineState,
-    decisions: V1ModelDecisions,
-    parserEventCount: Int,
-  ) {
-    when (val mode = decisions.branchMode) {
-      is BranchMode.I2EClone -> {
-        s.standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
-        s.standardMetadata.setBitField("egress_port", mode.clonePort)
-      }
-      is BranchMode.Replica -> {
-        s.standardMetadata.setBitField("instance_type", REPLICATION_INSTANCE_TYPE)
-        s.standardMetadata.setBitField("egress_port", mode.port.toLong())
-        s.standardMetadata.setBitField("egress_rid", mode.rid.toLong())
-      }
-      is BranchMode.Normal,
-      is BranchMode.E2EClone -> {
-        // Both Normal and E2EClone run ingress normally and check for I2E clone/resubmit/multicast.
-        val suppressI2E = (mode as? BranchMode.Normal)?.suppressI2EClone == true
-        val pendingClone = s.pendingOps.cloneSessionId
-        if (pendingClone != null && !suppressI2E) {
-          resolveCloneSession(ctx, s, pendingClone)?.let { clonePort ->
-            throw CloneFork(
-              pendingClone,
-              clonePort,
-              s.packetCtx.getEvents(),
-              snapshotPreservedMetadata(s, s.pendingOps.cloneFieldListId),
-              s.env.deepCopy(),
-              s.packetCtx.bytesConsumed,
-              s.pendingOps.copy(),
-              s.postParserEnv ?: error("no post-parser env for I2E clone"),
-            )
-          }
-        }
-        if (s.pendingOps.resubmit) {
-          throw ResubmitFork(
-            s.packetCtx.getEvents(),
-            snapshotPreservedMetadata(s, s.pendingOps.resubmitFieldListId),
-          )
-        }
-        val mcastGrp =
-          (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
-        if (mcastGrp != 0) {
-          // BMv2 silently ignores unknown multicast groups (no fork, no output).
-          val group = ctx.tableStore.getMulticastGroup(mcastGrp)
-          if (group != null) {
-            val replicas =
-              group.replicasList.map { r -> BranchMode.Replica(r.instance, replicaPort(r)) }
-            throw MulticastFork(
-              replicas,
-              s.packetCtx.getEvents(),
-              s.env.deepCopy(),
-              s.packetCtx.bytesConsumed,
-              s.pendingOps.copy(),
-            )
-          }
-        }
-        // Normal unicast: copy egress_spec → egress_port for uniform read below.
-        s.standardMetadata.fields["egress_port"] =
-          s.standardMetadata.fields["egress_spec"] ?: BitVal(0, s.portBits)
+  private fun ingressEgressBoundary(ctx: PipelineContext, s: PipelineState) {
+    // BMv2 priority order: I2E clone > resubmit > multicast > unicast/drop.
+    val pendingClone = s.pendingOps.cloneSessionId
+    if (pendingClone != null) {
+      resolveCloneSession(ctx, s, pendingClone)?.let { clonePort ->
+        throw CloneFork(
+          pendingClone,
+          clonePort,
+          s.packetCtx.getEvents(),
+          snapshotPreservedMetadata(s, s.pendingOps.cloneFieldListId),
+          s.env.deepCopy(),
+          s.packetCtx.bytesConsumed,
+          s.pendingOps.copy(),
+          s.postParserEnv ?: error("no post-parser env for I2E clone"),
+        )
       }
     }
+    if (s.pendingOps.resubmit) {
+      throw ResubmitFork(
+        s.packetCtx.getEvents(),
+        snapshotPreservedMetadata(s, s.pendingOps.resubmitFieldListId),
+      )
+    }
+    val mcastGrp = (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
+    if (mcastGrp != 0) {
+      val group = ctx.tableStore.getMulticastGroup(mcastGrp)
+      if (group != null) {
+        val replicas = group.replicasList.map { r -> Replica(r.instance, replicaPort(r)) }
+        throw MulticastFork(
+          replicas,
+          s.packetCtx.getEvents(),
+          s.env.deepCopy(),
+          s.packetCtx.bytesConsumed,
+          s.pendingOps.copy(),
+        )
+      }
+    }
+    // Normal unicast: copy egress_spec → egress_port.
+    s.standardMetadata.fields["egress_port"] =
+      s.standardMetadata.fields["egress_spec"] ?: BitVal(0, s.portBits)
   }
 
   /**
@@ -1002,34 +827,19 @@ class V1ModelArchitecture(
    *
    * BMv2 priority order after egress: E2E clone > recirculate > output/drop.
    */
-  private fun postEgressBoundary(
-    ctx: PipelineContext,
-    s: PipelineState,
-    decisions: V1ModelDecisions,
-  ) {
-    when (val mode = decisions.branchMode) {
-      is BranchMode.E2EClone -> {
-        s.standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
-        s.standardMetadata.setBitField("egress_port", mode.clonePort)
-        // Suppress chained E2E clones: BMv2 does not re-clone from a clone's egress run.
-        s.pendingOps.egressCloneSessionId = null
-      }
-      else -> {
-        val suppressE2E = (mode as? BranchMode.Normal)?.suppressE2EClone == true
-        val pendingE2EClone = s.pendingOps.egressCloneSessionId
-        if (pendingE2EClone != null && !suppressE2E) {
-          resolveCloneSession(ctx, s, pendingE2EClone)?.let { clonePort ->
-            throw EgressCloneFork(
-              pendingE2EClone,
-              clonePort,
-              s.packetCtx.getEvents(),
-              snapshotPreservedMetadata(s, s.pendingOps.egressCloneFieldListId),
-              s.env.deepCopy(),
-              s.packetCtx.bytesConsumed,
-              s.pendingOps.copy(),
-            )
-          }
-        }
+  private fun postEgressBoundary(ctx: PipelineContext, s: PipelineState) {
+    val pendingE2EClone = s.pendingOps.egressCloneSessionId
+    if (pendingE2EClone != null) {
+      resolveCloneSession(ctx, s, pendingE2EClone)?.let { clonePort ->
+        throw EgressCloneFork(
+          pendingE2EClone,
+          clonePort,
+          s.packetCtx.getEvents(),
+          snapshotPreservedMetadata(s, s.pendingOps.egressCloneFieldListId),
+          s.env.deepCopy(),
+          s.packetCtx.bytesConsumed,
+          s.pendingOps.copy(),
+        )
       }
     }
   }
@@ -1385,29 +1195,11 @@ class V1ModelArchitecture(
 // v1model-specific fork types and pipeline execution decisions
 // =============================================================================
 
-/**
- * Which mode this v1model pipeline execution is in.
- *
- * BMv2 priority ordering guarantees at most one mode per boundary crossing: ingress (I2E clone >
- * resubmit > multicast > unicast), egress (E2E clone > recirculate > output).
- */
-internal sealed class BranchMode {
-  /** Normal pipeline — may fork at any choice point. */
-  data class Normal(val suppressI2EClone: Boolean = false, val suppressE2EClone: Boolean = false) :
-    BranchMode()
-
-  /** I2E clone branch: skip ingress, set CLONE_I2E at boundary. */
-  data class I2EClone(val sessionId: Int, val clonePort: Long) : BranchMode()
-
-  /** E2E clone branch: re-run egress with CLONE_E2E after original egress completes. */
-  data class E2EClone(val sessionId: Int, val clonePort: Long) : BranchMode()
-
-  /** Multicast replica: set REPLICATION metadata at boundary. */
-  data class Replica(val rid: Int, val port: Int) : BranchMode()
-}
+/** Multicast replica descriptor: egress port and replication ID. */
+internal data class Replica(val rid: Int, val port: Int)
 
 /**
- * v1model-specific policies for re-execution of a pipeline branch in the trace tree.
+ * v1model-specific policies for pipeline execution.
  *
  * @property selectorMembers Forced member selections per table (action selector branches).
  * @property branchMode The execution mode for this branch (normal, clone, or replica).
@@ -1416,28 +1208,11 @@ internal sealed class BranchMode {
  * @property preservedMetadata Pre-filtered metadata fields to restore from
  *   clone/resubmit/recirculate.
  */
-
-/** Post-parser state snapshot for reuse in fork re-executions (avoids re-parsing). */
-internal data class PostParserSnapshot(
-  val env: Environment,
-  val bytesConsumed: Int,
-  /** Trace events through parser completion (includes packet ingress event). */
-  val eventsThroughParser: List<TraceEvent>,
-  val parserExitDrop: Boolean,
-  /** Name of the standard_metadata parameter, for resolving it from the restored [env]. */
-  val standardMetaParamName: String,
-)
-
 internal data class V1ModelDecisions(
   val selectorMembers: Map<String, Int> = emptyMap(),
-  val branchMode: BranchMode = BranchMode.Normal(),
   val instanceTypeOverride: Long? = null,
   val pipelineDepth: Int = 0,
   val preservedMetadata: Map<String, Value>? = null,
-  /** Cached table lookup results from before a selector fork, to avoid redundant O(n) scans. */
-  val tableLookupCache: Map<String, TableStore.LookupResult>? = null,
-  /** Post-parser state to restore instead of re-running the parser on fork re-executions. */
-  val postParserSnapshot: PostParserSnapshot? = null,
 )
 
 /**
@@ -1545,7 +1320,7 @@ internal class EgressCloneFork(
 
 /** Fork at the ingress→egress boundary when mcast_grp is set — one branch per replica. */
 internal class MulticastFork(
-  val replicas: List<BranchMode.Replica>,
+  val replicas: List<Replica>,
   eventsBeforeFork: List<TraceEvent>,
   /** Deep copy of the environment at the fork point (post-ingress). */
   val forkPointEnv: Environment,

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -139,8 +139,9 @@ class V1ModelArchitecture(
     try {
       trace = runPipeline(ctx, decisions)
     } catch (selectorFork: V1ModelSelectorFork) {
-      // Fork-on-write: continue each branch from the fork point instead of replaying.
       return buildSelectorForkTree(ctx, decisions, selectorFork, prefixLength)
+    } catch (multicastFork: MulticastFork) {
+      return buildMulticastForkTree(ctx, multicastFork, prefixLength)
     } catch (fork: ForkException) {
       return buildReplayForkTree(ctx, decisions, fork, prefixLength)
     }
@@ -222,15 +223,7 @@ class V1ModelArchitecture(
     val env = fork.forkPointEnv.deepCopy()
     val pendingOps = selectorFork.pendingOps.copy()
 
-    // Resolve standard_metadata from the restored environment.
-    val parserUserParams =
-      ctx.config.parsersList.first().paramsList.filter {
-        it.type.hasNamed() && it.type.named !in IO_TYPES
-      }
-    val standardMetaParamName = parserUserParams[2].name
-    val standardMetadata =
-      env.lookup(standardMetaParamName) as? StructVal
-        ?: error("standard_metadata not found in fork-point environment")
+    val standardMetadata = resolveStandardMetadata(ctx, env)
 
     val s = finishPipelineState(ctx, decisions, packetCtx, env, standardMetadata, pendingOps)
 
@@ -266,6 +259,66 @@ class V1ModelArchitecture(
     } catch (_: AssertionFailureException) {
       return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
     }
+  }
+
+  /**
+   * Handles a multicast fork via fork-on-write: each replica gets a deep copy of the fork-point
+   * state with its metadata (instance_type, egress_port, egress_rid) set, then runs egress +
+   * deparser independently.
+   */
+  private fun buildMulticastForkTree(
+    ctx: PipelineContext,
+    fork: MulticastFork,
+    prefixLength: Int = 0,
+  ): PipelineResult {
+    val buildBranch = { replica: BranchMode.Replica ->
+      val packetCtx = PacketContext(ctx.payload, fork.bytesConsumed)
+      val env = fork.forkPointEnv.deepCopy()
+      val pendingOps = fork.forkPointPendingOps.copy()
+
+      val standardMetadata = resolveStandardMetadata(ctx, env)
+      standardMetadata.setBitField("instance_type", REPLICATION_INSTANCE_TYPE)
+      standardMetadata.setBitField("egress_port", replica.port.toLong())
+      standardMetadata.setBitField("egress_rid", replica.rid.toLong())
+
+      val s =
+        finishPipelineState(ctx, V1ModelDecisions(), packetCtx, env, standardMetadata, pendingOps)
+      try {
+        runEgressAndDeparser(ctx, s)
+      } catch (nestedFork: V1ModelSelectorFork) {
+        // Nested action selector in egress — handle via fork-on-write.
+        buildSelectorForkTree(ctx, V1ModelDecisions(), nestedFork, 0).trace
+      } catch (_: AssertionFailureException) {
+        buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+      }
+    }
+
+    val results =
+      if (INTRA_PACKET_PARALLELISM_ENABLED) {
+        fork.replicas.parallelStream().map(buildBranch).toList()
+      } else {
+        fork.replicas.map(buildBranch)
+      }
+
+    val branches =
+      fork.replicas.zip(results).map { (replica, trace) ->
+        ForkBranch.newBuilder()
+          .setLabel("replica_${replica.rid}_port_${replica.port}")
+          .setSubtree(trace)
+          .build()
+      }
+    val levelEvents = fork.eventsBeforeFork.drop(prefixLength)
+    return PipelineResult(buildForkTree(levelEvents, ForkReason.MULTICAST, branches))
+  }
+
+  /** Resolves standard_metadata from the environment using the config's parser parameter names. */
+  private fun resolveStandardMetadata(ctx: PipelineContext, env: Environment): StructVal {
+    val parserUserParams =
+      ctx.config.parsersList.first().paramsList.filter {
+        it.type.hasNamed() && it.type.named !in IO_TYPES
+      }
+    return env.lookup(parserUserParams[2].name) as? StructVal
+      ?: error("standard_metadata not found in environment")
   }
 
   /** Handles non-selector forks (clone, multicast, resubmit, recirculate) via replay. */
@@ -752,7 +805,13 @@ class V1ModelArchitecture(
           if (group != null) {
             val replicas =
               group.replicasList.map { r -> BranchMode.Replica(r.instance, replicaPort(r)) }
-            throw MulticastFork(replicas, s.packetCtx.getEvents())
+            throw MulticastFork(
+              replicas,
+              s.packetCtx.getEvents(),
+              s.env.deepCopy(),
+              s.packetCtx.bytesConsumed,
+              s.pendingOps.copy(),
+            )
           }
         }
         // Normal unicast: copy egress_spec → egress_port for uniform read below.
@@ -1293,6 +1352,12 @@ internal class EgressCloneFork(
 internal class MulticastFork(
   val replicas: List<BranchMode.Replica>,
   eventsBeforeFork: List<TraceEvent>,
+  /** Deep copy of the environment at the fork point (post-ingress). */
+  val forkPointEnv: Environment,
+  /** Parser buffer position at the fork point. */
+  val bytesConsumed: Int,
+  /** Pending operations at the fork point. */
+  val forkPointPendingOps: V1ModelPendingOps,
 ) : ForkException(eventsBeforeFork)
 
 /** Fork at the ingress→egress boundary when resubmit was requested — single branch re-ingress. */

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -254,58 +254,18 @@ class V1ModelArchitecture(
       }
 
       if (selectorFork.duringIngress) {
-        // Fork was in ingress — run the full post-ingress pipeline.
+        // Fork was in ingress — run boundary + egress + deparser.
         ingressEgressBoundary(ctx, s, decisions, 0)
         if (egressPortIsDropPort(s)) {
           return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
         }
-
-        resetEgressSpec(s)
-        runControlStages(s, s.egressControls)
-        postEgressBoundary(ctx, s, decisions)
-
-        if (decisions.branchMode is BranchMode.E2EClone) {
-          resetEgressSpec(s)
-          runControlStages(s, s.egressControls)
-        }
-
-        if (egressSpecIsDropPort(s)) {
-          return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-        }
-      } else {
-        // Fork was in egress — boundary already ran, just check for E2E clone.
-        postEgressBoundary(ctx, s, decisions)
-
-        if (egressSpecIsDropPort(s)) {
-          return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-        }
+        return runEgressAndDeparser(ctx, s)
       }
-
-      if (s.deparserStage != null) {
-        s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.ENTER))
-        try {
-          s.interpreter.runControl(s.deparserStage.blockName, s.env)
-        } finally {
-          s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.EXIT))
-        }
-      }
+      // Fork was in egress — remaining egress stages already ran, just finish.
+      return runPostEgressAndDeparser(ctx, s)
     } catch (_: AssertionFailureException) {
       return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
     }
-
-    val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
-
-    if (s.pendingOps.recirculate) {
-      throw RecirculateFork(
-        outputBytes,
-        s.packetCtx.getEvents(),
-        snapshotPreservedMetadata(s, s.pendingOps.recirculateFieldListId),
-      )
-    }
-
-    val egressPort =
-      (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
-    return buildOutputTrace(s.packetCtx.getEvents(), egressPort, outputBytes)
   }
 
   /** Handles non-selector forks (clone, multicast, resubmit, recirculate) via replay. */
@@ -620,44 +580,65 @@ class V1ModelArchitecture(
         return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
       }
 
-      // --- Egress controls (egress, compute checksum) ---
-      // BMv2: egress_spec starts matching egress_port for each egress run. This
-      // ensures mark_to_drop() during egress is the only way to set the drop port,
-      // regardless of what ingress or a prior egress run left in egress_spec.
-      resetEgressSpec(s)
-      runControlStages(s, s.egressControls)
-
-      // --- Post-egress boundary (E2E clone / recirculate) ---
-      postEgressBoundary(ctx, s, decisions)
-
-      // E2E clone branch: postEgressBoundary set up clone metadata — run egress again.
-      if (decisions.branchMode is BranchMode.E2EClone) {
-        resetEgressSpec(s)
-        runControlStages(s, s.egressControls)
-      }
-
-      // mark_to_drop() called during egress (or the E2E clone's second egress run)
-      // sets egress_spec to the drop port.
-      if (egressSpecIsDropPort(s)) {
-        return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-      }
-
-      // --- Deparser ---
-      if (s.deparserStage != null) {
-        s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.ENTER))
-        try {
-          s.interpreter.runControl(s.deparserStage.blockName, s.env)
-        } finally {
-          s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.EXIT))
-        }
-      }
+      // --- Egress + deparser ---
+      return runEgressAndDeparser(ctx, s, decisions)
     } catch (_: AssertionFailureException) {
       return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
     }
+  }
 
-    // Append any bytes the parser did not extract (the un-parsed packet body).
-    // In P4, the deparser emits re-serialised headers; the remaining payload
-    // is transparently forwarded after them.
+  /**
+   * Runs egress controls, post-egress boundary, deparser, and output. Called after the
+   * ingress-egress boundary has set egress_port.
+   */
+  private fun runEgressAndDeparser(
+    ctx: PipelineContext,
+    s: PipelineState,
+    decisions: V1ModelDecisions = V1ModelDecisions(),
+  ): TraceTree {
+    resetEgressSpec(s)
+    runControlStages(s, s.egressControls)
+    postEgressBoundary(ctx, s, decisions)
+
+    // E2E clone branch: postEgressBoundary set up clone metadata — run egress again.
+    if (decisions.branchMode is BranchMode.E2EClone) {
+      resetEgressSpec(s)
+      runControlStages(s, s.egressControls)
+    }
+
+    if (egressSpecIsDropPort(s)) {
+      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+    }
+
+    return runDeparser(s)
+  }
+
+  /**
+   * Post-egress boundary + deparser + output. Used by [continueFromForkPoint] after resuming from a
+   * fork inside the egress controls (remaining egress stages already ran).
+   */
+  private fun runPostEgressAndDeparser(ctx: PipelineContext, s: PipelineState): TraceTree {
+    postEgressBoundary(ctx, s, V1ModelDecisions())
+
+    if (egressSpecIsDropPort(s)) {
+      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+    }
+
+    return runDeparser(s)
+  }
+
+  /** Deparser + output (or recirculate). The innermost pipeline tail. */
+  @Suppress("ThrowsCount")
+  private fun runDeparser(s: PipelineState): TraceTree {
+    if (s.deparserStage != null) {
+      s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.ENTER))
+      try {
+        s.interpreter.runControl(s.deparserStage.blockName, s.env)
+      } finally {
+        s.packetCtx.addTraceEvent(stageEvent(s.deparserStage, PipelineStageEvent.Direction.EXIT))
+      }
+    }
+
     val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
 
     if (s.pendingOps.recirculate) {

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -197,8 +197,8 @@ cores, 128 MB L3) running OpenJDK 21.
 | Workload | Sequential, 1 core | Sequential, 16 cores | Batch, 1 core | Batch, 16 cores |
 |----------|--------------------|----------------------|---------------|-----------------|
 | L3 forwarding | 2,500 | 2,600 | 2,600 | 29,000 |
-| WCMP ×16 members | 1,400 | 1,700 | 1,200 | 10,000 |
-| WCMP ×16 + mirror | 970 | 1,200 | 710 | 5,200 |
+| WCMP ×16 members | 1,900 | 2,200 | 1,600 | 12,000 |
+| WCMP ×16 + mirror | 1,300 | 1,600 | 1,000 | 8,000 |
 
 "Sequential" means one `InjectPacket` call at a time — send a packet,
 wait for the result, repeat. "Batch" uses the `InjectPackets` streaming
@@ -224,7 +224,7 @@ logging enabled — its analog of 4ward's trace trees.
 | Workload | BMv2 | 4ward, 1 core | 4ward, 16 cores |
 |----------|------|---------------|-----------------|
 | L3 forwarding | 4,500 | 2,500 | 29,000 |
-| WCMP ×16 | 4,400 | 1,400 | 10,000 |
+| WCMP ×16 | 4,400 | 1,900 | 12,000 |
 
 BMv2 is faster on single-core sequential throughput — it's a mature C++
 codebase and doesn't build trace trees. With concurrent processing,


### PR DESCRIPTION
## Summary

Replaces the pipeline replay approach with fork-point resume for all fork
types. Instead of re-executing the entire pipeline for each branch, captures
state at the fork point and continues each branch from there.

| Fork type | Fork point | What branches do |
|-----------|-----------|-----------------|
| Action selector | Inside interpreter | Continue with selected action + remaining stmts |
| I2E clone | Ingress-egress boundary | Original: remaining boundary + egress. Clone: post-parser env + egress |
| E2E clone | Post-egress boundary | Original: deparser. Clone: second egress + deparser |
| Multicast | Ingress-egress boundary | Each replica: set port/rid, run egress + deparser |
| Resubmit/recirculate | Pipeline boundaries | Restart pipeline (resume N/A) |

**Architecture** (read top-down):
1. `buildTraceTree` → `runPipeline`, on fork → `handleFork`
2. `handleFork` → exhaustive dispatch to per-type handler
3. Each handler calls `runBranch(configure = {...}, pipelineTail = {...})`
4. `runBranch` creates branch state, applies config, runs tail, handles nested forks
5. Selector forks are special (`continueFromForkPoint` — continuation capture)

Nested forks work naturally — `handleFork` dispatches recursively.

Also eliminates the entire old replay infrastructure: `BranchSpec`, `forkSpecs`,
`prefixLength`, `PostParserSnapshot`, `tableLookupCache`, `BranchMode`.

Fixes a trace bug where clone "original" branches were missing the "egress
ENTER" event (5 golden files updated). Adds 3 new golden tests (E2E clone,
resubmit, recirculate).

**wcmp×128** (10k packets, intra-packet parallelism off):

| Metric | Main | This PR | Delta |
|--------|------|---------|-------|
| Sequential | 240 pps | 345 pps | **+44%** |
| Parallel | 2299 pps | 3393 pps | **+48%** |

## Test plan

- [x] All 67 tests pass (17 golden trace tree tests)
- [x] Lint clean (`./tools/lint.sh`)
- [x] Benchmarked wcmp×128 sequential and parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)