### PR TITLE
Portable Runfiles::Create; drop BAZEL_CURRENT_REPOSITORY

### DIFF
--- a/p4runtime_cc/fourward_server.cc
+++ b/p4runtime_cc/fourward_server.cc
@@ -157,8 +157,12 @@ void KillAndReap(pid_t pid) {
 absl::StatusOr<FourwardServer> FourwardServer::Start(
     FourwardServerOptions options) {
   std::string runfiles_error;
-  std::unique_ptr<Runfiles> runfiles(
-      Runfiles::Create("", BAZEL_CURRENT_REPOSITORY, &runfiles_error));
+  // `FOURWARD_SERVER_RLOCATION` is a canonical path already, so we use the
+  // `Create(argv0, error)` overload rather than the one that takes
+  // `BAZEL_CURRENT_REPOSITORY` — the latter is only needed for resolving
+  // apparent names, and skipping it keeps the wrapper portable to
+  // environments that don't inject that macro (e.g. google3).
+  std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", &runfiles_error));
   if (runfiles == nullptr) {
     return absl::InternalError(
         absl::StrCat("failed to resolve runfiles: ", runfiles_error));


### PR DESCRIPTION
## Summary

\`BAZEL_CURRENT_REPOSITORY\` is a preprocessor macro that Bazel
injects per-cc_library for apparent-name resolution. google3's
build system doesn't inject it, so \`fourward_server.cc\` failed to
compile there.

Our runfile path comes from
\`$(rlocationpath //p4runtime:p4runtime_server)\`, which is already
canonical — no apparent-name resolution is needed. Switch to the
\`Runfiles::Create(argv0, error)\` overload that doesn't take a
source-repository argument. Build-portable as a side effect.

## Test plan

- [x] CI build+test on OSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)