### PR TITLE
p4runtime: accept text-format DeviceConfig in p4_device_config

### DIFF
--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -6,6 +6,7 @@ package fourward.p4runtime
 
 import com.google.protobuf.Any as ProtoAny
 import com.google.protobuf.ByteString
+import com.google.protobuf.TextFormat
 import fourward.ir.PipelineConfig
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.assertGrpcError
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildEthernetFrame
@@ -401,6 +402,20 @@ class P4RuntimeConformanceTest {
           .setP4Info(p4.config.v1.P4InfoOuterClass.P4Info.getDefaultInstance())
       )
     }
+  }
+
+  @Test
+  fun `39 - setForwardingPipelineConfig accepts text-format DeviceConfig in p4_device_config`() {
+    // p4_device_config is opaque to P4Runtime; 4ward's simulator accepts both
+    // binary- and text-format DeviceConfig so people who hand-edit a .txtpb
+    // ForwardingPipelineConfig don't have to know which encoding is in there.
+    val config = loadBasicTableConfig()
+    val textBytes = ByteString.copyFromUtf8(TextFormat.printer().printToString(config.device))
+    loadRawPipeline(
+      ForwardingPipelineConfig.newBuilder().setP4Info(config.p4Info).setP4DeviceConfig(textBytes)
+    )
+    val readBack = harness.getConfig()
+    assertEquals(config.device, fourward.ir.DeviceConfig.parseFrom(readBack.config.p4DeviceConfig))
   }
 
   // =========================================================================

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -1,6 +1,9 @@
 package fourward.p4runtime
 
 import com.google.protobuf.Any as ProtoAny
+import com.google.protobuf.ByteString
+import com.google.protobuf.InvalidProtocolBufferException
+import com.google.protobuf.TextFormat
 import com.google.rpc.Code
 import fourward.ir.DeviceConfig
 import fourward.ir.PipelineConfig
@@ -170,6 +173,33 @@ class P4RuntimeService(
     }
 
   /**
+   * Decodes the opaque [p4_device_config] bytes as a [DeviceConfig], accepting either binary or
+   * text-format protobuf. Lets callers paste a text-format DeviceConfig into a hand-edited `.txtpb`
+   * ForwardingPipelineConfig without first re-serializing it as binary.
+   */
+  private fun parseDeviceConfig(bytes: ByteString): DeviceConfig {
+    val binaryError =
+      try {
+        return DeviceConfig.parseFrom(bytes)
+      } catch (e: InvalidProtocolBufferException) {
+        e
+      }
+    try {
+      val builder = DeviceConfig.newBuilder()
+      TextFormat.merge(bytes.toStringUtf8(), builder)
+      return builder.build()
+    } catch (e: TextFormat.ParseException) {
+      throw Status.INVALID_ARGUMENT.withDescription(
+          "p4_device_config is not a valid DeviceConfig proto (expected serialized " +
+            "fourward.ir.DeviceConfig in binary or text format). " +
+            "binary parse: ${binaryError.message}; text parse: ${e.message}"
+        )
+        .withCause(e)
+        .asException()
+    }
+  }
+
+  /**
    * Validates the forwarding pipeline config and builds a [PipelineState] without activating it.
    * Used by VERIFY, VERIFY_AND_COMMIT, and VERIFY_AND_SAVE.
    */
@@ -181,17 +211,7 @@ class P4RuntimeService(
         .asException()
     }
 
-    val deviceConfig =
-      try {
-        DeviceConfig.parseFrom(fwdConfig.p4DeviceConfig)
-      } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
-        throw Status.INVALID_ARGUMENT.withDescription(
-            "p4_device_config is not a valid DeviceConfig proto " +
-              "(expected serialized fourward.ir.DeviceConfig): ${e.message}"
-          )
-          .withCause(e)
-          .asException()
-      }
+    val deviceConfig = parseDeviceConfig(fwdConfig.p4DeviceConfig)
 
     val pipelineConfig =
       PipelineConfig.newBuilder().setP4Info(fwdConfig.p4Info).setDevice(deviceConfig).build()

--- a/p4runtime/golden_errors/invalid-device-config.golden.txt
+++ b/p4runtime/golden_errors/invalid-device-config.golden.txt
@@ -1,1 +1,1 @@
-INVALID_ARGUMENT: p4_device_config is not a valid DeviceConfig proto (expected serialized fourward.ir.DeviceConfig): Protocol message tag had invalid wire type.
+INVALID_ARGUMENT: p4_device_config is not a valid DeviceConfig proto (expected serialized fourward.ir.DeviceConfig in binary or text format). binary parse: Protocol message tag had invalid wire type.; text parse: 1:8: Expected "{".


### PR DESCRIPTION
## The win

People reading a 4ward `.txtpb` `ForwardingPipelineConfig` and noticing
that `p4_device_config` looks like binary garbage no longer have to
care: the simulator now accepts both binary and text-format
`DeviceConfig` bytes there. Hand-edit the FPC, paste in a text-format
DeviceConfig, and it just works.

## What changed

`P4RuntimeService.parseDeviceConfig` tries binary `parseFrom` first,
falls back to `TextFormat.merge` on `InvalidProtocolBufferException`,
and reports both errors only if both fail. The compiler is unchanged
— `p4c-4ward` keeps emitting binary, so `.binpb` remains the
byte-for-byte binary encoding of `.txtpb`. This is purely read-side
leniency.

## Why this shape

Considered making the compiler propagate the outer encoding to the
inner bytes, but that breaks the nice property that `.binpb` *is* the
binary encoding of `.txtpb`. Read-side leniency keeps the producer
unambiguous and removes the user-facing footgun in one place.

## Test coverage

New conformance scenario `39 - setForwardingPipelineConfig accepts
text-format DeviceConfig in p4_device_config`. The existing
"reject garbage" scenario (`#37`) still passes — `not-a-proto` is
neither valid binary nor valid text — with an updated error message
that names both formats. Golden file refreshed accordingly.