### PR TITLE
Parameterized tests: enumerate cases at BUILD time

### DIFF
--- a/e2e_tests/bmv2_diff.bzl
+++ b/e2e_tests/bmv2_diff.bzl
@@ -58,6 +58,10 @@ def bmv2_diff_test_suite(name, tests, local_tests = {}, tags = [], includes = []
         test_class = "fourward.e2e.bmv2.Bmv2DiffTest",
         tags = tags,
         data = data,
+        jvm_flags = [
+            "-Dfourward.bmv2_diff_testcases=" +
+            ",".join(sorted(tests + list(local_tests.keys()))),
+        ],
         deps = [
             "//bazel:runfiles",
             "//simulator:ir_java_proto",

--- a/e2e_tests/bmv2_diff/Bmv2DiffTest.kt
+++ b/e2e_tests/bmv2_diff/Bmv2DiffTest.kt
@@ -23,13 +23,13 @@ class Bmv2DiffTest(private val testName: String) {
   companion object {
     @JvmStatic
     @Parameterized.Parameters(name = "{0}")
-    fun testCases(): List<Array<String>> {
-      val dir = fourward.bazel.repoRoot.resolve("e2e_tests/bmv2_diff").toFile()
-      return dir
-        .listFiles { f -> f.extension == "stf" }
-        ?.map { arrayOf(it.nameWithoutExtension) }
-        ?.sortedBy { it[0] } ?: emptyList()
-    }
+    fun testCases(): List<Array<String>> =
+      System.getProperty("fourward.bmv2_diff_testcases")
+        .orEmpty()
+        .split(",")
+        .filter { it.isNotEmpty() }
+        .sorted()
+        .map { arrayOf(it) }
   }
 
   @Test

--- a/e2e_tests/corpus.bzl
+++ b/e2e_tests/corpus.bzl
@@ -68,6 +68,9 @@ def corpus_test_suite(name, tests, tags = [], includes = [], stf_overrides = {})
         test_class = "fourward.e2e.corpus.CorpusStfTest",
         tags = tags,
         data = data,
+        jvm_flags = [
+            "-Dfourward.corpus_testcases=" + ",".join(sorted(tests)),
+        ],
         deps = [
             "//bazel:runfiles",
             "//stf",

--- a/e2e_tests/corpus/CorpusStfTest.kt
+++ b/e2e_tests/corpus/CorpusStfTest.kt
@@ -16,7 +16,6 @@ package fourward.e2e.corpus
 
 import fourward.stf.TestResult
 import fourward.stf.runStfTest
-import java.nio.file.Files
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,9 +24,9 @@ import org.junit.runners.Parameterized
 /**
  * Parameterized test that runs all p4c corpus STF tests in a single JVM.
  *
- * Test names are discovered at runtime from the .stf files present in the runfiles directory. Each
- * test launches a fresh simulator subprocess (the simulator resets state on each LoadPipeline), so
- * tests remain isolated despite sharing a JVM.
+ * Test names are enumerated at BUILD time (via the `corpus_test_suite` macro) and passed via
+ * `-Dfourward.corpus_testcases=...`. Runtime file-listing is avoided because hermetic sandboxes
+ * (google3, remote executors) serve runfiles via manifest, not as a real directory tree.
  */
 @RunWith(Parameterized::class)
 class CorpusStfTest(private val testName: String) {
@@ -35,16 +34,13 @@ class CorpusStfTest(private val testName: String) {
   companion object {
     @JvmStatic
     @Parameterized.Parameters(name = "{0}")
-    fun testCases(): List<Array<String>> {
-      val corpusDir = fourward.bazel.repoRoot.resolve("e2e_tests/corpus")
-      return Files.list(corpusDir).use { stream ->
-        stream
-          .filter { it.toString().endsWith(".stf") }
-          .map { arrayOf(it.fileName.toString().removeSuffix(".stf")) }
-          .sorted(Comparator.comparing { it[0] })
-          .toList()
-      }
-    }
+    fun testCases(): List<Array<String>> =
+      System.getProperty("fourward.corpus_testcases")
+        .orEmpty()
+        .split(",")
+        .filter { it.isNotEmpty() }
+        .sorted()
+        .map { arrayOf(it) }
   }
 
   @Test

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -100,6 +100,9 @@ kt_jvm_test(
     data = ["%s.stf" % n for n in _PASSING] +
            ["%s.golden.txtpb" % n for n in _PASSING] +
            [":%s" % n for n in _PASSING],
+    jvm_flags = [
+        "-Dfourward.trace_tree_goldens=" + ",".join(sorted(_PASSING)),
+    ],
     test_class = "fourward.e2e.tracetree.GoldenTraceTreeTest",
     deps = _TEST_DEPS + ["//simulator:p4info_java_proto"],
 )
@@ -109,6 +112,9 @@ kt_jvm_test(
     srcs = ["TraceTreeConsistencyTest.kt"],
     data = ["%s.stf" % n for n in _P4_PROGRAMS] +
            [":%s" % n for n in _P4_PROGRAMS],
+    jvm_flags = [
+        "-Dfourward.trace_tree_programs=" + ",".join(sorted(_P4_PROGRAMS)),
+    ],
     test_class = "fourward.e2e.tracetree.TraceTreeConsistencyTest",
     deps = _TEST_DEPS + ["//simulator:p4info_java_proto"],
 )
@@ -119,6 +125,9 @@ kt_jvm_test(
     data = ["%s.stf" % n for n in _MANUAL] +
            ["%s.golden.txtpb" % n for n in _MANUAL] +
            [":%s" % n for n in _MANUAL],
+    jvm_flags = [
+        "-Dfourward.trace_tree_goldens=" + ",".join(sorted(_MANUAL)),
+    ],
     tags = ["manual"],
     test_class = "fourward.e2e.tracetree.GoldenTraceTreeTest",
     deps = _TEST_DEPS,

--- a/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
+++ b/e2e_tests/trace_tree/GoldenTraceTreeTest.kt
@@ -33,13 +33,13 @@ class GoldenTraceTreeTest(private val testName: String) {
 
     @JvmStatic
     @Parameters(name = "{0}")
-    fun testCases(): List<Array<String>> {
-      val dir = repoRoot.resolve(PKG).toFile()
-      return dir
-        .listFiles { f -> f.name.endsWith(".golden.txtpb") }
-        ?.map { arrayOf(it.name.removeSuffix(".golden.txtpb")) }
-        ?.sortedBy { it[0] } ?: emptyList()
-    }
+    fun testCases(): List<Array<String>> =
+      System.getProperty("fourward.trace_tree_goldens")
+        .orEmpty()
+        .split(",")
+        .filter { it.isNotEmpty() }
+        .sorted()
+        .map { arrayOf(it) }
   }
 
   @Test

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -30,13 +30,13 @@ class TraceTreeConsistencyTest(private val testName: String) {
 
     @JvmStatic
     @Parameters(name = "{0}")
-    fun testCases(): List<Array<String>> {
-      val dir = fourward.bazel.repoRoot.resolve(PKG).toFile()
-      return dir
-        .listFiles { f -> f.name.endsWith(".stf") }
-        ?.map { arrayOf(it.name.removeSuffix(".stf")) }
-        ?.sortedBy { it[0] } ?: emptyList()
-    }
+    fun testCases(): List<Array<String>> =
+      System.getProperty("fourward.trace_tree_programs")
+        .orEmpty()
+        .split(",")
+        .filter { it.isNotEmpty() }
+        .sorted()
+        .map { arrayOf(it) }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Four `@Parameterized` tests discovered their cases via
`Files.list(repoRoot.resolve(PKG))`. That only works when runfiles are
materialized as a real directory tree. google3 and some remote
executors serve runfiles via manifest — `listFiles()` returns nothing
→ `Parameterized` produces no children → google3's JUnit4 runner
refuses the empty test class:

```
Top test must be a suite: fourward.e2e.tracetree.GoldenTraceTreeTest
```

All four tests already had their case lists explicit in BUILD. The
Kotlin `listFiles()` was just redundantly rediscovering what BUILD
already knew. Plumb the lists through via a jvm_flag:

```starlark
jvm_flags = [
    "-Dfourward.<key>=" + ",".join(sorted(<list>)),
]
```

Kotlin reads the property, splits on commas. Works in every runfiles
mode.

### Migrated

- `GoldenTraceTreeTest` — `fourward.trace_tree_goldens`
- `TraceTreeConsistencyTest` — `fourward.trace_tree_programs`
- `Bmv2DiffTest` — `fourward.bmv2_diff_testcases`
- `CorpusStfTest` — `fourward.corpus_testcases`

### Deferred

`P4TestgenSuiteTest` — its stf names are produced by p4testgen's
symbolic execution at build time and aren't known in the BUILD file.
Migrating that one requires the `_p4testgen_stfs` rule to emit a
per-program manifest file that the test reads. Separate PR.

## Test plan

- [x] `bazel test //e2e_tests/trace_tree:all //e2e_tests/bmv2_diff:bmv2_diff_test //e2e_tests/corpus:v1model_stf_corpus_test` — all pass locally.
- [ ] google3: `golden_trace_tree_test_manual` and peers should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)