### PR TITLE
WebServerTest: include response body in compile-endpoint failure

### DIFF
--- a/web/WebServerTest.kt
+++ b/web/WebServerTest.kt
@@ -135,7 +135,11 @@ class WebServerTest {
       """
         .trimIndent()
     conn.outputStream.write("""{"source":${WebServer.jsonEscape(p4)}}""".toByteArray())
-    assertTrue("compile should succeed (2xx)", conn.responseCode in 200..299)
+    val status = conn.responseCode
+    val body =
+      (if (status in 200..299) conn.inputStream else conn.errorStream)?.bufferedReader()?.readText()
+        ?: ""
+    assertTrue("compile should succeed (got $status); body: $body", status in 200..299)
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
The current assertion in `compile endpoint finds p4c-4ward and compiles`
is `assertTrue("compile should succeed (2xx)", conn.responseCode in 200..299)` —
when it fails (as it is currently in google3), we learn nothing about why.

Read the response body from `inputStream` on 2xx, `errorStream` on
non-2xx, and include it in the failure message. Next google3 run
surfaces the actual error instead of a bare status-range assertion.

No behavior change on the happy path.

## Test plan

- [x] `bazel test //web:WebServerTest` — passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)