### PR TITLE
fourward_pipeline: set explicit runfiles in DefaultInfo

### DIFF
--- a/bazel/fourward_pipeline.bzl
+++ b/bazel/fourward_pipeline.bzl
@@ -78,7 +78,11 @@ def _fourward_pipeline_impl(ctx):
         progress_message = "Compiling %{input} to 4ward pipeline",
     )
 
-    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+    # Explicit `runfiles` is required by google3; matches @p4c//bazel:p4_library.bzl.
+    return [DefaultInfo(
+        files = depset([ctx.outputs.out]),
+        runfiles = ctx.runfiles(files = [ctx.outputs.out]),
+    )]
 
 fourward_pipeline = rule(
     implementation = _fourward_pipeline_impl,


### PR DESCRIPTION
## Summary

\`fourward_pipeline\` was returning \`DefaultInfo(files = depset(...))\`
with no \`runfiles\` field. OSS Bazel infers \`runfiles\` from \`files\`
as a fallback when a consumer depends on the target via \`data\`, so
OSS tests passed. google3's build system is stricter and doesn't do
that fallback — the output never lands in the consumer's runfiles
tree, and tests downstream (e.g. \`GoldenErrorTest\`) fail at runtime:

    Cannot resolve runfile 'google3/third_party/fourward/e2e_tests/basic_table/basic_table.txtpb'

even with the right \`data = [...]\` attribute in the google3 BUILD.

Fix matches the pattern \`@p4c//bazel:p4_library.bzl\` already uses:
explicit \`runfiles = ctx.runfiles(files = outputs)\` in \`DefaultInfo\`.

## Test plan

- [x] OSS \`bazel test //...\` should still pass (change is additive).
- [ ] google3: \`GoldenErrorTest\` and \`WebServerTest\` runfile errors
      should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)