### PR TITLE
p4runtime_cc: BUILD cleanup + CI gate on deprecated Bazel deps

### DIFF
--- a/p4runtime_cc/BUILD.bazel
+++ b/p4runtime_cc/BUILD.bazel
@@ -6,27 +6,16 @@ package(
     licenses = ["notice"],
 )
 
-# C++ RAII wrapper for embedding the 4ward P4Runtime + Dataplane server as a
-# child process. See fourward_server.h for the full API contract.
-#
-# The server binary is propagated to consumers via `data`, so a cc_test that
-# depends on this library does not need to add anything else.
 cc_library(
     name = "fourward_server",
     srcs = ["fourward_server.cc"],
     hdrs = ["fourward_server.h"],
     data = ["//p4runtime:p4runtime_server"],
-    # `$(rlocationpath)` expands to the canonical runfile path under the
-    # current build's repo naming (e.g. `_main/...` when fourward is the root
-    # module, `fourward+/...` when a BCR consumer pulls it in). Baking this in
-    # via local_defines avoids hardcoding `_main/`, which would break for
-    # every consumer but ourselves.
+    # Runfile path baked in per build for BCR portability — the apparent
+    # repo name differs between root and BCR consumers.
     local_defines = [
-        "FOURWARD_SERVER_RLOCATION=\\\"$(rlocationpath //p4runtime:p4runtime_server)\\\"",
+        'FOURWARD_SERVER_RLOCATION=\\"$(rlocationpath //p4runtime:p4runtime_server)\\"',
     ],
-    # Exposed via the apparent include path "p4runtime_cc/fourward_server.h"
-    # for downstream consumers.
-    strip_include_prefix = "/",
     visibility = ["//visibility:public"],
     deps = [
         "//p4runtime:dataplane_cc_grpc",
@@ -39,8 +28,8 @@ cc_library(
         "@abseil-cpp//absl/time",
         "@bazel_tools//tools/cpp/runfiles",
         "@grpc//:grpc++",
-        "@p4runtime//:p4runtime_cc_grpc",
-        "@p4runtime//:p4runtime_cc_proto",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
     ],
 )
 
@@ -56,7 +45,7 @@ cc_test(
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@grpc//:grpc++",
-        "@p4runtime//:p4runtime_cc_grpc",
-        "@p4runtime//:p4runtime_cc_proto",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
     ],
 )

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -32,6 +32,24 @@ fi
 # TODO(buf-edition-2024): Re-enable buf lint/breaking once buf supports
 # edition 2024. Tracked in https://github.com/smolkaj/4ward/pull/4.
 
+echo "Checking for deprecated Bazel deps..."
+# `bazel query` returns targets whose `deprecation` attribute is non-empty
+# and that are reachable from anything in //... . We filter out toolchain
+# constant targets under @bazel_tools, which legitimately carry deprecation
+# messages unrelated to user code.
+deprecated=$(bazel query --keep_going \
+  'attr("deprecation", ".", deps(//...)) except @bazel_tools//...' 2>/dev/null || true)
+if [[ -n "$deprecated" ]]; then
+  echo "ERROR: Build targets depend on deprecated Bazel labels. Use the suggested successor:"
+  while IFS= read -r target; do
+    [[ -z "$target" ]] && continue
+    successor=$(bazel query --output=build "$target" 2>/dev/null \
+      | sed -n 's/.*deprecation = "\(.*\)".*/  \1/p')
+    printf '  %s\n%s\n' "$target" "${successor:-  (no hint)}"
+  done <<< "$deprecated"
+  rc=1
+fi
+
 echo "Checking for source files compiled into multiple kt_jvm_library targets..."
 if targets=$(bazel query 'kind("kt_jvm_library", //...)' 2>/dev/null); then
   duplicates=$(


### PR DESCRIPTION
## Summary

Follow-up polish on #570, plus a CI gate that prevents the class of
mistake caught during that review.

**BUILD cleanup (`p4runtime_cc/BUILD.bazel`):**

- Drop `strip_include_prefix = "/"`. Default `cc_library` behavior
  already exposes the header at `p4runtime_cc/fourward_server.h` — the
  attribute was noise.
- Replace the deprecated aliases `@p4runtime//:p4runtime_cc_grpc`
  and `:p4runtime_cc_proto` with their canonical location under
  `@p4runtime//proto/p4/v1:...`.
- Single-quoted Starlark for the `local_defines` value trims the escape
  from `\\\"` to `\\"`. Bazel's shell tokenization still needs the
  backslash so the quotes survive into the compiler argv, but the
  Starlark-level escape is one character lighter.
- Collapse file-level and per-attribute prose that restated what the
  rule already says. Keep only the one non-obvious note (why the
  rlocation is baked in).

**New CI gate (`tools/lint.sh`):** a "Checking for deprecated Bazel
deps" step that runs
`bazel query 'attr("deprecation", ".", deps(//...)) except @bazel_tools//...'`
and fails if any build target reaches a deprecated label, printing the
successor hint from the target's `deprecation` attribute. Verified by
temporarily regressing to the old deprecated label — the check surfaces
both the target and the successor cleanly.

## Test plan

- [x] `bazel test //p4runtime_cc:fourward_server_test` — still 8 passing
      integration tests with the new labels and simpler escape.
- [x] `./tools/lint.sh` clean.
- [x] Lint gate verified by temporarily reverting to deprecated labels;
      produces:
      `ERROR: Build targets depend on deprecated Bazel labels. Use the suggested successor:
         @p4runtime//:p4runtime_cc_proto
           Please use @p4runtime//proto/p4/v1:p4runtime_cc_proto instead.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)