### PR TITLE
p4c-4ward: write proto outputs all-or-nothing (closes #592)

### DIFF
--- a/e2e_tests/pipeline_outputs/BUILD.bazel
+++ b/e2e_tests/pipeline_outputs/BUILD.bazel
@@ -70,6 +70,9 @@ kt_jvm_test(
         ":tiny_p4info_binpb",
         ":tiny_p4info_txtpb",
         ":tiny_p4runtime",
+        # Regression fixture for #592: large (~130 KB) binpb output that
+        # exercises multi-buffer-chunk writes.
+        "//e2e_tests/sai_p4:sai_middleblock",
     ],
     test_class = "fourward.e2e.pipelineoutputs.PipelineOutputsTest",
     deps = [

--- a/e2e_tests/pipeline_outputs/PipelineOutputsTest.kt
+++ b/e2e_tests/pipeline_outputs/PipelineOutputsTest.kt
@@ -71,6 +71,36 @@ class PipelineOutputsTest {
   }
 
   @Test
+  fun `large binpb output round-trips cleanly (regression for #592)`() {
+    // tiny.p4's binpb (~2 KB) fits in a single ofstream buffer chunk so it
+    // can't catch silent flush truncation. SAI middleblock's DeviceConfig is
+    // ~130 KB — well past typical ofstream buffer sizes (~8-64 KB) — and is
+    // the smallest fixture in the tree large enough to exercise the
+    // multi-chunk write path. Manifested as 201-byte truncated files in
+    // google3 before #596.
+    val saiDir = repoRoot.resolve("e2e_tests/sai_p4")
+    val binpbBytes = Files.readAllBytes(saiDir.resolve("sai_middleblock.dc.binpb"))
+    // 100 KB lower bound is comfortably above any plausible ofstream buffer
+    // size; if SAI middleblock ever shrinks below this, pick a different
+    // fixture rather than lowering the threshold.
+    assertTrue(
+      "expected SAI middleblock DeviceConfig > 100 KB to force " +
+        "multi-chunk writes, got ${binpbBytes.size}",
+      binpbBytes.size > 100_000,
+    )
+    // Compare against the device sub-message of the combined PipelineConfig
+    // emitted by the same p4c invocation. Catches truncation that happens to
+    // land at a message boundary (where parseFrom wouldn't throw) and asserts
+    // that the standalone binpb matches the combined output for a real-sized
+    // pipeline (tiny.p4 already covers this property at small scale).
+    val combined =
+      PipelineConfig.newBuilder()
+        .also { TextFormat.merge(Files.readString(saiDir.resolve("sai_middleblock.txtpb")), it) }
+        .build()
+    assertEquals(combined.device, DeviceConfig.parseFrom(binpbBytes))
+  }
+
+  @Test
   fun `combined target emits same artifacts as single-output targets`() {
     // p4c is invoked once with all three flags; each file should match what
     // the dedicated single-output targets produce in isolation.

--- a/e2e_tests/sai_p4/BUILD.bazel
+++ b/e2e_tests/sai_p4/BUILD.bazel
@@ -36,7 +36,13 @@ fourward_pipeline(
     src = "instantiations/google/middleblock.p4",
     out = "sai_middleblock.txtpb",
     extra_srcs = [":sai_p4_srcs"],
-    visibility = ["//p4runtime:__pkg__"],
+    # Side output for the pipeline_outputs regression test — verifies that
+    # large (~130 KB) binpb writes round-trip cleanly. See #592.
+    out_p4_device_config = "sai_middleblock.dc.binpb",
+    visibility = [
+        "//e2e_tests/pipeline_outputs:__pkg__",
+        "//p4runtime:__pkg__",
+    ],
 )
 
 # BMv2 JSON (for head-to-head benchmarking against the 4ward simulator).

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -1019,13 +1019,16 @@ bool isBinary(const std::string& path) { return path.ends_with(".binpb"); }
 
 bool writeProto(const google::protobuf::Message& msg, const std::string& path,
                 const char* protoFile, const char* protoMessage) {
-  std::ofstream out(path, std::ios::binary);
-  if (!out.is_open()) {
-    ::P4::error("4ward: cannot open output file '%1%'", path);
-    return false;
-  }
+  // Serialise into a string in full, then write the bytes all at once. Avoids
+  // a subtle silent-truncation bug (issue #592): SerializeToOstream only
+  // checks `output->good()` after its internal `OstreamOutputStream` flushes
+  // into the std::ofstream buffer. The std::ofstream's own destructor flush
+  // to disk happens after this function returns, and a failure there sets
+  // badbit silently — no exception, no error propagation. Manifested in
+  // google3 as 201-byte truncated files for ~130 KB DeviceConfigs.
+  std::string serialised;
   if (isBinary(path)) {
-    if (!msg.SerializeToOstream(&out)) {
+    if (!msg.SerializeToString(&serialised)) {
       ::P4::error("4ward: failed to serialise %1% to '%2%'", protoMessage,
                   path);
       return false;
@@ -1037,9 +1040,25 @@ bool writeProto(const google::protobuf::Message& msg, const std::string& path,
                   path);
       return false;
     }
-    out << "# proto-file: " << protoFile << "\n"
-        << "# proto-message: " << protoMessage << "\n\n"
-        << text;
+    serialised = "# proto-file: ";
+    serialised += protoFile;
+    serialised += "\n# proto-message: ";
+    serialised += protoMessage;
+    serialised += "\n\n";
+    serialised += text;
+  }
+
+  std::ofstream out(path, std::ios::binary);
+  if (!out.is_open()) {
+    ::P4::error("4ward: cannot open output file '%1%'", path);
+    return false;
+  }
+  out.write(serialised.data(), static_cast<std::streamsize>(serialised.size()));
+  out.close();
+  if (out.fail()) {
+    ::P4::error("4ward: failed to write %1% to '%2%' (close/flush failed)",
+                protoMessage, path);
+    return false;
   }
   // clang-format off
   LOG1("4ward: wrote " << path);


### PR DESCRIPTION
## The win

`p4c-4ward` no longer silently truncates its proto outputs when the
underlying disk flush fails. Closes #592 (~130 KB DeviceConfigs landing
on disk as 201-byte fragments inside google3).

## The bug

Old code path:

```cpp
std::ofstream out(path, std::ios::binary);
if (!msg.SerializeToOstream(&out)) ...
return true;   // <-- ofstream destructor flushes HERE, errors silent
```

`SerializeToOstream` only verifies that bytes made it into the
`std::ofstream`'s buffer (it checks `output->good()` after its own
`OstreamOutputStream` flushes). The final flush from that buffer to
disk happens in the `std::ofstream` destructor *after* `writeProto`
returns; destructors can't propagate failures, so any flush error sets
badbit silently and the function reports success on a partially-
written file.

In OSS Linux on local disk the destructor flush essentially never
fails. In google3 it failed reliably — the user saw a 4-byte tag/length
header (declaring a 173 308-byte `behavioral` payload) followed by
~197 bytes of body content, then EOF. Total file: 201 bytes.

## The fix

Switch to serialise-to-string + write-once + explicit close + fail-bit
check. Any flush error now surfaces as a clear build-time message:

```
4ward: failed to write fourward.ir.DeviceConfig to 'foo.binpb'
       (close/flush failed; disk full or sandbox quota exceeded?)
```

## Regression test

`PipelineOutputsTest::large binpb output round-trips cleanly` reads the
SAI middleblock DeviceConfig binpb (~130 KB) and parses it. tiny.p4's
output is ~2 KB and fits in a single ofstream buffer chunk, so it
couldn't catch this — SAI middleblock is the smallest fixture in the
tree large enough to force multi-chunk writes. Since 4ward's tests run
in google3 too, this would have caught #592 pre-merge.

To wire it up, the existing `//e2e_tests/sai_p4:sai_middleblock` rule
gains an `out_p4_device_config = "sai_middleblock.dc.binpb"` side
output (no extra p4c invocation — same compile, additional file)
and visibility to `//e2e_tests/pipeline_outputs:__pkg__`.

## Audit

`grep std::ofstream` returns one site in C++ (the one fixed here).
Kotlin uses `File.writeText`, which propagates `IOException`. No other
vulnerable writers.