### PR TITLE
fourward_pipeline: opt-in p4info and device-config side outputs

### DIFF
--- a/bazel/fourward_pipeline.bzl
+++ b/bazel/fourward_pipeline.bzl
@@ -11,26 +11,58 @@ Usage:
         out_format = "p4runtime",
     )
 
-Output formats (`out_format`):
-  - `"native"` (default): `fourward.ir.PipelineConfig`
-  - `"p4runtime"`: `p4.v1.ForwardingPipelineConfig` (for `SetForwardingPipelineConfig`)
+The rule produces one or more proto files. Each output is independently
+configurable; specify the outputs you need:
 
-File extension of `out` determines serialization: `.txtpb` for text proto,
-`.binpb` for binary proto.
+  - `out` + `out_format`: the combined pipeline config.
+      - `out_format = "native"` (default): `fourward.ir.PipelineConfig`
+      - `out_format = "p4runtime"`: `p4.v1.ForwardingPipelineConfig`
+  - `out_p4info`: standalone `p4.config.v1.P4Info`.
+  - `out_p4_device_config`: standalone `fourward.ir.DeviceConfig`
+    (the payload 4ward places in `ForwardingPipelineConfig.p4_device_config`).
+
+At least one output attribute must be set.
+
+All output paths must end in `.txtpb` (text proto) or `.binpb` (binary
+proto); any other extension is rejected at analysis time.
 """
 
 load("@rules_cc//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_TYPE", "find_cc_toolchain", "use_cc_toolchain")
 
 _VALID_OUT_FORMATS = ["native", "p4runtime"]
+_VALID_EXTENSIONS = (".txtpb", ".binpb")
+
+# Each (attr_name, p4c_flag) pair maps an output attribute on the rule to the
+# p4c-4ward CLI flag that produces that file. Keep in sync with p4c_backend/
+# options.cpp.
+_OUTPUT_SPECS = [
+    ("out", "-o"),
+    ("out_p4info", "--out-p4info"),
+    ("out_p4_device_config", "--out-p4-device-config"),
+]
 
 def _fourward_pipeline_impl(ctx):
-    include_dirs = []
-    for inc in ctx.files.includes:
-        include_dirs.append(inc.dirname)
+    outputs = []
+    output_args = []
+    for attr_name, flag in _OUTPUT_SPECS:
+        file = getattr(ctx.outputs, attr_name)
+        if file == None:
+            continue
+        if not file.basename.endswith(_VALID_EXTENSIONS):
+            fail("fourward_pipeline: `{attr}` must end in .txtpb or .binpb, got '{name}'".format(
+                attr = attr_name,
+                name = file.basename,
+            ))
+        outputs.append(file)
+        output_args += [flag, file.path]
+    if not outputs:
+        fail("fourward_pipeline: at least one of `{names}` must be set.".format(
+            names = "`, `".join([name for name, _ in _OUTPUT_SPECS]),
+        ))
 
     p4c_args = []
-    for directory in include_dirs:
-        p4c_args += ["-I", directory]
+    for inc in ctx.files.includes:
+        p4c_args += ["-I", inc.dirname]
     p4c_args += ["-I", ctx.file._p4include_anchor.dirname]
 
     # Workspace root of the target's repo, so `#include "path/from/root.p4"`
@@ -40,10 +72,12 @@ def _fourward_pipeline_impl(ctx):
     for define in ctx.attr.defines:
         p4c_args.append("-D" + define)
 
+    # `--format` modifies the `-o` output's message type; harmless when `-o`
+    # is unset (p4c just ignores it).
     if ctx.attr.out_format == "p4runtime":
         p4c_args += ["--format", "p4runtime"]
-
-    p4c_args += ["-o", ctx.outputs.out.path, ctx.file.src.path]
+    p4c_args += output_args
+    p4c_args.append(ctx.file.src.path)
 
     inputs = depset(
         [ctx.file.src] + ctx.files.includes + ctx.files.extra_srcs,
@@ -57,7 +91,7 @@ def _fourward_pipeline_impl(ctx):
     cc_toolchain = find_cc_toolchain(ctx)
     p4c = ctx.executable._p4c_4ward
     ctx.actions.run_shell(
-        outputs = [ctx.outputs.out],
+        outputs = outputs,
         inputs = inputs,
         command = """
             function cc () {{ "{cc}" "$@"; }}
@@ -80,8 +114,8 @@ def _fourward_pipeline_impl(ctx):
 
     # Explicit `runfiles` is required by google3; matches @p4c//bazel:p4_library.bzl.
     return [DefaultInfo(
-        files = depset([ctx.outputs.out]),
-        runfiles = ctx.runfiles(files = [ctx.outputs.out]),
+        files = depset(outputs),
+        runfiles = ctx.runfiles(files = outputs),
     )]
 
 fourward_pipeline = rule(
@@ -94,18 +128,28 @@ fourward_pipeline = rule(
             doc = "P4 source file.",
         ),
         "out": attr.output(
-            mandatory = True,
-            doc = "Output file. Extension determines serialization: " +
-                  "`.txtpb` for text proto, `.binpb` for binary proto. " +
-                  "The proto message type is determined by `out_format`.",
+            doc = "Combined pipeline config. Message type is controlled by " +
+                  "`out_format`: `fourward.ir.PipelineConfig` (native) or " +
+                  "`p4.v1.ForwardingPipelineConfig` (p4runtime). Extension " +
+                  "must be `.txtpb` or `.binpb`.",
         ),
         "out_format": attr.string(
             default = "native",
-            doc = "Output proto message type. " +
+            doc = "Message type for `out`. " +
                   "`\"native\"` (default): `fourward.ir.PipelineConfig`. " +
                   "`\"p4runtime\"`: `p4.v1.ForwardingPipelineConfig` " +
-                  "(suitable for `SetForwardingPipelineConfig`).",
+                  "(suitable for `SetForwardingPipelineConfig`). " +
+                  "Ignored when `out` is unset.",
             values = _VALID_OUT_FORMATS,
+        ),
+        "out_p4info": attr.output(
+            doc = "Standalone `p4.config.v1.P4Info` output. Extension must " +
+                  "be `.txtpb` or `.binpb`.",
+        ),
+        "out_p4_device_config": attr.output(
+            doc = "Standalone `fourward.ir.DeviceConfig` output — the payload " +
+                  "4ward places in `ForwardingPipelineConfig.p4_device_config`. " +
+                  "Extension must be `.txtpb` or `.binpb`.",
         ),
         "includes": attr.label_list(
             allow_files = True,

--- a/e2e_tests/pipeline_outputs/BUILD.bazel
+++ b/e2e_tests/pipeline_outputs/BUILD.bazel
@@ -1,0 +1,83 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//bazel:fourward_pipeline.bzl", "fourward_pipeline")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
+
+# Combined output only — native PipelineConfig as text proto.
+fourward_pipeline(
+    name = "tiny_native",
+    src = "tiny.p4",
+    out = "tiny_native.txtpb",
+)
+
+# Combined output only — P4Runtime ForwardingPipelineConfig as binary proto.
+fourward_pipeline(
+    name = "tiny_p4runtime",
+    src = "tiny.p4",
+    out = "tiny_p4runtime.binpb",
+    out_format = "p4runtime",
+)
+
+# Standalone p4info outputs, one target per encoding.
+fourward_pipeline(
+    name = "tiny_p4info_txtpb",
+    src = "tiny.p4",
+    out_p4info = "tiny.p4info.txtpb",
+)
+
+fourward_pipeline(
+    name = "tiny_p4info_binpb",
+    src = "tiny.p4",
+    out_p4info = "tiny.p4info.binpb",
+)
+
+# Standalone device-config outputs, one target per encoding.
+fourward_pipeline(
+    name = "tiny_device_config_txtpb",
+    src = "tiny.p4",
+    out_p4_device_config = "tiny.device_config.txtpb",
+)
+
+fourward_pipeline(
+    name = "tiny_device_config_binpb",
+    src = "tiny.p4",
+    out_p4_device_config = "tiny.device_config.binpb",
+)
+
+# All three outputs from a single action, mixing encodings to ensure per-file
+# extension handling is independent.
+fourward_pipeline(
+    name = "tiny_all",
+    src = "tiny.p4",
+    out = "tiny_all.combined.binpb",
+    out_format = "p4runtime",
+    out_p4_device_config = "tiny_all.device_config.binpb",
+    out_p4info = "tiny_all.p4info.txtpb",
+)
+
+kt_jvm_test(
+    name = "PipelineOutputsTest",
+    srcs = ["PipelineOutputsTest.kt"],
+    data = [
+        ":tiny_all",
+        ":tiny_device_config_binpb",
+        ":tiny_device_config_txtpb",
+        ":tiny_native",
+        ":tiny_p4info_binpb",
+        ":tiny_p4info_txtpb",
+        ":tiny_p4runtime",
+    ],
+    test_class = "fourward.e2e.pipelineoutputs.PipelineOutputsTest",
+    deps = [
+        "//bazel:runfiles",
+        "//simulator:ir_java_proto",
+        "//simulator:p4info_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "@fourward_maven//:junit_junit",
+        "@protobuf//java/core",
+    ],
+)

--- a/e2e_tests/pipeline_outputs/PipelineOutputsTest.kt
+++ b/e2e_tests/pipeline_outputs/PipelineOutputsTest.kt
@@ -1,0 +1,117 @@
+package fourward.e2e.pipelineoutputs
+
+import com.google.protobuf.TextFormat
+import fourward.bazel.repoRoot
+import fourward.ir.DeviceConfig
+import fourward.ir.PipelineConfig
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import p4.config.v1.P4InfoOuterClass.P4Info
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+
+/**
+ * Verifies that `fourward_pipeline` emits each configured output as the expected proto message
+ * type, in both text and binary encodings. See the companion BUILD.bazel for the target
+ * configurations.
+ */
+class PipelineOutputsTest {
+
+  @Test
+  fun `out + out_format=native produces PipelineConfig as txtpb`() {
+    val path = runfile("tiny_native.txtpb")
+    assertHeader(path, "fourward.ir.PipelineConfig")
+    val cfg =
+      PipelineConfig.newBuilder().also { TextFormat.merge(Files.readString(path), it) }.build()
+    assertHasBasicTable(cfg.p4Info)
+    assertFalse(cfg.device.behavioral.controlsList.isEmpty())
+  }
+
+  @Test
+  fun `out + out_format=p4runtime produces ForwardingPipelineConfig as binpb`() {
+    val bytes = Files.readAllBytes(runfile("tiny_p4runtime.binpb"))
+    val fpc = ForwardingPipelineConfig.parseFrom(bytes)
+    assertHasBasicTable(fpc.p4Info)
+    // p4_device_config is an opaque blob; we only assert it decodes as our DeviceConfig.
+    val dc = DeviceConfig.parseFrom(fpc.p4DeviceConfig)
+    assertFalse(dc.behavioral.controlsList.isEmpty())
+  }
+
+  @Test
+  fun `out_p4info produces standalone P4Info in txtpb`() {
+    val path = runfile("tiny.p4info.txtpb")
+    assertHeader(path, "p4.config.v1.P4Info")
+    val p4info = P4Info.newBuilder().also { TextFormat.merge(Files.readString(path), it) }.build()
+    assertHasBasicTable(p4info)
+  }
+
+  @Test
+  fun `out_p4info produces standalone P4Info in binpb`() {
+    val bytes = Files.readAllBytes(runfile("tiny.p4info.binpb"))
+    val p4info = P4Info.parseFrom(bytes)
+    assertHasBasicTable(p4info)
+  }
+
+  @Test
+  fun `out_p4_device_config produces standalone DeviceConfig in txtpb`() {
+    val path = runfile("tiny.device_config.txtpb")
+    assertHeader(path, "fourward.ir.DeviceConfig")
+    val dc = DeviceConfig.newBuilder().also { TextFormat.merge(Files.readString(path), it) }.build()
+    assertFalse(dc.behavioral.controlsList.isEmpty())
+  }
+
+  @Test
+  fun `out_p4_device_config produces standalone DeviceConfig in binpb`() {
+    val bytes = Files.readAllBytes(runfile("tiny.device_config.binpb"))
+    val dc = DeviceConfig.parseFrom(bytes)
+    assertFalse(dc.behavioral.controlsList.isEmpty())
+  }
+
+  @Test
+  fun `combined target emits same artifacts as single-output targets`() {
+    // p4c is invoked once with all three flags; each file should match what
+    // the dedicated single-output targets produce in isolation.
+    val combined =
+      ForwardingPipelineConfig.parseFrom(Files.readAllBytes(runfile("tiny_all.combined.binpb")))
+    val standalone =
+      ForwardingPipelineConfig.parseFrom(Files.readAllBytes(runfile("tiny_p4runtime.binpb")))
+    assertEquals(standalone, combined)
+
+    val p4info =
+      P4Info.newBuilder()
+        .also { TextFormat.merge(Files.readString(runfile("tiny_all.p4info.txtpb")), it) }
+        .build()
+    val p4infoStandalone =
+      P4Info.newBuilder()
+        .also { TextFormat.merge(Files.readString(runfile("tiny.p4info.txtpb")), it) }
+        .build()
+    assertEquals(p4infoStandalone, p4info)
+
+    val dc = DeviceConfig.parseFrom(Files.readAllBytes(runfile("tiny_all.device_config.binpb")))
+    val dcStandalone =
+      DeviceConfig.parseFrom(Files.readAllBytes(runfile("tiny.device_config.binpb")))
+    assertEquals(dcStandalone, dc)
+  }
+
+  private fun runfile(name: String): Path = repoRoot.resolve("e2e_tests/pipeline_outputs/$name")
+
+  private fun assertHeader(path: Path, expectedMessage: String) {
+    val firstTwo = Files.readAllLines(path).take(2)
+    assertEquals(
+      "text-proto output must declare proto-file and proto-message",
+      2,
+      firstTwo.count { it.startsWith("# proto-") },
+    )
+    assertTrue(
+      "expected proto-message '$expectedMessage' in header, got: $firstTwo",
+      firstTwo.any { it == "# proto-message: $expectedMessage" },
+    )
+  }
+
+  private fun assertHasBasicTable(p4info: P4Info) {
+    assertEquals("expected exactly one table (tiny.p4 declares one)", 1, p4info.tablesCount)
+  }
+}

--- a/e2e_tests/pipeline_outputs/tiny.p4
+++ b/e2e_tests/pipeline_outputs/tiny.p4
@@ -1,0 +1,43 @@
+/* tiny.p4 — minimal v1model program used to exercise `fourward_pipeline`
+ * output configurations. A single exact-match table gives p4info and
+ * DeviceConfig non-trivial content to serialize.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header eth_t {
+    bit<48> dst;
+    bit<48> src;
+    bit<16> etype;
+}
+
+struct headers_t { eth_t eth; }
+struct metadata_t {}
+
+parser P(packet_in pkt, out headers_t hdr,
+         inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start { pkt.extract(hdr.eth); transition accept; }
+}
+
+control VC(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control CC(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control Ig(inout headers_t hdr, inout metadata_t meta,
+           inout standard_metadata_t smeta) {
+    action forward(bit<9> port) { smeta.egress_spec = port; }
+    action drop() { mark_to_drop(smeta); }
+    table t {
+        key = { hdr.eth.etype : exact; }
+        actions = { forward; drop; NoAction; }
+        default_action = drop();
+    }
+    apply { t.apply(); }
+}
+
+control Eg(inout headers_t hdr, inout metadata_t meta,
+           inout standard_metadata_t smeta) { apply {} }
+
+control D(packet_out pkt, in headers_t hdr) { apply { pkt.emit(hdr.eth); } }
+
+V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -17,7 +17,6 @@
 #include "p4c_backend/backend.h"
 
 #include <array>
-#include <filesystem>
 #include <fstream>
 #include <string>
 
@@ -1013,12 +1012,19 @@ void FourWardBackend::emitArchitecture(const IR::ToplevelBlock* toplevel) {
 
 namespace {
 
-// Write a proto message to a file. Binary if the path ends with .binpb or
-// .bin; text-format with a proto-file/proto-message header otherwise.
-bool writeProto(const google::protobuf::Message& msg, std::ostream& out,
-                bool binary, const char* protoFile, const char* protoMessage,
-                const std::string& path) {
-  if (binary) {
+// 4ward standardises on .txtpb / .binpb for proto files. `validateOutputs`
+// in main.cpp rejects anything else right after argument parsing, so by the
+// time we reach `writeProto` the suffix is guaranteed to be one of the two.
+bool isBinary(const std::string& path) { return path.ends_with(".binpb"); }
+
+bool writeProto(const google::protobuf::Message& msg, const std::string& path,
+                const char* protoFile, const char* protoMessage) {
+  std::ofstream out(path, std::ios::binary);
+  if (!out.is_open()) {
+    ::P4::error("4ward: cannot open output file '%1%'", path);
+    return false;
+  }
+  if (isBinary(path)) {
     if (!msg.SerializeToOstream(&out)) {
       ::P4::error("4ward: failed to serialise %1% to '%2%'", protoMessage,
                   path);
@@ -1035,47 +1041,44 @@ bool writeProto(const google::protobuf::Message& msg, std::ostream& out,
         << "# proto-message: " << protoMessage << "\n\n"
         << text;
   }
-  return true;
-}
-
-}  // namespace
-
-bool FourWardBackend::writePipelineConfig() const {
-  const std::string path = outputFilePath();
-  const bool binary = path.ends_with(".binpb") || path.ends_with(".bin");
-  std::ofstream out(path, std::ios::binary);
-  if (!out.is_open()) {
-    ::P4::error("4ward: cannot open output file '%1%'", path);
-    return false;
-  }
-
-  if (options_.format == FourWardOptions::Format::kP4runtime) {
-    // P4Runtime ForwardingPipelineConfig: p4info + Pipeline serialized into
-    // p4_device_config bytes.
-    p4::v1::ForwardingPipelineConfig fpc;
-    *fpc.mutable_p4info() = pipelineConfig_.p4info();
-    fpc.set_p4_device_config(pipelineConfig_.device().SerializeAsString());
-    if (!writeProto(fpc, out, binary, "@p4runtime//p4/v1/p4runtime.proto",
-                    "p4.v1.ForwardingPipelineConfig", path))
-      return false;
-  } else {
-    if (!writeProto(pipelineConfig_, out, binary,
-                    "@fourward//simulator/ir.proto",
-                    "fourward.ir.PipelineConfig", path))
-      return false;
-  }
-
   // clang-format off
   LOG1("4ward: wrote " << path);
   // clang-format on
   return true;
 }
 
-std::string FourWardBackend::outputFilePath() const {
-  if (options_.outputFile.has_value()) return *options_.outputFile;
-  return std::filesystem::path(options_.file)
-      .replace_extension(".txtpb")
-      .string();
+}  // namespace
+
+bool FourWardBackend::writeOutputs() const {
+  if (options_.outputFile.has_value()) {
+    if (options_.format == FourWardOptions::Format::kP4runtime) {
+      p4::v1::ForwardingPipelineConfig fpc;
+      *fpc.mutable_p4info() = pipelineConfig_.p4info();
+      fpc.set_p4_device_config(pipelineConfig_.device().SerializeAsString());
+      if (!writeProto(fpc, *options_.outputFile,
+                      "@p4runtime//p4/v1/p4runtime.proto",
+                      "p4.v1.ForwardingPipelineConfig")) {
+        return false;
+      }
+    } else if (!writeProto(pipelineConfig_, *options_.outputFile,
+                           "@fourward//simulator/ir.proto",
+                           "fourward.ir.PipelineConfig")) {
+      return false;
+    }
+  }
+  if (options_.outP4Info.has_value() &&
+      !writeProto(pipelineConfig_.p4info(), *options_.outP4Info,
+                  "@p4runtime//p4/config/v1/p4info.proto",
+                  "p4.config.v1.P4Info")) {
+    return false;
+  }
+  if (options_.outP4DeviceConfig.has_value() &&
+      !writeProto(pipelineConfig_.device(), *options_.outP4DeviceConfig,
+                  "@fourward//simulator/ir.proto",
+                  "fourward.ir.DeviceConfig")) {
+    return false;
+  }
+  return true;
 }
 
 }  // namespace P4::FourWard

--- a/p4c_backend/backend.h
+++ b/p4c_backend/backend.h
@@ -60,9 +60,9 @@ class FourWardBackend : public Inspector {
   // Must be called after process() (which builds the Architecture).
   void setPortTypeName(std::string portTypeName);
 
-  // Writes the accumulated PipelineConfig proto to the output file.
-  // Returns true on success.
-  bool writePipelineConfig() const;
+  // Writes each requested output file (combined `-o`, `--out-p4info`,
+  // `--out-p4-device-config`). Returns true on success.
+  bool writeOutputs() const;
 
  private:
   const FourWardOptions& options_;
@@ -90,8 +90,6 @@ class FourWardBackend : public Inspector {
   fourward::ir::Stmt emitStmt(const IR::StatOrDecl* node);
   fourward::ir::BlockStmt emitBlock(const IR::BlockStatement* block);
   static fourward::ir::SourceInfo emitSourceInfo(const IR::Node* node);
-
-  std::string outputFilePath() const;
 };
 
 }  // namespace P4::FourWard

--- a/p4c_backend/main.cpp
+++ b/p4c_backend/main.cpp
@@ -16,15 +16,26 @@
 
 // p4c-4ward: the 4ward p4c backend.
 //
-// Compiles a P4 program to a PipelineConfig proto binary suitable for loading
-// into the 4ward simulator. Usage:
+// Compiles a P4 program into one or more proto files for the 4ward simulator
+// and P4Runtime control plane. Each output is opt-in; at least one must be
+// requested:
 //
-//   p4c-4ward --arch v1model -o output.txtpb input.p4
+//   -o <file>                       Combined pipeline config
+//                                   (--format selects native or p4runtime)
+//   --out-p4info <file>             Standalone p4.config.v1.P4Info
+//   --out-p4-device-config <file>   Standalone fourward.ir.DeviceConfig
+//
+// All output paths must end in .txtpb (text proto) or .binpb (binary proto).
+//
+// Example:
+//
+//   p4c-4ward --arch v1model -o pipeline.binpb --format p4runtime input.p4
 
 #include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -49,6 +60,33 @@
 
 namespace IR = P4::IR;
 using P4::literals::operator""_cs;
+
+// Validates that every requested output path uses a .txtpb or .binpb
+// extension and that at least one output flag was supplied. Run upfront so a
+// typo or missing flag fails before any compilation work happens.
+static void checkOutputExtension(const std::optional<std::string>& path,
+                                 const char* flag) {
+  if (!path.has_value()) return;
+  if (!path->ends_with(".txtpb") && !path->ends_with(".binpb")) {
+    ::P4::error(
+        "4ward: %1% '%2%' has unsupported extension; "
+        "use .txtpb (text) or .binpb (binary)",
+        flag, *path);
+  }
+}
+
+static bool validateOutputs(const P4::FourWard::FourWardOptions& options) {
+  checkOutputExtension(options.outputFile, "-o");
+  checkOutputExtension(options.outP4Info, "--out-p4info");
+  checkOutputExtension(options.outP4DeviceConfig, "--out-p4-device-config");
+  if (!options.outputFile.has_value() && !options.outP4Info.has_value() &&
+      !options.outP4DeviceConfig.has_value()) {
+    ::P4::error(
+        "4ward: at least one output flag is required: -o, --out-p4info, or "
+        "--out-p4-device-config");
+  }
+  return ::P4::errorCount() == 0;
+}
 
 // Walks the post-frontend IR to extract @p4runtime_translation_mappings
 // annotations from Type_Newtype declarations.  These annotations specify
@@ -231,6 +269,7 @@ int main(int argc, char* const argv[]) {
       options.setInputFile();
     }
     if (::P4::errorCount() > 0) return EXIT_FAILURE;
+    if (!validateOutputs(options)) return EXIT_FAILURE;
 
     const IR::P4Program* program = P4::parseP4File(options);
     if (program == nullptr || ::P4::errorCount() > 0) return EXIT_FAILURE;
@@ -272,7 +311,7 @@ int main(int argc, char* const argv[]) {
     backend.process(toplevel);
     backend.setPortTypeName(derivePortTypeName(program));
 
-    if (!backend.writePipelineConfig()) return EXIT_FAILURE;
+    if (!backend.writeOutputs()) return EXIT_FAILURE;
     return ::P4::errorCount() > 0 ? EXIT_FAILURE : EXIT_SUCCESS;
   } catch (const std::exception& e) {
     std::cerr << "p4c-4ward: " << e.what() << '\n';

--- a/p4c_backend/options.cpp
+++ b/p4c_backend/options.cpp
@@ -33,8 +33,24 @@ FourWardOptions::FourWardOptions() {
         }
         return true;
       },
-      "output message type: 'native' (default, 4ward PipelineConfig) "
+      "output message type for -o: 'native' (4ward PipelineConfig) "
       "or 'p4runtime' (P4Runtime ForwardingPipelineConfig)");
+  registerOption(
+      "--out-p4info", "file",
+      [this](const char* arg) {
+        outP4Info = arg;
+        return true;
+      },
+      "write p4.config.v1.P4Info to <file> "
+      "(.txtpb for text-format, .binpb for binary)");
+  registerOption(
+      "--out-p4-device-config", "file",
+      [this](const char* arg) {
+        outP4DeviceConfig = arg;
+        return true;
+      },
+      "write fourward.ir.DeviceConfig to <file> "
+      "(.txtpb for text-format, .binpb for binary)");
 }
 
 }  // namespace P4::FourWard

--- a/p4c_backend/options.h
+++ b/p4c_backend/options.h
@@ -27,17 +27,27 @@ namespace P4::FourWard {
 
 class FourWardOptions : public CompilerOptions {
  public:
-  // Output file path. Extension determines encoding:
+  // Output file path for the combined pipeline proto. Extension determines
+  // encoding:
   //   .txtpb → text-format protobuf
   //   .binpb → binary protobuf
+  // The proto message type is controlled by `format`.
   std::optional<std::string> outputFile;
 
-  // Output message type.
-  //   "native" (default): 4ward-native PipelineConfig.
-  //   "p4runtime": P4Runtime ForwardingPipelineConfig (Pipeline proto
-  //                serialized into p4_device_config bytes).
+  // Output message type for `outputFile`.
+  //   "native" (default): fourward.ir.PipelineConfig.
+  //   "p4runtime":        p4.v1.ForwardingPipelineConfig (DeviceConfig
+  //                       serialized into p4_device_config bytes).
   enum class Format : std::uint8_t { kNative, kP4runtime };
   Format format = Format::kNative;
+
+  // Optional side outputs. Each writes a standalone proto message. Extension
+  // determines encoding as above. Enables pipelines that want p4info or the
+  // device-config blob independently of the combined form.
+  //   outP4Info:         p4.config.v1.P4Info
+  //   outP4DeviceConfig: fourward.ir.DeviceConfig
+  std::optional<std::string> outP4Info;
+  std::optional<std::string> outP4DeviceConfig;
 
   FourWardOptions();
 };


### PR DESCRIPTION
## The win

`fourward_pipeline` now exposes p4info and the device-config blob as
first-class side outputs, so consumers can grab the artifact they
actually need without unpacking the combined `PipelineConfig` /
`ForwardingPipelineConfig`. Previously the rule had a single `out`
attribute and downstream callers had to peel apart whichever combined
form they got.

## What's new

Two opt-in output attrs alongside the existing `out`:

- `out_p4info` → `p4.config.v1.P4Info`
- `out_p4_device_config` → `fourward.ir.DeviceConfig` (the payload that
  4ward stores in `ForwardingPipelineConfig.p4_device_config`)

`p4c-4ward` gains matching `--out-p4info` / `--out-p4-device-config`
flags and now strictly enforces `.txtpb` / `.binpb` extensions on every
output (the unused `.bin` alias is gone). The rule does the same check
at analysis time. `out` is no longer mandatory — at least one of the
three output attrs must be set, otherwise the rule fails loudly with a
clear message.

## Why this shape

I considered collapsing `out` + `out_format` into four orthogonal
attrs (one per proto type), but `out_p4_device_config` carries a
`DeviceConfig` — a *part* of `PipelineConfig`, not a duplicate of it —
so the existing combined surface stays useful and there is no
redundancy. Going additive avoids churning every existing caller.

## Test coverage

New `e2e_tests/pipeline_outputs/` runs the rule with each combination
of outputs (each encoding × each output shape, plus an all-three-at-once
target) and verifies the files parse as the expected proto type, with
the correct `# proto-file:` / `# proto-message:` headers in text mode.