### PR TITLE
Switch to unmapped() runfiles for google3 compatibility

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -23,6 +23,10 @@ kt_jvm_test(
         "Runfiles.kt",
         "//p4c_backend:p4c-4ward",
         "@p4c//p4include",
+        "@p4c//p4include:core.p4",
+    ],
+    jvm_flags = [
+        "-Dfourward.p4include=$(rlocationpath @p4c//p4include:core.p4)",
     ],
     test_class = "fourward.bazel.RunfilesTest",
     deps = [

--- a/bazel/Runfiles.kt
+++ b/bazel/Runfiles.kt
@@ -4,19 +4,19 @@ import com.google.devtools.build.runfiles.Runfiles
 import java.nio.file.Files
 import java.nio.file.Path
 
-// "The main repository always has the empty string as the canonical name."
-// https://bazel.build/external/overview#canonical-repo-name
-private val runfiles: Runfiles = Runfiles.preload().withSourceRepository("")
+// unmapped(): no repo-mapping translation — paths are looked up as-is in the
+// runfiles directory or manifest. Works in both OSS Bazel (where main-repo
+// paths start with `_main/`) and google3 (where copybara rewrites `_main` to
+// the google3 prefix). External-repo paths must use canonical names or be
+// injected by the BUILD rule via $(rlocationpath ...).
+private val runfiles: Runfiles = Runfiles.preload().unmapped()
 
 /**
  * Resolves a runfiles path to an absolute [Path].
  *
- * The first path component identifies the repo in the runfiles directory tree:
- * - Main repo: `resolveRunfile("_main/web/frontend/index.html")`
- * - External: `resolveRunfile("p4c/p4include/core.p4")`
- *
- * `_main` is the workspace name ([ctx.workspace_name]) under bzlmod. External repos use their
- * apparent name (e.g. `p4c` for `@p4c`).
+ * [path] must start with a repo directory prefix. Bare paths will not resolve.
+ * - Main repo: `"_main/web/frontend/index.html"`
+ * - External repo: inject via `$(rlocationpath ...)` in BUILD
  *
  * @throws IllegalStateException if the path cannot be resolved.
  */

--- a/bazel/RunfilesTest.kt
+++ b/bazel/RunfilesTest.kt
@@ -14,15 +14,18 @@ class RunfilesTest {
   }
 
   @Test
-  fun `resolves external-repo file via apparent name`() {
-    val path = resolveRunfile("p4c/p4include/core.p4")
-    assertTrue("resolved path should exist: $path", Files.isRegularFile(path))
-  }
-
-  @Test
   fun `resolves p4c-4ward binary`() {
     val path = resolveRunfile("_main/p4c_backend/p4c-4ward")
     assertTrue(Files.isExecutable(path))
+  }
+
+  @Test
+  fun `resolves external-repo file via rlocationpath property`() {
+    // External repos use canonical names that differ across environments.
+    // Production code gets the path via $(rlocationpath ...) in BUILD jvm_flags.
+    // This test verifies the same mechanism works.
+    val path = resolveRunfile(requireP4IncludeProperty())
+    assertTrue("resolved path should exist: $path", Files.isRegularFile(path))
   }
 
   @Test


### PR DESCRIPTION
Fixes google3 test failures — `withSourceRepository("")` doesn't work in WORKSPACE-based builds.