### PR TITLE
DataplaneService: synchronise pre-packet hook registration

### DIFF
--- a/p4runtime/DataplaneService.kt
+++ b/p4runtime/DataplaneService.kt
@@ -144,6 +144,24 @@ class DataplaneService(
         .asException()
     }
 
+    // Synchronisation handshake: tell the client the hook is live. From the
+    // client's perspective, every packet emitted *after* this message is
+    // guaranteed to flow through the hook — no timing guesses needed.
+    // Mirrors the SubscriptionActive sentinel that subscribeResults emits.
+    //
+    // The sentinel must be sent *before* the forwarder is launched. Sending it
+    // through the `invocations` channel after launching the forwarder would be
+    // racier, not safer: the broker may already be firing into the rendezvous
+    // channel from another thread (the hook is live the moment registerHook
+    // returns true), so a concurrent packet event could win the rendezvous
+    // before our sentinel does. Bypassing the channel entirely keeps ordering
+    // tied to lexical structure rather than thread races.
+    send(
+      PrePacketHookInvocation.newBuilder()
+        .setRegistered(PrePacketHookInvocation.HookRegistered.getDefaultInstance())
+        .build()
+    )
+
     // Forward invocations from the internal channel to the gRPC stream.
     launch {
       for (invocation in invocations) {

--- a/p4runtime/DataplaneServiceTest.kt
+++ b/p4runtime/DataplaneServiceTest.kt
@@ -2,6 +2,9 @@ package fourward.p4runtime
 
 import com.google.protobuf.ByteString
 import fourward.dataplane.DataplaneGrpcKt.DataplaneCoroutineStub
+import fourward.dataplane.InjectPacketRequest
+import fourward.dataplane.PrePacketHookInvocation
+import fourward.dataplane.PrePacketHookResponse
 import fourward.dataplane.SubscribeResultsRequest
 import fourward.dataplane.SubscribeResultsResponse
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.assertGrpcError
@@ -9,7 +12,10 @@ import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildEthernetFrame
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.buildExactEntry
 import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
 import io.grpc.Status
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
@@ -25,6 +31,7 @@ import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 
@@ -316,39 +323,47 @@ class DataplaneServiceTest {
   // =========================================================================
 
   @Test
+  fun `RegisterPrePacketHook first message is HookRegistered`() = runBlocking {
+    harness.loadPipeline(loadPassthroughConfig())
+    val dataplaneStub = DataplaneCoroutineStub(harness.channel)
+    val responseChannel = Channel<PrePacketHookResponse>(UNLIMITED)
+    val first = dataplaneStub.registerPrePacketHook(responseChannel.consumeAsFlow()).first()
+    assertTrue("first message should be HookRegistered", first.hasRegistered())
+  }
+
+  @Test
+  fun `RegisterPrePacketHook rejects second registration with ALREADY_EXISTS`() = runBlocking {
+    // Pins the invariant that the sentinel send() must come *after* the
+    // broker.registerHook() success check — otherwise a duplicate registrant
+    // would receive a HookRegistered before being told ALREADY_EXISTS.
+    harness.loadPipeline(loadPassthroughConfig())
+    val dataplaneStub = DataplaneCoroutineStub(harness.channel)
+    val (firstHook, _) = registerHookAndAwaitReady(dataplaneStub)
+
+    assertGrpcError(Status.Code.ALREADY_EXISTS, "already registered") {
+      val secondResponses = Channel<PrePacketHookResponse>(UNLIMITED)
+      runBlocking { dataplaneStub.registerPrePacketHook(secondResponses.consumeAsFlow()).first() }
+    }
+
+    firstHook.cancel()
+  }
+
+  @Test
   fun `pre-packet hook fires before InjectPacket`() = runBlocking {
     harness.loadPipeline(loadPassthroughConfig())
     val dataplaneStub = DataplaneCoroutineStub(harness.channel)
+    val (hookJob, packetEvents) = registerHookAndAwaitReady(dataplaneStub)
 
-    val invocationsReceived =
-      kotlinx.coroutines.channels.Channel<fourward.dataplane.PrePacketHookInvocation>(10)
-    val responseChannel =
-      kotlinx.coroutines.channels.Channel<fourward.dataplane.PrePacketHookResponse>(UNLIMITED)
-
-    // Register the hook — collect invocations and send responses.
-    val hookJob =
-      async(Dispatchers.IO) {
-        dataplaneStub.registerPrePacketHook(responseChannel.consumeAsFlow()).collect { invocation ->
-          invocationsReceived.send(invocation)
-          responseChannel.send(fourward.dataplane.PrePacketHookResponse.getDefaultInstance())
-        }
-      }
-
-    delay(200) // Let the hook register.
-
-    // Inject a packet — the hook should fire first.
     val packet = buildEthernetFrame(42)
     dataplaneStub.injectPacket(
-      fourward.dataplane.InjectPacketRequest.newBuilder()
+      InjectPacketRequest.newBuilder()
         .setDataplaneIngressPort(0)
         .setPayload(ByteString.copyFrom(packet))
         .build()
     )
 
-    // Verify the hook was invoked and carries a snapshot of installed entities.
-    // With no entries installed, the entities list should be empty.
-    val invocation = withTimeout(5000) { invocationsReceived.receive() }
-    assertTrue("entities should be empty before any writes", invocation.entitiesList.isEmpty())
+    val event = withTimeout(5000) { packetEvents.receive() }
+    assertTrue("entities should be empty before any writes", event.entitiesList.isEmpty())
 
     hookJob.cancel()
   }
@@ -357,38 +372,23 @@ class DataplaneServiceTest {
   fun `pre-packet hook invocation carries installed entities`() = runBlocking {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-
-    // Install a table entry before registering the hook.
     harness.installEntry(buildExactEntry(config, matchValue = 0x0800, port = 1))
 
     val dataplaneStub = DataplaneCoroutineStub(harness.channel)
-    val invocationsReceived =
-      kotlinx.coroutines.channels.Channel<fourward.dataplane.PrePacketHookInvocation>(10)
-    val responseChannel =
-      kotlinx.coroutines.channels.Channel<fourward.dataplane.PrePacketHookResponse>(UNLIMITED)
-
-    val hookJob =
-      async(Dispatchers.IO) {
-        dataplaneStub.registerPrePacketHook(responseChannel.consumeAsFlow()).collect { invocation ->
-          invocationsReceived.send(invocation)
-          responseChannel.send(fourward.dataplane.PrePacketHookResponse.getDefaultInstance())
-        }
-      }
-
-    delay(200)
+    val (hookJob, packetEvents) = registerHookAndAwaitReady(dataplaneStub)
 
     val packet = buildEthernetFrame(42)
     dataplaneStub.injectPacket(
-      fourward.dataplane.InjectPacketRequest.newBuilder()
+      InjectPacketRequest.newBuilder()
         .setDataplaneIngressPort(0)
         .setPayload(ByteString.copyFrom(packet))
         .build()
     )
 
-    val invocation = withTimeout(5000) { invocationsReceived.receive() }
+    val event = withTimeout(5000) { packetEvents.receive() }
     assertTrue(
       "hook invocation should carry the installed table entry",
-      invocation.entitiesList.any { it.hasTableEntry() },
+      event.entitiesList.any { it.hasTableEntry() },
     )
 
     hookJob.cancel()
@@ -398,32 +398,50 @@ class DataplaneServiceTest {
   fun `pre-packet hook fires before PacketOut`() = runBlocking {
     harness.loadPipeline(loadPassthroughConfig())
     val dataplaneStub = DataplaneCoroutineStub(harness.channel)
+    val (hookJob, packetEvents) = registerHookAndAwaitReady(dataplaneStub)
 
-    val invocationsReceived =
-      kotlinx.coroutines.channels.Channel<fourward.dataplane.PrePacketHookInvocation>(10)
-    val responseChannel =
-      kotlinx.coroutines.channels.Channel<fourward.dataplane.PrePacketHookResponse>(UNLIMITED)
-
-    val hookJob =
-      async(Dispatchers.IO) {
-        dataplaneStub.registerPrePacketHook(responseChannel.consumeAsFlow()).collect { invocation ->
-          invocationsReceived.send(invocation)
-          responseChannel.send(fourward.dataplane.PrePacketHookResponse.getDefaultInstance())
-        }
-      }
-
-    delay(200) // Let the hook register.
-
-    // Send a PacketOut via P4Runtime StreamChannel — the hook must fire.
     val stream = harness.openStream()
     stream.arbitrate()
     val packet = buildEthernetFrame(42)
     stream.sendPacket(packet, ingressPort = 0, timeoutMs = 100)
 
-    // Verify the hook was invoked. withTimeout throws if no invocation arrives.
-    withTimeout(5000) { invocationsReceived.receive() }
+    withTimeout(5000) { packetEvents.receive() }
 
     hookJob.cancel()
     stream.close()
+  }
+
+  /**
+   * Registers a pre-packet hook and suspends until the server confirms registration via the
+   * `registered` sentinel on [PrePacketHookInvocation]. After this returns, packets emitted by the
+   * test are guaranteed to flow through the hook — no timing-based guesses needed. The returned
+   * channel yields packet events only; the registration sentinel is consumed here.
+   */
+  private suspend fun CoroutineScope.registerHookAndAwaitReady(
+    dataplaneStub: DataplaneCoroutineStub
+  ): Pair<Job, Channel<PrePacketHookInvocation.PacketEvent>> {
+    val packetEvents = Channel<PrePacketHookInvocation.PacketEvent>(10)
+    val responseChannel = Channel<PrePacketHookResponse>(UNLIMITED)
+    val ready = CompletableDeferred<Unit>()
+
+    val hookJob =
+      launch(Dispatchers.IO) {
+        dataplaneStub.registerPrePacketHook(responseChannel.consumeAsFlow()).collect { invocation ->
+          when (invocation.eventCase) {
+            PrePacketHookInvocation.EventCase.REGISTERED -> {
+              ready.complete(Unit)
+            }
+            PrePacketHookInvocation.EventCase.PACKET -> {
+              packetEvents.send(invocation.packet)
+              responseChannel.send(PrePacketHookResponse.getDefaultInstance())
+            }
+            PrePacketHookInvocation.EventCase.EVENT_NOT_SET ->
+              fail("server emitted PrePacketHookInvocation with no event set")
+          }
+        }
+      }
+
+    withTimeout(5000) { ready.await() }
+    return hookJob to packetEvents
   }
 }

--- a/p4runtime/PacketBroker.kt
+++ b/p4runtime/PacketBroker.kt
@@ -79,8 +79,11 @@ class PacketBroker(
     runBlocking {
       val invocation =
         PrePacketHookInvocation.newBuilder()
-          .addAllEntities(readAllEntities())
-          .apply { readP4Info()?.let { setP4Info(it) } }
+          .setPacket(
+            PrePacketHookInvocation.PacketEvent.newBuilder()
+              .addAllEntities(readAllEntities())
+              .apply { readP4Info()?.let { setP4Info(it) } }
+          )
           .build()
       h.invocations.send(invocation)
       val response = h.responses.receive()

--- a/p4runtime/dataplane.proto
+++ b/p4runtime/dataplane.proto
@@ -118,18 +118,38 @@ message SubscribeResultsResponse {
 
 message SubscriptionActive {}
 
-// Sent by the server before processing packets. The server holds the
-// write lock and waits for the client's response before proceeding.
+// Server -> client message on the RegisterPrePacketHook stream. Mirrors the
+// SubscribeResultsResponse shape — a oneof whose first variant is a
+// registration sentinel — so clients can synchronise on "hook is live"
+// without timing-based guesses.
 message PrePacketHookInvocation {
-  // Snapshot of all P4Runtime entities currently installed on the server,
-  // read under the write lock. The client can use this to derive entries
-  // that depend on the current forwarding state (e.g. auxiliary entries
-  // mirroring gNMI config).
-  repeated p4.v1.Entity entities = 1;
+  oneof event {
+    // Sent exactly once as the first message. Confirms the hook is
+    // registered and no packet events will be missed.
+    HookRegistered registered = 3;
 
-  // The P4Info from the loaded pipeline, enabling the client to interpret
-  // the entities above (e.g. map table/action IDs to names).
-  p4.config.v1.P4Info p4info = 2;
+    // Sent before each packet flows through the pipeline. The server
+    // holds the write lock and waits for the client's
+    // PrePacketHookResponse before proceeding.
+    PacketEvent packet = 4;
+  }
+
+  message HookRegistered {}
+
+  message PacketEvent {
+    // Snapshot of all P4Runtime entities currently installed on the
+    // server, read under the write lock. The client can use this to
+    // derive entries that depend on the current forwarding state (e.g.
+    // auxiliary entries mirroring gNMI config).
+    repeated p4.v1.Entity entities = 1;
+
+    // The P4Info from the loaded pipeline, enabling the client to
+    // interpret the entities above (e.g. map table/action IDs to names).
+    p4.config.v1.P4Info p4info = 2;
+  }
+
+  // Field numbers retired during the move into the `packet` oneof variant.
+  reserved 1, 2;
 }
 
 // Sent by the client in response to a PrePacketHookInvocation. Contains


### PR DESCRIPTION
## The win

Pre-packet-hook tests in `DataplaneServiceTest` are no longer flaky.
The fix isn't in the tests — it's a missing piece of the service
contract: `RegisterPrePacketHook` now emits a registration sentinel
as its first message, just like `SubscribeResults` already does with
`SubscriptionActive`. Clients (tests today, production callers
tomorrow) synchronously establish "hook is live" before triggering
events. No timing guesses, no retries.

## The bug it kills

```kotlin
launch { dataplaneStub.registerPrePacketHook(...).collect { ... } }
delay(200)              // hope hook is registered
sendPacket(...)         // hope this packet hits a registered hook
```

If 200 ms wasn't enough for the bidi handshake + `registerHook` on a
slow CI runner, the packet flowed past an unregistered hook → 5 s
receive timeout → structured-concurrency cancellation →
`StatusException(CANCELLED)`. Hit on PR #590's ubuntu run yesterday.

## Restoring consistency with `SubscribeResults`

The sibling RPC `SubscribeResults` already had this pattern — its
response message is a oneof of `SubscriptionActive` (the sentinel)
and `ProcessPacketResult`, and its tests use it as a sync barrier
(see `DataplaneServiceTest::SubscribeResults first message is
SubscriptionActive` and `SubscribeResults receives results from both
InjectPacket and PacketOut`). `RegisterPrePacketHook` was the
inconsistent sibling — same race-prone shape, no sentinel. This PR
makes the two RPCs symmetric.

## The contract change

`PrePacketHookInvocation` becomes a oneof:

```proto
message PrePacketHookInvocation {
  oneof event {
    HookRegistered registered = 3;   // first message; mirrors SubscriptionActive
    PacketEvent   packet     = 4;   // per-packet events
  }
  message HookRegistered {}
  message PacketEvent {
    repeated p4.v1.Entity entities = 1;
    p4.config.v1.P4Info p4info = 2;
  }
  reserved 1, 2;  // moved into PacketEvent
}
```

- Server emits `HookRegistered` immediately after `broker.registerHook()`.
- `PacketBroker.fireHookIfRegistered` wraps emissions in
  `setPacket(PacketEvent...)`.
- The three tests use a `registerHookAndAwaitReady` helper that
  awaits the sentinel synchronously and yields a `PacketEvent`
  channel to the test body. Switch on `EventCase` is exhaustive per
  AGENTS.md.

## Why service-side, not test-side retry

The previous draft of this PR was a test-side retry loop —
"send packets until the hook fires." That's a workaround: it dances
around the race instead of removing it. The race lived in the
service contract (no way for *any* client to know when registration
was complete). Fixing the contract removes the race for tests today
and for any production client tomorrow.

## Validation

`bazel test //p4runtime:DataplaneServiceTest --runs_per_test=20 --cache_test_results=no`
passes 20/20 locally with tight timing (5.5–5.8 s). Full suite green
(70/70).