### PR TITLE
CI: bump --remote_timeout 3s → 10s

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,7 +64,7 @@ coverage --instrumentation_filter=//simulator[/:],//p4runtime[/:]
 build:ci --remote_cache=grpcs://4ward.buildbuddy.io
 build:ci --remote_download_toplevel
 build:ci --remote_upload_local_results
-build:ci --remote_timeout=3s
+build:ci --remote_timeout=10s
 build:ci --remote_cache_compression
 build:ci --bes_results_url=https://4ward.buildbuddy.io/invocation/
 build:ci --bes_backend=grpcs://4ward.buildbuddy.io


### PR DESCRIPTION
Short version: the `3s` remote timeout was aggressive enough that
larger BuildBuddy cache fetches were timing out mid-transfer and
falling back to local compile — silently wiping the cache benefit.
`60s` is Bazel's own default and matches what BuildBuddy's docs
recommend for typical CI throughput.

Expected impact: fewer cold rebuilds per CI run, especially on the
slower macOS runner.

## Test plan

- [x] No code change; `.bazelrc` only.
- [ ] Compare `Build and test` durations before/after on a handful of
      PRs to confirm the improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)