### PR TITLE
Shared disk cache for local builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,6 +40,14 @@ build --@protobuf//bazel/toolchains:prefer_prebuilt_protoc=true
 # Print test output for failing tests.
 test --test_output=errors
 
+# Shared on-disk action cache for local builds. Each worktree has its own
+# Bazel output base (keyed by the workspace path), so without this every new
+# worktree pays for a full cold build of transitive deps (JVM deps, p4c,
+# grpc, …). CI uses BuildBuddy's remote cache on fresh runners instead —
+# disk cache would just add overhead — so the empty override disables it.
+build --disk_cache=~/.cache/bazel/disk_cache
+build:ci --disk_cache=
+
 # clang-tidy: run via `bazel build //p4c_backend/... --config=clang-tidy`.
 # The config flag is set unconditionally so switching to --config=clang-tidy
 # does not change it and Bazel can reuse its analysis cache.


### PR DESCRIPTION
## Summary

Each Bazel worktree currently pays for a full cold build of transitive
deps (JVM deps, p4c, grpc, absl) on its first build, because Bazel's
per-output-base action cache is keyed by the workspace-path hash and
each worktree has a distinct path. On this machine: ~150 output bases
totaling several hundred GB of mostly-redundant compile output.

Fix: \`--disk_cache=~/.cache/bazel/disk_cache\` adds a shared,
content-addressable action cache that all worktrees consult. First
build in a new worktree now fetches previously-compiled actions by
content hash instead of recomputing them.

Scoped to local builds: CI already has BuildBuddy's remote cache and
fresh runners, so the disk cache would just add overhead. An empty
\`--disk_cache=\` under \`build:ci\` disables it for CI.

## Test plan

- [x] Local: \`bazel info disk_cache\` reports the expected path in a
      fresh worktree; a second worktree's first build hits cached
      actions instead of rebuilding.
- [x] CI unchanged (see \`build:ci\` override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)