### PR TITLE
Clarify that performance numbers are data plane only

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ enough for production test workloads.
 | Architecture customization | no | [**first-class support**](docs/ROADMAP.md#track-5-architecture-customization) |
 | Interactive playground | no | [**browser-based IDE**](#web-playground) with trace playback & packet decoding |
 | Error messages | opaque | [**actionable, with valid options**](docs/ROADMAP.md#track-11-error-quality) — [75 golden-tested](p4runtime/golden_errors/) |
-| Throughput (16-way selector) | [~4,500 pps ÷ 16 paths](docs/PERFORMANCE.md#bmv2-comparison) | [**~2,000 pps, all 16 paths**](docs/PERFORMANCE.md) ([head-to-head on SAI P4](docs/PERFORMANCE.md#bmv2-comparison)) |
-| Parallelism (16-way selector) | single-threaded | [**13,000 pps on 16 cores**](docs/PERFORMANCE.md) — parallel across packets and forks |
+| Data plane throughput (16-way selector) | [~4,500 pps ÷ 16 paths](docs/PERFORMANCE.md#bmv2-comparison) | [**~2,000 pps, all 16 paths**](docs/PERFORMANCE.md) ([head-to-head on SAI P4](docs/PERFORMANCE.md#bmv2-comparison)) |
+| Data plane parallelism (16-way selector) | single-threaded | [**13,000 pps on 16 cores**](docs/PERFORMANCE.md) — parallel across packets and forks |
 | Extensibility | limited | [**AI-friendly codebase**](docs/ROADMAP.md#why-4ward-is-easier-to-extend) — if AI can extend it, anyone can |
 | CI | slow | **[~2 min](https://4ward.buildbuddy.io/trends/)**, rigorous |
 | Development pace | slow | **[AI-fast](docs/AI_WORKFLOW.md)** |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,8 +1,18 @@
 # Dataplane Performance
 
+This document covers **data plane** performance only: how fast 4ward
+processes packets. All numbers below are packet throughput.
+
+**Control plane** operations (table programming via `Write`, pipeline
+loading via `SetForwardingPipelineConfig`) have not been measured or
+optimized. They are expected to be slow — and that's fine. 4ward's
+target use cases (testing, validation, trace exploration) are
+data-plane-bound: the control plane sets up state once, then the data
+plane processes thousands of packets. If control plane performance
+matters for your use case, let us know.
+
 4ward optimizes for correctness, observability, and extensibility — yet
-achieves practical throughput for production test workloads. This document
-covers our benchmark methodology, results, and comparison with BMv2.
+achieves practical throughput for production test workloads.
 
 ## Benchmark setup
 

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -186,7 +186,12 @@ message OutputPacket {
 }
 ```
 
-## Performance
+## Data plane performance
+
+The numbers below cover **data plane** throughput (packet processing).
+Control plane operations (table writes, pipeline loading) have not been
+optimized — 4ward targets use cases where the control plane sets up
+state once, then the data plane processes many packets.
 
 While 4ward optimizes for correctness and observability over raw speed,
 it is fast enough for production test workloads like DVaaS. The


### PR DESCRIPTION
## Summary

Makes explicit what was implicit: all performance numbers in the docs
are data plane (packet processing) throughput. Control plane operations
(table writes, pipeline loading) have not been measured or optimized —
and that's intentional.

- **README.md**: "Throughput" → "Data plane throughput"
- **PERFORMANCE.md**: Added scope statement at the top
- **userdocs/reference/grpc.md**: "Performance" → "Data plane performance"

🤖 Generated with [Claude Code](https://claude.com/claude-code)