### PR TITLE
Add p4runtime_cc: C++ wrapper for embedding the server as a subprocess

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,15 @@ issues) where helpful. Do not add comments that merely restate the code.
 find and use the successor immediately — don't suppress the warning. A
 deprecated call that works today is a broken call on the next upgrade.
 
+For C++, follow the [Google C++ Style Guide] and
+[Abseil Tips of the Week]. In particular, keep namespaces flat
+([TotW #130]) — don't introduce sub-namespaces that don't earn their
+keep. `namespace fourward` is almost always enough.
+
+[Google C++ Style Guide]: https://google.github.io/styleguide/cppguide.html
+[Abseil Tips of the Week]: https://abseil.io/tips/
+[TotW #130]: https://abseil.io/tips/130
+
 If you take a shortcut or skip a corner case, note it in
 [LIMITATIONS.md](docs/LIMITATIONS.md) with a `TODO` comment at the site.
 Mark workarounds with a prominent `WORKAROUND` comment explaining what is
@@ -169,6 +178,7 @@ simulator/simulator.proto    Shared types for simulator clients (P4Runtime, STF,
 simulator/*.kt               Kotlin simulator (the heart of 4ward).
 p4c_backend/*.{h,cpp}        C++ p4c backend plugin (emits proto IR from P4 source).
 p4runtime/*.kt               P4Runtime gRPC server (Kotlin).
+p4runtime_cc/*.{h,cc}        C++ RAII wrapper that embeds the server as a subprocess.
 cli/*.kt                     Standalone CLI (4ward compile / sim / run).
 web/*.kt                     Web playground server and graph extractors (Kotlin).
 examples/*.p4                Ready-to-run example programs.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -150,6 +150,7 @@ use_repo(pip, "pip")
 # --- Dev tools ---
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
+
 # Not dev_dependency: //p4runtime_cc:fourward_server_test is visible to BCR
 # consumers building `@fourward//...`, so its `@googletest` dep must resolve
 # outside the root-module context too.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -150,7 +150,10 @@ use_repo(pip, "pip")
 # --- Dev tools ---
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
-bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
+# Not dev_dependency: //p4runtime_cc:fourward_server_test is visible to BCR
+# consumers building `@fourward//...`, so its `@googletest` dep must resolve
+# outside the root-module context too.
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 
 # Runs clang-tidy as a Bazel aspect — no compile_commands.json needed.
 # Usage: bazel build //p4c_backend/... --config=clang-tidy

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,6 +32,11 @@ bazel_dep(name = "grpc", version = "1.80.0")  # For cc_grpc_library (dataplane_c
 bazel_dep(name = "grpc-java", version = "1.78.0.bcr.1")
 bazel_dep(name = "grpc_kotlin", version = "1.5.0")
 
+# Abseil — idiomatic C++ utilities (absl::Status, absl::Duration, absl::StrCat)
+# used by //p4runtime_cc. Declared directly so the apparent name @abseil-cpp
+# resolves under strict deps; it is also pulled transitively via @grpc.
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
+
 # WORKAROUND for strict-deps issues in grpc_kotlin@1.5.0 — see
 # `bazel/grpc_kotlin.patch` for the details and upstream PR link.
 single_version_override(
@@ -145,6 +150,7 @@ use_repo(pip, "pip")
 # --- Dev tools ---
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 
 # Runs clang-tidy as a Bazel aspect — no compile_commands.json needed.
 # Usage: bazel build //p4c_backend/... --config=clang-tidy

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ report in about 5. No flakes, no "works on my machine." See for yourself on the
 guides, reference pages, and concept explainers for the web playground, CLI,
 and gRPC API. Working in a C++ codebase?
 **[Embedding in C++](https://smolkaj.github.io/4ward/reference/embedding-cc/)**
-lets you use 4ward without writing a line of Kotlin or Java.
+lets you treat 4ward like a native C++ library.
 
 **[Tutorial](examples/tutorial.t)** — a hands-on walkthrough from hello
 world to machine-readable trace output. Doubles as a regression test (cram

--- a/README.md
+++ b/README.md
@@ -323,7 +323,9 @@ report in about 5. No flakes, no "works on my machine." See for yourself on the
 
 **[User documentation](https://smolkaj.github.io/4ward/)** — getting started
 guides, reference pages, and concept explainers for the web playground, CLI,
-and gRPC API.
+and gRPC API. C++ consumers embedding the server in their own harnesses
+should start at
+**[Embedding in C++](https://smolkaj.github.io/4ward/reference/embedding-cc/)**.
 
 **[Tutorial](examples/tutorial.t)** — a hands-on walkthrough from hello
 world to machine-readable trace output. Doubles as a regression test (cram

--- a/README.md
+++ b/README.md
@@ -278,10 +278,15 @@ ergonomics (sealed classes, pattern matching).
 - **Java?** Kotlin, but worse.
 - **OCaml?** Excellent fit, but not well-supported within Google's ecosystem :(
 
-> [!IMPORTANT]  
-> **You don't need to know Kotlin to contribute to 4ward!**
-> [The AI writes the code](docs/AI_WORKFLOW.md) — you just need to know your
-requirements.
+> [!IMPORTANT]
+> **You don't need to know Kotlin to contribute to — or use — 4ward.**
+> [The AI writes the code](docs/AI_WORKFLOW.md); you just need to know
+> your requirements. And if you're consuming 4ward from another
+> language, Kotlin is an implementation detail: C++ projects can embed
+> the server via
+> [`//p4runtime_cc:fourward_server`](https://smolkaj.github.io/4ward/reference/embedding-cc/)
+> with all-C++ BUILD files, and any language with a gRPC client can
+> speak to the server directly.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ report in about 5. No flakes, no "works on my machine." See for yourself on the
 
 **[User documentation](https://smolkaj.github.io/4ward/)** — getting started
 guides, reference pages, and concept explainers for the web playground, CLI,
-and gRPC API. C++ consumers embedding the server in their own harnesses
-should start at
-**[Embedding in C++](https://smolkaj.github.io/4ward/reference/embedding-cc/)**.
+and gRPC API. Working in a C++ codebase?
+**[Embedding in C++](https://smolkaj.github.io/4ward/reference/embedding-cc/)**
+lets you use 4ward without writing a line of Kotlin or Java.
 
 **[Tutorial](examples/tutorial.t)** — a hands-on walkthrough from hello
 world to machine-readable trace output. Doubles as a regression test (cram

--- a/README.md
+++ b/README.md
@@ -279,14 +279,10 @@ ergonomics (sealed classes, pattern matching).
 - **OCaml?** Excellent fit, but not well-supported within Google's ecosystem :(
 
 > [!IMPORTANT]
-> **You don't need to know Kotlin to contribute to — or use — 4ward.**
-> [The AI writes the code](docs/AI_WORKFLOW.md); you just need to know
-> your requirements. And if you're consuming 4ward from another
-> language, Kotlin is an implementation detail: C++ projects can embed
-> the server via
-> [`//p4runtime_cc:fourward_server`](https://smolkaj.github.io/4ward/reference/embedding-cc/)
-> with all-C++ BUILD files, and any language with a gRPC client can
-> speak to the server directly.
+> **You don't need Kotlin to contribute to — or use — 4ward.**
+> [AI writes the code](docs/AI_WORKFLOW.md); C++ projects embed via
+> [`//p4runtime_cc:fourward_server`](https://smolkaj.github.io/4ward/reference/embedding-cc/);
+> any gRPC client works in any language.
 
 ## Project structure
 

--- a/docs/ENTRY_POINTS.md
+++ b/docs/ENTRY_POINTS.md
@@ -147,10 +147,14 @@ gRPC semantics (status codes, streaming) without network flakiness.
 **Target:** `//p4runtime_cc:fourward_server`
 **API:** `fourward::FourwardServer::Start()` (C++)
 
-An RAII wrapper that spawns the P4Runtime server as a child process, waits
-until it is accepting gRPC calls, and tears it down on destruction. The
-server's listening port is discovered via a machine-readable `--port-file`
-that the server writes atomically once it is ready to serve.
+Use 4ward from C++ without writing a line of Kotlin or Java. `Start()`
+spawns the P4Runtime + Dataplane server as a subprocess, blocks until it
+is accepting RPCs, and returns an RAII handle that owns the subprocess
+plus factories for both service stubs. Destruction kills the subprocess.
+Your project's BUILD files stay all-C++; the JVM is an implementation
+detail of the server binary. Startup synchronization goes through a
+machine-readable `--port-file` that the server writes atomically once
+it is ready to serve.
 
 ```cpp
 #include "p4runtime_cc/fourward_server.h"

--- a/docs/ENTRY_POINTS.md
+++ b/docs/ENTRY_POINTS.md
@@ -167,10 +167,7 @@ auto dataplane = server.NewDataplaneStub();
 `Options` exposes `device_id`, `port` (unset = kernel picks ephemeral),
 `drop_port`, `cpu_port`, and `startup_timeout`.
 
-**When to use:** C++ test harnesses, reference implementations, or
-differential-testing infrastructure that wants to drive 4ward without
-pulling Kotlin or JVM build tooling into its own project. The canonical
-replacement for hand-rolled subprocess wrappers.
+**When to use:** Any C++ project that needs to drive 4ward.
 
 See the [user-facing embedding guide](https://smolkaj.github.io/4ward/reference/embedding-cc/)
 for the Bazel setup and full example.

--- a/docs/ENTRY_POINTS.md
+++ b/docs/ENTRY_POINTS.md
@@ -167,7 +167,7 @@ auto dataplane = server.NewDataplaneStub();
 `Options` exposes `device_id`, `port` (unset = kernel picks ephemeral),
 `drop_port`, `cpu_port`, and `startup_timeout`.
 
-**When to use:** Any C++ project that needs to drive 4ward.
+**When to use:** Any C++ project that wants to use 4ward.
 
 See the [user-facing embedding guide](https://smolkaj.github.io/4ward/reference/embedding-cc/)
 for the Bazel setup and full example.

--- a/docs/ENTRY_POINTS.md
+++ b/docs/ENTRY_POINTS.md
@@ -152,9 +152,7 @@ spawns the P4Runtime + Dataplane server as a subprocess, blocks until it
 is accepting RPCs, and returns an RAII handle that owns the subprocess
 plus factories for both service stubs. Destruction kills the subprocess.
 Your project's BUILD files stay all-C++; the JVM is an implementation
-detail of the server binary. Startup synchronization goes through a
-machine-readable `--port-file` that the server writes atomically once
-it is ready to serve.
+detail of the server binary.
 
 ```cpp
 #include "p4runtime_cc/fourward_server.h"

--- a/docs/ENTRY_POINTS.md
+++ b/docs/ENTRY_POINTS.md
@@ -147,12 +147,12 @@ gRPC semantics (status codes, streaming) without network flakiness.
 **Target:** `//p4runtime_cc:fourward_server`
 **API:** `fourward::FourwardServer::Start()` (C++)
 
-Use 4ward from C++ without writing a line of Kotlin or Java. `Start()`
-spawns the P4Runtime + Dataplane server as a subprocess, blocks until it
-is accepting RPCs, and returns an RAII handle that owns the subprocess
-plus factories for both service stubs. Destruction kills the subprocess.
-Your project's BUILD files stay all-C++; the JVM is an implementation
-detail of the server binary.
+Treat 4ward like a native C++ library. `Start()` spawns the P4Runtime +
+Dataplane server as a subprocess, blocks until it is accepting RPCs, and
+returns an RAII handle with factories for both service stubs on a shared
+gRPC channel; destruction kills the subprocess. Your project sees a C++
+API and a Bazel target — the server's implementation language is out of
+sight.
 
 ```cpp
 #include "p4runtime_cc/fourward_server.h"

--- a/docs/ENTRY_POINTS.md
+++ b/docs/ENTRY_POINTS.md
@@ -149,17 +149,16 @@ gRPC semantics (status codes, streaming) without network flakiness.
 
 An RAII wrapper that spawns the P4Runtime server as a child process, waits
 until it is accepting gRPC calls, and tears it down on destruction. The
-server's listening port is discovered via a machine-readable
-`--port-file`, not the stdout banner — so log-format changes never break
-embedders.
+server's listening port is discovered via a machine-readable `--port-file`
+that the server writes atomically once it is ready to serve.
 
 ```cpp
 #include "p4runtime_cc/fourward_server.h"
 
 ASSIGN_OR_RETURN(fourward::FourwardServer server,
                  fourward::FourwardServer::Start());
-auto channel = grpc::CreateChannel(server.Address(),
-                                   grpc::InsecureChannelCredentials());
+auto p4rt = server.NewP4RuntimeStub();
+auto dataplane = server.NewDataplaneStub();
 // ... drive the server via gRPC; subprocess is killed on scope exit ...
 ```
 

--- a/docs/ENTRY_POINTS.md
+++ b/docs/ENTRY_POINTS.md
@@ -53,10 +53,11 @@ with a hardware switch or BMv2.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--port=<N>` | 9559 | gRPC listen port |
+| `--port=<N>` | 9559 | gRPC listen port (use `0` to let the kernel pick an ephemeral port) |
 | `--device-id=<N>` | 1 | P4Runtime device ID |
 | `--drop-port=<N>` | *(derived)* | Override the drop port value |
 | `--cpu-port=<N>` | *(derived)* | Override the CPU port value |
+| `--port-file=<PATH>` | *(off)* | After binding, atomically write the listening port here. Intended for embedders (see the [C++ wrapper](#c-embedding-wrapper)). |
 
 In addition to the standard P4Runtime RPCs, the server exposes a **Dataplane
 service** for direct packet injection:
@@ -141,6 +142,38 @@ P4RuntimeTestHarness().use { harness ->
 loading, PacketOut/PacketIn routing, `@p4runtime_translation`. Gives you full
 gRPC semantics (status codes, streaming) without network flakiness.
 
+## C++ embedding wrapper
+
+**Target:** `//p4runtime_cc:fourward_server`
+**API:** `fourward::FourwardServer::Start()` (C++)
+
+An RAII wrapper that spawns the P4Runtime server as a child process, waits
+until it is accepting gRPC calls, and tears it down on destruction. The
+server's listening port is discovered via a machine-readable
+`--port-file`, not the stdout banner — so log-format changes never break
+embedders.
+
+```cpp
+#include "p4runtime_cc/fourward_server.h"
+
+ASSIGN_OR_RETURN(fourward::FourwardServer server,
+                 fourward::FourwardServer::Start());
+auto channel = grpc::CreateChannel(server.Address(),
+                                   grpc::InsecureChannelCredentials());
+// ... drive the server via gRPC; subprocess is killed on scope exit ...
+```
+
+`Options` exposes `device_id`, `port` (unset = kernel picks ephemeral),
+`drop_port`, `cpu_port`, and `startup_timeout`.
+
+**When to use:** C++ test harnesses, reference implementations, or
+differential-testing infrastructure that wants to drive 4ward without
+pulling Kotlin or JVM build tooling into its own project. The canonical
+replacement for hand-rolled subprocess wrappers.
+
+See the [user-facing embedding guide](https://smolkaj.github.io/4ward/reference/embedding-cc/)
+for the Bazel setup and full example.
+
 ## Intrinsic port configuration
 
 All entry points share the same defaults for intrinsic ports (drop port, CPU
@@ -155,6 +188,7 @@ override them in whatever way fits its context. See the
 | **Web playground** | Same as P4Runtime server | Same as P4Runtime server |
 | **STF runner** | Constructor param | N/A (no P4Runtime layer) |
 | **Test harness** | Constructor param | Constructor param |
+| **C++ wrapper** | `Options::drop_port` | `Options::cpu_port` |
 
 ### Defaults
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - gRPC API:
       - Getting Started: getting-started/grpc.md
       - Reference: reference/grpc.md
+      - Embedding in C++: reference/embedding-cc.md
   - Concepts:
       - Trace Trees: concepts/traces.md
       - Type Translation: concepts/type-translation.md

--- a/p4runtime/P4RuntimeServer.kt
+++ b/p4runtime/P4RuntimeServer.kt
@@ -3,6 +3,9 @@ package fourward.p4runtime
 import fourward.simulator.Simulator
 import io.grpc.Server
 import io.grpc.netty.NettyServerBuilder
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.util.concurrent.Executors
 import kotlinx.coroutines.sync.Mutex
 
@@ -80,10 +83,23 @@ fun main(args: Array<String>) {
     flagValue(args, "--device-id")?.toLongOrNull() ?: P4RuntimeService.DEFAULT_DEVICE_ID
   val dropPort = flagValue(args, "--drop-port")?.toIntOrNull()
   val cpuPortConfig = CpuPortConfig.fromFlag(flagValue(args, "--cpu-port"))
+  val portFile = flagValue(args, "--port-file")?.let(Path::of)
 
   val server = P4RuntimeServer(port, deviceId, dropPort, cpuPortConfig).start()
   println("P4Runtime server listening on port ${server.port()}")
+
+  // Machine-readable readiness signal for embedders. Write the port to a temp
+  // file and rename into place atomically so a concurrent reader never sees a
+  // partial value. See p4runtime_cc/fourward_server.h for the embedding API.
+  portFile?.let { writePortFileAtomic(it, server.port()) }
+
   server.blockUntilShutdown()
+}
+
+private fun writePortFileAtomic(path: Path, port: Int) {
+  val tmp = path.resolveSibling("${path.fileName}.tmp")
+  Files.writeString(tmp, port.toString())
+  Files.move(tmp, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
 }
 
 private fun flagValue(args: Array<String>, flag: String): String? =

--- a/p4runtime_cc/BUILD.bazel
+++ b/p4runtime_cc/BUILD.bazel
@@ -29,6 +29,8 @@ cc_library(
     strip_include_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
+        "//p4runtime:dataplane_cc_grpc",
+        "//p4runtime:dataplane_cc_proto",
         "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
@@ -36,6 +38,9 @@ cc_library(
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/time",
         "@bazel_tools//tools/cpp/runfiles",
+        "@grpc//:grpc++",
+        "@p4runtime//:p4runtime_cc_grpc",
+        "@p4runtime//:p4runtime_cc_proto",
     ],
 )
 

--- a/p4runtime_cc/BUILD.bazel
+++ b/p4runtime_cc/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+# C++ RAII wrapper for embedding the 4ward P4Runtime + Dataplane server as a
+# child process. See fourward_server.h for the full API contract. A consumer
+# target must additionally list `@fourward//p4runtime:p4runtime_server` in its
+# `data` so the server binary is materialized into its runfiles tree.
+cc_library(
+    name = "fourward_server",
+    srcs = ["fourward_server.cc"],
+    hdrs = ["fourward_server.h"],
+    # Exposed via the apparent include path "p4runtime_cc/fourward_server.h"
+    # for downstream consumers.
+    strip_include_prefix = "/",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+        "@abseil-cpp//absl/time",
+        "@bazel_tools//tools/cpp/runfiles",
+    ],
+)
+
+cc_test(
+    name = "fourward_server_test",
+    srcs = ["fourward_server_test.cc"],
+    data = ["//p4runtime:p4runtime_server"],
+    deps = [
+        ":fourward_server",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/time",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@grpc//:grpc++",
+        "@p4runtime//:p4runtime_cc_grpc",
+        "@p4runtime//:p4runtime_cc_proto",
+    ],
+)

--- a/p4runtime_cc/BUILD.bazel
+++ b/p4runtime_cc/BUILD.bazel
@@ -7,18 +7,29 @@ package(
 )
 
 # C++ RAII wrapper for embedding the 4ward P4Runtime + Dataplane server as a
-# child process. See fourward_server.h for the full API contract. A consumer
-# target must additionally list `@fourward//p4runtime:p4runtime_server` in its
-# `data` so the server binary is materialized into its runfiles tree.
+# child process. See fourward_server.h for the full API contract.
+#
+# The server binary is propagated to consumers via `data`, so a cc_test that
+# depends on this library does not need to add anything else.
 cc_library(
     name = "fourward_server",
     srcs = ["fourward_server.cc"],
     hdrs = ["fourward_server.h"],
+    data = ["//p4runtime:p4runtime_server"],
+    # `$(rlocationpath)` expands to the canonical runfile path under the
+    # current build's repo naming (e.g. `_main/...` when fourward is the root
+    # module, `fourward+/...` when a BCR consumer pulls it in). Baking this in
+    # via local_defines avoids hardcoding `_main/`, which would break for
+    # every consumer but ourselves.
+    local_defines = [
+        "FOURWARD_SERVER_RLOCATION=\\\"$(rlocationpath //p4runtime:p4runtime_server)\\\"",
+    ],
     # Exposed via the apparent include path "p4runtime_cc/fourward_server.h"
     # for downstream consumers.
     strip_include_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
+        "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
@@ -31,7 +42,6 @@ cc_library(
 cc_test(
     name = "fourward_server_test",
     srcs = ["fourward_server_test.cc"],
-    data = ["//p4runtime:p4runtime_server"],
     deps = [
         ":fourward_server",
         "@abseil-cpp//absl/status",

--- a/p4runtime_cc/fourward_server.cc
+++ b/p4runtime_cc/fourward_server.cc
@@ -11,12 +11,15 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <charconv>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -82,10 +85,15 @@ void RemoveScratchDir(const std::string& path) {
 
 absl::StatusOr<int> ReadPortFile(const std::string& path) {
   std::ifstream in(path);
+  std::string contents((std::istreambuf_iterator<char>(in)),
+                       std::istreambuf_iterator<char>());
   int port = 0;
-  if (!(in >> port) || port <= 0 || port > 65535) {
+  auto [ptr, ec] = std::from_chars(contents.data(),
+                                   contents.data() + contents.size(), port);
+  if (ec != std::errc() || port <= 0 || port > 65535) {
     return absl::InternalError(
-        absl::StrCat("port file at ", path, " has invalid contents"));
+        absl::StrCat("port file at ", path, " has invalid contents: '",
+                     contents, "'"));
   }
   return port;
 }

--- a/p4runtime_cc/fourward_server.cc
+++ b/p4runtime_cc/fourward_server.cc
@@ -1,0 +1,254 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "p4runtime_cc/fourward_server.h"
+
+#include <signal.h>
+#include <spawn.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/strip.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+extern char** environ;
+
+namespace fourward {
+namespace {
+
+using ::bazel::tools::cpp::runfiles::Runfiles;
+
+// Bazel label of the server binary. Resolved via runfiles at launch so the
+// wrapper works identically from `bazel test` and installed-binary scenarios.
+constexpr char kServerRunfile[] = "_main/p4runtime/p4runtime_server";
+
+absl::Status PosixError(const std::string& what, int err) {
+  return absl::InternalError(
+      absl::StrCat(what, ": ", std::strerror(err), " (errno=", err, ")"));
+}
+
+// Creates a unique scratch directory under $TEST_TMPDIR (honored by Bazel
+// test shards) or /tmp. Not deleted on Shutdown — the test harness cleans
+// $TEST_TMPDIR, and for non-test embeds a handful of stale dirs under /tmp
+// are harmless relative to the cost of racing cleanup against a still-alive
+// subprocess on error paths.
+absl::StatusOr<std::string> MakeScratchDir() {
+  const char* base = std::getenv("TEST_TMPDIR");
+  if (base == nullptr || *base == '\0') base = "/tmp";
+  std::string tmpl = absl::StrCat(base, "/fourward-server-XXXXXX");
+  std::vector<char> buf(tmpl.begin(), tmpl.end());
+  buf.push_back('\0');
+  if (mkdtemp(buf.data()) == nullptr) {
+    return PosixError("mkdtemp", errno);
+  }
+  return std::string(buf.data());
+}
+
+absl::StatusOr<int> ReadPortFile(const std::string& path) {
+  std::ifstream in(path);
+  if (!in) return PosixError(absl::StrCat("open ", path), errno);
+  std::stringstream ss;
+  ss << in.rdbuf();
+  std::string contents = ss.str();
+  // The writer uses atomic rename, so a successful open never observes a
+  // partial value — but it may still observe trailing whitespace from a
+  // future writer. Be forgiving.
+  absl::string_view trimmed = absl::StripAsciiWhitespace(contents);
+  int port = 0;
+  if (!absl::SimpleAtoi(trimmed, &port) || port <= 0 || port > 65535) {
+    return absl::InternalError(
+        absl::StrCat("port file at ", path, " has invalid contents: '",
+                     contents, "'"));
+  }
+  return port;
+}
+
+// Waits for `path` to exist (meaning: the server has bound and published its
+// port) or `deadline` to elapse. Returns DeadlineExceededError on timeout.
+// The child's exit is checked on each poll so we don't hang forever if the
+// server crashed before writing the file.
+absl::Status WaitForPortFile(const std::string& path, pid_t child_pid,
+                             absl::Time deadline) {
+  constexpr absl::Duration kPoll = absl::Milliseconds(25);
+  while (absl::Now() < deadline) {
+    struct stat st;
+    if (::stat(path.c_str(), &st) == 0 && st.st_size > 0) {
+      return absl::OkStatus();
+    }
+
+    int status = 0;
+    pid_t waited = ::waitpid(child_pid, &status, WNOHANG);
+    if (waited == child_pid) {
+      return absl::InternalError(absl::StrFormat(
+          "server subprocess exited before reporting its port "
+          "(pid=%d, status=0x%x). Check server stderr for a stack trace.",
+          child_pid, status));
+    }
+
+    absl::SleepFor(kPoll);
+  }
+  return absl::DeadlineExceededError(absl::StrCat(
+      "server did not publish its port to ", path, " before the timeout"));
+}
+
+// Reaps `pid` with a bounded wait; returns true if the process is gone.
+bool TryReap(pid_t pid, absl::Duration budget) {
+  absl::Time deadline = absl::Now() + budget;
+  do {
+    int status = 0;
+    pid_t waited = ::waitpid(pid, &status, WNOHANG);
+    if (waited == pid) return true;
+    if (waited < 0 && errno == ECHILD) return true;
+    absl::SleepFor(absl::Milliseconds(20));
+  } while (absl::Now() < deadline);
+  return false;
+}
+
+}  // namespace
+
+absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
+  std::string runfiles_error;
+  std::unique_ptr<Runfiles> runfiles(
+      Runfiles::Create("", BAZEL_CURRENT_REPOSITORY, &runfiles_error));
+  if (runfiles == nullptr) {
+    return absl::InternalError(
+        absl::StrCat("failed to resolve runfiles: ", runfiles_error));
+  }
+  std::string server_path = runfiles->Rlocation(kServerRunfile);
+  if (server_path.empty() || ::access(server_path.c_str(), X_OK) != 0) {
+    return absl::NotFoundError(absl::StrCat(
+        "4ward P4Runtime server binary not found in runfiles (expected ",
+        kServerRunfile,
+        "). Does your cc_test list `@fourward//p4runtime:p4runtime_server` "
+        "in `data`?"));
+  }
+
+  absl::StatusOr<std::string> scratch = MakeScratchDir();
+  if (!scratch.ok()) return std::move(scratch).status();
+  std::string port_file = absl::StrCat(*scratch, "/port");
+
+  // Build argv. posix_spawn takes a char* const[]; build strings first,
+  // then snapshot their c_str()s into the argv array.
+  std::vector<std::string> args = {
+      server_path,
+      absl::StrCat("--port=", options.port.value_or(0)),
+      absl::StrCat("--device-id=", options.device_id),
+      absl::StrCat("--port-file=", port_file),
+  };
+  if (options.drop_port.has_value()) {
+    args.push_back(absl::StrCat("--drop-port=", *options.drop_port));
+  }
+  switch (options.cpu_port.kind) {
+    case CpuPort::Kind::kAuto:
+      break;  // Default; omit the flag.
+    case CpuPort::Kind::kDisabled:
+      args.emplace_back("--cpu-port=none");
+      break;
+    case CpuPort::Kind::kOverride:
+      args.push_back(absl::StrCat("--cpu-port=", options.cpu_port.port));
+      break;
+  }
+  std::vector<char*> argv;
+  argv.reserve(args.size() + 1);
+  for (auto& a : args) argv.push_back(a.data());
+  argv.push_back(nullptr);
+
+  // Put the server into its own process group so SIGTERM to the group fans
+  // out to any JVM grandchildren (e.g. native Netty helpers) without
+  // touching the parent test process. posix_spawn with POSIX_SPAWN_SETPGROUP
+  // + pgroup=0 is the portable way to request that.
+  posix_spawnattr_t attr;
+  if (int rc = posix_spawnattr_init(&attr); rc != 0) {
+    return PosixError("posix_spawnattr_init", rc);
+  }
+  if (int rc = posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP);
+      rc != 0) {
+    posix_spawnattr_destroy(&attr);
+    return PosixError("posix_spawnattr_setflags", rc);
+  }
+  if (int rc = posix_spawnattr_setpgroup(&attr, 0); rc != 0) {
+    posix_spawnattr_destroy(&attr);
+    return PosixError("posix_spawnattr_setpgroup", rc);
+  }
+
+  pid_t pid = -1;
+  int spawn_rc = posix_spawn(&pid, server_path.c_str(), /*file_actions=*/nullptr,
+                             &attr, argv.data(), environ);
+  posix_spawnattr_destroy(&attr);
+  if (spawn_rc != 0) return PosixError("posix_spawn", spawn_rc);
+
+  absl::Time deadline = absl::Now() + options.startup_timeout;
+  if (absl::Status s = WaitForPortFile(port_file, pid, deadline); !s.ok()) {
+    ::kill(pid, SIGKILL);
+    TryReap(pid, absl::Seconds(5));
+    return s;
+  }
+  absl::StatusOr<int> port = ReadPortFile(port_file);
+  if (!port.ok()) {
+    ::kill(pid, SIGKILL);
+    TryReap(pid, absl::Seconds(5));
+    return std::move(port).status();
+  }
+
+  return FourwardServer(pid, *port, options.device_id);
+}
+
+FourwardServer::FourwardServer(pid_t pid, int port, uint64_t device_id)
+    : pid_(pid),
+      port_(port),
+      device_id_(device_id),
+      address_(absl::StrCat("localhost:", port)) {}
+
+FourwardServer::FourwardServer(FourwardServer&& other) noexcept
+    : pid_(other.pid_),
+      port_(other.port_),
+      device_id_(other.device_id_),
+      address_(std::move(other.address_)) {
+  other.pid_ = -1;
+}
+
+FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
+  if (this != &other) {
+    Shutdown();
+    pid_ = other.pid_;
+    port_ = other.port_;
+    device_id_ = other.device_id_;
+    address_ = std::move(other.address_);
+    other.pid_ = -1;
+  }
+  return *this;
+}
+
+FourwardServer::~FourwardServer() { Shutdown(); }
+
+void FourwardServer::Shutdown() {
+  if (pid_ <= 0) return;
+  // Signal the process group so any JVM-spawned helpers go too.
+  ::killpg(pid_, SIGTERM);
+  if (!TryReap(pid_, absl::Seconds(5))) {
+    ::killpg(pid_, SIGKILL);
+    TryReap(pid_, absl::Seconds(2));
+  }
+  pid_ = -1;
+}
+
+}  // namespace fourward

--- a/p4runtime_cc/fourward_server.cc
+++ b/p4runtime_cc/fourward_server.cc
@@ -14,21 +14,25 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "absl/cleanup/cleanup.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/strip.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "tools/cpp/runfiles/runfiles.h"
+
+#ifndef FOURWARD_SERVER_RLOCATION
+#error "FOURWARD_SERVER_RLOCATION must be set by the BUILD rule"
+#endif
 
 extern char** environ;
 
@@ -37,9 +41,11 @@ namespace {
 
 using ::bazel::tools::cpp::runfiles::Runfiles;
 
-// Bazel label of the server binary. Resolved via runfiles at launch so the
-// wrapper works identically from `bazel test` and installed-binary scenarios.
-constexpr char kServerRunfile[] = "_main/p4runtime/p4runtime_server";
+// Runfile path of the server binary, baked in from BUILD via
+// `$(rlocationpath //p4runtime:p4runtime_server)`. Has the canonical repo
+// name (e.g. `_main/...` or `fourward+/...`) appropriate to the current
+// build.
+constexpr char kServerRunfile[] = FOURWARD_SERVER_RLOCATION;
 
 absl::Status PosixError(const std::string& what, int err) {
   return absl::InternalError(
@@ -47,10 +53,7 @@ absl::Status PosixError(const std::string& what, int err) {
 }
 
 // Creates a unique scratch directory under $TEST_TMPDIR (honored by Bazel
-// test shards) or /tmp. Not deleted on Shutdown — the test harness cleans
-// $TEST_TMPDIR, and for non-test embeds a handful of stale dirs under /tmp
-// are harmless relative to the cost of racing cleanup against a still-alive
-// subprocess on error paths.
+// test shards) or /tmp.
 absl::StatusOr<std::string> MakeScratchDir() {
   const char* base = std::getenv("TEST_TMPDIR");
   if (base == nullptr || *base == '\0') base = "/tmp";
@@ -63,21 +66,21 @@ absl::StatusOr<std::string> MakeScratchDir() {
   return std::string(buf.data());
 }
 
+// Best-effort recursive removal of `path`; errors are swallowed because
+// cleanup runs from destructors and we've already done our job if the
+// process was reaped.
+void RemoveScratchDir(const std::string& path) {
+  if (path.empty()) return;
+  std::error_code ec;
+  std::filesystem::remove_all(path, ec);
+}
+
 absl::StatusOr<int> ReadPortFile(const std::string& path) {
   std::ifstream in(path);
-  if (!in) return PosixError(absl::StrCat("open ", path), errno);
-  std::stringstream ss;
-  ss << in.rdbuf();
-  std::string contents = ss.str();
-  // The writer uses atomic rename, so a successful open never observes a
-  // partial value — but it may still observe trailing whitespace from a
-  // future writer. Be forgiving.
-  absl::string_view trimmed = absl::StripAsciiWhitespace(contents);
   int port = 0;
-  if (!absl::SimpleAtoi(trimmed, &port) || port <= 0 || port > 65535) {
+  if (!(in >> port) || port <= 0 || port > 65535) {
     return absl::InternalError(
-        absl::StrCat("port file at ", path, " has invalid contents: '",
-                     contents, "'"));
+        absl::StrCat("port file at ", path, " has invalid contents"));
   }
   return port;
 }
@@ -123,6 +126,17 @@ bool TryReap(pid_t pid, absl::Duration budget) {
   return false;
 }
 
+// Kills the process group led by `pid` (SIGTERM then SIGKILL) and reaps the
+// child. Safe to call when `pid <= 0`.
+void KillAndReap(pid_t pid) {
+  if (pid <= 0) return;
+  ::killpg(pid, SIGTERM);
+  if (!TryReap(pid, absl::Seconds(5))) {
+    ::killpg(pid, SIGKILL);
+    TryReap(pid, absl::Seconds(2));
+  }
+}
+
 }  // namespace
 
 absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
@@ -137,17 +151,23 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
   if (server_path.empty() || ::access(server_path.c_str(), X_OK) != 0) {
     return absl::NotFoundError(absl::StrCat(
         "4ward P4Runtime server binary not found in runfiles (expected ",
-        kServerRunfile,
-        "). Does your cc_test list `@fourward//p4runtime:p4runtime_server` "
-        "in `data`?"));
+        kServerRunfile, "). Resolved path: '", server_path, "'"));
   }
 
   absl::StatusOr<std::string> scratch = MakeScratchDir();
   if (!scratch.ok()) return std::move(scratch).status();
   std::string port_file = absl::StrCat(*scratch, "/port");
 
-  // Build argv. posix_spawn takes a char* const[]; build strings first,
-  // then snapshot their c_str()s into the argv array.
+  // One guard owns every in-flight resource until Start() commits. On any
+  // early return (spawn failure, port-file timeout, malformed port, …) the
+  // guard kills the child and removes the scratch dir. On success we cancel
+  // it and transfer ownership of scratch to the FourwardServer instance.
+  pid_t pid = -1;
+  absl::Cleanup guard = [&] {
+    KillAndReap(pid);
+    RemoveScratchDir(*scratch);
+  };
+
   std::vector<std::string> args = {
       server_path,
       absl::StrCat("--port=", options.port.value_or(0)),
@@ -167,6 +187,8 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
       args.push_back(absl::StrCat("--cpu-port=", options.cpu_port.port));
       break;
   }
+  // posix_spawn needs a NULL-terminated char* const[]; build argv from the
+  // `args` strings after they're fully populated so pointers stay valid.
   std::vector<char*> argv;
   argv.reserve(args.size() + 1);
   for (auto& a : args) argv.push_back(a.data());
@@ -174,55 +196,52 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
 
   // Put the server into its own process group so SIGTERM to the group fans
   // out to any JVM grandchildren (e.g. native Netty helpers) without
-  // touching the parent test process. posix_spawn with POSIX_SPAWN_SETPGROUP
-  // + pgroup=0 is the portable way to request that.
+  // touching the parent. posix_spawn with POSIX_SPAWN_SETPGROUP + pgroup=0
+  // is the portable way to request that.
   posix_spawnattr_t attr;
   if (int rc = posix_spawnattr_init(&attr); rc != 0) {
     return PosixError("posix_spawnattr_init", rc);
   }
+  absl::Cleanup attr_destroy = [&] { posix_spawnattr_destroy(&attr); };
   if (int rc = posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP);
       rc != 0) {
-    posix_spawnattr_destroy(&attr);
     return PosixError("posix_spawnattr_setflags", rc);
   }
   if (int rc = posix_spawnattr_setpgroup(&attr, 0); rc != 0) {
-    posix_spawnattr_destroy(&attr);
     return PosixError("posix_spawnattr_setpgroup", rc);
   }
 
-  pid_t pid = -1;
-  int spawn_rc = posix_spawn(&pid, server_path.c_str(), /*file_actions=*/nullptr,
-                             &attr, argv.data(), environ);
-  posix_spawnattr_destroy(&attr);
-  if (spawn_rc != 0) return PosixError("posix_spawn", spawn_rc);
+  if (int rc = posix_spawn(&pid, server_path.c_str(), /*file_actions=*/nullptr,
+                           &attr, argv.data(), environ);
+      rc != 0) {
+    return PosixError("posix_spawn", rc);
+  }
 
   absl::Time deadline = absl::Now() + options.startup_timeout;
   if (absl::Status s = WaitForPortFile(port_file, pid, deadline); !s.ok()) {
-    ::kill(pid, SIGKILL);
-    TryReap(pid, absl::Seconds(5));
     return s;
   }
   absl::StatusOr<int> port = ReadPortFile(port_file);
-  if (!port.ok()) {
-    ::kill(pid, SIGKILL);
-    TryReap(pid, absl::Seconds(5));
-    return std::move(port).status();
-  }
+  if (!port.ok()) return std::move(port).status();
 
-  return FourwardServer(pid, *port, options.device_id);
+  std::move(guard).Cancel();
+  return FourwardServer(pid, *port, options.device_id, std::move(*scratch));
 }
 
-FourwardServer::FourwardServer(pid_t pid, int port, uint64_t device_id)
+FourwardServer::FourwardServer(pid_t pid, int port, uint64_t device_id,
+                               std::string scratch_dir)
     : pid_(pid),
       port_(port),
       device_id_(device_id),
-      address_(absl::StrCat("localhost:", port)) {}
+      address_(absl::StrCat("localhost:", port)),
+      scratch_dir_(std::move(scratch_dir)) {}
 
 FourwardServer::FourwardServer(FourwardServer&& other) noexcept
     : pid_(other.pid_),
       port_(other.port_),
       device_id_(other.device_id_),
-      address_(std::move(other.address_)) {
+      address_(std::move(other.address_)),
+      scratch_dir_(std::move(other.scratch_dir_)) {
   other.pid_ = -1;
 }
 
@@ -233,6 +252,7 @@ FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
     port_ = other.port_;
     device_id_ = other.device_id_;
     address_ = std::move(other.address_);
+    scratch_dir_ = std::move(other.scratch_dir_);
     other.pid_ = -1;
   }
   return *this;
@@ -241,14 +261,10 @@ FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
 FourwardServer::~FourwardServer() { Shutdown(); }
 
 void FourwardServer::Shutdown() {
-  if (pid_ <= 0) return;
-  // Signal the process group so any JVM-spawned helpers go too.
-  ::killpg(pid_, SIGTERM);
-  if (!TryReap(pid_, absl::Seconds(5))) {
-    ::killpg(pid_, SIGKILL);
-    TryReap(pid_, absl::Seconds(2));
-  }
+  KillAndReap(pid_);
   pid_ = -1;
+  RemoveScratchDir(scratch_dir_);
+  scratch_dir_.clear();
 }
 
 }  // namespace fourward

--- a/p4runtime_cc/fourward_server.cc
+++ b/p4runtime_cc/fourward_server.cc
@@ -28,6 +28,8 @@
 #include "absl/strings/str_format.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "grpcpp/create_channel.h"
+#include "grpcpp/security/credentials.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
 #ifndef FOURWARD_SERVER_RLOCATION
@@ -224,24 +226,32 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
   absl::StatusOr<int> port = ReadPortFile(port_file);
   if (!port.ok()) return std::move(port).status();
 
+  std::string address = absl::StrCat("localhost:", *port);
+  auto channel =
+      grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
+
   std::move(guard).Cancel();
-  return FourwardServer(pid, *port, options.device_id, std::move(*scratch));
+  return FourwardServer(pid, *port, options.device_id, std::move(*scratch),
+                        std::move(channel));
 }
 
 FourwardServer::FourwardServer(pid_t pid, int port, uint64_t device_id,
-                               std::string scratch_dir)
+                               std::string scratch_dir,
+                               std::shared_ptr<grpc::Channel> channel)
     : pid_(pid),
       port_(port),
       device_id_(device_id),
       address_(absl::StrCat("localhost:", port)),
-      scratch_dir_(std::move(scratch_dir)) {}
+      scratch_dir_(std::move(scratch_dir)),
+      channel_(std::move(channel)) {}
 
 FourwardServer::FourwardServer(FourwardServer&& other) noexcept
     : pid_(other.pid_),
       port_(other.port_),
       device_id_(other.device_id_),
       address_(std::move(other.address_)),
-      scratch_dir_(std::move(other.scratch_dir_)) {
+      scratch_dir_(std::move(other.scratch_dir_)),
+      channel_(std::move(other.channel_)) {
   other.pid_ = -1;
 }
 
@@ -253,6 +263,7 @@ FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
     device_id_ = other.device_id_;
     address_ = std::move(other.address_);
     scratch_dir_ = std::move(other.scratch_dir_);
+    channel_ = std::move(other.channel_);
     other.pid_ = -1;
   }
   return *this;
@@ -261,6 +272,10 @@ FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
 FourwardServer::~FourwardServer() { Shutdown(); }
 
 void FourwardServer::Shutdown() {
+  // Drop our channel reference first. Stubs held by callers keep their own
+  // shared_ptr alive and will surface CANCELLED/UNAVAILABLE for in-flight
+  // RPCs once the subprocess dies — which we do next.
+  channel_.reset();
   KillAndReap(pid_);
   pid_ = -1;
   RemoveScratchDir(scratch_dir_);

--- a/p4runtime_cc/fourward_server.cc
+++ b/p4runtime_cc/fourward_server.cc
@@ -13,7 +13,6 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
-#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -49,10 +48,14 @@ using ::bazel::tools::cpp::runfiles::Runfiles;
 // build.
 constexpr char kServerRunfile[] = FOURWARD_SERVER_RLOCATION;
 
-absl::Status PosixError(const std::string& what, int err) {
-  return absl::InternalError(
-      absl::StrCat(what, ": ", std::strerror(err), " (errno=", err, ")"));
-}
+// Flag names passed to the Kotlin server, kept in one place so the drift
+// between wrapper and server is easy to audit.
+constexpr char kFlagPort[] = "--port=";
+constexpr char kFlagDeviceId[] = "--device-id=";
+constexpr char kFlagPortFile[] = "--port-file=";
+constexpr char kFlagDropPort[] = "--drop-port=";
+constexpr char kFlagCpuPort[] = "--cpu-port=";
+constexpr char kCpuPortNoneValue[] = "none";
 
 // Creates a unique scratch directory under $TEST_TMPDIR (honored by Bazel
 // test shards) or /tmp.
@@ -63,7 +66,7 @@ absl::StatusOr<std::string> MakeScratchDir() {
   std::vector<char> buf(tmpl.begin(), tmpl.end());
   buf.push_back('\0');
   if (mkdtemp(buf.data()) == nullptr) {
-    return PosixError("mkdtemp", errno);
+    return absl::ErrnoToStatus(errno, "mkdtemp");
   }
   return std::string(buf.data());
 }
@@ -129,11 +132,13 @@ bool TryReap(pid_t pid, absl::Duration budget) {
 }
 
 // Kills the process group led by `pid` (SIGTERM then SIGKILL) and reaps the
-// child. Safe to call when `pid <= 0`.
+// child. Safe to call when `pid <= 0`. The 4ward server holds no persistent
+// state (see AGENTS.md invariant #5), so a 1s SIGTERM grace is ample; the
+// remaining 2s covers SIGKILL reap after the escalation.
 void KillAndReap(pid_t pid) {
   if (pid <= 0) return;
   ::killpg(pid, SIGTERM);
-  if (!TryReap(pid, absl::Seconds(5))) {
+  if (!TryReap(pid, absl::Seconds(1))) {
     ::killpg(pid, SIGKILL);
     TryReap(pid, absl::Seconds(2));
   }
@@ -141,7 +146,8 @@ void KillAndReap(pid_t pid) {
 
 }  // namespace
 
-absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
+absl::StatusOr<FourwardServer> FourwardServer::Start(
+    FourwardServerOptions options) {
   std::string runfiles_error;
   std::unique_ptr<Runfiles> runfiles(
       Runfiles::Create("", BAZEL_CURRENT_REPOSITORY, &runfiles_error));
@@ -150,10 +156,10 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
         absl::StrCat("failed to resolve runfiles: ", runfiles_error));
   }
   std::string server_path = runfiles->Rlocation(kServerRunfile);
-  if (server_path.empty() || ::access(server_path.c_str(), X_OK) != 0) {
+  if (server_path.empty()) {
     return absl::NotFoundError(absl::StrCat(
         "4ward P4Runtime server binary not found in runfiles (expected ",
-        kServerRunfile, "). Resolved path: '", server_path, "'"));
+        kServerRunfile, ")"));
   }
 
   absl::StatusOr<std::string> scratch = MakeScratchDir();
@@ -172,25 +178,23 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
 
   std::vector<std::string> args = {
       server_path,
-      absl::StrCat("--port=", options.port.value_or(0)),
-      absl::StrCat("--device-id=", options.device_id),
-      absl::StrCat("--port-file=", port_file),
+      absl::StrCat(kFlagPort, options.port.value_or(0)),
+      absl::StrCat(kFlagDeviceId, options.device_id),
+      absl::StrCat(kFlagPortFile, port_file),
   };
   if (options.drop_port.has_value()) {
-    args.push_back(absl::StrCat("--drop-port=", *options.drop_port));
+    args.push_back(absl::StrCat(kFlagDropPort, *options.drop_port));
   }
   switch (options.cpu_port.kind) {
     case CpuPort::Kind::kAuto:
       break;  // Default; omit the flag.
     case CpuPort::Kind::kDisabled:
-      args.emplace_back("--cpu-port=none");
+      args.push_back(absl::StrCat(kFlagCpuPort, kCpuPortNoneValue));
       break;
     case CpuPort::Kind::kOverride:
-      args.push_back(absl::StrCat("--cpu-port=", options.cpu_port.port));
+      args.push_back(absl::StrCat(kFlagCpuPort, options.cpu_port.port));
       break;
   }
-  // posix_spawn needs a NULL-terminated char* const[]; build argv from the
-  // `args` strings after they're fully populated so pointers stay valid.
   std::vector<char*> argv;
   argv.reserve(args.size() + 1);
   for (auto& a : args) argv.push_back(a.data());
@@ -202,21 +206,21 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
   // is the portable way to request that.
   posix_spawnattr_t attr;
   if (int rc = posix_spawnattr_init(&attr); rc != 0) {
-    return PosixError("posix_spawnattr_init", rc);
+    return absl::ErrnoToStatus(rc, "posix_spawnattr_init");
   }
   absl::Cleanup attr_destroy = [&] { posix_spawnattr_destroy(&attr); };
   if (int rc = posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP);
       rc != 0) {
-    return PosixError("posix_spawnattr_setflags", rc);
+    return absl::ErrnoToStatus(rc, "posix_spawnattr_setflags");
   }
   if (int rc = posix_spawnattr_setpgroup(&attr, 0); rc != 0) {
-    return PosixError("posix_spawnattr_setpgroup", rc);
+    return absl::ErrnoToStatus(rc, "posix_spawnattr_setpgroup");
   }
 
   if (int rc = posix_spawn(&pid, server_path.c_str(), /*file_actions=*/nullptr,
                            &attr, argv.data(), environ);
       rc != 0) {
-    return PosixError("posix_spawn", rc);
+    return absl::ErrnoToStatus(rc, "posix_spawn");
   }
 
   absl::Time deadline = absl::Now() + options.startup_timeout;
@@ -226,9 +230,8 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(Options options) {
   absl::StatusOr<int> port = ReadPortFile(port_file);
   if (!port.ok()) return std::move(port).status();
 
-  std::string address = absl::StrCat("localhost:", *port);
-  auto channel =
-      grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
+  auto channel = grpc::CreateChannel(absl::StrCat("localhost:", *port),
+                                     grpc::InsecureChannelCredentials());
 
   std::move(guard).Cancel();
   return FourwardServer(pid, *port, options.device_id, std::move(*scratch),
@@ -241,30 +244,24 @@ FourwardServer::FourwardServer(pid_t pid, int port, uint64_t device_id,
     : pid_(pid),
       port_(port),
       device_id_(device_id),
-      address_(absl::StrCat("localhost:", port)),
       scratch_dir_(std::move(scratch_dir)),
       channel_(std::move(channel)) {}
 
 FourwardServer::FourwardServer(FourwardServer&& other) noexcept
-    : pid_(other.pid_),
+    : pid_(std::exchange(other.pid_, -1)),
       port_(other.port_),
       device_id_(other.device_id_),
-      address_(std::move(other.address_)),
       scratch_dir_(std::move(other.scratch_dir_)),
-      channel_(std::move(other.channel_)) {
-  other.pid_ = -1;
-}
+      channel_(std::move(other.channel_)) {}
 
 FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
   if (this != &other) {
     Shutdown();
-    pid_ = other.pid_;
+    pid_ = std::exchange(other.pid_, -1);
     port_ = other.port_;
     device_id_ = other.device_id_;
-    address_ = std::move(other.address_);
     scratch_dir_ = std::move(other.scratch_dir_);
     channel_ = std::move(other.channel_);
-    other.pid_ = -1;
   }
   return *this;
 }
@@ -272,9 +269,9 @@ FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
 FourwardServer::~FourwardServer() { Shutdown(); }
 
 void FourwardServer::Shutdown() {
-  // Drop our channel reference first. Stubs held by callers keep their own
-  // shared_ptr alive and will surface CANCELLED/UNAVAILABLE for in-flight
-  // RPCs once the subprocess dies — which we do next.
+  // Drop our channel reference before killing the subprocess so the channel
+  // has a chance to finalize cleanly rather than noticing the socket die
+  // from under it.
   channel_.reset();
   KillAndReap(pid_);
   pid_ = -1;

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -27,10 +27,6 @@
 //     }
 //
 // Add this target to `deps`; nothing else is needed.
-//
-// Startup contract (stable): the server is launched with `--port-file=PATH`
-// and atomically writes its listening port there once it is accepting RPCs.
-// File existence is the readiness signal; contents are the port.
 
 #include <sys/types.h>
 

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -24,7 +24,6 @@
 //       auto stub = server.NewP4RuntimeStub();
 //       // ... drive the server via gRPC ...
 //       return absl::OkStatus();
-//       // Server is killed when `server` goes out of scope.
 //     }
 //
 // A Bazel consumer only needs to add this target to `deps`; the server binary
@@ -34,7 +33,7 @@
 // and atomically writes its listening port there once it is accepting RPCs.
 // File existence is the readiness signal; contents are the port.
 
-#include <sys/types.h>  // pid_t
+#include <sys/types.h>
 
 #include <cstdint>
 #include <memory>
@@ -42,6 +41,7 @@
 #include <string>
 
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
 #include "grpcpp/channel.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
@@ -86,17 +86,15 @@ struct FourwardServerOptions {
 
 class FourwardServer {
  public:
-  using Options = FourwardServerOptions;
-
   // Forks a server subprocess and blocks until it is accepting gRPC calls.
   // Returns NotFoundError if the server binary is missing from runfiles,
-  // DeadlineExceededError on startup timeout, InternalError on other
-  // lifecycle failures.
-  static absl::StatusOr<FourwardServer> Start(Options options = {});
+  // DeadlineExceededError on startup timeout, and a canonical-errno-mapped
+  // status on other lifecycle failures.
+  static absl::StatusOr<FourwardServer> Start(
+      FourwardServerOptions options = {});
 
   ~FourwardServer();
 
-  // Move-only. The server is killed by whichever instance owns the PID.
   FourwardServer(FourwardServer&& other) noexcept;
   FourwardServer& operator=(FourwardServer&& other) noexcept;
   FourwardServer(const FourwardServer&) = delete;
@@ -113,7 +111,7 @@ class FourwardServer {
   }
 
   // Address suitable for grpc::CreateChannel, e.g. "localhost:42517".
-  const std::string& Address() const { return address_; }
+  std::string Address() const { return absl::StrCat("localhost:", port_); }
 
   // TCP port the server is listening on.
   int Port() const { return port_; }
@@ -128,7 +126,6 @@ class FourwardServer {
   // Shared insecure channel to the server, suitable for helpers that accept
   // `shared_ptr<grpc::Channel>` directly (e.g. p4_pdpi).
   const std::shared_ptr<grpc::Channel>& Channel() const { return channel_; }
-  // PID of the server subprocess.
   pid_t Pid() const { return pid_; }
 
  private:
@@ -142,7 +139,6 @@ class FourwardServer {
   pid_t pid_ = -1;
   int port_ = 0;
   uint64_t device_id_ = 0;
-  std::string address_;
   // Scratch directory holding the `--port-file`. Removed on Shutdown.
   std::string scratch_dir_;
   std::shared_ptr<grpc::Channel> channel_;

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -16,15 +16,17 @@
 //
 //     #include "p4runtime_cc/fourward_server.h"
 //
-//     ASSERT_OK_AND_ASSIGN(auto server, fourward::FourwardServer::Start());
-//     auto channel = grpc::CreateChannel(server.Address(),
+//     absl::StatusOr<fourward::FourwardServer> server =
+//         fourward::FourwardServer::Start();
+//     ASSERT_TRUE(server.ok()) << server.status();
+//     auto channel = grpc::CreateChannel(server->Address(),
 //                                        grpc::InsecureChannelCredentials());
 //     auto stub = p4::v1::P4Runtime::NewStub(channel);
 //     // ... drive the server via gRPC ...
 //     // Server is killed when `server` goes out of scope.
 //
-// A Bazel consumer must list `@fourward//p4runtime:p4runtime_server` in its
-// `data` attribute so the server binary is present in runfiles.
+// A Bazel consumer only needs to add this target to `deps`; the server binary
+// is propagated through `cc_library.data` into the test's runfiles.
 //
 // Startup contract (stable): the server is launched with `--port-file=PATH`,
 // to which it atomically writes its listening port once it is accepting RPCs.
@@ -109,15 +111,18 @@ class FourwardServer {
   pid_t Pid() const { return pid_; }
 
  private:
-  FourwardServer(pid_t pid, int port, uint64_t device_id);
+  FourwardServer(pid_t pid, int port, uint64_t device_id,
+                 std::string scratch_dir);
 
-  // Sends SIGTERM, reaps with a timeout, then SIGKILLs if still alive.
+  // Kills the subprocess (SIGTERM → SIGKILL) and removes the scratch dir.
   void Shutdown();
 
   pid_t pid_ = -1;
   int port_ = 0;
   uint64_t device_id_ = 0;
   std::string address_;
+  // Scratch directory holding the `--port-file`. Removed on Shutdown.
+  std::string scratch_dir_;
 };
 
 }  // namespace fourward

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -26,8 +26,7 @@
 //       return absl::OkStatus();
 //     }
 //
-// A Bazel consumer only needs to add this target to `deps`; the server binary
-// is propagated through `cc_library.data` into the test's runfiles.
+// Add this target to `deps`; nothing else is needed.
 //
 // Startup contract (stable): the server is launched with `--port-file=PATH`
 // and atomically writes its listening port there once it is accepting RPCs.

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -75,7 +75,7 @@ struct FourwardServerOptions {
   CpuPort cpu_port = CpuPort::Auto();
 
   // Maximum time to wait for Start() to complete.
-  absl::Duration startup_timeout = absl::Seconds(30);
+  absl::Duration startup_timeout = absl::Seconds(5);
 };
 
 class FourwardServer {

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -20,9 +20,7 @@
 //     absl::Status RunAgainstFourward() {
 //       ASSIGN_OR_RETURN(fourward::FourwardServer server,
 //                        fourward::FourwardServer::Start());
-//       auto channel = grpc::CreateChannel(server.Address(),
-//                                          grpc::InsecureChannelCredentials());
-//       auto stub = p4::v1::P4Runtime::NewStub(channel);
+//       auto stub = server.NewP4RuntimeStub();
 //       // ... drive the server via gRPC ...
 //       return absl::OkStatus();
 //       // Server is killed when `server` goes out of scope.
@@ -31,20 +29,22 @@
 // A Bazel consumer only needs to add this target to `deps`; the server binary
 // is propagated through `cc_library.data` into the test's runfiles.
 //
-// Startup contract (stable): the server is launched with `--port-file=PATH`,
-// to which it atomically writes its listening port once it is accepting RPCs.
-// This wrapper polls for the file and parses the port, which is why the
-// log-format of the banner on stdout is NOT part of the contract and may
-// change without notice.
+// Startup contract (stable): the server is launched with `--port-file=PATH`
+// and atomically writes its listening port there once it is accepting RPCs.
+// File existence is the readiness signal; contents are the port.
 
 #include <sys/types.h>  // pid_t
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
+#include "grpcpp/channel.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "p4runtime/dataplane.grpc.pb.h"
 
 namespace fourward {
 
@@ -113,9 +113,22 @@ class FourwardServer {
   // PID of the server subprocess. Primarily useful for diagnostics.
   pid_t Pid() const { return pid_; }
 
+  // Stub factories for the two services the server hosts. Both share a single
+  // insecure channel created at Start() and reused across calls. TLS and
+  // custom channel args are intentionally unsupported — this wrapper targets
+  // localhost use.
+  std::unique_ptr<p4::v1::P4Runtime::Stub> NewP4RuntimeStub() const {
+    return p4::v1::P4Runtime::NewStub(channel_);
+  }
+  std::unique_ptr<fourward::dataplane::Dataplane::Stub> NewDataplaneStub()
+      const {
+    return fourward::dataplane::Dataplane::NewStub(channel_);
+  }
+
  private:
   FourwardServer(pid_t pid, int port, uint64_t device_id,
-                 std::string scratch_dir);
+                 std::string scratch_dir,
+                 std::shared_ptr<grpc::Channel> channel);
 
   // Kills the subprocess (SIGTERM → SIGKILL) and removes the scratch dir.
   void Shutdown();
@@ -126,6 +139,7 @@ class FourwardServer {
   std::string address_;
   // Scratch directory holding the `--port-file`. Removed on Shutdown.
   std::string scratch_dir_;
+  std::shared_ptr<grpc::Channel> channel_;
 };
 
 }  // namespace fourward

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -74,8 +74,7 @@ struct FourwardServerOptions {
   // CPU port configuration (the `--cpu-port` flag).
   CpuPort cpu_port = CpuPort::Auto();
 
-  // Maximum time to wait for the server to become ready. JVM warm-up on cold
-  // caches dominates — 30s is generous but not paranoid.
+  // Maximum time to wait for Start() to complete.
   absl::Duration startup_timeout = absl::Seconds(30);
 };
 

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -4,14 +4,14 @@
 #ifndef FOURWARD_P4RUNTIME_CC_FOURWARD_SERVER_H_
 #define FOURWARD_P4RUNTIME_CC_FOURWARD_SERVER_H_
 
-// Use 4ward from C++ without writing a line of Kotlin or Java.
+// Treat 4ward like a native C++ library.
 //
 // FourwardServer is an RAII handle to a 4ward P4Runtime + Dataplane gRPC
 // server running as a child process. `Start()` spawns it, blocks until it
 // is accepting RPCs, and hands back a value that owns the subprocess, a
 // shared gRPC channel, and factories for both service stubs. Destruction
-// kills the subprocess. Your project's BUILD files stay all-C++; the JVM
-// is an implementation detail of the server binary.
+// kills the subprocess. Your project sees a C++ API and a Bazel target;
+// the server's implementation language never enters the picture.
 //
 // Example (`ASSIGN_OR_RETURN` is the common project-local macro that early-
 // returns on a non-OK `absl::Status`; any equivalent works):

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -4,13 +4,14 @@
 #ifndef FOURWARD_P4RUNTIME_CC_FOURWARD_SERVER_H_
 #define FOURWARD_P4RUNTIME_CC_FOURWARD_SERVER_H_
 
-// RAII wrapper that brings up a 4ward P4Runtime + Dataplane gRPC server as a
-// child process, waits until it is ready to serve RPCs, and tears it down
-// when the wrapper goes out of scope.
+// Use 4ward from C++ without writing a line of Kotlin or Java.
 //
-// Intended for C++ clients (tests, reference harnesses, differential-testing
-// infrastructure) that want to embed 4ward without touching the JVM toolchain
-// directly.
+// FourwardServer is an RAII handle to a 4ward P4Runtime + Dataplane gRPC
+// server running as a child process. `Start()` spawns it, blocks until it
+// is accepting RPCs, and hands back a value that owns the subprocess, a
+// shared gRPC channel, and factories for both service stubs. Destruction
+// kills the subprocess. Your project's BUILD files stay all-C++; the JVM
+// is an implementation detail of the server binary.
 //
 // Example (`ASSIGN_OR_RETURN` is the common project-local macro that early-
 // returns on a non-OK `absl::Status`; any equivalent works):
@@ -101,6 +102,16 @@ class FourwardServer {
   FourwardServer(const FourwardServer&) = delete;
   FourwardServer& operator=(const FourwardServer&) = delete;
 
+  // Stub factories for the two services the server hosts. The common way to
+  // drive the server — `server.NewP4RuntimeStub()->Write(...)` etc.
+  std::unique_ptr<p4::v1::P4Runtime::Stub> NewP4RuntimeStub() const {
+    return p4::v1::P4Runtime::NewStub(channel_);
+  }
+  std::unique_ptr<fourward::dataplane::Dataplane::Stub> NewDataplaneStub()
+      const {
+    return fourward::dataplane::Dataplane::NewStub(channel_);
+  }
+
   // Address suitable for grpc::CreateChannel, e.g. "localhost:42517".
   const std::string& Address() const { return address_; }
 
@@ -110,24 +121,15 @@ class FourwardServer {
   // P4Runtime device ID exposed by the server.
   uint64_t DeviceId() const { return device_id_; }
 
-  // PID of the server subprocess. Primarily useful for diagnostics.
-  pid_t Pid() const { return pid_; }
-
-  // Shared insecure channel to the server, created once at Start() and
-  // reused. TLS and custom channel args are intentionally unsupported — this
-  // wrapper targets localhost use. Exposed for third-party helper libraries
-  // (e.g. p4_pdpi) that accept a `shared_ptr<grpc::Channel>`.
+  // Escape hatches. Not needed to drive the server — reach for these when
+  // interoperating with third-party helpers or diagnosing a misbehaving
+  // subprocess.
+  //
+  // Shared insecure channel to the server, suitable for helpers that accept
+  // `shared_ptr<grpc::Channel>` directly (e.g. p4_pdpi).
   const std::shared_ptr<grpc::Channel>& Channel() const { return channel_; }
-
-  // Stub factories for the two services the server hosts. Equivalent to
-  // `p4::v1::P4Runtime::NewStub(server.Channel())` etc.
-  std::unique_ptr<p4::v1::P4Runtime::Stub> NewP4RuntimeStub() const {
-    return p4::v1::P4Runtime::NewStub(channel_);
-  }
-  std::unique_ptr<fourward::dataplane::Dataplane::Stub> NewDataplaneStub()
-      const {
-    return fourward::dataplane::Dataplane::NewStub(channel_);
-  }
+  // PID of the server subprocess.
+  pid_t Pid() const { return pid_; }
 
  private:
   FourwardServer(pid_t pid, int port, uint64_t device_id,

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -113,10 +113,14 @@ class FourwardServer {
   // PID of the server subprocess. Primarily useful for diagnostics.
   pid_t Pid() const { return pid_; }
 
-  // Stub factories for the two services the server hosts. Both share a single
-  // insecure channel created at Start() and reused across calls. TLS and
-  // custom channel args are intentionally unsupported — this wrapper targets
-  // localhost use.
+  // Shared insecure channel to the server, created once at Start() and
+  // reused. TLS and custom channel args are intentionally unsupported — this
+  // wrapper targets localhost use. Exposed for third-party helper libraries
+  // (e.g. p4_pdpi) that accept a `shared_ptr<grpc::Channel>`.
+  const std::shared_ptr<grpc::Channel>& Channel() const { return channel_; }
+
+  // Stub factories for the two services the server hosts. Equivalent to
+  // `p4::v1::P4Runtime::NewStub(server.Channel())` etc.
   std::unique_ptr<p4::v1::P4Runtime::Stub> NewP4RuntimeStub() const {
     return p4::v1::P4Runtime::NewStub(channel_);
   }

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -1,0 +1,125 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FOURWARD_P4RUNTIME_CC_FOURWARD_SERVER_H_
+#define FOURWARD_P4RUNTIME_CC_FOURWARD_SERVER_H_
+
+// RAII wrapper that brings up a 4ward P4Runtime + Dataplane gRPC server as a
+// child process, waits until it is ready to serve RPCs, and tears it down
+// when the wrapper goes out of scope.
+//
+// Intended for C++ clients (tests, reference harnesses, differential-testing
+// infrastructure) that want to embed 4ward without touching the JVM toolchain
+// directly.
+//
+// Example:
+//
+//     #include "p4runtime_cc/fourward_server.h"
+//
+//     ASSERT_OK_AND_ASSIGN(auto server, fourward::FourwardServer::Start());
+//     auto channel = grpc::CreateChannel(server.Address(),
+//                                        grpc::InsecureChannelCredentials());
+//     auto stub = p4::v1::P4Runtime::NewStub(channel);
+//     // ... drive the server via gRPC ...
+//     // Server is killed when `server` goes out of scope.
+//
+// A Bazel consumer must list `@fourward//p4runtime:p4runtime_server` in its
+// `data` attribute so the server binary is present in runfiles.
+//
+// Startup contract (stable): the server is launched with `--port-file=PATH`,
+// to which it atomically writes its listening port once it is accepting RPCs.
+// This wrapper polls for the file and parses the port, which is why the
+// log-format of the banner on stdout is NOT part of the contract and may
+// change without notice.
+
+#include <sys/types.h>  // pid_t
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+
+namespace fourward {
+
+// Packet-in/out CPU port configuration. Mirrors the Kotlin CpuPortConfig:
+// Auto (infer from P4Info's controller_header, the default), Disabled (no
+// CPU port — packet I/O rejected), or Override (use this specific port).
+struct CpuPort {
+  enum class Kind { kAuto, kDisabled, kOverride };
+
+  static CpuPort Auto() { return {Kind::kAuto, 0}; }
+  static CpuPort Disabled() { return {Kind::kDisabled, 0}; }
+  static CpuPort Override(int port) { return {Kind::kOverride, port}; }
+
+  Kind kind = Kind::kAuto;
+  int port = 0;  // meaningful only when kind == kOverride
+};
+
+struct FourwardServerOptions {
+  // P4Runtime device ID exposed by the server (the `--device-id` flag).
+  uint64_t device_id = 1;
+
+  // TCP port the server binds on. If unset, the kernel assigns an ephemeral
+  // port — the recommended default, since it avoids collisions when multiple
+  // servers run in parallel (e.g. in a test shard).
+  std::optional<int> port = std::nullopt;
+
+  // v1model drop-port override (the `--drop-port` flag). If unset, the
+  // simulator's built-in default is used.
+  std::optional<int> drop_port = std::nullopt;
+
+  // CPU port configuration (the `--cpu-port` flag).
+  CpuPort cpu_port = CpuPort::Auto();
+
+  // Maximum time to wait for the server to become ready. JVM warm-up on cold
+  // caches dominates — 30s is generous but not paranoid.
+  absl::Duration startup_timeout = absl::Seconds(30);
+};
+
+class FourwardServer {
+ public:
+  using Options = FourwardServerOptions;
+
+  // Forks a server subprocess and blocks until it is accepting gRPC calls.
+  // Returns NotFoundError if the server binary is missing from runfiles,
+  // DeadlineExceededError on startup timeout, InternalError on other
+  // lifecycle failures.
+  static absl::StatusOr<FourwardServer> Start(Options options = {});
+
+  ~FourwardServer();
+
+  // Move-only. The server is killed by whichever instance owns the PID.
+  FourwardServer(FourwardServer&& other) noexcept;
+  FourwardServer& operator=(FourwardServer&& other) noexcept;
+  FourwardServer(const FourwardServer&) = delete;
+  FourwardServer& operator=(const FourwardServer&) = delete;
+
+  // Address suitable for grpc::CreateChannel, e.g. "localhost:42517".
+  const std::string& Address() const { return address_; }
+
+  // TCP port the server is listening on.
+  int Port() const { return port_; }
+
+  // P4Runtime device ID exposed by the server.
+  uint64_t DeviceId() const { return device_id_; }
+
+  // PID of the server subprocess. Primarily useful for diagnostics.
+  pid_t Pid() const { return pid_; }
+
+ private:
+  FourwardServer(pid_t pid, int port, uint64_t device_id);
+
+  // Sends SIGTERM, reaps with a timeout, then SIGKILLs if still alive.
+  void Shutdown();
+
+  pid_t pid_ = -1;
+  int port_ = 0;
+  uint64_t device_id_ = 0;
+  std::string address_;
+};
+
+}  // namespace fourward
+
+#endif  // FOURWARD_P4RUNTIME_CC_FOURWARD_SERVER_H_

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -12,18 +12,21 @@
 // infrastructure) that want to embed 4ward without touching the JVM toolchain
 // directly.
 //
-// Example:
+// Example (`ASSIGN_OR_RETURN` is the common project-local macro that early-
+// returns on a non-OK `absl::Status`; any equivalent works):
 //
 //     #include "p4runtime_cc/fourward_server.h"
 //
-//     absl::StatusOr<fourward::FourwardServer> server =
-//         fourward::FourwardServer::Start();
-//     ASSERT_TRUE(server.ok()) << server.status();
-//     auto channel = grpc::CreateChannel(server->Address(),
-//                                        grpc::InsecureChannelCredentials());
-//     auto stub = p4::v1::P4Runtime::NewStub(channel);
-//     // ... drive the server via gRPC ...
-//     // Server is killed when `server` goes out of scope.
+//     absl::Status RunAgainstFourward() {
+//       ASSIGN_OR_RETURN(fourward::FourwardServer server,
+//                        fourward::FourwardServer::Start());
+//       auto channel = grpc::CreateChannel(server.Address(),
+//                                          grpc::InsecureChannelCredentials());
+//       auto stub = p4::v1::P4Runtime::NewStub(channel);
+//       // ... drive the server via gRPC ...
+//       return absl::OkStatus();
+//       // Server is killed when `server` goes out of scope.
+//     }
 //
 // A Bazel consumer only needs to add this target to `deps`; the server binary
 // is propagated through `cc_library.data` into the test's runfiles.

--- a/p4runtime_cc/fourward_server_test.cc
+++ b/p4runtime_cc/fourward_server_test.cc
@@ -38,9 +38,10 @@ void ExpectHealthy(const FourwardServer& server) {
   EXPECT_FALSE(resp.p4runtime_api_version().empty());
 }
 
-TEST(FourwardServerTest, ExposesBothP4RuntimeAndDataplaneStubs) {
+TEST(FourwardServerTest, ExposesChannelAndBothStubFactories) {
   absl::StatusOr<FourwardServer> server = FourwardServer::Start();
   ASSERT_TRUE(server.ok()) << server.status();
+  EXPECT_NE(server->Channel(), nullptr);
   EXPECT_NE(server->NewP4RuntimeStub(), nullptr);
   EXPECT_NE(server->NewDataplaneStub(), nullptr);
 }

--- a/p4runtime_cc/fourward_server_test.cc
+++ b/p4runtime_cc/fourward_server_test.cc
@@ -28,10 +28,7 @@ namespace {
 // pipeline to be loaded (FAILED_PRECONDITION otherwise), which is orthogonal
 // to the "is the server up" question under test.
 void ExpectHealthy(const FourwardServer& server) {
-  auto channel = grpc::CreateChannel(server.Address(),
-                                     grpc::InsecureChannelCredentials());
-  auto stub = p4::v1::P4Runtime::NewStub(channel);
-
+  auto stub = server.NewP4RuntimeStub();
   p4::v1::CapabilitiesRequest req;
   p4::v1::CapabilitiesResponse resp;
   grpc::ClientContext ctx;
@@ -39,6 +36,13 @@ void ExpectHealthy(const FourwardServer& server) {
   EXPECT_TRUE(status.ok()) << "Capabilities failed: code=" << status.error_code()
                            << " msg=" << status.error_message();
   EXPECT_FALSE(resp.p4runtime_api_version().empty());
+}
+
+TEST(FourwardServerTest, ExposesBothP4RuntimeAndDataplaneStubs) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+  ASSERT_TRUE(server.ok()) << server.status();
+  EXPECT_NE(server->NewP4RuntimeStub(), nullptr);
+  EXPECT_NE(server->NewDataplaneStub(), nullptr);
 }
 
 TEST(FourwardServerTest, StartExposesLiveGrpcEndpoint) {

--- a/p4runtime_cc/fourward_server_test.cc
+++ b/p4runtime_cc/fourward_server_test.cc
@@ -38,14 +38,6 @@ void ExpectHealthy(const FourwardServer& server) {
   EXPECT_FALSE(resp.p4runtime_api_version().empty());
 }
 
-TEST(FourwardServerTest, ExposesChannelAndBothStubFactories) {
-  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
-  ASSERT_TRUE(server.ok()) << server.status();
-  EXPECT_NE(server->Channel(), nullptr);
-  EXPECT_NE(server->NewP4RuntimeStub(), nullptr);
-  EXPECT_NE(server->NewDataplaneStub(), nullptr);
-}
-
 TEST(FourwardServerTest, StartExposesLiveGrpcEndpoint) {
   absl::StatusOr<FourwardServer> server = FourwardServer::Start();
   ASSERT_TRUE(server.ok()) << server.status();
@@ -54,6 +46,9 @@ TEST(FourwardServerTest, StartExposesLiveGrpcEndpoint) {
   EXPECT_EQ(server->Address(), absl::StrCat("localhost:", server->Port()));
   EXPECT_EQ(server->DeviceId(), 1u);
   EXPECT_GT(server->Pid(), 0);
+  EXPECT_NE(server->Channel(), nullptr);
+  EXPECT_NE(server->NewP4RuntimeStub(), nullptr);
+  EXPECT_NE(server->NewDataplaneStub(), nullptr);
 
   ExpectHealthy(*server);
 }

--- a/p4runtime_cc/fourward_server_test.cc
+++ b/p4runtime_cc/fourward_server_test.cc
@@ -1,0 +1,141 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "p4runtime_cc/fourward_server.h"
+
+#include <signal.h>
+#include <sys/types.h>
+
+#include <chrono>
+#include <thread>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/time/time.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+
+namespace fourward {
+namespace {
+
+// Issues a Capabilities RPC and asserts it succeeds. This proves the server
+// is not just TCP-listening but actually serving gRPC. Capabilities is used
+// rather than GetForwardingPipelineConfig because the latter requires a
+// pipeline to be loaded (FAILED_PRECONDITION otherwise), which is orthogonal
+// to the "is the server up" question under test.
+void ExpectHealthy(const FourwardServer& server) {
+  auto channel = grpc::CreateChannel(server.Address(),
+                                     grpc::InsecureChannelCredentials());
+  auto stub = p4::v1::P4Runtime::NewStub(channel);
+
+  p4::v1::CapabilitiesRequest req;
+  p4::v1::CapabilitiesResponse resp;
+  grpc::ClientContext ctx;
+  grpc::Status status = stub->Capabilities(&ctx, req, &resp);
+  EXPECT_TRUE(status.ok()) << "Capabilities failed: code=" << status.error_code()
+                           << " msg=" << status.error_message();
+  EXPECT_FALSE(resp.p4runtime_api_version().empty());
+}
+
+TEST(FourwardServerTest, StartExposesLiveGrpcEndpoint) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+  ASSERT_TRUE(server.ok()) << server.status();
+
+  EXPECT_GT(server->Port(), 0);
+  EXPECT_EQ(server->Address(), absl::StrCat("localhost:", server->Port()));
+  EXPECT_EQ(server->DeviceId(), 1u);
+  EXPECT_GT(server->Pid(), 0);
+
+  ExpectHealthy(*server);
+}
+
+TEST(FourwardServerTest, CustomDeviceIdFlowsThroughToP4Runtime) {
+  absl::StatusOr<FourwardServer> server =
+      FourwardServer::Start({.device_id = 42});
+  ASSERT_TRUE(server.ok()) << server.status();
+  EXPECT_EQ(server->DeviceId(), 42u);
+  ExpectHealthy(*server);
+}
+
+TEST(FourwardServerTest, ParallelServersGetDistinctEphemeralPorts) {
+  absl::StatusOr<FourwardServer> a = FourwardServer::Start();
+  absl::StatusOr<FourwardServer> b = FourwardServer::Start();
+  ASSERT_TRUE(a.ok()) << a.status();
+  ASSERT_TRUE(b.ok()) << b.status();
+  EXPECT_NE(a->Port(), b->Port());
+  ExpectHealthy(*a);
+  ExpectHealthy(*b);
+}
+
+TEST(FourwardServerTest, DestructionKillsSubprocess) {
+  pid_t pid;
+  {
+    absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+    ASSERT_TRUE(server.ok()) << server.status();
+    pid = server->Pid();
+    ExpectHealthy(*server);
+  }
+
+  // The server had `Shutdown()` called in the destructor. Poll waitid(NOWAIT)
+  // so we don't race the reap; once it returns ECHILD the process is gone.
+  // (Our own child was already waitpid()'d inside Shutdown; this probe just
+  // confirms the kernel has no such PID anymore.)
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (::kill(pid, 0) != 0) return;  // process gone — success.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  FAIL() << "server pid " << pid << " was still alive 5s after destruction";
+}
+
+TEST(FourwardServerTest, MoveConstructionPreservesOwnership) {
+  absl::StatusOr<FourwardServer> original = FourwardServer::Start();
+  ASSERT_TRUE(original.ok()) << original.status();
+  pid_t original_pid = original->Pid();
+  int original_port = original->Port();
+
+  FourwardServer moved = *std::move(original);
+
+  EXPECT_EQ(moved.Pid(), original_pid);
+  EXPECT_EQ(moved.Port(), original_port);
+  ExpectHealthy(moved);
+}
+
+TEST(FourwardServerTest, DropAndCpuPortFlagsAcceptedByServer) {
+  // This is mostly a smoke test — the wrapper passes the flags through, and
+  // the server comes up. Deeper validation of drop/cpu port semantics belongs
+  // in the Kotlin-side tests.
+  absl::StatusOr<FourwardServer> with_drop =
+      FourwardServer::Start({.drop_port = 511});
+  ASSERT_TRUE(with_drop.ok()) << with_drop.status();
+  ExpectHealthy(*with_drop);
+
+  absl::StatusOr<FourwardServer> cpu_disabled =
+      FourwardServer::Start({.cpu_port = CpuPort::Disabled()});
+  ASSERT_TRUE(cpu_disabled.ok()) << cpu_disabled.status();
+  ExpectHealthy(*cpu_disabled);
+
+  absl::StatusOr<FourwardServer> cpu_override =
+      FourwardServer::Start({.cpu_port = CpuPort::Override(192)});
+  ASSERT_TRUE(cpu_override.ok()) << cpu_override.status();
+  ExpectHealthy(*cpu_override);
+}
+
+TEST(FourwardServerTest, StartupTimeoutYieldsDeadlineExceeded) {
+  // A 1-nanosecond timeout is unreachable: even if the JVM had booted
+  // instantly the port file poll loop cannot observe it that fast. The
+  // wrapper must surface DEADLINE_EXCEEDED rather than hanging or
+  // returning OK with a bogus port.
+  absl::StatusOr<FourwardServer> server =
+      FourwardServer::Start({.startup_timeout = absl::Nanoseconds(1)});
+  ASSERT_FALSE(server.ok());
+  EXPECT_EQ(server.status().code(), absl::StatusCode::kDeadlineExceeded)
+      << server.status();
+}
+
+}  // namespace
+}  // namespace fourward

--- a/p4runtime_cc/fourward_server_test.cc
+++ b/p4runtime_cc/fourward_server_test.cc
@@ -105,6 +105,31 @@ TEST(FourwardServerTest, MoveConstructionPreservesOwnership) {
   ExpectHealthy(moved);
 }
 
+TEST(FourwardServerTest, MoveAssignmentKillsOldAndAdoptsNew) {
+  absl::StatusOr<FourwardServer> a = FourwardServer::Start();
+  absl::StatusOr<FourwardServer> b = FourwardServer::Start();
+  ASSERT_TRUE(a.ok()) << a.status();
+  ASSERT_TRUE(b.ok()) << b.status();
+  pid_t pid_a = a->Pid();
+  pid_t pid_b = b->Pid();
+  ASSERT_NE(pid_a, pid_b);
+
+  // Move-assign b into a: a's old subprocess must be killed, b's must live
+  // and serve RPCs through the moved-to wrapper.
+  *a = *std::move(b);
+
+  EXPECT_EQ(a->Pid(), pid_b);
+  ExpectHealthy(*a);
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (::kill(pid_a, 0) != 0) return;
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  FAIL() << "old subprocess pid " << pid_a
+         << " should have been killed by move-assign";
+}
+
 TEST(FourwardServerTest, DropAndCpuPortFlagsAcceptedByServer) {
   // This is mostly a smoke test — the wrapper passes the flags through, and
   // the server comes up. Deeper validation of drop/cpu port semantics belongs

--- a/userdocs/reference/embedding-cc.md
+++ b/userdocs/reference/embedding-cc.md
@@ -1,0 +1,82 @@
+---
+description: "Embedding the 4ward server in a C++ program via the p4runtime_cc wrapper — Bazel setup, example usage, and the stable startup contract downstream wrappers can rely on."
+---
+
+# Embedding the server in C++
+
+`//p4runtime_cc:fourward_server` is a C++ RAII wrapper that brings up the
+4ward P4Runtime + Dataplane server as a child process, waits until it is
+accepting gRPC calls, and tears it down when it goes out of scope. Use it
+when you want to drive 4ward from C++ test harnesses, reference
+implementations, or differential-testing infrastructure without pulling
+Kotlin or the JVM build tools into your own project.
+
+## Bazel dependency
+
+```starlark
+cc_test(
+    name = "my_test",
+    srcs = ["my_test.cc"],
+    deps = [
+        "@fourward//p4runtime_cc:fourward_server",
+        # ... your gRPC / P4Runtime deps ...
+    ],
+)
+```
+
+The library propagates the server binary through its `data` attribute, so
+consumers do not need to list `@fourward//p4runtime:p4runtime_server`
+themselves.
+
+## Example
+
+```cpp
+#include "p4runtime_cc/fourward_server.h"
+#include "grpcpp/grpcpp.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+
+absl::Status RunAgainstFourward() {
+  ASSIGN_OR_RETURN(fourward::FourwardServer server,
+                   fourward::FourwardServer::Start());
+
+  auto channel = grpc::CreateChannel(server.Address(),
+                                     grpc::InsecureChannelCredentials());
+  auto stub = p4::v1::P4Runtime::NewStub(channel);
+  // ... drive the server via gRPC ...
+
+  return absl::OkStatus();
+  // `server` is killed here via SIGTERM; the scratch directory holding its
+  // port-file is removed on the same path.
+}
+```
+
+Options cover `device_id`, the listening `port` (unset by default — the
+kernel picks an ephemeral port), `drop_port`, `cpu_port`, and
+`startup_timeout`. See [`fourward_server.h`](https://github.com/smolkaj/4ward/blob/main/p4runtime_cc/fourward_server.h)
+for the full API.
+
+## Startup contract
+
+The wrapper does not rely on the server's log banner to discover its port.
+Instead it passes `--port-file=PATH`, and the server atomically writes its
+listening port to `PATH` once it is accepting RPCs. File existence is the
+readiness signal; file contents are the port.
+
+That contract is stable and suitable for hand-rolled wrappers in other
+languages:
+
+| Flag | Semantics |
+|------|-----------|
+| `--port=N` | Pin the listening port. `--port=0` (the default) lets the kernel pick an ephemeral port — recommended for parallel test shards. |
+| `--port-file=PATH` | After binding, the server atomically writes the bound port as ASCII to `PATH` (via tempfile + rename, so a concurrent reader never sees a partial value). |
+
+The banner on stdout (`P4Runtime server listening on port N`) is for
+humans only and may change without notice. Always synchronize on the
+port-file.
+
+## Related
+
+- [`p4runtime_cc/`](https://github.com/smolkaj/4ward/tree/main/p4runtime_cc)
+  — source of the wrapper.
+- [gRPC API reference](grpc.md) — server flags, RPC surface, and proto
+  definitions.

--- a/userdocs/reference/embedding-cc.md
+++ b/userdocs/reference/embedding-cc.md
@@ -1,18 +1,18 @@
 ---
-description: "Use 4ward from C++ without writing a line of Kotlin or Java — Bazel setup, example usage, and the stable startup contract wrappers in other languages can rely on."
+description: "Treat 4ward like a native C++ library — Bazel setup, example usage, and the stable startup contract wrappers in other languages can rely on."
 ---
 
 # Embedding the server in C++
 
-**Use 4ward from C++ without writing a line of Kotlin or Java.** Your
-project's BUILD files stay all-C++; the JVM is an implementation detail
-of the server binary.
+**Treat 4ward like a native C++ library.** Depend on
+`//p4runtime_cc:fourward_server`, construct a `FourwardServer`, and
+you have factories for P4Runtime and Dataplane stubs on a shared gRPC
+channel. Your project sees a C++ API and a Bazel target; the server's
+implementation language never enters the picture.
 
-`//p4runtime_cc:fourward_server` is the RAII handle. `Start()` spawns
-the P4Runtime + Dataplane server as a subprocess, blocks until it is
-accepting RPCs, and returns a value that owns the subprocess, a shared
-gRPC channel, and factories for both service stubs. Destruction kills
-the subprocess.
+Under the hood, `Start()` spawns the server as a subprocess, blocks
+until it is accepting RPCs, and returns an RAII handle. Destruction
+kills the subprocess.
 
 ## Bazel dependency
 

--- a/userdocs/reference/embedding-cc.md
+++ b/userdocs/reference/embedding-cc.md
@@ -1,15 +1,18 @@
 ---
-description: "Embedding the 4ward server in a C++ program via the p4runtime_cc wrapper — Bazel setup, example usage, and the stable startup contract downstream wrappers can rely on."
+description: "Use 4ward from C++ without writing a line of Kotlin or Java — Bazel setup, example usage, and the stable startup contract wrappers in other languages can rely on."
 ---
 
 # Embedding the server in C++
 
-`//p4runtime_cc:fourward_server` is a C++ RAII wrapper that brings up the
-4ward P4Runtime + Dataplane server as a child process, waits until it is
-accepting gRPC calls, and tears it down when it goes out of scope. Use it
-when you want to drive 4ward from C++ test harnesses, reference
-implementations, or differential-testing infrastructure without pulling
-Kotlin or the JVM build tools into your own project.
+**Use 4ward from C++ without writing a line of Kotlin or Java.** Your
+project's BUILD files stay all-C++; the JVM is an implementation detail
+of the server binary.
+
+`//p4runtime_cc:fourward_server` is the RAII handle. `Start()` spawns
+the P4Runtime + Dataplane server as a subprocess, blocks until it is
+accepting RPCs, and returns a value that owns the subprocess, a shared
+gRPC channel, and factories for both service stubs. Destruction kills
+the subprocess.
 
 ## Bazel dependency
 

--- a/userdocs/reference/embedding-cc.md
+++ b/userdocs/reference/embedding-cc.md
@@ -32,16 +32,13 @@ themselves.
 
 ```cpp
 #include "p4runtime_cc/fourward_server.h"
-#include "grpcpp/grpcpp.h"
-#include "p4/v1/p4runtime.grpc.pb.h"
 
 absl::Status RunAgainstFourward() {
   ASSIGN_OR_RETURN(fourward::FourwardServer server,
                    fourward::FourwardServer::Start());
 
-  auto channel = grpc::CreateChannel(server.Address(),
-                                     grpc::InsecureChannelCredentials());
-  auto stub = p4::v1::P4Runtime::NewStub(channel);
+  auto p4rt = server.NewP4RuntimeStub();
+  auto dataplane = server.NewDataplaneStub();
   // ... drive the server via gRPC ...
 
   return absl::OkStatus();
@@ -50,6 +47,9 @@ absl::Status RunAgainstFourward() {
 }
 ```
 
+Both stubs share a single insecure channel to `localhost:<port>` managed
+by the wrapper.
+
 Options cover `device_id`, the listening `port` (unset by default — the
 kernel picks an ephemeral port), `drop_port`, `cpu_port`, and
 `startup_timeout`. See [`fourward_server.h`](https://github.com/smolkaj/4ward/blob/main/p4runtime_cc/fourward_server.h)
@@ -57,22 +57,16 @@ for the full API.
 
 ## Startup contract
 
-The wrapper does not rely on the server's log banner to discover its port.
-Instead it passes `--port-file=PATH`, and the server atomically writes its
-listening port to `PATH` once it is accepting RPCs. File existence is the
-readiness signal; file contents are the port.
-
-That contract is stable and suitable for hand-rolled wrappers in other
-languages:
+The wrapper spawns the server with `--port-file=PATH`. The server
+atomically writes its listening port to `PATH` once it is accepting RPCs;
+file existence is the readiness signal, file contents are the port. The
+contract is stable and suitable for hand-rolled wrappers in other
+languages.
 
 | Flag | Semantics |
 |------|-----------|
 | `--port=N` | Pin the listening port. `--port=0` (the default) lets the kernel pick an ephemeral port — recommended for parallel test shards. |
-| `--port-file=PATH` | After binding, the server atomically writes the bound port as ASCII to `PATH` (via tempfile + rename, so a concurrent reader never sees a partial value). |
-
-The banner on stdout (`P4Runtime server listening on port N`) is for
-humans only and may change without notice. Always synchronize on the
-port-file.
+| `--port-file=PATH` | After binding, the server atomically writes the bound port as ASCII to `PATH` (tempfile + rename, so a concurrent reader never sees a partial value). |
 
 ## Related
 

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -14,10 +14,11 @@ bazel run //p4runtime:p4runtime_server -- [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--port` | 9559 | gRPC listen port |
+| `--port` | 9559 | gRPC listen port (use `0` to let the kernel assign an ephemeral port; pair with `--port-file` to discover it) |
 | `--device-id` | 1 | P4Runtime device ID |
 | `--drop-port` | `2^N - 1` | Override drop port (e.g., 511 for 9-bit ports) |
 | `--cpu-port` | `2^N - 2` | Override CPU port (e.g., 510 for 9-bit ports; auto-enabled when `@controller_header` is present) |
+| `--port-file` | — | After binding, atomically write the listening port to this path. File-exists ≡ ready to serve. Intended for embedders — see [Embedding in C++](embedding-cc.md). |
 
 ## P4Runtime service
 


### PR DESCRIPTION
## Summary

**Treat 4ward like a native C++ library.** A new library —
`@fourward//p4runtime_cc:fourward_server` — lets your C++ project
depend on 4ward the same way it depends on any `cc_library`,
construct a `FourwardServer`, and immediately have stub factories for
both P4Runtime and Dataplane on a shared gRPC channel. Your project
sees a C++ API and a Bazel target; the server's implementation
language never enters the picture.

```cpp
ASSIGN_OR_RETURN(fourward::FourwardServer server,
                 fourward::FourwardServer::Start());
auto p4rt = server.NewP4RuntimeStub();
auto dataplane = server.NewDataplaneStub();
// ... drive the server via gRPC; subprocess is killed on scope exit.
```

C++ consumers today (pins/DVaaS harnesses, internal test rigs) have
been hand-rolling their own subprocess wrappers, each parsing the
server's `"listening on port N"` stdout banner to discover the port.
That banner is a log message, not a contract. This PR replaces it with
a stable one and ships the canonical wrapper built on top.

## Design notes

**Hardened startup contract.** The server grows a `--port-file=PATH`
flag and atomically writes its port there once it is accepting RPCs
(tempfile + rename, so concurrent readers never see a partial value).
File existence is the readiness signal; file contents are the port.
The contract is documented so wrappers in other languages can rely on
the same synchronization.

**Kernel-picked port by default.** `Options::port` is
`std::optional<int>`; leaving it unset lets the kernel assign an
ephemeral port (safe for parallel test shards). A pinned port is still
available for production embeds.

**Clean teardown.** The server is spawned into its own process group so
`SIGTERM` fans out to JVM helpers without touching the parent.
Destruction escalates `SIGTERM` → `SIGKILL` on a 5s budget and drops
the channel before killing the subprocess, so the lifetime dance
happens once, inside the wrapper.

**Full flag surface.** `Options` exposes `device_id`, `port`,
`drop_port`, `cpu_port` (Auto / Disabled / Override), and
`startup_timeout`. `Channel()` is available for third-party helpers
(`p4_pdpi` etc.) that accept a `shared_ptr<grpc::Channel>` directly;
stub factories are the common path and they share that single channel.

## Docs

- New user-facing page: **[Embedding in C++](userdocs/reference/embedding-cc.md)**
  under the gRPC API section of the site nav.
- `docs/ENTRY_POINTS.md` gets a dedicated wrapper section, a
  `--port-file` row in the server flag table, and the wrapper added to
  the intrinsic-port override matrix.
- The "Why Kotlin?" callout in the top-level README now closes the
  consumption side of the loop — C++ projects depend on this library
  like any `cc_library`, any gRPC client works in any language.
- `AGENTS.md` gains a brief Abseil-TotWs pointer
  (flat namespaces; [TotW #130]) after I tripped over that one on the
  first draft.

[TotW #130]: https://abseil.io/tips/130

## Test plan

- [x] `bazel test //p4runtime_cc:fourward_server_test` — 8 integration
      tests driving a real subprocess (live gRPC, stub factories for
      both services, custom device_id, parallel servers on distinct
      ports, destruction reaps the PID, move semantics,
      `drop_port`/`cpu_port` flag plumbing, deadline exceeded).
- [x] `bazel test //p4runtime:all --test_tag_filters=-heavy` — no
      regression in the Kotlin server from the `--port-file` change.
- [x] `./tools/format.sh --check` clean.
- [x] `./tools/lint.sh` clean.
- [x] `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)