### PR TITLE
designs: P4Runtime differential testing proposal (#595)

### DIFF
--- a/designs/p4runtime_diff.md
+++ b/designs/p4runtime_diff.md
@@ -1,0 +1,205 @@
+# P4Runtime Differential Testing Design
+
+**Status: proposal**
+
+Tracks issue #595.
+
+## Goal
+
+Cross-validate 4ward's P4Runtime gRPC server against BMv2's
+`simple_switch_grpc` on a corpus of write/read scenarios, so that subtle
+spec divergences (like the §8.3 bytestring encoding bug fixed in #594) get
+caught by an external oracle rather than relying on our own reading of the
+spec.
+
+## What we already have
+
+The `e2e_tests/bmv2_diff/` harness drives BMv2 and 4ward through equivalent
+data-plane operations and compares output packets bit-for-bit. It uses
+BMv2's C++ `simple_switch` library directly (`bmv2_driver.cpp` issues
+`TABLE_ADD`, `PACKET`, etc., commands over stdin/stdout). The corpus is
+~50 STF tests pulled from `@p4c//testdata/p4_16_samples`.
+
+This validates that the **data plane** behaves the same way given the same
+table state. It does not exercise the **P4Runtime control plane** — the
+gRPC API itself is bypassed entirely in favor of BMv2's internal C++
+plumbing.
+
+## What's missing
+
+The §8.3 bug lived in the gRPC adapter — in code BMv2 never sees and our
+existing harness never touches. The same is likely true of other
+P4Runtime-spec corners: status codes, batch atomicity, role config, idle
+timeout, default-action semantics, action-profile group membership rules,
+counter/meter direct-vs-indirect dispatch. Any of these could diverge
+silently between 4ward and BMv2 today.
+
+A control-plane differential harness would speak P4Runtime gRPC to both
+servers and compare responses byte-by-byte (or with documented
+canonicalizations).
+
+## Design
+
+### Topology
+
+```
+                 ┌──────────────────────────────┐
+                 │   P4Runtime test scenario     │
+                 │   (Write/Read sequences)      │
+                 └────────────┬─────────────────┘
+                              │ same gRPC requests
+              ┌───────────────┴───────────────┐
+              ▼                               ▼
+   ┌──────────────────────┐       ┌──────────────────────┐
+   │   4ward p4runtime    │       │  BMv2                │
+   │   server subprocess  │       │  simple_switch_grpc  │
+   └──────────┬───────────┘       └──────────┬───────────┘
+              │ WriteResponse,               │ WriteResponse,
+              │ ReadResponse                 │ ReadResponse
+              └───────────────┬──────────────┘
+                              ▼
+                       diff (with allowed
+                       canonicalizations)
+                              │
+                              ▼
+                          pass/fail
+```
+
+Both servers are spawned as subprocesses, each listening on a separate
+gRPC port. The test harness is a Kotlin gRPC client that issues identical
+requests to both and diffs responses.
+
+### Building `simple_switch_grpc`
+
+The current BMv2 Bazel patch builds `simple_switch_lib` and the
+`behavioral_model` binary, but not `simple_switch_grpc`. That binary
+depends on `p4lang/PI`, which is a separate repo and a non-trivial Bazel
+port (PI itself depends on protobuf, gRPC, and several p4lang sub-deps).
+
+Two paths to consider, in order of preference:
+
+1. **Patch the existing `behavioral_model` Bazel module to also build
+   `simple_switch_grpc`** by pulling in `p4lang/PI` as a `git_override`'d
+   `bazel_dep`. Highest-fidelity, hermetic. The cost is writing Bazel
+   rules for PI — likely the largest single chunk of work in this
+   project, comparable in scope to the existing behavioral_model patch.
+
+2. **Use a prebuilt `simple_switch_grpc` binary fetched as an
+   `http_file`.** Lower hermeticity, faster to land, but introduces a
+   binary dependency that's hard to keep in sync with the rest of the
+   BMv2 dep. Only useful as a stopgap.
+
+Recommend (1). It's the right architectural choice, and it sets up future
+work (P4Runtime extern-related testing, gNMI, etc.) on the same footing.
+
+### Test scenarios
+
+Start small. The corpus is **not** the existing STF tests — those are
+data-plane oriented. The corpus is a new set of Kotlin-defined sequences,
+each describing:
+
+- A pipeline config (P4 program + P4Info).
+- A sequence of P4Runtime requests: `SetForwardingPipelineConfig`,
+  `Write` (insert/modify/delete), `Read`, `StreamChannel` events.
+- For each request, the expected outcome class: success, specific gRPC
+  error code, etc. — used as a sanity check before the diff fires.
+
+Initial scenarios:
+
+- **Round-trip canonical form.** Write a TableEntry with various
+  encodings; Read it back; both servers must return the same canonical
+  form. (This is the §8.3 regression test, externally validated.)
+- **Modify-after-padded-write.** Write with padded encoding; Modify with
+  canonical encoding; both servers must treat them as the same key.
+- **Out-of-range values.** Write with a value exceeding the field
+  bitwidth; both servers must return `OUT_OF_RANGE` (or
+  `INVALID_ARGUMENT` — note documented divergence).
+- **Batch atomicity.** A `WriteRequest` with one valid + one invalid
+  update under each `Atomicity` mode.
+- **Default action semantics.** Modify default; read; verify both
+  servers' read-back behavior.
+
+Each scenario is one Kotlin test. Failures point at the divergent fields
+in the responses.
+
+### Allowed divergences
+
+Some differences are non-bugs and need to be canonicalized away before
+diffing:
+
+- **Field ordering** in repeated fields (e.g. `match` lists) — sort by
+  `field_id` before compare.
+- **Error message text** — compare error code only, not description.
+- **Counter/meter timing values** — compare presence/structure, not
+  values, or use a tolerance. Out of scope for the first cut; only
+  exercise scenarios that don't depend on these.
+- **Server-assigned IDs** (action profile member handles, multicast
+  group node handles) — record and substitute, don't compare directly.
+
+A sealed `DiffStrategy` per response type makes these choices explicit,
+and a divergence in a strategy that wasn't anticipated counts as a test
+failure.
+
+## Phasing
+
+1. **Phase 1: BMv2 PI Bazel port.** Extend the BMv2 patch to build
+   `simple_switch_grpc`. No 4ward code changes; gate completion on
+   spawning the binary from a Bazel test and seeing it accept a
+   gRPC connection.
+2. **Phase 2: Harness skeleton.** A `Bmv2P4RuntimeRunner` that wraps the
+   BMv2 subprocess. A test that spawns both servers, sets a pipeline
+   config on both, performs a single Write+Read, and asserts the
+   responses match. One scenario, end-to-end.
+3. **Phase 3: Initial scenario corpus.** Add the five scenarios above.
+   Document divergences found. Some are 4ward bugs (file as issues with
+   reproducers); some are BMv2 bugs (file upstream); some are
+   spec-ambiguous (raise with the P4 API working group).
+4. **Phase 4: Corpus growth.** Iterate. Add scenarios as P4Runtime
+   features land in 4ward.
+
+Phase 1 is a real chunk of Bazel work and could be its own PR. Phases
+2 and 3 should land together — a harness with no scenarios isn't useful.
+
+## Non-goals
+
+- **Replacing the existing `bmv2_diff` data-plane harness.** Different
+  layer, different oracle, different failure modes. Both stay.
+- **Behavioral parity with BMv2 across the full P4Runtime API.** BMv2
+  has features 4ward doesn't (and vice versa); the corpus targets the
+  intersection. Documented divergences are an output, not a defect.
+- **Continuous coverage of every P4Runtime field.** This is a
+  spec-conformance harness, not a fuzzer. Targeted scenarios beat broad
+  coverage when the goal is catching subtle spec divergences.
+
+## Risks
+
+- **PI's Bazel port is the long pole.** If it turns out PI's transitive
+  dependencies are incompatible with our Bazel config (e.g. protobuf
+  version skew), Phase 1 stalls. Pre-flight by attempting a minimal
+  `cc_library(name = "PI", srcs = ...)` build before committing to the
+  full design.
+- **Test flakiness from subprocess management.** Two servers per test
+  scenario with port allocation, startup races, and graceful shutdown
+  is more failure surface than the existing single-process harness.
+  Reuse `e2e_tests/bmv2_diff/Bmv2Runner.kt`'s patterns where they
+  apply.
+- **Divergences could be overwhelming.** If the first run finds 30
+  divergences, triage becomes a project of its own. Mitigation: start
+  with high-confidence scenarios (the §8.3 fix is one), expand from
+  there.
+
+## Alternatives considered
+
+- **STF-as-control-plane.** Keep extending the existing harness with
+  more STF tests. Doesn't help — STF doesn't exercise the gRPC layer.
+- **Drive 4ward's P4Runtime server, drive BMv2 via its existing C++
+  driver, diff the resulting data-plane behavior.** Backwards: tests
+  the data plane through different control-plane paths. The bug we'd
+  catch is "did the control plane translate to the same data-plane
+  state?" — useful, but doesn't catch gRPC-API-only bugs (status codes,
+  encoding rules, etc.).
+- **p4lang's existing P4Runtime conformance test suite.** Worth
+  checking — but the suites I know about (PTF, p4runtime-shell tests)
+  are written against specific testbeds, not as a library you can
+  point at two implementations and diff. May change if a more general
+  suite has emerged.

--- a/designs/p4runtime_diff.md
+++ b/designs/p4runtime_diff.md
@@ -36,11 +36,12 @@ canonicalizations.
 
 The §8.3 bytestring fix in #594 lived in the gRPC adapter — code BMv2's
 C++ API never reaches and our existing differential harness
-(`e2e_tests/bmv2_diff/`, 187 STF tests) never touches. The same is
-likely true of other corners: status codes, batch atomicity, role
-config, idle timeout, default-action semantics, action-profile group
-membership rules. Today, 4ward's tests encode our *reading* of the spec;
-a control-plane differential harness uses an external implementation as
+(`e2e_tests/bmv2_diff/`, 187 STF tests) never touches. Candidate
+corners that could be similarly affected include status codes, batch
+atomicity, role config, idle timeout, default-action semantics, and
+action-profile group membership rules — none verified, hence the
+proposal. Today, 4ward's tests encode our *reading* of the spec; a
+control-plane differential harness uses an external implementation as
 oracle.
 
 ## Design
@@ -50,11 +51,32 @@ oracle.
 `bazel/behavioral_model.patch` builds `simple_switch_lib` and its
 transitive deps but explicitly omits PI ("Minimal build: no Thrift, no
 nanomsg, no debugger, no PI"). The `simple_switch_grpc` binary depends
-on [`p4lang/PI`](https://github.com/p4lang/PI), which carries a Thrift
-dependency and a wider protobuf/gRPC surface than the existing patch
-covers. Realistic estimate: 2–3× the size of the current 223-line
-patch, plus pulling PI in as a `git_override`'d `bazel_dep`. **This is
-Phase 1 below and is the dominant risk** (see Risks).
+on [`p4lang/PI`](https://github.com/p4lang/PI).
+
+Some prior art reduces the cost:
+
+- **Upstream PI already has WORKSPACE-style Bazel rules** for the core
+  library (`pihdrs`, `piutils`, `pip4info`, `pi`, …). See PI's
+  [`BUILD`](https://github.com/p4lang/PI/blob/main/BUILD) and
+  [`bazel/deps.bzl`](https://github.com/p4lang/PI/blob/main/bazel/deps.bzl).
+  Stratum already consumes it as a Bazel dep
+  ([`stratum/bazel/deps.bzl`](https://github.com/stratum/stratum/blob/main/bazel/deps.bzl)),
+  proving it works in production.
+- **What's missing upstream**: BUILD files for `targets/bmv2/` (the
+  `simple_switch_grpc` target plugin) and `bin/`. Those are
+  autotools-only today. We'd write them.
+- **Bzlmod shim**: 4ward uses Bzlmod, PI is WORKSPACE-only, no BCR
+  module exists. We'd add a small `MODULE.bazel` wrapping the
+  upstream WORKSPACE rules.
+- **Version skew**: PI pins protobuf/gRPC versions that may diverge
+  from ours; resolving that is the most likely source of incidental
+  scope.
+
+Net: the core PI port is reuse, not greenfield; the
+`simple_switch_grpc`/`bin/` BUILD files plus a Bzlmod shim are the
+genuinely new work. Plausibly 1–2 weeks of focused work, dominated by
+version-skew triage. **This is Phase 1 and remains the dominant risk**
+(see Risks).
 
 ### Scenarios
 
@@ -75,9 +97,9 @@ Initial scenarios:
   with canonical encoding; both servers must treat them as the same
   key.
 - **Out-of-range values.** Write with a value exceeding the field
-  bitwidth; both must reject. Note documented divergence on the
-  specific gRPC code (4ward returns `OUT_OF_RANGE`; BMv2's code
-  unknown until measured).
+  bitwidth; both must reject. 4ward returns `OUT_OF_RANGE` per spec;
+  BMv2's actual code is to be measured during Phase 2 and recorded as
+  either an expected match or a documented divergence.
 - **Batch atomicity.** A `WriteRequest` with one valid + one invalid
   update under each `Atomicity` mode.
 - **Default action semantics.** Modify default; read; verify both
@@ -117,10 +139,11 @@ failure.
 
 ## Phasing
 
-1. **PI Bazel port.** Extend the BMv2 patch (or write a new patch on a
-   `git_override`'d `p4lang/PI` dep) until `simple_switch_grpc` builds
-   under Bazel and accepts a gRPC connection from a test. No 4ward
-   code changes. Likely its own PR.
+1. **PI Bazel port.** Pull `p4lang/PI` in as a `git_override`'d
+   `bazel_dep`, reusing its upstream WORKSPACE Bazel rules; add the
+   missing BUILD files for `targets/bmv2/` and `bin/`; resolve
+   version skew with our protobuf/gRPC. No 4ward code changes; ships
+   as its own PR.
 2. **Harness skeleton.** A `Bmv2P4RuntimeRunner`. A test that spawns
    both servers, sets a pipeline config on each, performs one
    Write+Read, asserts responses match.
@@ -153,13 +176,17 @@ useful.
   port allocation, startup races, and graceful shutdown is more
   failure surface than the existing single-process harness. Reusing
   `Bmv2Runner.kt`'s lifecycle is mitigation.
-- **Divergence triage.** If the first run of Phase 3 finds 30
-  divergences, triage becomes its own project. Mitigation: scenarios
-  are ordered by confidence, starting with the §8.3 regression test
-  where 4ward and the spec demonstrably agree.
-- **CI cost.** Two gRPC servers per scenario will not fit the
-  default-test budget. Plan to tag the suite `heavy` and run only on
-  CI, like the existing bmv2 diff tests.
+- **Divergence triage.** Baseline rate is unknown until Phase 3 runs.
+  Mitigation: scenarios are ordered by confidence, starting with the
+  §8.3 regression test where 4ward and the spec demonstrably agree —
+  any divergence there is a BMv2 bug, not ours. If volume turns out
+  to be high, scenarios get a `divergence-classified` tag and fail
+  only on unclassified differences.
+- **CI cost.** Two gRPC servers per scenario doesn't fit the default
+  test budget; tag the suite `heavy` and skip locally, run on CI.
+  Only two `heavy` targets exist today (`bmv2_diff_test` and the
+  `P4RuntimeWriteErrorTest` heavy variant), so adding a peer suite
+  is well within the existing pattern.
 
 ## Alternatives considered
 
@@ -177,3 +204,6 @@ useful.
   are written against specific testbeds, not as libraries you point
   at two implementations and diff. None replace the proposed harness;
   individual test cases from them may be portable into the corpus.
+- **Stratum's PI consumption.** Stratum already pins PI as a Bazel
+  dep but uses it as a *backend*, not for differential testing. Their
+  Bazel wiring is reusable as reference; their use case is not.

--- a/designs/p4runtime_diff.md
+++ b/designs/p4runtime_diff.md
@@ -1,46 +1,16 @@
 # P4Runtime Differential Testing Design
 
-**Status: proposal**
+**Status: proposal.** Tracks issue #595; realizes the open question in
+[`docs/TESTING_STRATEGY.md`](../docs/TESTING_STRATEGY.md) §"Open
+questions" ("What's the equivalent of BMv2 diff testing?") and the
+external-validation goal in [`docs/ROADMAP.md`](../docs/ROADMAP.md)
+Track 9.
 
-Tracks issue #595.
+## Proposal
 
-## Goal
-
-Cross-validate 4ward's P4Runtime gRPC server against BMv2's
-`simple_switch_grpc` on a corpus of write/read scenarios, so that subtle
-spec divergences (like the §8.3 bytestring encoding bug fixed in #594) get
-caught by an external oracle rather than relying on our own reading of the
-spec.
-
-## What we already have
-
-The `e2e_tests/bmv2_diff/` harness drives BMv2 and 4ward through equivalent
-data-plane operations and compares output packets bit-for-bit. It uses
-BMv2's C++ `simple_switch` library directly (`bmv2_driver.cpp` issues
-`TABLE_ADD`, `PACKET`, etc., commands over stdin/stdout). The corpus is
-~50 STF tests pulled from `@p4c//testdata/p4_16_samples`.
-
-This validates that the **data plane** behaves the same way given the same
-table state. It does not exercise the **P4Runtime control plane** — the
-gRPC API itself is bypassed entirely in favor of BMv2's internal C++
-plumbing.
-
-## What's missing
-
-The §8.3 bug lived in the gRPC adapter — in code BMv2 never sees and our
-existing harness never touches. The same is likely true of other
-P4Runtime-spec corners: status codes, batch atomicity, role config, idle
-timeout, default-action semantics, action-profile group membership rules,
-counter/meter direct-vs-indirect dispatch. Any of these could diverge
-silently between 4ward and BMv2 today.
-
-A control-plane differential harness would speak P4Runtime gRPC to both
-servers and compare responses byte-by-byte (or with documented
-canonicalizations).
-
-## Design
-
-### Topology
+Drive 4ward's P4Runtime gRPC server and BMv2's `simple_switch_grpc` with
+the same gRPC requests, diff the responses with a small set of documented
+canonicalizations.
 
 ```
                  ┌──────────────────────────────┐
@@ -58,148 +28,152 @@ canonicalizations).
               │ ReadResponse                 │ ReadResponse
               └───────────────┬──────────────┘
                               ▼
-                       diff (with allowed
-                       canonicalizations)
-                              │
-                              ▼
-                          pass/fail
+                        diff (with allowed
+                        canonicalizations)
 ```
 
-Both servers are spawned as subprocesses, each listening on a separate
-gRPC port. The test harness is a Kotlin gRPC client that issues identical
-requests to both and diffs responses.
+## Why
 
-### Building `simple_switch_grpc`
+The §8.3 bytestring fix in #594 lived in the gRPC adapter — code BMv2's
+C++ API never reaches and our existing differential harness
+(`e2e_tests/bmv2_diff/`, 187 STF tests) never touches. The same is
+likely true of other corners: status codes, batch atomicity, role
+config, idle timeout, default-action semantics, action-profile group
+membership rules. Today, 4ward's tests encode our *reading* of the spec;
+a control-plane differential harness uses an external implementation as
+oracle.
 
-The current BMv2 Bazel patch builds `simple_switch_lib` and the
-`behavioral_model` binary, but not `simple_switch_grpc`. That binary
-depends on `p4lang/PI`, which is a separate repo and a non-trivial Bazel
-port (PI itself depends on protobuf, gRPC, and several p4lang sub-deps).
+## Design
 
-Two paths to consider, in order of preference:
+### Building `simple_switch_grpc` is the long pole
 
-1. **Patch the existing `behavioral_model` Bazel module to also build
-   `simple_switch_grpc`** by pulling in `p4lang/PI` as a `git_override`'d
-   `bazel_dep`. Highest-fidelity, hermetic. The cost is writing Bazel
-   rules for PI — likely the largest single chunk of work in this
-   project, comparable in scope to the existing behavioral_model patch.
+`bazel/behavioral_model.patch` builds `simple_switch_lib` and its
+transitive deps but explicitly omits PI ("Minimal build: no Thrift, no
+nanomsg, no debugger, no PI"). The `simple_switch_grpc` binary depends
+on [`p4lang/PI`](https://github.com/p4lang/PI), which carries a Thrift
+dependency and a wider protobuf/gRPC surface than the existing patch
+covers. Realistic estimate: 2–3× the size of the current 223-line
+patch, plus pulling PI in as a `git_override`'d `bazel_dep`. **This is
+Phase 1 below and is the dominant risk** (see Risks).
 
-2. **Use a prebuilt `simple_switch_grpc` binary fetched as an
-   `http_file`.** Lower hermeticity, faster to land, but introduces a
-   binary dependency that's hard to keep in sync with the rest of the
-   BMv2 dep. Only useful as a stopgap.
+### Scenarios
 
-Recommend (1). It's the right architectural choice, and it sets up future
-work (P4Runtime extern-related testing, gNMI, etc.) on the same footing.
-
-### Test scenarios
-
-Start small. The corpus is **not** the existing STF tests — those are
-data-plane oriented. The corpus is a new set of Kotlin-defined sequences,
-each describing:
+The corpus is a new set of Kotlin-defined sequences, not the existing
+STF corpus (which is data-plane oriented). Each scenario describes:
 
 - A pipeline config (P4 program + P4Info).
-- A sequence of P4Runtime requests: `SetForwardingPipelineConfig`,
-  `Write` (insert/modify/delete), `Read`, `StreamChannel` events.
-- For each request, the expected outcome class: success, specific gRPC
-  error code, etc. — used as a sanity check before the diff fires.
+- A sequence of P4Runtime requests.
+- For each request, the expected outcome class — used as a sanity
+  check before the diff fires.
 
 Initial scenarios:
 
 - **Round-trip canonical form.** Write a TableEntry with various
   encodings; Read it back; both servers must return the same canonical
-  form. (This is the §8.3 regression test, externally validated.)
-- **Modify-after-padded-write.** Write with padded encoding; Modify with
-  canonical encoding; both servers must treat them as the same key.
+  form. (The §8.3 regression test, externally validated.)
+- **Modify-after-padded-write.** Write with padded encoding; Modify
+  with canonical encoding; both servers must treat them as the same
+  key.
 - **Out-of-range values.** Write with a value exceeding the field
-  bitwidth; both servers must return `OUT_OF_RANGE` (or
-  `INVALID_ARGUMENT` — note documented divergence).
+  bitwidth; both must reject. Note documented divergence on the
+  specific gRPC code (4ward returns `OUT_OF_RANGE`; BMv2's code
+  unknown until measured).
 - **Batch atomicity.** A `WriteRequest` with one valid + one invalid
   update under each `Atomicity` mode.
 - **Default action semantics.** Modify default; read; verify both
   servers' read-back behavior.
 
-Each scenario is one Kotlin test. Failures point at the divergent fields
-in the responses.
+Five scenarios is the Phase 3 target. Phase 4 grows to ~20, prioritised
+by recent P4Runtime feature work.
 
-### Allowed divergences
+### Canonicalizations before diff
 
-Some differences are non-bugs and need to be canonicalized away before
+Some differences are non-bugs and must be canonicalized away before
 diffing:
 
-- **Field ordering** in repeated fields (e.g. `match` lists) — sort by
-  `field_id` before compare.
+- **Field ordering** in repeated fields (`match` lists) — sort by
+  `field_id`.
 - **Error message text** — compare error code only, not description.
-- **Counter/meter timing values** — compare presence/structure, not
-  values, or use a tolerance. Out of scope for the first cut; only
-  exercise scenarios that don't depend on these.
 - **Server-assigned IDs** (action profile member handles, multicast
-  group node handles) — record and substitute, don't compare directly.
+  group node handles) — record and substitute.
+- **Counter/meter timing values** — out of scope for the first cut;
+  initial scenarios avoid these.
 
-A sealed `DiffStrategy` per response type makes these choices explicit,
-and a divergence in a strategy that wasn't anticipated counts as a test
+A sealed `DiffStrategy` per response type makes these choices explicit;
+divergence in a strategy that wasn't anticipated counts as a test
 failure.
+
+### Reuse of existing infrastructure
+
+- `e2e_tests/bmv2_diff/Bmv2Runner.kt` already manages a BMv2 subprocess
+  with port allocation, startup readiness checks, and graceful
+  shutdown. Phase 2's `Bmv2P4RuntimeRunner` should mirror that
+  lifecycle directly — same patterns, different transport.
+- 4ward already exposes a `p4runtime_server` Kotlin binary
+  (`p4runtime/BUILD.bazel`); the harness spawns it as a subprocess
+  the same way DVaaS integration (designs/dvaas_integration.md) does.
+- The gRPC client is the standard P4Runtime Kotlin stub already used
+  by `P4RuntimeConformanceTest`.
 
 ## Phasing
 
-1. **Phase 1: BMv2 PI Bazel port.** Extend the BMv2 patch to build
-   `simple_switch_grpc`. No 4ward code changes; gate completion on
-   spawning the binary from a Bazel test and seeing it accept a
-   gRPC connection.
-2. **Phase 2: Harness skeleton.** A `Bmv2P4RuntimeRunner` that wraps the
-   BMv2 subprocess. A test that spawns both servers, sets a pipeline
-   config on both, performs a single Write+Read, and asserts the
-   responses match. One scenario, end-to-end.
-3. **Phase 3: Initial scenario corpus.** Add the five scenarios above.
-   Document divergences found. Some are 4ward bugs (file as issues with
-   reproducers); some are BMv2 bugs (file upstream); some are
-   spec-ambiguous (raise with the P4 API working group).
-4. **Phase 4: Corpus growth.** Iterate. Add scenarios as P4Runtime
-   features land in 4ward.
+1. **PI Bazel port.** Extend the BMv2 patch (or write a new patch on a
+   `git_override`'d `p4lang/PI` dep) until `simple_switch_grpc` builds
+   under Bazel and accepts a gRPC connection from a test. No 4ward
+   code changes. Likely its own PR.
+2. **Harness skeleton.** A `Bmv2P4RuntimeRunner`. A test that spawns
+   both servers, sets a pipeline config on each, performs one
+   Write+Read, asserts responses match.
+3. **Initial scenario corpus.** The five scenarios above. Triage
+   divergences: file 4ward bugs as issues, file BMv2 bugs upstream,
+   raise spec ambiguities with the P4 API working group.
+4. **Corpus growth.** Add scenarios as P4Runtime features land.
 
-Phase 1 is a real chunk of Bazel work and could be its own PR. Phases
-2 and 3 should land together — a harness with no scenarios isn't useful.
+Phases 2 and 3 land together — a harness with no scenarios isn't
+useful.
 
 ## Non-goals
 
 - **Replacing the existing `bmv2_diff` data-plane harness.** Different
   layer, different oracle, different failure modes. Both stay.
 - **Behavioral parity with BMv2 across the full P4Runtime API.** BMv2
-  has features 4ward doesn't (and vice versa); the corpus targets the
+  has features 4ward doesn't (and vice versa). The corpus targets the
   intersection. Documented divergences are an output, not a defect.
 - **Continuous coverage of every P4Runtime field.** This is a
-  spec-conformance harness, not a fuzzer. Targeted scenarios beat broad
-  coverage when the goal is catching subtle spec divergences.
+  spec-conformance harness, not a fuzzer.
 
 ## Risks
 
-- **PI's Bazel port is the long pole.** If it turns out PI's transitive
-  dependencies are incompatible with our Bazel config (e.g. protobuf
-  version skew), Phase 1 stalls. Pre-flight by attempting a minimal
-  `cc_library(name = "PI", srcs = ...)` build before committing to the
-  full design.
-- **Test flakiness from subprocess management.** Two servers per test
-  scenario with port allocation, startup races, and graceful shutdown
-  is more failure surface than the existing single-process harness.
-  Reuse `e2e_tests/bmv2_diff/Bmv2Runner.kt`'s patterns where they
-  apply.
-- **Divergences could be overwhelming.** If the first run finds 30
-  divergences, triage becomes a project of its own. Mitigation: start
-  with high-confidence scenarios (the §8.3 fix is one), expand from
-  there.
+- **PI's Bazel port is the long pole.** PI itself depends on Thrift,
+  protobuf, gRPC, and several p4lang sub-deps. If transitive
+  dependencies clash with our existing protobuf/gRPC versions, Phase
+  1 stalls. Pre-flight by attempting a minimal `cc_library(name =
+  "PI")` build before committing to the full design.
+- **Subprocess management flakiness.** Two servers per scenario with
+  port allocation, startup races, and graceful shutdown is more
+  failure surface than the existing single-process harness. Reusing
+  `Bmv2Runner.kt`'s lifecycle is mitigation.
+- **Divergence triage.** If the first run of Phase 3 finds 30
+  divergences, triage becomes its own project. Mitigation: scenarios
+  are ordered by confidence, starting with the §8.3 regression test
+  where 4ward and the spec demonstrably agree.
+- **CI cost.** Two gRPC servers per scenario will not fit the
+  default-test budget. Plan to tag the suite `heavy` and run only on
+  CI, like the existing bmv2 diff tests.
 
 ## Alternatives considered
 
-- **STF-as-control-plane.** Keep extending the existing harness with
-  more STF tests. Doesn't help — STF doesn't exercise the gRPC layer.
-- **Drive 4ward's P4Runtime server, drive BMv2 via its existing C++
-  driver, diff the resulting data-plane behavior.** Backwards: tests
-  the data plane through different control-plane paths. The bug we'd
-  catch is "did the control plane translate to the same data-plane
-  state?" — useful, but doesn't catch gRPC-API-only bugs (status codes,
-  encoding rules, etc.).
-- **p4lang's existing P4Runtime conformance test suite.** Worth
-  checking — but the suites I know about (PTF, p4runtime-shell tests)
-  are written against specific testbeds, not as a library you can
-  point at two implementations and diff. May change if a more general
-  suite has emerged.
+- **STF-as-control-plane.** Extending the existing harness with more
+  STF tests doesn't help — STF doesn't exercise the gRPC layer.
+- **Diff data-plane behavior across two control-plane paths.** Drive
+  4ward via gRPC and BMv2 via its existing C++ driver, then compare
+  output packets. Catches "did the control plane translate to the
+  same data-plane state?" but not gRPC-API-only bugs (status codes,
+  encoding rules).
+- **Existing P4Runtime conformance suites.**
+  [`p4lang/PI`'s PTF tests](https://github.com/p4lang/PI),
+  [`p4runtime-shell`](https://github.com/p4lang/p4runtime-shell), and
+  [`fabric-p4test`](https://github.com/opennetworkinglab/fabric-p4test)
+  are written against specific testbeds, not as libraries you point
+  at two implementations and diff. None replace the proposed harness;
+  individual test cases from them may be portable into the corpus.


### PR DESCRIPTION
## Summary

Design doc scoping the work for issue #595 — cross-validating 4ward's P4Runtime gRPC server against BMv2's `simple_switch_grpc`.

## What changed

- New file: `designs/p4runtime_diff.md` (205 lines).

## Highlights

- **Acknowledges existing infra.** The `e2e_tests/bmv2_diff/` harness already does data-plane diff against BMv2 via its C++ API. The control-plane gRPC layer is the gap.
- **Identifies the long pole**: porting `p4lang/PI` to Bazel so `simple_switch_grpc` actually builds in this repo. Phased so that work is its own milestone.
- **Targeted scenarios, not fuzzing.** Initial corpus deliberately small — round-trip canonical form (the §8.3 regression test, externally validated), modify-after-padded-write, out-of-range, batch atomicity, default action semantics.
- **Documents allowed divergences.** Field ordering, error message text, server-assigned IDs — explicit canonicalization, not silent ignores.
- **Risks and alternatives** sections — honest about what could go wrong and what was considered.

Drafted as a starting point — open to scope changes before any implementation begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)