### PR TITLE
web: portable runfile lookups for p4c-4ward and frontend

### DIFF
--- a/bazel/Runfiles.kt
+++ b/bazel/Runfiles.kt
@@ -32,11 +32,19 @@ fun resolveRunfileOrNull(path: String): Path? {
 }
 
 /**
- * Returns the `fourward.p4include` system property, which the BUILD rule must set via `jvm_flags =
+ * Returns the `fourward.p4include` system property. BUILD must set it via `jvm_flags =
  * ["-Dfourward.p4include=$(rlocationpath @p4c//p4include:core.p4)"]`.
  */
-fun requireP4IncludeProperty(): String =
-  checkNotNull(System.getProperty("fourward.p4include")) {
-    "fourward.p4include system property not set. " +
-      "The kt_jvm_binary must pass -Dfourward.p4include=\$(rlocationpath @p4c//p4include:core.p4)"
+fun requireP4IncludeProperty(): String = requireRunfileProperty("fourward.p4include")
+
+/**
+ * Returns the value of a system property that the BUILD rule sets via `jvm_flags =
+ * ["-D<key>=$(rlocationpath <label>)"]`. This is how runfile paths are passed from BUILD to Kotlin
+ * without hardcoding a repo prefix — works uniformly under OSS Bazel (`_main/...`), BCR consumers
+ * (`fourward+/...`), and google3 (`third_party/fourward/...`).
+ */
+fun requireRunfileProperty(key: String): String =
+  checkNotNull(System.getProperty(key)) {
+    "$key system property not set. Expected BUILD to pass " +
+      "-D$key=\$(rlocationpath <label>) in jvm_flags."
   }

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -55,6 +55,8 @@ kt_jvm_binary(
     ] + glob(["frontend/**"]),
     jvm_flags = [
         "-Dfourward.p4include=$(rlocationpath @p4c//p4include:core.p4)",
+        "-Dfourward.p4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
+        "-Dfourward.web_frontend_anchor=$(rlocationpath :frontend/index.html)",
     ],
     main_class = "fourward.web.PlaygroundServerKt",
     visibility = ["//visibility:public"],
@@ -71,6 +73,8 @@ kt_jvm_test(
     ] + glob(["frontend/**"]),
     jvm_flags = [
         "-Dfourward.p4include=$(rlocationpath @p4c//p4include:core.p4)",
+        "-Dfourward.p4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
+        "-Dfourward.web_frontend_anchor=$(rlocationpath :frontend/index.html)",
     ],
     test_class = "fourward.web.WebServerTest",
     deps = [

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -5,6 +5,7 @@ import com.google.protobuf.util.JsonFormat
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
 import fourward.bazel.requireP4IncludeProperty
+import fourward.bazel.requireRunfileProperty
 import fourward.bazel.resolveRunfile
 import fourward.bazel.resolveRunfileOrNull
 import fourward.ir.PipelineConfig
@@ -304,9 +305,12 @@ class WebServer(
     }
 
     // 2. Bazel runfiles (works across OSS Bazel and google3/blaze).
-    resolveRunfileOrNull("_main/web/frontend/$relativePath")?.let { file ->
-      if (Files.isRegularFile(file)) return Files.readAllBytes(file)
-    }
+    val frontendDir = resolveRunfile(requireRunfileProperty("fourward.web_frontend_anchor")).parent
+    frontendDir
+      ?.resolve(relativePath)
+      ?.normalize()
+      ?.takeIf { it.startsWith(frontendDir) }
+      ?.let { file -> if (Files.isRegularFile(file)) return Files.readAllBytes(file) }
 
     // 3. Classpath.
     return javaClass.getResourceAsStream("/frontend/$relativePath")?.readAllBytes()
@@ -337,7 +341,7 @@ class WebServer(
   }
 
   private fun findP4c(): Path? {
-    resolveRunfileOrNull("_main/p4c_backend/p4c-4ward")?.let {
+    resolveRunfileOrNull(requireRunfileProperty("fourward.p4c_4ward"))?.let {
       if (Files.isExecutable(it)) return it
     }
     val pathDirs = System.getenv("PATH")?.split(":") ?: emptyList()


### PR DESCRIPTION
## Summary

\`WebServer.kt\` had two remaining hardcoded \`_main/\` runfile prefixes:
the p4c-4ward binary and the frontend static-asset directory. Both
work in OSS (where \`_main/\` is the apparent repo name) and both fail
under google3's stricter runfiles resolution.

Migrate to the BUILD-injected property pattern already used for
p4include: a generalized \`requireRunfileProperty(key)\` reads a system
property that BUILD sets via \`-D<key>=$(rlocationpath ...)\`.

- \`fourward.p4c_4ward\` → path to \`//p4c_backend:p4c-4ward\`
- \`fourward.web_frontend_anchor\` → path to \`:frontend/index.html\` (its
  parent is the frontend directory; all static assets resolve off that
  single injected value)

BUILD rules for \`playground\` and \`WebServerTest\` pass both.
\`requireP4IncludeProperty\` becomes a thin wrapper over the
generalized helper.

## Test plan

- [x] \`bazel test //web:WebServerTest\` — passes in OSS.
- [ ] google3 \`WebServerTest\` runfile errors should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)