### PR TITLE
Runfiles.kt: consolidate around resolveRunfileProperty

### DIFF
--- a/bazel/Runfiles.kt
+++ b/bazel/Runfiles.kt
@@ -12,13 +12,37 @@ import java.nio.file.Path
 private val runfiles: Runfiles = Runfiles.preload().unmapped()
 
 /**
- * Resolves a runfiles path to an absolute [Path].
+ * Resolves a runfile path supplied by BUILD via `jvm_flags = ["-D<key>=$(rlocationpath <label>)"]`.
+ * This is the preferred way to locate runfiles: the rlocationpath expansion yields a canonical
+ * prefix that works uniformly in OSS Bazel (`_main/...`), BCR consumers (`fourward+/...`), and
+ * google3 (`third_party/fourward/...`), so Kotlin never needs to know the current repo name.
+ *
+ * @throws IllegalStateException if the property is unset or the file is not in runfiles.
+ */
+fun resolveRunfileProperty(key: String): Path = resolveRunfile(requireRunfileProperty(key))
+
+/**
+ * Like [resolveRunfileProperty] but returns null if the property is unset or the file is missing.
+ */
+fun resolveRunfilePropertyOrNull(key: String): Path? =
+  System.getProperty(key)?.let(::resolveRunfileOrNull)
+
+/**
+ * Returns the value of a system property that the BUILD rule sets via `jvm_flags =
+ * ["-D<key>=$(rlocationpath <label>)"]`. Prefer [resolveRunfileProperty] unless you need the raw
+ * string (e.g., to pass to a subprocess).
+ */
+fun requireRunfileProperty(key: String): String =
+  checkNotNull(System.getProperty(key)) {
+    "$key system property not set. Expected BUILD to pass " +
+      "-D$key=\$(rlocationpath <label>) in jvm_flags."
+  }
+
+/**
+ * Resolves a runfiles path to an absolute [Path]. Prefer [resolveRunfileProperty] for new code — it
+ * avoids the portability footgun of hardcoding `_main/...` paths that break under BCR and google3.
  *
  * [path] must start with a repo directory prefix. Bare paths will not resolve.
- * - Main repo: `"_main/web/frontend/index.html"`
- * - External repo: inject via `$(rlocationpath ...)` in BUILD
- *
- * @throws IllegalStateException if the path cannot be resolved.
  */
 fun resolveRunfile(path: String): Path =
   resolveRunfileOrNull(path)
@@ -30,13 +54,3 @@ fun resolveRunfileOrNull(path: String): Path? {
   val p = Path.of(resolved)
   return if (Files.exists(p)) p else null
 }
-
-/**
- * Returns the `fourward.p4include` system property, which the BUILD rule must set via `jvm_flags =
- * ["-Dfourward.p4include=$(rlocationpath @p4c//p4include:core.p4)"]`.
- */
-fun requireP4IncludeProperty(): String =
-  checkNotNull(System.getProperty("fourward.p4include")) {
-    "fourward.p4include system property not set. " +
-      "The kt_jvm_binary must pass -Dfourward.p4include=\$(rlocationpath @p4c//p4include:core.p4)"
-  }

--- a/bazel/RunfilesTest.kt
+++ b/bazel/RunfilesTest.kt
@@ -24,7 +24,7 @@ class RunfilesTest {
     // External repos use canonical names that differ across environments.
     // Production code gets the path via $(rlocationpath ...) in BUILD jvm_flags.
     // This test verifies the same mechanism works.
-    val path = resolveRunfile(requireP4IncludeProperty())
+    val path = resolveRunfileProperty("fourward.p4include")
     assertTrue("resolved path should exist: $path", Files.isRegularFile(path))
   }
 

--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -50,6 +50,7 @@ kt_jvm_binary(
     ],
     jvm_flags = [
         "-Dfourward.p4include=$(rlocationpath @p4c//p4include:core.p4)",
+        "-Dfourward.p4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
     ],
     main_class = "fourward.cli.MainKt",
     visibility = ["//visibility:public"],

--- a/cli/Compile.kt
+++ b/cli/Compile.kt
@@ -1,8 +1,7 @@
 package fourward.cli
 
-import fourward.bazel.requireP4IncludeProperty
-import fourward.bazel.resolveRunfile
-import fourward.bazel.resolveRunfileOrNull
+import fourward.bazel.resolveRunfileProperty
+import fourward.bazel.resolveRunfilePropertyOrNull
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -63,7 +62,7 @@ fun compileToTemp(p4Source: Path, includeDirs: List<Path>): Pair<Path?, Int> {
 /** Locates the p4c-4ward binary: runfiles → env → PATH. Returns null if not found. */
 private fun findP4c4ward(): Path? {
   // 1. Bazel runfiles: works when invoked via `bazel run //cli:4ward`.
-  resolveRunfileOrNull("_main/p4c_backend/p4c-4ward")?.let { if (Files.isExecutable(it)) return it }
+  resolveRunfilePropertyOrNull("fourward.p4c_4ward")?.let { if (Files.isExecutable(it)) return it }
 
   // 2. Explicit env var.
   val envPath = System.getenv("P4C_4WARD_PATH")
@@ -90,7 +89,7 @@ private fun findP4c4ward(): Path? {
 private fun resolveIncludeDirs(userDirs: List<Path>): List<Path> {
   val dirs = mutableListOf<Path>()
 
-  resolveRunfile(requireP4IncludeProperty()).parent?.let { dirs.add(it) }
+  resolveRunfileProperty("fourward.p4include").parent?.let { dirs.add(it) }
 
   dirs.addAll(userDirs)
   return dirs

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -232,6 +232,10 @@ kt_jvm_test(
         "//e2e_tests/trace_tree:clone_with_egress",
         "//e2e_tests/translated_type",
     ] + glob(["golden_errors/*.golden.txt"]),
+    jvm_flags = [
+        "-Dfourward.constraint_validator=$(rlocationpath :constraint_validator)",
+        "-Dfourward.golden_errors_anchor=$(rlocationpath :golden_errors/action-not-valid-for-profile.golden.txt)",
+    ],
     test_class = "fourward.p4runtime.GoldenErrorTest",
     deps = [
         ":dataplane_java_proto",
@@ -347,6 +351,9 @@ kt_jvm_test(
         "//e2e_tests/basic_table",
         "//e2e_tests/constrained_table",
     ],
+    jvm_flags = [
+        "-Dfourward.constraint_validator=$(rlocationpath :constraint_validator)",
+    ],
     test_class = "fourward.p4runtime.ConstraintValidatorTest",
     deps = [
         ":p4runtime",
@@ -435,6 +442,9 @@ kt_jvm_test(
         "//e2e_tests/basic_table",
         "//e2e_tests/constrained_table",
     ],
+    jvm_flags = [
+        "-Dfourward.constraint_validator=$(rlocationpath :constraint_validator)",
+    ],
     test_class = "fourward.p4runtime.P4RuntimeConstraintTest",
     deps = [
         ":dataplane_java_proto",
@@ -466,6 +476,9 @@ kt_jvm_test(
     data = [
         "enriched_trace.golden.txtpb",
         "//e2e_tests/translated_port",
+    ],
+    jvm_flags = [
+        "-Dfourward.enriched_trace_golden=$(rlocationpath :enriched_trace.golden.txtpb)",
     ],
     test_class = "fourward.p4runtime.EnrichedTraceGoldenTest",
     deps = [
@@ -655,6 +668,9 @@ kt_jvm_test(
     data = [
         ":constraint_validator",
         "//e2e_tests/sai_p4:sai_middleblock",
+    ],
+    jvm_flags = [
+        "-Dfourward.constraint_validator=$(rlocationpath :constraint_validator)",
     ],
     test_class = "fourward.p4runtime.SaiP4ConstraintTest",
     deps = [

--- a/p4runtime/ConstraintValidatorTest.kt
+++ b/p4runtime/ConstraintValidatorTest.kt
@@ -161,6 +161,6 @@ class ConstraintValidatorTest {
 
   companion object {
     private val VALIDATOR_BINARY: Path =
-      fourward.bazel.resolveRunfile("_main/p4runtime/constraint_validator")
+      fourward.bazel.resolveRunfileProperty("fourward.constraint_validator")
   }
 }

--- a/p4runtime/EnrichedTraceGoldenTest.kt
+++ b/p4runtime/EnrichedTraceGoldenTest.kt
@@ -63,7 +63,7 @@ class EnrichedTraceGoldenTest {
   }
 
   private fun loadGolden(): TraceTree {
-    val path = fourward.bazel.resolveRunfile("_main/$GOLDEN_PATH")
+    val path = fourward.bazel.resolveRunfileProperty("fourward.enriched_trace_golden")
     val builder = TraceTree.newBuilder()
     TextFormat.merge(path.toFile().readText(), builder)
     return builder.build()
@@ -103,9 +103,5 @@ class EnrichedTraceGoldenTest {
         .build()
 
     return P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry).build()
-  }
-
-  companion object {
-    private const val GOLDEN_PATH = "p4runtime/enriched_trace.golden.txtpb"
   }
 }

--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -1719,13 +1719,13 @@ class GoldenErrorTest(private val testName: String) {
       )
 
     private val VALIDATOR_BINARY: Path =
-      fourward.bazel.resolveRunfile("_main/p4runtime/constraint_validator")
+      fourward.bazel.resolveRunfileProperty("fourward.constraint_validator")
 
     private const val MCAST_ACTION_ID = 99997
 
     private const val DCTR_ID = 800
 
     private fun goldenDir(): java.nio.file.Path =
-      fourward.bazel.resolveRunfile("_main/p4runtime/golden_errors")
+      fourward.bazel.resolveRunfileProperty("fourward.golden_errors_anchor").parent
   }
 }

--- a/p4runtime/P4RuntimeConstraintTest.kt
+++ b/p4runtime/P4RuntimeConstraintTest.kt
@@ -172,6 +172,6 @@ class P4RuntimeConstraintTest {
 
   companion object {
     private val VALIDATOR_BINARY: Path =
-      fourward.bazel.resolveRunfile("_main/p4runtime/constraint_validator")
+      fourward.bazel.resolveRunfileProperty("fourward.constraint_validator")
   }
 }

--- a/p4runtime/SaiP4ConstraintTest.kt
+++ b/p4runtime/SaiP4ConstraintTest.kt
@@ -304,7 +304,7 @@ class SaiP4ConstraintTest {
   companion object {
     private const val MAC_LEN = 6
     private val VALIDATOR_BINARY: Path =
-      fourward.bazel.resolveRunfile("_main/p4runtime/constraint_validator")
+      fourward.bazel.resolveRunfileProperty("fourward.constraint_validator")
 
     // Shared across all tests — pipeline load + constraint validator subprocess is expensive.
     private lateinit var harness: P4RuntimeTestHarness

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -55,6 +55,8 @@ kt_jvm_binary(
     ] + glob(["frontend/**"]),
     jvm_flags = [
         "-Dfourward.p4include=$(rlocationpath @p4c//p4include:core.p4)",
+        "-Dfourward.p4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
+        "-Dfourward.web_frontend_anchor=$(rlocationpath :frontend/index.html)",
     ],
     main_class = "fourward.web.PlaygroundServerKt",
     visibility = ["//visibility:public"],
@@ -71,6 +73,8 @@ kt_jvm_test(
     ] + glob(["frontend/**"]),
     jvm_flags = [
         "-Dfourward.p4include=$(rlocationpath @p4c//p4include:core.p4)",
+        "-Dfourward.p4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
+        "-Dfourward.web_frontend_anchor=$(rlocationpath :frontend/index.html)",
     ],
     test_class = "fourward.web.WebServerTest",
     deps = [

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -4,9 +4,8 @@ import com.google.protobuf.TextFormat
 import com.google.protobuf.util.JsonFormat
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
-import fourward.bazel.requireP4IncludeProperty
-import fourward.bazel.resolveRunfile
-import fourward.bazel.resolveRunfileOrNull
+import fourward.bazel.resolveRunfileProperty
+import fourward.bazel.resolveRunfilePropertyOrNull
 import fourward.ir.PipelineConfig
 import fourward.simulator.Simulator
 import java.net.InetSocketAddress
@@ -304,9 +303,12 @@ class WebServer(
     }
 
     // 2. Bazel runfiles (works across OSS Bazel and google3/blaze).
-    resolveRunfileOrNull("_main/web/frontend/$relativePath")?.let { file ->
-      if (Files.isRegularFile(file)) return Files.readAllBytes(file)
-    }
+    val frontendDir = resolveRunfileProperty("fourward.web_frontend_anchor").parent
+    frontendDir
+      ?.resolve(relativePath)
+      ?.normalize()
+      ?.takeIf { it.startsWith(frontendDir) }
+      ?.let { file -> if (Files.isRegularFile(file)) return Files.readAllBytes(file) }
 
     // 3. Classpath.
     return javaClass.getResourceAsStream("/frontend/$relativePath")?.readAllBytes()
@@ -323,7 +325,7 @@ class WebServer(
 
     val cmd = mutableListOf(p4c.toString())
 
-    resolveRunfile(requireP4IncludeProperty()).parent?.let { p4include ->
+    resolveRunfileProperty("fourward.p4include").parent?.let { p4include ->
       cmd += listOf("-I", p4include.toString())
     }
 
@@ -337,7 +339,7 @@ class WebServer(
   }
 
   private fun findP4c(): Path? {
-    resolveRunfileOrNull("_main/p4c_backend/p4c-4ward")?.let {
+    resolveRunfilePropertyOrNull("fourward.p4c_4ward")?.let {
       if (Files.isExecutable(it)) return it
     }
     val pathDirs = System.getenv("PATH")?.split(":") ?: emptyList()


### PR DESCRIPTION
## Summary

Replaces the old split API (\`resolveRunfile\`, \`resolveRunfileOrNull\`,
\`requireP4IncludeProperty\`) with a single preferred way to locate
runfiles:

\`\`\`kotlin
fun resolveRunfileProperty(key: String): Path
fun resolveRunfilePropertyOrNull(key: String): Path?
\`\`\`

BUILD targets inject \`-D<key>=$(rlocationpath <label>)\` in
\`jvm_flags\`; Kotlin reads the property. The rlocationpath expansion
yields a canonical prefix that works in every build environment —
OSS root (\`_main/...\`), BCR consumers (\`fourward+/...\`), and
google3 (\`third_party/fourward/...\`). No hardcoded prefixes in
Kotlin; BUILD documents each target's runfile deps by name.

Migrates the clean cases (one rlocationpath per call site):

- \`cli/Compile.kt\`: p4c-4ward binary + p4include.
- \`web/WebServer.kt\`: p4c-4ward, p4include, and the frontend
  directory (anchored on \`index.html\`'s rlocationpath, \`.parent\`).
- \`p4runtime/\`: four tests that all look up the shared
  \`constraint_validator\` binary, plus \`GoldenErrorTest\`'s
  \`golden_errors/\` directory (anchored on one golden file), plus
  \`EnrichedTraceGoldenTest\`'s single golden.

\`requireP4IncludeProperty\` is gone.

**Supersedes #577** — its changes are incorporated here.

## Deliberately out of scope

Remaining \`_main/...\` callers still work in OSS and remain for
follow-up migrations:
- \`stf/Runner.kt\`
- \`P4RuntimeTestHarness.loadConfig\`
- \`e2e_tests/{bmv2_diff,p4testgen,trace_tree,corpus}/\` helpers
- \`e2e_tests/GoldenFile.kt\`

Those need per-test-target anchor plumbing (each test target adds a
\`-Dfourward.pkg_anchor=$(rlocationpath ...)\` flag), which is
mechanical but large and better handled incrementally.

## Test plan

- [x] \`bazel test //bazel:RunfilesTest //web:WebServerTest //p4runtime:GoldenErrorTest //p4runtime:ConstraintValidatorTest //p4runtime:P4RuntimeConstraintTest //p4runtime:SaiP4ConstraintTest //p4runtime:EnrichedTraceGoldenTest\` — all pass.
- [x] \`./tools/format.sh --check\` clean.
- [ ] google3: web + constraint_validator + enriched trace tests
      should resolve correctly via Copybara's \`\$(rlocationpath)\`
      rewriting of the injected flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)