### PR TITLE
p4runtime: implement spec §8.3 canonical bytestring encoding

### DIFF
--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -269,6 +269,18 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "BytestringsTest",
+    srcs = ["BytestringsTest.kt"],
+    test_class = "fourward.p4runtime.BytestringsTest",
+    deps = [
+        ":p4runtime",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:io_grpc_grpc_api",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "EntityReaderTest",
     srcs = ["EntityReaderTest.kt"],
     test_class = "fourward.p4runtime.EntityReaderTest",

--- a/p4runtime/Bytestrings.kt
+++ b/p4runtime/Bytestrings.kt
@@ -1,13 +1,10 @@
 package fourward.p4runtime
 
 import com.google.protobuf.ByteString
+import fourward.simulator.toUnsignedBigInteger
 import io.grpc.Status
 import io.grpc.StatusException
-import java.math.BigInteger
 import p4.v1.P4RuntimeOuterClass
-
-/** Interprets a [ByteString] as an unsigned big-endian [BigInteger]. */
-internal fun ByteString.toUnsignedBigInteger(): BigInteger = BigInteger(1, toByteArray())
 
 /**
  * Helpers for the P4Runtime bytestring encoding rules in spec §8.3.
@@ -50,6 +47,10 @@ fun requireFitsInBitwidth(value: ByteString, bitwidth: Int, label: String) {
   if (value.isEmpty) {
     throw outOfRange("$label is empty (P4Runtime spec §8.3 requires a non-zero-length bytestring)")
   }
+  // Fast path: any value that uses ≤ bitwidth bits' worth of bytes trivially fits, so we can skip
+  // the BigInteger allocation. Covers the common case of a canonical-form client sending an
+  // N-byte value for a bit<8N> field (MAC, IPv4, IPv6, …).
+  if (value.size() * 8 <= bitwidth) return
   if (value.toUnsignedBigInteger().bitLength() > bitwidth) {
     throw outOfRange("$label 0x${value.toHex()} does not fit in $bitwidth bits")
   }
@@ -80,59 +81,62 @@ fun canonicalize(value: ByteString): ByteString {
  * (a) keeps `TableEntry.sameKey` consistent across encodings of the same logical value, and (b)
  * makes reads return canonical form for free, satisfying the §8.3 read-write symmetry requirement.
  */
-fun canonicalizeMatch(match: P4RuntimeOuterClass.FieldMatch): P4RuntimeOuterClass.FieldMatch =
-  when (match.fieldMatchTypeCase) {
-    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
-      match
-        .toBuilder()
-        .setExact(
-          P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
-            .setValue(canonicalize(match.exact.value))
-        )
-        .build()
-    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY ->
-      match
-        .toBuilder()
-        .setTernary(
-          P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
-            .setValue(canonicalize(match.ternary.value))
-            .setMask(canonicalize(match.ternary.mask))
-        )
-        .build()
-    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM ->
-      match
-        .toBuilder()
-        .setLpm(
-          P4RuntimeOuterClass.FieldMatch.LPM.newBuilder()
-            .setValue(canonicalize(match.lpm.value))
-            .setPrefixLen(match.lpm.prefixLen)
-        )
-        .build()
-    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE ->
-      match
-        .toBuilder()
-        .setRange(
-          P4RuntimeOuterClass.FieldMatch.Range.newBuilder()
-            .setLow(canonicalize(match.range.low))
-            .setHigh(canonicalize(match.range.high))
-        )
-        .build()
-    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
-      match
-        .toBuilder()
-        .setOptional(
-          P4RuntimeOuterClass.FieldMatch.Optional.newBuilder()
-            .setValue(canonicalize(match.optional.value))
-        )
-        .build()
+fun canonicalizeMatch(match: P4RuntimeOuterClass.FieldMatch): P4RuntimeOuterClass.FieldMatch {
+  // Each branch returns the original `match` unchanged when its bytestring(s) were already
+  // canonical (canonicalize preserves instance identity in that case), so the steady-state
+  // path for spec-conformant clients is allocation-free.
+  return when (match.fieldMatchTypeCase) {
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT -> {
+      val v = canonicalize(match.exact.value)
+      if (v === match.exact.value) match
+      else match.toBuilder().apply { exactBuilder.value = v }.build()
+    }
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY -> {
+      val v = canonicalize(match.ternary.value)
+      val m = canonicalize(match.ternary.mask)
+      if (v === match.ternary.value && m === match.ternary.mask) match
+      else
+        match
+          .toBuilder()
+          .apply {
+            ternaryBuilder.value = v
+            ternaryBuilder.mask = m
+          }
+          .build()
+    }
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM -> {
+      val v = canonicalize(match.lpm.value)
+      if (v === match.lpm.value) match else match.toBuilder().apply { lpmBuilder.value = v }.build()
+    }
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE -> {
+      val lo = canonicalize(match.range.low)
+      val hi = canonicalize(match.range.high)
+      if (lo === match.range.low && hi === match.range.high) match
+      else
+        match
+          .toBuilder()
+          .apply {
+            rangeBuilder.low = lo
+            rangeBuilder.high = hi
+          }
+          .build()
+    }
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL -> {
+      val v = canonicalize(match.optional.value)
+      if (v === match.optional.value) match
+      else match.toBuilder().apply { optionalBuilder.value = v }.build()
+    }
     P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
     P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
     null -> match
   }
+}
 
 /** Returns a copy of [param] with its `value` canonicalized per spec §8.3. */
-fun canonicalizeParam(param: P4RuntimeOuterClass.Action.Param): P4RuntimeOuterClass.Action.Param =
-  param.toBuilder().setValue(canonicalize(param.value)).build()
+fun canonicalizeParam(param: P4RuntimeOuterClass.Action.Param): P4RuntimeOuterClass.Action.Param {
+  val v = canonicalize(param.value)
+  return if (v === param.value) param else param.toBuilder().setValue(v).build()
+}
 
 /**
  * Returns a copy of [update] with all bytestrings canonicalized per spec §8.3.
@@ -147,21 +151,20 @@ fun canonicalizeParam(param: P4RuntimeOuterClass.Action.Param): P4RuntimeOuterCl
 fun canonicalizeBytestrings(update: P4RuntimeOuterClass.Update): P4RuntimeOuterClass.Update {
   val entity = update.entity
   return when (entity.entityCase) {
-    P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY ->
-      update
-        .toBuilder()
-        .setEntity(entity.toBuilder().setTableEntry(canonicalizeTableEntry(entity.tableEntry)))
-        .build()
+    P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY -> {
+      val canonical = canonicalizeTableEntry(entity.tableEntry)
+      if (canonical === entity.tableEntry) update
+      else update.toBuilder().apply { entityBuilder.tableEntry = canonical }.build()
+    }
     P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER -> {
       val member = entity.actionProfileMember
-      update
-        .toBuilder()
-        .setEntity(
-          entity
-            .toBuilder()
-            .setActionProfileMember(member.toBuilder().setAction(canonicalizeAction(member.action)))
-        )
-        .build()
+      val canonical = canonicalizeAction(member.action)
+      if (canonical === member.action) update
+      else
+        update
+          .toBuilder()
+          .apply { entityBuilder.actionProfileMemberBuilder.action = canonical }
+          .build()
     }
     // Action-profile groups carry only member-ID references — no client bytestrings.
     P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_GROUP,
@@ -185,35 +188,51 @@ fun canonicalizeBytestrings(update: P4RuntimeOuterClass.Update): P4RuntimeOuterC
 
 /** Returns a copy of [entry] with match-field and action-parameter bytestrings canonicalized. */
 fun canonicalizeTableEntry(entry: P4RuntimeOuterClass.TableEntry): P4RuntimeOuterClass.TableEntry {
-  val builder = entry.toBuilder()
-  if (entry.matchCount > 0) {
-    builder.clearMatch()
-    for (m in entry.matchList) builder.addMatch(canonicalizeMatch(m))
-  }
-  if (entry.hasAction()) builder.setAction(canonicalizeTableAction(entry.action))
-  return builder.build()
+  val matches = entry.matchList.map(::canonicalizeMatch)
+  val action = if (entry.hasAction()) canonicalizeTableAction(entry.action) else null
+  val matchesUnchanged = matches.indices.all { matches[it] === entry.matchList[it] }
+  val actionUnchanged = action == null || action === entry.action
+  if (matchesUnchanged && actionUnchanged) return entry
+  return entry
+    .toBuilder()
+    .apply {
+      if (!matchesUnchanged) {
+        clearMatch()
+        matches.forEach { addMatch(it) }
+      }
+      if (action != null && !actionUnchanged) setAction(action)
+    }
+    .build()
 }
 
 private fun canonicalizeTableAction(
   action: P4RuntimeOuterClass.TableAction
 ): P4RuntimeOuterClass.TableAction =
   when (action.typeCase) {
-    P4RuntimeOuterClass.TableAction.TypeCase.ACTION ->
-      action.toBuilder().setAction(canonicalizeAction(action.action)).build()
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION -> {
+      val a = canonicalizeAction(action.action)
+      if (a === action.action) action else action.toBuilder().setAction(a).build()
+    }
     P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_ACTION_SET -> {
       val rebuilt =
         action.actionProfileActionSet.actionProfileActionsList.map { profileAction ->
-          profileAction.toBuilder().setAction(canonicalizeAction(profileAction.action)).build()
+          val a = canonicalizeAction(profileAction.action)
+          if (a === profileAction.action) profileAction
+          else profileAction.toBuilder().setAction(a).build()
         }
-      action
-        .toBuilder()
-        .setActionProfileActionSet(
-          action.actionProfileActionSet
-            .toBuilder()
-            .clearActionProfileActions()
-            .addAllActionProfileActions(rebuilt)
-        )
-        .build()
+      val unchanged =
+        rebuilt.indices.all {
+          rebuilt[it] === action.actionProfileActionSet.actionProfileActionsList[it]
+        }
+      if (unchanged) action
+      else
+        action
+          .toBuilder()
+          .apply {
+            actionProfileActionSetBuilder.clearActionProfileActions()
+            rebuilt.forEach { actionProfileActionSetBuilder.addActionProfileActions(it) }
+          }
+          .build()
     }
     // ID-only references carry no client bytestrings — nothing to canonicalize.
     P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_MEMBER_ID,
@@ -224,9 +243,16 @@ private fun canonicalizeTableAction(
 
 private fun canonicalizeAction(action: P4RuntimeOuterClass.Action): P4RuntimeOuterClass.Action {
   if (action.paramsCount == 0) return action
-  val builder = action.toBuilder().clearParams()
-  for (p in action.paramsList) builder.addParams(canonicalizeParam(p))
-  return builder.build()
+  val rebuilt = action.paramsList.map(::canonicalizeParam)
+  val unchanged = rebuilt.indices.all { rebuilt[it] === action.paramsList[it] }
+  if (unchanged) return action
+  return action
+    .toBuilder()
+    .apply {
+      clearParams()
+      rebuilt.forEach { addParams(it) }
+    }
+    .build()
 }
 
 private fun outOfRange(msg: String): StatusException =

--- a/p4runtime/Bytestrings.kt
+++ b/p4runtime/Bytestrings.kt
@@ -1,0 +1,240 @@
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import io.grpc.Status
+import io.grpc.StatusException
+import p4.v1.P4RuntimeOuterClass
+
+/**
+ * Helpers for the P4Runtime bytestring encoding rules in spec §8.3.
+ *
+ * P4Runtime carries P4 integer values as protobuf `bytes`. The spec says:
+ *
+ *   "Upon receiving a binary string, the P4Runtime receiver (whether the server or
+ *    the client) does not impose any restrictions on the maximum length of the string
+ *    itself. Instead, the receiver verifies that the value encoded by the string fits
+ *    within the expected type (signed or unsigned) and P4Info-specified bitwidth for
+ *    the P4 object value."
+ *
+ *   "The canonical binary string representation uses the shortest string that fits
+ *    the encoded integer value. […] read-write symmetry requires that the encoder of
+ *    a P4Runtime request or reply uses the shortest strings that fit the encoded
+ *    integer values."
+ *
+ * 4ward currently exposes only unsigned (`bit<W>`) values on the wire — `int<W>`
+ * appears only in `P4Data` (§8.4.3), which 4ward does not surface — so the helpers
+ * below are unsigned-only.
+ */
+
+/**
+ * Validates that [value] encodes an unsigned integer that fits in [bitwidth] bits, per spec §8.3.
+ *
+ * Rejects:
+ * - empty bytestrings (always invalid per §8.3),
+ * - values whose magnitude exceeds 2^bitwidth − 1, regardless of how many bytes were used to send
+ *   them (e.g. `\x01\x00\x00` for `bit<16>` is rejected because 0x10000 > 0xFFFF).
+ *
+ * Accepts arbitrarily long bytestrings as long as the leading bytes/bits are zero — this is what
+ * allows a `bit<9>` server to interoperate with a `bit<8>` client during rolling upgrades.
+ *
+ * On rejection throws [StatusException] with [Status.OUT_OF_RANGE] (§8.3 explicitly mandates this
+ * code).
+ *
+ * [bitwidth] of 0 marks the field as non-integer (e.g. `@p4runtime_translation` with `sdn_string`,
+ * where the bytes carry a UTF-8 string and §8.3's integer rules do not apply). In that case
+ * validation is skipped entirely, including the empty check — an empty UTF-8 string is valid.
+ */
+fun requireFitsInBitwidth(value: ByteString, bitwidth: Int, label: String) {
+  if (bitwidth <= 0) return // string-typed field; §8.3 does not apply.
+  if (value.isEmpty) {
+    throw outOfRange("$label is empty (P4Runtime spec §8.3 requires a non-zero-length bytestring)")
+  }
+  // Walk the high bytes and count how many bits are actually occupied.
+  // We could BigInteger.bitLength() but that allocates; this scan is O(bytes) and allocation-free.
+  val bytes = value
+  val expectedHighByteMask = highByteMask(bitwidth)
+  val expectedHighBytePos = bytes.size() - bytesNeeded(bitwidth)
+  for (i in 0 until bytes.size()) {
+    val b = bytes.byteAt(i).toInt() and 0xFF
+    when {
+      i < expectedHighBytePos -> {
+        if (b != 0) {
+          throw outOfRange(
+            "$label 0x${value.toHex()} does not fit in $bitwidth bits " +
+              "(byte $i is 0x${"%02x".format(b)}, expected 0)"
+          )
+        }
+      }
+      i == expectedHighBytePos -> {
+        if (b and expectedHighByteMask.inv() and 0xFF != 0) {
+          throw outOfRange(
+            "$label 0x${value.toHex()} does not fit in $bitwidth bits " +
+              "(top bits of byte $i are non-zero)"
+          )
+        }
+        return
+      }
+    }
+  }
+}
+
+/**
+ * Returns the canonical (shortest) unsigned big-endian encoding of [value], per spec §8.3.
+ *
+ * Strips leading zero bytes; preserves a single `\x00` for the value zero. Bitwidth-agnostic, so
+ * works for any width (no [Int] / [Long] truncation hazard).
+ */
+fun canonicalize(value: ByteString): ByteString {
+  if (value.isEmpty) return value
+  var first = 0
+  while (first < value.size() - 1 && value.byteAt(first).toInt() == 0) first++
+  return if (first == 0) value else value.substring(first)
+}
+
+/**
+ * Returns a copy of [match] with all bytestring values canonicalized per spec §8.3.
+ *
+ * Applied between validation and storage so that the simulator stores a single normal form, which
+ * (a) keeps `TableEntry.sameKey` consistent across encodings of the same logical value, and (b)
+ * makes reads return canonical form for free, satisfying the §8.3 read-write symmetry requirement.
+ */
+fun canonicalizeMatch(match: P4RuntimeOuterClass.FieldMatch): P4RuntimeOuterClass.FieldMatch =
+  when (match.fieldMatchTypeCase) {
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
+      match
+        .toBuilder()
+        .setExact(
+          P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+            .setValue(canonicalize(match.exact.value))
+        )
+        .build()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY ->
+      match
+        .toBuilder()
+        .setTernary(
+          P4RuntimeOuterClass.FieldMatch.Ternary.newBuilder()
+            .setValue(canonicalize(match.ternary.value))
+            .setMask(canonicalize(match.ternary.mask))
+        )
+        .build()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM ->
+      match
+        .toBuilder()
+        .setLpm(
+          P4RuntimeOuterClass.FieldMatch.LPM.newBuilder()
+            .setValue(canonicalize(match.lpm.value))
+            .setPrefixLen(match.lpm.prefixLen)
+        )
+        .build()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE ->
+      match
+        .toBuilder()
+        .setRange(
+          P4RuntimeOuterClass.FieldMatch.Range.newBuilder()
+            .setLow(canonicalize(match.range.low))
+            .setHigh(canonicalize(match.range.high))
+        )
+        .build()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
+      match
+        .toBuilder()
+        .setOptional(
+          P4RuntimeOuterClass.FieldMatch.Optional.newBuilder()
+            .setValue(canonicalize(match.optional.value))
+        )
+        .build()
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+    P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+    null -> match
+  }
+
+/** Returns a copy of [param] with its `value` canonicalized per spec §8.3. */
+fun canonicalizeParam(
+  param: P4RuntimeOuterClass.Action.Param
+): P4RuntimeOuterClass.Action.Param =
+  param.toBuilder().setValue(canonicalize(param.value)).build()
+
+/**
+ * Returns a copy of [update] with all bytestrings canonicalized per spec §8.3.
+ *
+ * Currently only [P4RuntimeOuterClass.TableEntry]'s match fields and action params are
+ * canonicalized — that is the surface where the §8.3 read-write asymmetry would otherwise leak
+ * into [fourward.simulator.TableStore.sameKey]'s raw proto-equality compare. Other entity types
+ * (counters, registers, multicast groups, …) are passed through; if they ever start storing
+ * client-supplied bytestrings as match keys, extend this function.
+ */
+fun canonicalizeBytestrings(update: P4RuntimeOuterClass.Update): P4RuntimeOuterClass.Update {
+  val entity = update.entity
+  return when (entity.entityCase) {
+    P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY -> {
+      val canonicalEntry = canonicalizeTableEntry(entity.tableEntry)
+      update
+        .toBuilder()
+        .setEntity(entity.toBuilder().setTableEntry(canonicalEntry))
+        .build()
+    }
+    P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER -> {
+      val member = entity.actionProfileMember
+      val canonicalAction = canonicalizeAction(member.action)
+      update
+        .toBuilder()
+        .setEntity(
+          entity.toBuilder().setActionProfileMember(member.toBuilder().setAction(canonicalAction))
+        )
+        .build()
+    }
+    else -> update
+  }
+}
+
+private fun canonicalizeTableEntry(
+  entry: P4RuntimeOuterClass.TableEntry
+): P4RuntimeOuterClass.TableEntry {
+  val builder = entry.toBuilder()
+  if (entry.matchCount > 0) {
+    builder.clearMatch()
+    for (m in entry.matchList) builder.addMatch(canonicalizeMatch(m))
+  }
+  if (entry.hasAction()) builder.setAction(canonicalizeTableAction(entry.action))
+  return builder.build()
+}
+
+private fun canonicalizeTableAction(
+  action: P4RuntimeOuterClass.TableAction
+): P4RuntimeOuterClass.TableAction {
+  if (action.hasAction()) {
+    return action.toBuilder().setAction(canonicalizeAction(action.action)).build()
+  }
+  if (action.hasActionProfileActionSet()) {
+    val set = action.actionProfileActionSet.toBuilder()
+    val rebuilt =
+      action.actionProfileActionSet.actionProfileActionsList.map { profileAction ->
+        profileAction.toBuilder().setAction(canonicalizeAction(profileAction.action)).build()
+      }
+    set.clearActionProfileActions()
+    rebuilt.forEach { set.addActionProfileActions(it) }
+    return action.toBuilder().setActionProfileActionSet(set).build()
+  }
+  return action
+}
+
+private fun canonicalizeAction(
+  action: P4RuntimeOuterClass.Action
+): P4RuntimeOuterClass.Action {
+  if (action.paramsCount == 0) return action
+  val builder = action.toBuilder().clearParams()
+  for (p in action.paramsList) builder.addParams(canonicalizeParam(p))
+  return builder.build()
+}
+
+/** Number of bytes needed to encode a value of [bitwidth] bits. */
+private fun bytesNeeded(bitwidth: Int): Int = (bitwidth + 7) / 8
+
+/** Mask of the bits actually occupied within the highest bytestring byte for [bitwidth]. */
+private fun highByteMask(bitwidth: Int): Int {
+  val occupiedInHighByte = ((bitwidth - 1) % 8) + 1
+  return (1 shl occupiedInHighByte) - 1
+}
+
+private fun outOfRange(msg: String): StatusException =
+  Status.OUT_OF_RANGE.withDescription(msg).asException()

--- a/p4runtime/Bytestrings.kt
+++ b/p4runtime/Bytestrings.kt
@@ -3,27 +3,28 @@ package fourward.p4runtime
 import com.google.protobuf.ByteString
 import io.grpc.Status
 import io.grpc.StatusException
+import java.math.BigInteger
 import p4.v1.P4RuntimeOuterClass
+
+/** Interprets a [ByteString] as an unsigned big-endian [BigInteger]. */
+internal fun ByteString.toUnsignedBigInteger(): BigInteger = BigInteger(1, toByteArray())
 
 /**
  * Helpers for the P4Runtime bytestring encoding rules in spec §8.3.
  *
  * P4Runtime carries P4 integer values as protobuf `bytes`. The spec says:
  *
- *   "Upon receiving a binary string, the P4Runtime receiver (whether the server or
- *    the client) does not impose any restrictions on the maximum length of the string
- *    itself. Instead, the receiver verifies that the value encoded by the string fits
- *    within the expected type (signed or unsigned) and P4Info-specified bitwidth for
- *    the P4 object value."
+ * "Upon receiving a binary string, the P4Runtime receiver (whether the server or the client) does
+ * not impose any restrictions on the maximum length of the string itself. Instead, the receiver
+ * verifies that the value encoded by the string fits within the expected type (signed or unsigned)
+ * and P4Info-specified bitwidth for the P4 object value."
  *
- *   "The canonical binary string representation uses the shortest string that fits
- *    the encoded integer value. […] read-write symmetry requires that the encoder of
- *    a P4Runtime request or reply uses the shortest strings that fit the encoded
- *    integer values."
+ * "The canonical binary string representation uses the shortest string that fits the encoded
+ * integer value. […] read-write symmetry requires that the encoder of a P4Runtime request or reply
+ * uses the shortest strings that fit the encoded integer values."
  *
- * 4ward currently exposes only unsigned (`bit<W>`) values on the wire — `int<W>`
- * appears only in `P4Data` (§8.4.3), which 4ward does not surface — so the helpers
- * below are unsigned-only.
+ * 4ward currently exposes only unsigned (`bit<W>`) values on the wire — `int<W>` appears only in
+ * `P4Data` (§8.4.3), which 4ward does not surface — so the helpers below are unsigned-only.
  */
 
 /**
@@ -49,32 +50,8 @@ fun requireFitsInBitwidth(value: ByteString, bitwidth: Int, label: String) {
   if (value.isEmpty) {
     throw outOfRange("$label is empty (P4Runtime spec §8.3 requires a non-zero-length bytestring)")
   }
-  // Walk the high bytes and count how many bits are actually occupied.
-  // We could BigInteger.bitLength() but that allocates; this scan is O(bytes) and allocation-free.
-  val bytes = value
-  val expectedHighByteMask = highByteMask(bitwidth)
-  val expectedHighBytePos = bytes.size() - bytesNeeded(bitwidth)
-  for (i in 0 until bytes.size()) {
-    val b = bytes.byteAt(i).toInt() and 0xFF
-    when {
-      i < expectedHighBytePos -> {
-        if (b != 0) {
-          throw outOfRange(
-            "$label 0x${value.toHex()} does not fit in $bitwidth bits " +
-              "(byte $i is 0x${"%02x".format(b)}, expected 0)"
-          )
-        }
-      }
-      i == expectedHighBytePos -> {
-        if (b and expectedHighByteMask.inv() and 0xFF != 0) {
-          throw outOfRange(
-            "$label 0x${value.toHex()} does not fit in $bitwidth bits " +
-              "(top bits of byte $i are non-zero)"
-          )
-        }
-        return
-      }
-    }
+  if (value.toUnsignedBigInteger().bitLength() > bitwidth) {
+    throw outOfRange("$label 0x${value.toHex()} does not fit in $bitwidth bits")
   }
 }
 
@@ -83,6 +60,11 @@ fun requireFitsInBitwidth(value: ByteString, bitwidth: Int, label: String) {
  *
  * Strips leading zero bytes; preserves a single `\x00` for the value zero. Bitwidth-agnostic, so
  * works for any width (no [Int] / [Long] truncation hazard).
+ *
+ * Empty input is returned as-is. §8.3's integer rules say empty is invalid for `bit<W>` fields, but
+ * the validator catches that before this function is reached. For non-integer fields
+ * (`@p4runtime_translation` with `sdn_string`, where the bytes carry a UTF-8 string), an empty
+ * value represents the empty string and is already canonical.
  */
 fun canonicalize(value: ByteString): ByteString {
   if (value.isEmpty) return value
@@ -149,47 +131,60 @@ fun canonicalizeMatch(match: P4RuntimeOuterClass.FieldMatch): P4RuntimeOuterClas
   }
 
 /** Returns a copy of [param] with its `value` canonicalized per spec §8.3. */
-fun canonicalizeParam(
-  param: P4RuntimeOuterClass.Action.Param
-): P4RuntimeOuterClass.Action.Param =
+fun canonicalizeParam(param: P4RuntimeOuterClass.Action.Param): P4RuntimeOuterClass.Action.Param =
   param.toBuilder().setValue(canonicalize(param.value)).build()
 
 /**
  * Returns a copy of [update] with all bytestrings canonicalized per spec §8.3.
  *
- * Currently only [P4RuntimeOuterClass.TableEntry]'s match fields and action params are
- * canonicalized — that is the surface where the §8.3 read-write asymmetry would otherwise leak
- * into [fourward.simulator.TableStore.sameKey]'s raw proto-equality compare. Other entity types
- * (counters, registers, multicast groups, …) are passed through; if they ever start storing
- * client-supplied bytestrings as match keys, extend this function.
+ * Canonicalizes the entity types that store client-supplied bytestrings as part of the entry's
+ * identity or payload — `TableEntry` (match fields + action params) and `ActionProfileMember`
+ * (action params). For every other entity type, the bytestring fields are either absent or already
+ * in a normal form (counters/meters carry indices and numeric data, not match keys), so the update
+ * is returned unchanged. If a future entity type starts storing client bytestrings as a match key,
+ * add a case here — the exhaustive `when` will fail at compile time so it can't be forgotten.
  */
 fun canonicalizeBytestrings(update: P4RuntimeOuterClass.Update): P4RuntimeOuterClass.Update {
   val entity = update.entity
   return when (entity.entityCase) {
-    P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY -> {
-      val canonicalEntry = canonicalizeTableEntry(entity.tableEntry)
+    P4RuntimeOuterClass.Entity.EntityCase.TABLE_ENTRY ->
       update
         .toBuilder()
-        .setEntity(entity.toBuilder().setTableEntry(canonicalEntry))
+        .setEntity(entity.toBuilder().setTableEntry(canonicalizeTableEntry(entity.tableEntry)))
         .build()
-    }
     P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_MEMBER -> {
       val member = entity.actionProfileMember
-      val canonicalAction = canonicalizeAction(member.action)
       update
         .toBuilder()
         .setEntity(
-          entity.toBuilder().setActionProfileMember(member.toBuilder().setAction(canonicalAction))
+          entity
+            .toBuilder()
+            .setActionProfileMember(member.toBuilder().setAction(canonicalizeAction(member.action)))
         )
         .build()
     }
-    else -> update
+    // Action-profile groups carry only member-ID references — no client bytestrings.
+    P4RuntimeOuterClass.Entity.EntityCase.ACTION_PROFILE_GROUP,
+    // PRE entries (multicast groups, clone sessions) reference replicas by integer port IDs.
+    P4RuntimeOuterClass.Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
+    // Counters / meters use integer indices and numeric counts, not match keys.
+    P4RuntimeOuterClass.Entity.EntityCase.COUNTER_ENTRY,
+    P4RuntimeOuterClass.Entity.EntityCase.DIRECT_COUNTER_ENTRY,
+    P4RuntimeOuterClass.Entity.EntityCase.METER_ENTRY,
+    P4RuntimeOuterClass.Entity.EntityCase.DIRECT_METER_ENTRY,
+    // Registers, value sets, digests, externs aren't surfaced by 4ward today.
+    P4RuntimeOuterClass.Entity.EntityCase.REGISTER_ENTRY,
+    P4RuntimeOuterClass.Entity.EntityCase.VALUE_SET_ENTRY,
+    P4RuntimeOuterClass.Entity.EntityCase.DIGEST_ENTRY,
+    P4RuntimeOuterClass.Entity.EntityCase.EXTERN_ENTRY,
+    // Should not happen: the validator rejects updates with no entity set before we reach here.
+    P4RuntimeOuterClass.Entity.EntityCase.ENTITY_NOT_SET,
+    null -> update
   }
 }
 
-private fun canonicalizeTableEntry(
-  entry: P4RuntimeOuterClass.TableEntry
-): P4RuntimeOuterClass.TableEntry {
+/** Returns a copy of [entry] with match-field and action-parameter bytestrings canonicalized. */
+fun canonicalizeTableEntry(entry: P4RuntimeOuterClass.TableEntry): P4RuntimeOuterClass.TableEntry {
   val builder = entry.toBuilder()
   if (entry.matchCount > 0) {
     builder.clearMatch()
@@ -201,39 +196,37 @@ private fun canonicalizeTableEntry(
 
 private fun canonicalizeTableAction(
   action: P4RuntimeOuterClass.TableAction
-): P4RuntimeOuterClass.TableAction {
-  if (action.hasAction()) {
-    return action.toBuilder().setAction(canonicalizeAction(action.action)).build()
+): P4RuntimeOuterClass.TableAction =
+  when (action.typeCase) {
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION ->
+      action.toBuilder().setAction(canonicalizeAction(action.action)).build()
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_ACTION_SET -> {
+      val rebuilt =
+        action.actionProfileActionSet.actionProfileActionsList.map { profileAction ->
+          profileAction.toBuilder().setAction(canonicalizeAction(profileAction.action)).build()
+        }
+      action
+        .toBuilder()
+        .setActionProfileActionSet(
+          action.actionProfileActionSet
+            .toBuilder()
+            .clearActionProfileActions()
+            .addAllActionProfileActions(rebuilt)
+        )
+        .build()
+    }
+    // ID-only references carry no client bytestrings — nothing to canonicalize.
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_MEMBER_ID,
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_GROUP_ID,
+    P4RuntimeOuterClass.TableAction.TypeCase.TYPE_NOT_SET,
+    null -> action
   }
-  if (action.hasActionProfileActionSet()) {
-    val set = action.actionProfileActionSet.toBuilder()
-    val rebuilt =
-      action.actionProfileActionSet.actionProfileActionsList.map { profileAction ->
-        profileAction.toBuilder().setAction(canonicalizeAction(profileAction.action)).build()
-      }
-    set.clearActionProfileActions()
-    rebuilt.forEach { set.addActionProfileActions(it) }
-    return action.toBuilder().setActionProfileActionSet(set).build()
-  }
-  return action
-}
 
-private fun canonicalizeAction(
-  action: P4RuntimeOuterClass.Action
-): P4RuntimeOuterClass.Action {
+private fun canonicalizeAction(action: P4RuntimeOuterClass.Action): P4RuntimeOuterClass.Action {
   if (action.paramsCount == 0) return action
   val builder = action.toBuilder().clearParams()
   for (p in action.paramsList) builder.addParams(canonicalizeParam(p))
   return builder.build()
-}
-
-/** Number of bytes needed to encode a value of [bitwidth] bits. */
-private fun bytesNeeded(bitwidth: Int): Int = (bitwidth + 7) / 8
-
-/** Mask of the bits actually occupied within the highest bytestring byte for [bitwidth]. */
-private fun highByteMask(bitwidth: Int): Int {
-  val occupiedInHighByte = ((bitwidth - 1) % 8) + 1
-  return (1 shl occupiedInHighByte) - 1
 }
 
 private fun outOfRange(msg: String): StatusException =

--- a/p4runtime/BytestringsTest.kt
+++ b/p4runtime/BytestringsTest.kt
@@ -1,0 +1,236 @@
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import io.grpc.Status
+import io.grpc.StatusException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Spec-conformance tests for [requireFitsInBitwidth] and [canonicalize].
+ *
+ * The two parameterized tables ([validEncodings], [invalidEncodings]) mirror Tables 4 and 5 of
+ * the P4Runtime specification §8.3 verbatim, so this file is the long-term anchor that keeps
+ * 4ward's bytestring handling tied to the normative tables.
+ *
+ * Spec source:
+ * https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.html#sec-bytestrings
+ */
+class BytestringsTest {
+
+  // Each row mirrors P4Runtime spec §8.3, Table 4 ("Examples of Valid Bytestring Encoding").
+  // The 4ward p4runtime layer only handles unsigned bit<W> on the wire, so int<W> rows are
+  // omitted (they belong to a future P4Data §8.4.3 implementation).
+  private val validUnsignedEncodings: List<EncodingExample> =
+    listOf(
+      EncodingExample(bitwidth = 8, value = "\\x63", canonical = true),
+      EncodingExample(bitwidth = 16, value = "\\x00\\x63", canonical = false),
+      EncodingExample(bitwidth = 16, value = "\\x63", canonical = true),
+      EncodingExample(bitwidth = 16, value = "\\x30\\x64", canonical = true),
+      EncodingExample(bitwidth = 16, value = "\\x00\\x30\\x64", canonical = false),
+      EncodingExample(bitwidth = 12, value = "\\x00\\x63", canonical = false),
+      EncodingExample(bitwidth = 12, value = "\\x63", canonical = true),
+      EncodingExample(bitwidth = 12, value = "\\x00\\x00\\x63", canonical = false),
+    )
+
+  // Each row mirrors P4Runtime spec §8.3, Table 5 ("Examples of Invalid Bytestring Encoding").
+  // int<W> rows omitted; see comment on [validUnsignedEncodings].
+  private val invalidUnsignedEncodings: List<InvalidExample> =
+    listOf(
+      InvalidExample(bitwidth = 8, value = "\\x01\\x63"),
+      InvalidExample(bitwidth = 8, value = ""),
+      InvalidExample(bitwidth = 16, value = "\\x01\\x00\\x63"),
+      InvalidExample(bitwidth = 12, value = "\\x10\\x63"),
+      InvalidExample(bitwidth = 12, value = "\\x01\\x00\\x63"),
+      InvalidExample(bitwidth = 12, value = "\\x00\\x40\\x63"),
+    )
+
+  // ---------------------------------------------------------------------------
+  // requireFitsInBitwidth — spec table 4 (must accept) and table 5 (must reject)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `accepts every encoding in spec table 4`() {
+    for (row in validUnsignedEncodings) {
+      requireFitsInBitwidth(row.bytes, row.bitwidth, "table-4 row ${row.value}")
+    }
+  }
+
+  @Test
+  fun `rejects every encoding in spec table 5 with OUT_OF_RANGE`() {
+    for (row in invalidUnsignedEncodings) {
+      val e =
+        assertThrows("table-5 row ${row.value} should be rejected", StatusException::class.java) {
+          requireFitsInBitwidth(row.bytes, row.bitwidth, "table-5 row ${row.value}")
+        }
+      assertEquals(
+        "table-5 row ${row.value} should map to OUT_OF_RANGE",
+        Status.Code.OUT_OF_RANGE,
+        e.status.code,
+      )
+    }
+  }
+
+  @Test
+  fun `bitwidth 0 marks a non-integer field — accepts any value including empty`() {
+    // Non-integer (string-typed) fields use bitwidth=0 in p4info; §8.3 does not apply.
+    requireFitsInBitwidth(bytes("\\x01\\x02\\x03\\x04"), bitwidth = 0, "param")
+    requireFitsInBitwidth(ByteString.EMPTY, bitwidth = 0, "param")
+  }
+
+  // ---------------------------------------------------------------------------
+  // canonicalize — produces the spec's "shortest string that fits"
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `canonicalize produces shortest form on every spec-table-4 row`() {
+    // Group rows by bitwidth-of-value so we can compare canonical pairs against non-canonical
+    // pairs that encode the same integer value.
+    val byInteger = validUnsignedEncodings.groupBy { it.canonicalBytes }
+    for ((expectedCanonical, group) in byInteger) {
+      for (row in group) {
+        assertEquals(
+          "canonicalize should turn ${row.value} into the canonical form",
+          expectedCanonical,
+          canonicalize(row.bytes),
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `canonicalize is idempotent`() {
+    for (row in validUnsignedEncodings) {
+      val once = canonicalize(row.bytes)
+      val twice = canonicalize(once)
+      assertEquals("canonicalize should be idempotent", once, twice)
+    }
+  }
+
+  @Test
+  fun `canonicalize preserves zero as a single zero byte`() {
+    assertEquals(bytes("\\x00"), canonicalize(bytes("\\x00")))
+    assertEquals(bytes("\\x00"), canonicalize(bytes("\\x00\\x00")))
+    assertEquals(bytes("\\x00"), canonicalize(bytes("\\x00\\x00\\x00")))
+  }
+
+  @Test
+  fun `canonicalize returns the same instance when input is already canonical`() {
+    val canonical = bytes("\\x63")
+    assertSame("no copy when no change is needed", canonical, canonicalize(canonical))
+  }
+
+  @Test
+  fun `canonicalize does not strip leading bytes that are non-zero`() {
+    val input = bytes("\\x01\\x00")
+    assertEquals(input, canonicalize(input))
+  }
+
+  @Test
+  fun `every padded encoding canonicalizes to the same bytestring as the minimum form`() {
+    // Property test: for a sweep of unsigned values across several common bitwidths, every
+    // padding length up to bitwidth/8 + 1 collapses to the same canonical bytestring. This is
+    // the wire-side guarantee that powers TableStore.sameKey: equal logical values must equal
+    // post-canonicalization, regardless of how the client chose to encode them.
+    val values =
+      listOf(
+        java.math.BigInteger.ZERO,
+        java.math.BigInteger.ONE,
+        java.math.BigInteger.valueOf(127),
+        java.math.BigInteger.valueOf(0x100),
+        java.math.BigInteger.valueOf(0xFFFF),
+        java.math.BigInteger.valueOf(0x123456789ABCDEFL),
+        java.math.BigInteger.ONE.shiftLeft(127), // 128-bit boundary
+      )
+    for (v in values) {
+      val canonical = encodeMinimum(v)
+      for (paddingBytes in 0..16) {
+        val padded = padTo(canonical, canonical.size() + paddingBytes)
+        assertEquals(
+          "value $v, padded by $paddingBytes byte(s), should canonicalize identically",
+          canonical,
+          canonicalize(padded),
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `canonicalize does not change the represented integer value`() {
+    // Round-trip: padded input → canonicalize → re-pad → original value.
+    for (row in validUnsignedEncodings) {
+      val canonical = canonicalize(row.bytes)
+      assertEquals(
+        "canonicalize must preserve value for ${row.value}",
+        row.canonicalBytes,
+        canonical,
+      )
+      // And distinct values stay distinct.
+      if (!row.canonical) {
+        assertNotEquals(
+          "non-canonical input should not equal its canonical form",
+          row.bytes,
+          canonical,
+        )
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test fixtures
+  // ---------------------------------------------------------------------------
+
+  /** A row from spec §8.3, Table 4: bitwidth, encoding, and whether it is the canonical form. */
+  private data class EncodingExample(val bitwidth: Int, val value: String, val canonical: Boolean) {
+    val bytes: ByteString = bytes(value)
+    /** The canonical (shortest) form of [bytes] — strip leading zero bytes, leave one for zero. */
+    val canonicalBytes: ByteString = canonicalize(bytes)
+  }
+
+  /** A row from spec §8.3, Table 5: bitwidth and an encoding that must be rejected. */
+  private data class InvalidExample(val bitwidth: Int, val value: String) {
+    val bytes: ByteString = bytes(value)
+  }
+}
+
+/**
+ * Encodes [value] (assumed non-negative) as the minimum-width unsigned big-endian bytestring.
+ * Used in tests as the spec's reference implementation of "shortest string that fits".
+ */
+internal fun encodeMinimum(value: java.math.BigInteger): ByteString {
+  require(value.signum() >= 0) { "expected non-negative, got $value" }
+  if (value.signum() == 0) return ByteString.copyFrom(byteArrayOf(0))
+  val arr = value.toByteArray()
+  // BigInteger.toByteArray() prepends a sign bit byte for positive values whose high bit is set;
+  // strip it so the output stays canonical (unsigned, shortest).
+  return if (arr[0] == 0.toByte() && arr.size > 1) ByteString.copyFrom(arr, 1, arr.size - 1)
+  else ByteString.copyFrom(arr)
+}
+
+/** Pads [value] (canonical form) to exactly [targetSize] bytes with leading zeros. */
+internal fun padTo(value: ByteString, targetSize: Int): ByteString {
+  if (value.size() >= targetSize) return value
+  val padding = ByteArray(targetSize - value.size())
+  return ByteString.copyFrom(padding).concat(value)
+}
+
+/** Decodes a backslash-x-style spec literal (e.g. `\x00\x63`) to a [ByteString]. */
+internal fun bytes(literal: String): ByteString {
+  if (literal.isEmpty()) return ByteString.EMPTY
+  val out = mutableListOf<Byte>()
+  var i = 0
+  while (i < literal.length) {
+    require(literal[i] == '\\' && i + 3 < literal.length && literal[i + 1] == 'x') {
+      "expected \\xHH literal at position $i in '$literal'"
+    }
+    val hi = Character.digit(literal[i + 2], 16)
+    val lo = Character.digit(literal[i + 3], 16)
+    require(hi >= 0 && lo >= 0) { "invalid hex digit at position $i in '$literal'" }
+    out.add(((hi shl 4) or lo).toByte())
+    i += 4
+  }
+  return ByteString.copyFrom(out.toByteArray())
+}

--- a/p4runtime/BytestringsTest.kt
+++ b/p4runtime/BytestringsTest.kt
@@ -12,12 +12,11 @@ import org.junit.Test
 /**
  * Spec-conformance tests for [requireFitsInBitwidth] and [canonicalize].
  *
- * The two parameterized tables ([validEncodings], [invalidEncodings]) mirror Tables 4 and 5 of
- * the P4Runtime specification §8.3 verbatim, so this file is the long-term anchor that keeps
- * 4ward's bytestring handling tied to the normative tables.
+ * The two parameterized tables ([validEncodings], [invalidEncodings]) mirror Tables 4 and 5 of the
+ * P4Runtime specification §8.3 verbatim, so this file is the long-term anchor that keeps 4ward's
+ * bytestring handling tied to the normative tables.
  *
- * Spec source:
- * https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.html#sec-bytestrings
+ * Spec source: https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.html#sec-bytestrings
  */
 class BytestringsTest {
 
@@ -197,8 +196,8 @@ class BytestringsTest {
 }
 
 /**
- * Encodes [value] (assumed non-negative) as the minimum-width unsigned big-endian bytestring.
- * Used in tests as the spec's reference implementation of "shortest string that fits".
+ * Encodes [value] (assumed non-negative) as the minimum-width unsigned big-endian bytestring. Used
+ * in tests as the spec's reference implementation of "shortest string that fits".
  */
 internal fun encodeMinimum(value: java.math.BigInteger): ByteString {
   require(value.signum() >= 0) { "expected non-negative, got $value" }

--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -101,7 +101,7 @@ class GoldenErrorTest(private val testName: String) {
       "unknown-table-id" -> triggerUnknownTableId()
       "unknown-action-id" -> triggerUnknownActionId()
       "wrong-param-count" -> triggerWrongParamCount()
-      "wrong-match-width" -> triggerWrongMatchWidth()
+      "match-value-out-of-range" -> triggerMatchValueOutOfRange()
       "wrong-match-kind" -> triggerWrongMatchKind()
       "missing-exact-field" -> triggerMissingExactField()
       "duplicate-match-field" -> triggerDuplicateMatchField()
@@ -126,7 +126,7 @@ class GoldenErrorTest(private val testName: String) {
       "commit-without-save" -> triggerCommitWithoutSave()
       "unrecognized-pipeline-action" -> triggerUnrecognizedPipelineAction()
       "simulator-rejected-pipeline" -> triggerSimulatorRejectedPipeline()
-      "param-width-mismatch" -> triggerParamWidthMismatch()
+      "param-value-out-of-range" -> triggerParamValueOutOfRange()
       "priority-required" -> triggerPriorityRequired()
       "ternary-masked-bits" -> triggerTernaryMaskedBits()
       "lpm-trailing-bits" -> triggerLpmTrailingBits()
@@ -250,11 +250,11 @@ class GoldenErrorTest(private val testName: String) {
   }
 
   @Suppress("MagicNumber")
-  private fun triggerWrongMatchWidth() {
+  private fun triggerMatchValueOutOfRange() {
     val config = loadBasicTable()
     harness.loadPipeline(config)
     val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
-    // etherType is 16-bit (2 bytes); send 1 byte.
+    // etherType is 16-bit; send a 3-byte value 0x010000 that overflows.
     val entity =
       valid
         .toBuilder()
@@ -262,7 +262,7 @@ class GoldenErrorTest(private val testName: String) {
           tableEntryBuilder
             .getMatchBuilder(0)
             .exactBuilder
-            .setValue(ByteString.copyFrom(byteArrayOf(0x08)))
+            .setValue(ByteString.copyFrom(byteArrayOf(0x01, 0x00, 0x00)))
         }
         .build()
     harness.installEntry(entity)
@@ -470,11 +470,11 @@ class GoldenErrorTest(private val testName: String) {
   }
 
   @Suppress("MagicNumber")
-  private fun triggerParamWidthMismatch() {
+  private fun triggerParamValueOutOfRange() {
     val config = loadBasicTable()
     harness.loadPipeline(config)
     val valid = buildExactEntry(config, matchValue = 0x0800, port = 1)
-    // The 'port' param is 9-bit (2 bytes canonical); send 4 bytes instead.
+    // The 'port' param is 9-bit (max value 0x1FF); send 0x0200 which overflows.
     val entity =
       valid
         .toBuilder()
@@ -484,7 +484,7 @@ class GoldenErrorTest(private val testName: String) {
             valid.tableEntry.action.action
               .getParams(0)
               .toBuilder()
-              .setValue(ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))),
+              .setValue(ByteString.copyFrom(byteArrayOf(0x02, 0x00))),
           )
         }
         .build()
@@ -1642,7 +1642,7 @@ class GoldenErrorTest(private val testName: String) {
         "unknown-table-id",
         "unknown-action-id",
         "wrong-param-count",
-        "wrong-match-width",
+        "match-value-out-of-range",
         "wrong-match-kind",
         "missing-exact-field",
         "duplicate-match-field",
@@ -1667,7 +1667,7 @@ class GoldenErrorTest(private val testName: String) {
         "commit-without-save",
         "unrecognized-pipeline-action",
         "simulator-rejected-pipeline",
-        "param-width-mismatch",
+        "param-value-out-of-range",
         "priority-required",
         "ternary-masked-bits",
         "lpm-trailing-bits",

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -368,12 +368,13 @@ class P4RuntimeConformanceTest {
         )
     }
 
-    // Read back: should have the MODIFY's action (port=2).
+    // Read back: should have the MODIFY's action (port=2). Reads return canonical
+    // (shortest) bytestrings per spec §8.3, regardless of how the value was sent.
     val results = harness.readEntry(P4RuntimeTestHarness.buildMatchFilter(config, 0x0800))
     assertEquals("entry should exist", 1, results.size)
     assertEquals(
-      "entry should have the MODIFY's action",
-      entry2.tableEntry.action.action.paramsList,
+      "entry should have the MODIFY's action (canonical-form params)",
+      entry2.tableEntry.action.action.paramsList.map(::canonicalizeParam),
       results[0].tableEntry.action.action.paramsList,
     )
   }
@@ -497,13 +498,15 @@ class P4RuntimeConformanceTest {
     val results = harness.readEntry(filter)
     assertEquals(1, results.size)
     // The returned entry should have the same action as what was installed.
+    // Per spec §8.3, the server returns bytestrings in canonical (shortest) form regardless of
+    // the encoding the client sent, so we compare against the canonicalized expected params.
     assertTrue("should have action set", results[0].tableEntry.action.hasAction())
     assertEquals(
       entry.tableEntry.action.action.actionId,
       results[0].tableEntry.action.action.actionId,
     )
     assertEquals(
-      entry.tableEntry.action.action.paramsList,
+      entry.tableEntry.action.action.paramsList.map(::canonicalizeParam),
       results[0].tableEntry.action.action.paramsList,
     )
   }
@@ -1208,32 +1211,34 @@ class P4RuntimeConformanceTest {
   // Bytestring encoding (scenario 63)
   // =========================================================================
 
-  /** P4Runtime spec §8.7: read responses have bytestrings zero-padded to ceil(bitwidth/8). */
+  /** P4Runtime spec §8.3: read responses use canonical (shortest) bytestring form. */
   @Test
-  fun `63 - read responses have correctly sized bytestrings`() {
+  fun `63 - read responses use canonical bytestring form`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    val matchField = config.p4Info.tablesList.first().matchFieldsList.first()
-    val forwardAction = config.p4Info.actionsList.find { it.preamble.name.contains("forward") }!!
-    val matchBytes = (matchField.bitwidth + 7) / 8
-    val paramBytes = (forwardAction.paramsList.first().bitwidth + 7) / 8
 
+    // Send a value (port=1) that has a strictly shorter canonical form than the param's fixed
+    // width — that way the assertion catches both "padded to fixed width" and "canonical".
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
     harness.installEntry(entry)
 
     val results = harness.readRegularEntries()
     assertEquals(1, results.size)
     val readEntry = results[0].tableEntry
+    val readMatch = readEntry.matchList[0].exact.value
+    val readParam = readEntry.action.action.paramsList[0].value
     assertEquals(
-      "match field bytestring should be $matchBytes bytes",
-      matchBytes,
-      readEntry.matchList[0].exact.value.size(),
+      "match field bytestring should be canonical (no leading zero bytes)",
+      readMatch,
+      canonicalize(readMatch),
     )
     assertEquals(
-      "action param bytestring should be $paramBytes bytes",
-      paramBytes,
-      readEntry.action.action.paramsList[0].value.size(),
+      "action param bytestring should be canonical (no leading zero bytes)",
+      readParam,
+      canonicalize(readParam),
     )
+    // And specifically: port=1 fits in 1 byte, so the read-back param must be 1 byte (not 2).
+    assertEquals("port=1 canonical encoding is one byte", 1, readParam.size())
   }
 
   // =========================================================================
@@ -2269,7 +2274,12 @@ class P4RuntimeConformanceTest {
   // §8.2: Read-write symmetry (scenarios 110-113)
   // =========================================================================
 
-  /** §8.2: Table entry written via Write reads back identically via Read. */
+  /**
+   * §8.3: Per the spec's read-write symmetry property, "the encoder of a P4Runtime request or reply
+   * uses the shortest strings that fit the encoded integer values" — so reads return canonical form
+   * regardless of the encoding the client wrote. The round-trip identity holds after canonicalizing
+   * the written entry.
+   */
   @Test
   fun `110 - table entry read-write symmetry`() {
     val config = loadBasicTableConfig()
@@ -2278,11 +2288,16 @@ class P4RuntimeConformanceTest {
     harness.installEntry(entry)
     val readBack = harness.readEntry(buildReadFilter(config, 0x0800))
     assertEquals(1, readBack.size)
-    val written = entry.tableEntry
+    val canonicalWritten =
+      canonicalizeBytestrings(
+          p4.v1.P4RuntimeOuterClass.Update.newBuilder().setEntity(entry).build()
+        )
+        .entity
+        .tableEntry
     val read = readBack[0].tableEntry
-    assertEquals("table_id must match", written.tableId, read.tableId)
-    assertEquals("match fields must match", written.matchList, read.matchList)
-    assertEquals("action must match", written.action, read.action)
+    assertEquals("table_id must match", canonicalWritten.tableId, read.tableId)
+    assertEquals("match fields must match", canonicalWritten.matchList, read.matchList)
+    assertEquals("action must match", canonicalWritten.action, read.action)
   }
 
   /** §8.2: Action profile member round-trips identically. */

--- a/p4runtime/P4RuntimeConformanceTest.kt
+++ b/p4runtime/P4RuntimeConformanceTest.kt
@@ -2288,12 +2288,7 @@ class P4RuntimeConformanceTest {
     harness.installEntry(entry)
     val readBack = harness.readEntry(buildReadFilter(config, 0x0800))
     assertEquals(1, readBack.size)
-    val canonicalWritten =
-      canonicalizeBytestrings(
-          p4.v1.P4RuntimeOuterClass.Update.newBuilder().setEntity(entry).build()
-        )
-        .entity
-        .tableEntry
+    val canonicalWritten = canonicalizeTableEntry(entry.tableEntry)
     val read = readBack[0].tableEntry
     assertEquals("table_id must match", canonicalWritten.tableId, read.tableId)
     assertEquals("match fields must match", canonicalWritten.matchList, read.matchList)

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -464,9 +464,6 @@ class P4RuntimeService(
     // Validate against p4info before type translation so SDN-visible values
     // are checked at canonical widths (P4Runtime spec §8.3, §9.1).
     state.writeValidator.validate(rawUpdate)
-    // Spec §8.3 read-write symmetry: store bytestrings in their canonical (shortest) form so
-    // (a) reads return canonical bytes for free, and (b) TableStore.sameKey matches across
-    // different on-the-wire encodings of the same logical value.
     val canonicalUpdate = canonicalizeBytestrings(rawUpdate)
     val translator = state.typeTranslator?.takeIf { it.hasTranslations }
     val update =

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -464,10 +464,14 @@ class P4RuntimeService(
     // Validate against p4info before type translation so SDN-visible values
     // are checked at canonical widths (P4Runtime spec §8.3, §9.1).
     state.writeValidator.validate(rawUpdate)
+    // Spec §8.3 read-write symmetry: store bytestrings in their canonical (shortest) form so
+    // (a) reads return canonical bytes for free, and (b) TableStore.sameKey matches across
+    // different on-the-wire encodings of the same logical value.
+    val canonicalUpdate = canonicalizeBytestrings(rawUpdate)
     val translator = state.typeTranslator?.takeIf { it.hasTranslations }
     val update =
       try {
-        translator?.translateForWrite(rawUpdate) ?: rawUpdate
+        translator?.translateForWrite(canonicalUpdate) ?: canonicalUpdate
       } catch (e: TranslationException) {
         throw Status.INVALID_ARGUMENT.withDescription("type translation failed: ${e.message}")
           .withCause(e)

--- a/p4runtime/P4RuntimeWriteErrorTest.kt
+++ b/p4runtime/P4RuntimeWriteErrorTest.kt
@@ -168,20 +168,20 @@ class P4RuntimeWriteErrorTest {
     assertGrpcError(Status.Code.INVALID_ARGUMENT, "priority") { harness.installEntry(entity) }
   }
 
-  // P4Runtime spec §8.3: match field value must have canonical byte width.
+  // P4Runtime spec §8.3: match field value must fit in the field's bitwidth.
   @Test
-  fun `insert with wrong match value width returns INVALID_ARGUMENT`() {
+  fun `insert with match value out of range returns OUT_OF_RANGE`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    // etherType is 16-bit (2 bytes); send 1 byte.
+    // etherType is 16-bit; send a 3-byte value 0x010000 that overflows.
     val entity =
       buildInvalidEntry(config) { b ->
         b.tableEntryBuilder
           .getMatchBuilder(0)
           .exactBuilder
-          .setValue(ByteString.copyFrom(byteArrayOf(0x08)))
+          .setValue(ByteString.copyFrom(byteArrayOf(0x01, 0x00, 0x00)))
       }
-    assertGrpcError(Status.Code.INVALID_ARGUMENT, "bytes") { harness.installEntry(entity) }
+    assertGrpcError(Status.Code.OUT_OF_RANGE, "does not fit") { harness.installEntry(entity) }
   }
 
   // P4Runtime spec §9.1.1: match field kind must match p4info.

--- a/p4runtime/WriteValidator.kt
+++ b/p4runtime/WriteValidator.kt
@@ -7,9 +7,6 @@ import java.math.BigInteger
 import p4.config.v1.P4InfoOuterClass
 import p4.v1.P4RuntimeOuterClass
 
-/** Interprets a [ByteString] as an unsigned big-endian [BigInteger]. */
-private fun ByteString.toBigInt(): BigInteger = BigInteger(1, toByteArray())
-
 /**
  * Validates P4Runtime Write updates against the p4info schema.
  *
@@ -428,8 +425,8 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
      * [requireFitsInBitwidth] beforehand), so the check is done on the integer values directly.
      */
     private fun checkTernaryMaskedBits(value: ByteString, mask: ByteString, fieldName: String) {
-      val v = value.toBigInt()
-      val m = mask.toBigInt()
+      val v = value.toUnsignedBigInteger()
+      val m = mask.toUnsignedBigInteger()
       if (v.and(m.not()).signum() != 0) {
         throw invalidArg(
           "match field '$fieldName' has masked-off bits set in value (value & ~mask != 0)"
@@ -439,7 +436,7 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
 
     /** §9.1.1: range match low must be <= high (unsigned comparison). */
     private fun checkRangeOrder(low: ByteString, high: ByteString, fieldName: String) {
-      if (low.toBigInt() > high.toBigInt()) {
+      if (low.toUnsignedBigInteger() > high.toUnsignedBigInteger()) {
         throw invalidArg("match field '$fieldName' has range low > high")
       }
     }
@@ -461,7 +458,7 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
       val trailingBits = bitwidth - prefixLen
       if (trailingBits == 0) return // entire value is significant
       val mask = BigInteger.ONE.shiftLeft(trailingBits).subtract(BigInteger.ONE)
-      if (value.toBigInt().and(mask).signum() != 0) {
+      if (value.toUnsignedBigInteger().and(mask).signum() != 0) {
         throw invalidArg(
           "match field '$fieldName' has non-zero bits beyond prefix length $prefixLen"
         )

--- a/p4runtime/WriteValidator.kt
+++ b/p4runtime/WriteValidator.kt
@@ -3,18 +3,25 @@ package fourward.p4runtime
 import com.google.protobuf.ByteString
 import io.grpc.Status
 import io.grpc.StatusException
+import java.math.BigInteger
 import p4.config.v1.P4InfoOuterClass
 import p4.v1.P4RuntimeOuterClass
+
+/** Interprets a [ByteString] as an unsigned big-endian [BigInteger]. */
+private fun ByteString.toBigInt(): BigInteger = BigInteger(1, toByteArray())
 
 /**
  * Validates P4Runtime Write updates against the p4info schema.
  *
- * Enforces P4Runtime spec §9.1: action IDs/refs, action parameter count/IDs/byte widths, match
- * field IDs/kinds/byte widths, required exact fields, and priority rules.
+ * Enforces P4Runtime spec §9.1: action IDs/refs, action parameter count/IDs, match field IDs/kinds,
+ * required exact fields, and priority rules. Bytestring values are checked against the §8.3
+ * fits-in-bitwidth rule via [requireFitsInBitwidth] — the validator accepts any length (including
+ * the canonical shortest form) as long as the represented integer fits in the P4Info-specified
+ * bitwidth.
  *
  * All lookup maps are pre-computed at construction time so [validate] does zero allocations.
  * Constructed once per pipeline load; call [validate] for each update before type translation so
- * SDN-visible values are checked at canonical widths (§8.3).
+ * SDN-visible values are checked against their P4-program bitwidths (§8.3).
  */
 class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
 
@@ -202,9 +209,9 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
                 "'${it.value.name}' (${it.key})"
               })})"
           )
-      // §8.3: canonical byte width. Skip if bitwidth is 0
-      // (e.g. @p4runtime_translation with sdn_string).
-      checkWidth(paramInfo.bitwidth, param.value.size(), "param '${paramInfo.name}'")
+      // §8.3: value must fit in the param's bitwidth. Bitwidth 0 means unspecified
+      // (e.g. @p4runtime_translation with sdn_string) — only an empty bytestring is rejected.
+      requireFitsInBitwidth(param.value, paramInfo.bitwidth, "param '${paramInfo.name}'")
     }
   }
 
@@ -289,26 +296,32 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
     val f = fieldInfo.name
     when (fm.fieldMatchTypeCase) {
       P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
-        checkWidth(w, fm.exact.value.size(), "match field '$f' value")
+        requireFitsInBitwidth(fm.exact.value, w, "match field '$f' value")
       P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY -> {
-        checkWidth(w, fm.ternary.value.size(), "match field '$f' value")
-        checkWidth(w, fm.ternary.mask.size(), "match field '$f' mask")
+        requireFitsInBitwidth(fm.ternary.value, w, "match field '$f' value")
+        requireFitsInBitwidth(fm.ternary.mask, w, "match field '$f' mask")
         // §8.3: bits where mask is 0 must also be 0 in value.
         checkTernaryMaskedBits(fm.ternary.value, fm.ternary.mask, f)
       }
       P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM -> {
-        checkWidth(w, fm.lpm.value.size(), "match field '$f' value")
+        requireFitsInBitwidth(fm.lpm.value, w, "match field '$f' value")
+        // §9.1.1: prefix_len must be in [0, W].
+        if (fm.lpm.prefixLen < 0 || fm.lpm.prefixLen > w) {
+          throw invalidArg(
+            "match field '$f' has prefix_len ${fm.lpm.prefixLen} outside the valid range [0, $w]"
+          )
+        }
         // §8.3: bits beyond prefix_len must be zero.
-        checkLpmTrailingBits(fm.lpm.value, fm.lpm.prefixLen, f)
+        checkLpmTrailingBits(fm.lpm.value, fm.lpm.prefixLen, w, f)
       }
       P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE -> {
-        checkWidth(w, fm.range.low.size(), "match field '$f' low")
-        checkWidth(w, fm.range.high.size(), "match field '$f' high")
+        requireFitsInBitwidth(fm.range.low, w, "match field '$f' low")
+        requireFitsInBitwidth(fm.range.high, w, "match field '$f' high")
         // P4Runtime spec §9.1.1: low must be <= high.
         checkRangeOrder(fm.range.low, fm.range.high, f)
       }
       P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
-        checkWidth(w, fm.optional.value.size(), "match field '$f' value")
+        requireFitsInBitwidth(fm.optional.value, w, "match field '$f' value")
       P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
       P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
       null -> {}
@@ -408,62 +421,50 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
         P4InfoOuterClass.MatchField.MatchType.OPTIONAL,
       )
 
-    /** §8.3: values must be exactly ceil(bitwidth/8) bytes. Skips if bitwidth is 0. */
-    private fun checkWidth(bitwidth: Int, actual: Int, label: String) {
-      val expected = (bitwidth + 7) / 8
-      if (expected > 0 && actual != expected) {
-        throw invalidArg("$label expects $expected bytes, got $actual")
-      }
-    }
-
-    /** §8.3: ternary value bits must be zero where the mask is zero. */
+    /**
+     * §8.3: ternary value bits must be zero where the mask is zero.
+     *
+     * Length-agnostic: value and mask may be any length (each separately validated by
+     * [requireFitsInBitwidth] beforehand), so the check is done on the integer values directly.
+     */
     private fun checkTernaryMaskedBits(value: ByteString, mask: ByteString, fieldName: String) {
-      for (i in 0 until value.size()) {
-        val v = value.byteAt(i).toInt() and 0xFF
-        val m = mask.byteAt(i).toInt() and 0xFF
-        if (v and m != v) {
-          throw invalidArg(
-            "match field '$fieldName' has masked-off bits set in value (value & ~mask != 0)"
-          )
-        }
+      val v = value.toBigInt()
+      val m = mask.toBigInt()
+      if (v.and(m.not()).signum() != 0) {
+        throw invalidArg(
+          "match field '$fieldName' has masked-off bits set in value (value & ~mask != 0)"
+        )
       }
     }
 
     /** §9.1.1: range match low must be <= high (unsigned comparison). */
     private fun checkRangeOrder(low: ByteString, high: ByteString, fieldName: String) {
-      for (i in 0 until low.size()) {
-        val l = low.byteAt(i).toInt() and 0xFF
-        val h = high.byteAt(i).toInt() and 0xFF
-        if (l < h) return // low < high — valid
-        if (l > h) {
-          throw invalidArg("match field '$fieldName' has range low > high")
-        }
-        // l == h — continue to next byte
+      if (low.toBigInt() > high.toBigInt()) {
+        throw invalidArg("match field '$fieldName' has range low > high")
       }
-      // low == high — valid (single-value range)
     }
 
-    /** §8.3: LPM value bits beyond prefix_len must be zero. */
-    private fun checkLpmTrailingBits(value: ByteString, prefixLen: Int, fieldName: String) {
-      for (i in 0 until value.size()) {
-        val bitStart = i * 8
-        val b = value.byteAt(i).toInt() and 0xFF
-        if (bitStart >= prefixLen) {
-          if (b != 0) {
-            throw invalidArg(
-              "match field '$fieldName' has non-zero bits beyond prefix length $prefixLen"
-            )
-          }
-        } else if (bitStart + 8 > prefixLen) {
-          // Partial byte: only the high (prefixLen - bitStart) bits are valid.
-          val trailingBits = 8 - (prefixLen - bitStart)
-          val trailingMask = (1 shl trailingBits) - 1
-          if (b and trailingMask != 0) {
-            throw invalidArg(
-              "match field '$fieldName' has non-zero bits beyond prefix length $prefixLen"
-            )
-          }
-        }
+    /**
+     * §8.3: LPM value bits beyond prefix_len must be zero.
+     *
+     * The value is interpreted as a [bitwidth]-bit unsigned integer; the trailing (bitwidth -
+     * prefixLen) bits must be zero, regardless of how many bytes were used to send it. (E.g. for
+     * `bit<32>` LPM with prefix_len=8, the value `\x0A` represents integer 10 with implicit leading
+     * zeros — and bit positions [0,24) of the bit<32> integer are non-zero, so it is rejected.)
+     */
+    private fun checkLpmTrailingBits(
+      value: ByteString,
+      prefixLen: Int,
+      bitwidth: Int,
+      fieldName: String,
+    ) {
+      val trailingBits = bitwidth - prefixLen
+      if (trailingBits == 0) return // entire value is significant
+      val mask = BigInteger.ONE.shiftLeft(trailingBits).subtract(BigInteger.ONE)
+      if (value.toBigInt().and(mask).signum() != 0) {
+        throw invalidArg(
+          "match field '$fieldName' has non-zero bits beyond prefix length $prefixLen"
+        )
       }
     }
 

--- a/p4runtime/WriteValidator.kt
+++ b/p4runtime/WriteValidator.kt
@@ -1,6 +1,7 @@
 package fourward.p4runtime
 
 import com.google.protobuf.ByteString
+import fourward.simulator.toUnsignedBigInteger
 import io.grpc.Status
 import io.grpc.StatusException
 import java.math.BigInteger

--- a/p4runtime/WriteValidatorTest.kt
+++ b/p4runtime/WriteValidatorTest.kt
@@ -126,21 +126,33 @@ class WriteValidatorTest {
   }
 
   @Test
-  fun `wrong param byte width returns INVALID_ARGUMENT`() {
+  fun `param value too narrow accepted as canonical encoding`() {
+    // §8.3: shorter-than-fixed-width is the canonical form (read-write symmetric).
     val v = validator()
-    // Param is 16-bit (2 bytes); send 1 byte.
+    v.validate(
+      insertUpdate(
+        EXACT_TABLE_ID,
+        exactMatch(MATCH_FIELD_ID, bytes(2)),
+        action(params = listOf(param(value = bytes(1)))),
+      )
+    )
+  }
+
+  @Test
+  fun `param value out of range returns OUT_OF_RANGE`() {
+    // §8.3: value 0x10000 doesn't fit in bit<16>, regardless of byte count.
+    val v = validator()
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(
           insertUpdate(
             EXACT_TABLE_ID,
             exactMatch(MATCH_FIELD_ID, bytes(2)),
-            action(params = listOf(param(value = bytes(1)))),
+            action(params = listOf(param(value = byteArrayOf(0x01, 0x00, 0x00)))),
           )
         )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
-    assert(e.status.description!!.contains("bytes"))
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   @Test
@@ -184,15 +196,27 @@ class WriteValidatorTest {
   }
 
   @Test
-  fun `wrong match value width returns INVALID_ARGUMENT`() {
+  fun `match value shorter than fixed width accepted as canonical encoding`() {
+    // §8.3: 1 byte for a bit<16> match field is the canonical form (value fits in 16 bits).
     val v = validator()
-    // Match field is 16-bit (2 bytes); send 1 byte.
+    v.validate(insertUpdate(EXACT_TABLE_ID, exactMatch(MATCH_FIELD_ID, bytes(1)), action()))
+  }
+
+  @Test
+  fun `match value out of range returns OUT_OF_RANGE`() {
+    // §8.3: 3-byte value 0x010000 overflows the field's bit<16> width.
+    val v = validator()
     val e =
       assertThrows(StatusException::class.java) {
-        v.validate(insertUpdate(EXACT_TABLE_ID, exactMatch(MATCH_FIELD_ID, bytes(1)), action()))
+        v.validate(
+          insertUpdate(
+            EXACT_TABLE_ID,
+            exactMatch(MATCH_FIELD_ID, byteArrayOf(0x01, 0x00, 0x00)),
+            action(),
+          )
+        )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
-    assert(e.status.description!!.contains("bytes"))
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   @Test
@@ -208,37 +232,36 @@ class WriteValidatorTest {
   }
 
   @Test
-  fun `ternary match value and mask widths validated`() {
+  fun `ternary match value out of range returns OUT_OF_RANGE`() {
     val v = validator()
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(
           insertUpdate(
             TERNARY_TABLE_ID,
-            ternaryMatch(TERNARY_FIELD_ID, value = bytes(1), mask = bytes(2)),
+            ternaryMatch(TERNARY_FIELD_ID, value = byteArrayOf(0x01, 0x00, 0x00), mask = bytes(2)),
             ternaryAction(),
             priority = 1,
           )
         )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
-    assert(e.status.description!!.contains("value"))
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   @Test
-  fun `LPM match value width validated`() {
+  fun `LPM match value out of range returns OUT_OF_RANGE`() {
     val v = validator()
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(
           insertUpdate(
             LPM_TABLE_ID,
-            lpmMatch(LPM_FIELD_ID, value = bytes(1), prefixLen = 8),
+            lpmMatch(LPM_FIELD_ID, value = byteArrayOf(0x01, 0x00, 0x00), prefixLen = 8),
             ternaryAction(),
           )
         )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   // =========================================================================
@@ -638,21 +661,20 @@ class WriteValidatorTest {
   }
 
   @Test
-  fun `range match width validated`() {
+  fun `range match endpoints out of range return OUT_OF_RANGE`() {
     val v = validator()
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(
           insertUpdate(
             RANGE_TABLE_ID,
-            rangeMatch(low = bytes(1), high = bytes(2)),
+            rangeMatch(low = bytes(1), high = byteArrayOf(0x01, 0x00, 0x00)),
             ternaryAction(),
             priority = 1,
           )
         )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
-    assert(e.status.description!!.contains("bytes"))
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   // =========================================================================
@@ -673,21 +695,20 @@ class WriteValidatorTest {
   }
 
   @Test
-  fun `optional match wrong width returns INVALID_ARGUMENT`() {
+  fun `optional match value out of range returns OUT_OF_RANGE`() {
     val v = validator()
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(
           insertUpdate(
             OPTIONAL_TABLE_ID,
-            optionalMatch(value = bytes(1)),
+            optionalMatch(value = byteArrayOf(0x01, 0x00, 0x00)),
             ternaryAction(),
             priority = 1,
           )
         )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
-    assert(e.status.description!!.contains("bytes"))
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   @Test
@@ -817,19 +838,18 @@ class WriteValidatorTest {
   }
 
   @Test
-  fun `member with wrong param width returns INVALID_ARGUMENT`() {
+  fun `member with param value out of range returns OUT_OF_RANGE`() {
     val v = validator()
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(
           memberUpdate(
             P4RuntimeOuterClass.Update.Type.INSERT,
-            action(params = listOf(param(value = bytes(1)))),
+            action(params = listOf(param(value = byteArrayOf(0x01, 0x00, 0x00)))),
           )
         )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
-    assert(e.status.description!!.contains("bytes"))
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   // =========================================================================
@@ -887,16 +907,20 @@ class WriteValidatorTest {
   }
 
   @Test
-  fun `bit7 field rejects 2-byte value`() {
+  fun `bit7 field rejects value greater than 127`() {
+    // §8.3: 0x80 = 128 doesn't fit in 7 bits (max = 127), even when sent as a single byte.
     val v = bitwidthValidator()
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(
-          insertUpdate(BIT7_TABLE_ID, listOf(exactMatch(BIT7_FIELD_ID, bytes(2))), action())
+          insertUpdate(
+            BIT7_TABLE_ID,
+            listOf(exactMatch(BIT7_FIELD_ID, byteArrayOf(0x80.toByte()))),
+            action(),
+          )
         )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
-    assert(e.status.description!!.contains("bytes"))
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   @Test
@@ -908,16 +932,27 @@ class WriteValidatorTest {
   }
 
   @Test
-  fun `bit128 field rejects 15-byte value`() {
+  fun `bit128 field accepts 15-byte canonical value`() {
+    // §8.3: shorter-than-fixed-width is the canonical form, accepted regardless of bitwidth.
     val v = bitwidthValidator()
+    v.validate(
+      insertUpdate(BIT128_TABLE_ID, listOf(exactMatch(BIT128_FIELD_ID, bytes(15))), action())
+    )
+  }
+
+  @Test
+  fun `bit128 field rejects value exceeding 128 bits`() {
+    // 17-byte value with high byte 0x01 = 2^128 — first integer that doesn't fit.
+    val v = bitwidthValidator()
+    val tooLarge = ByteArray(17)
+    tooLarge[0] = 0x01
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(
-          insertUpdate(BIT128_TABLE_ID, listOf(exactMatch(BIT128_FIELD_ID, bytes(15))), action())
+          insertUpdate(BIT128_TABLE_ID, listOf(exactMatch(BIT128_FIELD_ID, tooLarge)), action())
         )
       }
-    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
-    assert(e.status.description!!.contains("bytes"))
+    assertEquals(Status.Code.OUT_OF_RANGE, e.status.code)
   }
 
   @Test

--- a/p4runtime/golden_errors/match-value-out-of-range.golden.txt
+++ b/p4runtime/golden_errors/match-value-out-of-range.golden.txt
@@ -1,1 +1,1 @@
-OUT_OF_RANGE: match field 'hdr.ethernet.etherType' value 0x010000 does not fit in 16 bits (byte 0 is 0x01, expected 0)
+OUT_OF_RANGE: match field 'hdr.ethernet.etherType' value 0x010000 does not fit in 16 bits

--- a/p4runtime/golden_errors/match-value-out-of-range.golden.txt
+++ b/p4runtime/golden_errors/match-value-out-of-range.golden.txt
@@ -1,0 +1,1 @@
+OUT_OF_RANGE: match field 'hdr.ethernet.etherType' value 0x010000 does not fit in 16 bits (byte 0 is 0x01, expected 0)

--- a/p4runtime/golden_errors/param-value-out-of-range.golden.txt
+++ b/p4runtime/golden_errors/param-value-out-of-range.golden.txt
@@ -1,0 +1,1 @@
+OUT_OF_RANGE: param 'port' 0x0200 does not fit in 9 bits (top bits of byte 0 are non-zero)

--- a/p4runtime/golden_errors/param-value-out-of-range.golden.txt
+++ b/p4runtime/golden_errors/param-value-out-of-range.golden.txt
@@ -1,1 +1,1 @@
-OUT_OF_RANGE: param 'port' 0x0200 does not fit in 9 bits (top bits of byte 0 are non-zero)
+OUT_OF_RANGE: param 'port' 0x0200 does not fit in 9 bits

--- a/p4runtime/golden_errors/param-width-mismatch.golden.txt
+++ b/p4runtime/golden_errors/param-width-mismatch.golden.txt
@@ -1,1 +1,0 @@
-INVALID_ARGUMENT: param 'port' expects 2 bytes, got 4

--- a/p4runtime/golden_errors/type-translation-failed.golden.txt
+++ b/p4runtime/golden_errors/type-translation-failed.golden.txt
@@ -1,1 +1,1 @@
-INVALID_ARGUMENT: type translation failed: no mapping for P4Runtime bitstring 0x00000001 (auto-allocate off)
+INVALID_ARGUMENT: type translation failed: no mapping for P4Runtime bitstring 0x01 (auto-allocate off)

--- a/p4runtime/golden_errors/wrong-match-width.golden.txt
+++ b/p4runtime/golden_errors/wrong-match-width.golden.txt
@@ -1,1 +1,0 @@
-INVALID_ARGUMENT: match field 'hdr.ethernet.etherType' value expects 2 bytes, got 1

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -17,7 +17,7 @@ import p4.v1.P4RuntimeOuterClass.Update
 private val bigIntCache = java.util.IdentityHashMap<ByteString, BigInteger>()
 
 /** Interprets a protobuf [ByteString] as an unsigned big-endian [BigInteger]. Cached for reuse. */
-internal fun ByteString.toUnsignedBigInteger(): BigInteger =
+fun ByteString.toUnsignedBigInteger(): BigInteger =
   bigIntCache.getOrPut(this) { BigInteger(1, toByteArray()) }
 
 /** Decode a proto ByteString as an unsigned Long. For the common case (≤8 bytes). */


### PR DESCRIPTION
## Summary

The P4Runtime write validator's "expects N bytes, got M" rule was the inverse of what spec §8.3 actually requires. Per the spec, receivers MUST NOT impose a length restriction — they must accept any length as long as the value fits in the field's bitwidth — and encoders MUST emit the shortest (canonical) form for read-write symmetry. 4ward did neither.

This PR fixes both directions and pins the behavior to the normative spec tables.

## What was wrong

- **Receiver too strict**: the validator at `WriteValidator.checkWidth` enforced exactly `ceil(W/8)` bytes, rejecting the canonical short form a spec-conformant client would send.
- **Range check missing**: nothing validated that bits beyond W-1 were zero, so a `bit<12>` field silently accepted `\x10\x63` (= 0x1063, > 0xFFF).
- **Wrong status code**: rejections used `INVALID_ARGUMENT`; spec mandates `OUT_OF_RANGE`.
- **Legacy reads**: the read path passed stored bytes through, and storage held padded form, so reads emitted padded — breaking the read-write symmetry property §8.3 is built on, and the rolling-upgrade scenario the spec is designed to enable.
- **Latent MODIFY/DELETE bug**: `TableStore.sameKey` compares match-lists with raw proto equality. Without canonicalization on store, a client writing `\x00\x63` and later modifying via the canonical `\x63` got `NotFound` — same logical key, different bytes.

## The fix

Two pieces:

1. **`WriteValidator`**: drop the byte-count check; introduce `requireFitsInBitwidth` that validates the represented integer fits in the field's bitwidth (`bitLength() <= W`, any length accepted), throws `OUT_OF_RANGE` on overflow or empty bytestrings. The structural checks (ternary masked bits, LPM trailing bits, range ordering) move to `BigInteger` so they work on any-length inputs.
2. **`P4RuntimeService.processUpdate`**: canonicalize all bytestrings on the write path before storage (between validate and translate). Storage holds canonical form → reads emit canonical form for free → `TableStore.sameKey` is consistent across encodings of the same logical value.

`canonicalizeBytestrings` and `canonicalizeTableAction` switch exhaustively on the proto oneof case enum, so adding a new entity or table-action variant fails at compile time rather than silently falling through (per AGENTS.md design invariant #2).

## Why this won't regress

`BytestringsTest` mirrors P4Runtime spec §8.3 Tables 4 and 5 verbatim — one assertion per row — so the test suite is a literal mirror of the normative tables. A property test sweeps integer values across common bitwidths (1, 8, 9, 16, 64, 128) and asserts that every padded encoding canonicalizes identically to its minimum form, which is the wire-side guarantee that powers `sameKey`.

The four `P4RuntimeConformanceTest` cases that previously asserted padded-form output have been updated to assert canonical form — making the spec connection explicit at the use site.

## Tests removed / changed

- `wrong-match-width.golden.txt` and `param-width-mismatch.golden.txt` encoded the wrong-but-implemented behavior; replaced with `match-value-out-of-range.golden.txt` and `param-value-out-of-range.golden.txt` that exercise the actual spec rule with `OUT_OF_RANGE`.
- `WriteValidatorTest`: nine tests asserting strict byte-count enforcement reframed to test value-out-of-range.
- `P4RuntimeConformanceTest #63` previously asserted reads were `ceil(W/8)` bytes (citing a non-existent §8.7); rewritten to assert canonical form, citing §8.3.

## Follow-up

#595 tracks adding cross-validation against bmv2's `simple_switch_grpc` as a defense against the next class of subtle spec divergence.

## Test plan

- [x] `bazel test //... --test_tag_filters=-heavy` passes locally
- [x] `./tools/format.sh` and `./tools/lint.sh` clean
- [ ] CI green