### PR TITLE
Drop empty golden_trace_tree_test_manual target

### DIFF
--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -50,8 +50,6 @@ _P4_PROGRAMS = _GOLDEN + _STF_ONLY
 
 _PASSING = _GOLDEN
 
-_MANUAL = []
-
 [fourward_pipeline(
     name = name,
     src = "%s.p4" % name,
@@ -117,18 +115,4 @@ kt_jvm_test(
     ],
     test_class = "fourward.e2e.tracetree.TraceTreeConsistencyTest",
     deps = _TEST_DEPS + ["//simulator:p4info_java_proto"],
-)
-
-kt_jvm_test(
-    name = "golden_trace_tree_test_manual",
-    srcs = ["GoldenTraceTreeTest.kt"],
-    data = ["%s.stf" % n for n in _MANUAL] +
-           ["%s.golden.txtpb" % n for n in _MANUAL] +
-           [":%s" % n for n in _MANUAL],
-    jvm_flags = [
-        "-Dfourward.trace_tree_goldens=" + ",".join(sorted(_MANUAL)),
-    ],
-    tags = ["manual"],
-    test_class = "fourward.e2e.tracetree.GoldenTraceTreeTest",
-    deps = _TEST_DEPS,
 )


### PR DESCRIPTION
`_MANUAL = []` has been empty since the target was introduced. The resulting
`kt_jvm_test` has zero parameterized cases, which surfaces under google3's
JUnit4 runner as:

```
Top test must be a suite: fourward.e2e.tracetree.GoldenTraceTreeTest
```

Parameterized with no children isn't recognized as a suite class. OSS `bazel
test //...` filters out `manual`-tagged targets so never tried to run it;
google3 ignores the tag and tries anyway.

If manual golden cases are ever added, re-declare the target at that point.

## Test plan

- [x] `bazel build //e2e_tests/trace_tree/...` — clean.
- [ ] google3: `golden_trace_tree_test_manual` no longer exists to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)