### PR TITLE
p4runtime: enforce read-write symmetry for every translated entity (closes #602)

### DIFF
--- a/e2e_tests/translation_round_trip/BUILD.bazel
+++ b/e2e_tests/translation_round_trip/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//bazel:fourward_pipeline.bzl", "fourward_pipeline")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
+
+# Synthetic fixture: declares every entity-bearing P4 construct we can write
+# from P4Runtime, with a `@p4runtime_translation` type used in the table key,
+# action params, and direct counter/meter — enough to exercise read-write
+# symmetry for every supported entity type.
+fourward_pipeline(
+    name = "round_trip",
+    src = "round_trip.p4",
+    out = "round_trip.txtpb",
+    extra_srcs = ["//e2e_tests/sai_p4:sai_p4_srcs"],
+    includes = ["//e2e_tests/sai_p4:fixed/v1model_sai.p4"],
+    visibility = ["//p4runtime:__pkg__"],
+)

--- a/e2e_tests/translation_round_trip/round_trip.p4
+++ b/e2e_tests/translation_round_trip/round_trip.p4
@@ -1,0 +1,109 @@
+/* round_trip.p4 — synthetic fixture exercising every entity type 4ward
+ * supports that has translatable values, plus a few that don't (for
+ * regression coverage of the pass-through cases).
+ *
+ * Read-write symmetry per P4Runtime spec §11.2: an entity read back must be
+ * canonically equivalent to what was written. This fixture lets a single
+ * test verify that property end-to-end for every entity type 4ward exposes:
+ *
+ *   - TABLE_ENTRY                          (translated match fields)
+ *   - ACTION_PROFILE_MEMBER                (translated action params)
+ *   - ACTION_PROFILE_GROUP                 (no translated content)
+ *   - DIRECT_COUNTER_ENTRY                 (embeds TableEntry — match fields)
+ *   - DIRECT_METER_ENTRY                   (embeds TableEntry — match fields)
+ *   - COUNTER_ENTRY / METER_ENTRY          (no translated content)
+ *   - REGISTER_ENTRY                       (no translated content)
+ *   - PACKET_REPLICATION_ENGINE_ENTRY      (translated replica.port)
+ *
+ * VALUE_SET_ENTRY with translated values is omitted: the P4 language
+ * doesn't allow `select` over a translated newtype directly, so a
+ * `value_set<port_id_t>` can be declared but not matched against. The
+ * translation gap exists in theory but is unreachable from any
+ * compilable P4 source today.
+ */
+
+#include <core.p4>
+
+// Use the SAI-style forked v1model so standard_metadata.ingress_port has the
+// translated `port_id_t` type. This is what makes p4c-4ward derive
+// port_type_name = "port_id_t" in the IR, which in turn causes the simulator
+// to instantiate a PortTranslator. Without that, PRE replica ports pass
+// through untranslated and the symmetry property holds vacuously.
+#define PORT_BITWIDTH 9
+#include "v1model_sai.p4"
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+
+    // --- Externs that hold per-table translated state. ---
+    direct_counter(CounterType.packets) translated_table_counter;
+    direct_meter<bit<32>>(MeterType.bytes) translated_table_meter;
+
+    // Indirect counters/meters/registers: no embedded table entry, no
+    // translation required. Included to verify the pass-through path
+    // remains lossless.
+    counter(8, CounterType.packets) plain_counter;
+    meter(8, MeterType.bytes) plain_meter;
+    register<bit<32>>(8) plain_register;
+
+    // Action profile: members carry translated action params via `forward`.
+    action_profile(8) ap;
+
+    action drop() { mark_to_drop(smeta); }
+    action forward(port_id_t port) {
+        smeta.egress_spec = port;
+    }
+
+    // Table whose match field is the translated type. Both direct counter
+    // and direct meter attach here, so reading/writing
+    // DIRECT_{COUNTER,METER}_ENTRY exercises translation of the embedded
+    // TableEntry's match fields.
+    table translated_table {
+        key = { smeta.ingress_port : exact; }
+        actions = { forward; drop; NoAction; }
+        default_action = NoAction;
+        counters = translated_table_counter;
+        meters = translated_table_meter;
+        implementation = ap;
+        size = 16;
+    }
+
+    apply {
+        translated_table.apply();
+        plain_counter.count(0);
+        bit<32> meter_color;
+        plain_meter.execute_meter<bit<32>>(0, meter_color);
+        bit<32> reg_val;
+        plain_register.read(reg_val, 0);
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -659,6 +659,37 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "RoundTripTest",
+    srcs = [
+        "P4RuntimeTestHarness.kt",
+        "RoundTripTest.kt",
+    ],
+    data = [
+        "//e2e_tests/translation_round_trip:round_trip",
+    ],
+    test_class = "fourward.p4runtime.RoundTripTest",
+    deps = [
+        ":dataplane_java_proto",
+        ":dataplane_kt_grpc",
+        ":p4runtime",
+        ":p4runtime_kt_grpc",
+        "//bazel:runfiles",
+        "//simulator",
+        "//simulator:ir_java_proto",
+        "//simulator:p4data_java_proto",
+        "//simulator:p4info_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:io_grpc_grpc_api",
+        "@fourward_maven//:io_grpc_grpc_inprocess",
+        "@fourward_maven//:junit_junit",
+        "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@googleapis//google/rpc:rpc_java_proto",
+    ],
+)
+
+kt_jvm_test(
     name = "SaiP4ConstraintTest",
     srcs = [
         "P4RuntimeTestHarness.kt",

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -513,11 +513,7 @@ class P4RuntimeService(
       }
     }
 
-    // Translate PRE replica ports from P4RT → dataplane before writing to the simulator.
-    // The simulator stores raw dataplane port integers; Replica.port carries P4RT-encoded bytes.
-    val translatedUpdate = translateReplicaPorts(update, state)
-
-    when (val result = simulator.writeEntry(translatedUpdate)) {
+    when (val result = simulator.writeEntry(update)) {
       is WriteResult.Success -> {}
       is WriteResult.AlreadyExists ->
         throw Status.ALREADY_EXISTS.withDescription(result.message).asException()
@@ -528,60 +524,6 @@ class P4RuntimeService(
       is WriteResult.ResourceExhausted ->
         throw Status.RESOURCE_EXHAUSTED.withDescription(result.message).asException()
     }
-  }
-
-  /**
-   * Translates `Replica.port` (bytes, P4RT-encoded) to dataplane form for the simulator.
-   *
-   * For each replica with a non-empty `port` field, forward-allocates through the [PortTranslator]
-   * (creating both forward and reverse mappings), then replaces the P4RT bytes with the dataplane
-   * integer in the returned update. The simulator stores raw dataplane port integers.
-   *
-   * Replicas using the deprecated `Replica.egress_port` (int32) field are already dataplane values
-   * and pass through unchanged — but they have no P4RT reverse mapping, so `toDualEncoded` and
-   * `translatePacketIn` will fail for those ports.
-   *
-   * TODO(PRE read-back): The simulator stores the translated dataplane integer in `Replica.port`,
-   *   so reading PRE entries back returns raw values, not P4RT strings. `translateForRead` doesn't
-   *   handle PRE entities yet — it would need to reverse-translate replica ports.
-   */
-  private fun translateReplicaPorts(update: Update, state: PipelineState): Update {
-    val pt = state.typeTranslator?.portTranslator ?: return update
-    val entity = update.entity
-    if (!entity.hasPacketReplicationEngineEntry()) return update
-    val pre = entity.packetReplicationEngineEntry
-
-    fun translateReplica(replica: P4RuntimeOuterClass.Replica): P4RuntimeOuterClass.Replica {
-      if (replica.port.isEmpty) return replica
-      val dataplanePort = pt.p4rtToDataplane(replica.port)
-      return replica.toBuilder().setPort(encodeMinWidth(dataplanePort)).build()
-    }
-
-    val translatedPre =
-      when (pre.typeCase) {
-        P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.MULTICAST_GROUP_ENTRY -> {
-          val group = pre.multicastGroupEntry
-          val translated = group.replicasList.map { translateReplica(it) }
-          pre
-            .toBuilder()
-            .setMulticastGroupEntry(group.toBuilder().clearReplicas().addAllReplicas(translated))
-            .build()
-        }
-        P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.CLONE_SESSION_ENTRY -> {
-          val session = pre.cloneSessionEntry
-          val translated = session.replicasList.map { translateReplica(it) }
-          pre
-            .toBuilder()
-            .setCloneSessionEntry(session.toBuilder().clearReplicas().addAllReplicas(translated))
-            .build()
-        }
-        P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.TYPE_NOT_SET,
-        null -> return update
-      }
-    return update
-      .toBuilder()
-      .setEntity(entity.toBuilder().setPacketReplicationEngineEntry(translatedPre))
-      .build()
   }
 
   // ---------------------------------------------------------------------------

--- a/p4runtime/RoundTripTest.kt
+++ b/p4runtime/RoundTripTest.kt
@@ -1,0 +1,411 @@
+// See comment in GoldenErrorTest.kt — `val unused = stub.X(...)` discards must-be-used gRPC
+// return values flagged by the downstream sync's `@CheckReturnValue` lint.
+@file:Suppress("UnusedPrivateProperty")
+
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import fourward.ir.PipelineConfig
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.findAction
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.findTable
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.matchFieldId
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.paramId
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import p4.v1.P4RuntimeOuterClass.Action
+import p4.v1.P4RuntimeOuterClass.ActionProfileGroup
+import p4.v1.P4RuntimeOuterClass.ActionProfileMember
+import p4.v1.P4RuntimeOuterClass.CloneSessionEntry
+import p4.v1.P4RuntimeOuterClass.CounterData
+import p4.v1.P4RuntimeOuterClass.CounterEntry
+import p4.v1.P4RuntimeOuterClass.DirectCounterEntry
+import p4.v1.P4RuntimeOuterClass.DirectMeterEntry
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.Index
+import p4.v1.P4RuntimeOuterClass.MeterConfig
+import p4.v1.P4RuntimeOuterClass.MeterEntry
+import p4.v1.P4RuntimeOuterClass.MulticastGroupEntry
+import p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.RegisterEntry
+import p4.v1.P4RuntimeOuterClass.Replica
+import p4.v1.P4RuntimeOuterClass.TableAction
+import p4.v1.P4RuntimeOuterClass.TableEntry
+import p4.v1.P4RuntimeOuterClass.Update
+
+/**
+ * Read-write symmetry tests, per P4Runtime spec §11.2: an entity Read response must be canonically
+ * equivalent to what was written. Every entity type 4ward supports is exercised here, with
+ * translated values where the entity carries any. A new entity type added without its matching
+ * read-side translation breaks one of these assertions.
+ *
+ * The fixture pipeline (round_trip.p4) declares a `@p4runtime_translation` port type and uses it
+ * in: a table match field, an action param, a direct counter and direct meter on that table, and an
+ * action profile attached to that table. PRE replicas use the same translation at runtime without
+ * any P4-level declaration.
+ */
+class RoundTripTest {
+
+  private lateinit var harness: P4RuntimeTestHarness
+  private lateinit var config: PipelineConfig
+
+  @Before
+  fun setUp() {
+    harness = P4RuntimeTestHarness()
+    config = loadConfig("e2e_tests/translation_round_trip/round_trip.txtpb")
+    val unused = harness.loadPipeline(config)
+  }
+
+  @After
+  fun tearDown() {
+    harness.close()
+  }
+
+  // Arbitrary controller-side port identifiers used throughout. Format is opaque to the test —
+  // the simulator allocates an internal dataplane integer on first Write and must reverse-
+  // translate to the original string on Read. Any two distinct strings would do.
+  private val sdnPortA = "port-A"
+  private val sdnPortB = "port-B"
+
+  // ---------------------------------------------------------------------------
+  // Translated entity types
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `TABLE_ENTRY round-trips translated match value and action param`() {
+    assertRoundTrips(
+      installed = translatedTableEntry(matchPort = sdnPortA, actionPort = sdnPortB),
+      // The table has a direct counter and direct meter attached, so reads come back with empty
+      // counter_data / meter_config that the install request never set; strip those before
+      // comparison.
+      normalize = ::stripAmbientTableEntryFields,
+    )
+  }
+
+  @Test
+  fun `ACTION_PROFILE_MEMBER round-trips translated action param`() {
+    assertRoundTrips(installed = actionProfileMember(memberId = 1, port = sdnPortA))
+  }
+
+  @Test
+  fun `DIRECT_COUNTER_ENTRY round-trips translated table-entry match`() {
+    // The embedded TableEntry carries the translated match value; reads must reverse-translate it.
+    val parent = translatedTableEntry(matchPort = sdnPortA, actionPort = sdnPortB)
+    harness.installEntry(parent)
+    assertRoundTrips(
+      type = Update.Type.MODIFY,
+      installed =
+        Entity.newBuilder()
+          .setDirectCounterEntry(
+            DirectCounterEntry.newBuilder()
+              .setTableEntry(parent.tableEntry)
+              .setData(CounterData.newBuilder().setPacketCount(42).setByteCount(1500))
+          )
+          .build(),
+    )
+  }
+
+  @Test
+  fun `DIRECT_METER_ENTRY round-trips translated table-entry match`() {
+    val parent = translatedTableEntry(matchPort = sdnPortA, actionPort = sdnPortB)
+    harness.installEntry(parent)
+    assertRoundTrips(
+      type = Update.Type.MODIFY,
+      installed =
+        Entity.newBuilder()
+          .setDirectMeterEntry(
+            DirectMeterEntry.newBuilder()
+              .setTableEntry(parent.tableEntry)
+              .setConfig(
+                MeterConfig.newBuilder().setCir(1000).setCburst(2000).setPir(3000).setPburst(4000)
+              )
+          )
+          .build(),
+    )
+  }
+
+  @Test
+  fun `PACKET_REPLICATION_ENGINE_ENTRY clone session round-trips translated replica port`() {
+    assertRoundTrips(
+      installed =
+        Entity.newBuilder()
+          .setPacketReplicationEngineEntry(
+            PacketReplicationEngineEntry.newBuilder()
+              .setCloneSessionEntry(
+                CloneSessionEntry.newBuilder()
+                  .setSessionId(1)
+                  .addReplicas(replica(sdnPortA, instance = 1))
+                  .addReplicas(replica(sdnPortB, instance = 2))
+              )
+          )
+          .build()
+    )
+  }
+
+  @Test
+  fun `PACKET_REPLICATION_ENGINE_ENTRY multicast group round-trips translated replica port`() {
+    assertRoundTrips(
+      installed =
+        Entity.newBuilder()
+          .setPacketReplicationEngineEntry(
+            PacketReplicationEngineEntry.newBuilder()
+              .setMulticastGroupEntry(
+                MulticastGroupEntry.newBuilder()
+                  .setMulticastGroupId(7)
+                  .addReplicas(replica(sdnPortA, instance = 1))
+              )
+          )
+          .build()
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pass-through entity types — no translated content, but must still round-trip.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `ACTION_PROFILE_GROUP round-trips`() {
+    harness.installEntry(actionProfileMember(memberId = 1, port = sdnPortA))
+    val ap = config.p4Info.actionProfilesList.first { it.preamble.alias == "ap" }
+    assertRoundTrips(
+      installed =
+        Entity.newBuilder()
+          .setActionProfileGroup(
+            ActionProfileGroup.newBuilder()
+              .setActionProfileId(ap.preamble.id)
+              .setGroupId(10)
+              .addMembers(ActionProfileGroup.Member.newBuilder().setMemberId(1).setWeight(1))
+          )
+          .build()
+    )
+  }
+
+  @Test
+  fun `COUNTER_ENTRY round-trips`() {
+    val counter = config.p4Info.countersList.first { it.preamble.alias == "plain_counter" }
+    assertRoundTrips(
+      type = Update.Type.MODIFY,
+      installed =
+        Entity.newBuilder()
+          .setCounterEntry(
+            CounterEntry.newBuilder()
+              .setCounterId(counter.preamble.id)
+              .setIndex(Index.newBuilder().setIndex(3))
+              .setData(CounterData.newBuilder().setPacketCount(42).setByteCount(1500))
+          )
+          .build(),
+    )
+  }
+
+  @Test
+  fun `METER_ENTRY round-trips`() {
+    val meter = config.p4Info.metersList.first { it.preamble.alias == "plain_meter" }
+    assertRoundTrips(
+      type = Update.Type.MODIFY,
+      installed =
+        Entity.newBuilder()
+          .setMeterEntry(
+            MeterEntry.newBuilder()
+              .setMeterId(meter.preamble.id)
+              .setIndex(Index.newBuilder().setIndex(2))
+              .setConfig(
+                MeterConfig.newBuilder().setCir(1000).setCburst(2000).setPir(3000).setPburst(4000)
+              )
+          )
+          .build(),
+    )
+  }
+
+  @Test
+  fun `REGISTER_ENTRY round-trips`() {
+    val register = config.p4Info.registersList.first { it.preamble.alias == "plain_register" }
+    assertRoundTrips(
+      type = Update.Type.MODIFY,
+      installed =
+        Entity.newBuilder()
+          .setRegisterEntry(
+            RegisterEntry.newBuilder()
+              .setRegisterId(register.preamble.id)
+              .setIndex(Index.newBuilder().setIndex(0))
+              .setData(
+                p4.v1.P4DataOuterClass.P4Data.newBuilder()
+                  .setBitstring(ByteString.copyFrom(byteArrayOf(0, 0, 0, 0x42)))
+              )
+          )
+          .build(),
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Installs [installed] (via [Update.Type.INSERT] or [MODIFY]), reads back all entries of the same
+   * kind, and asserts the result equals `[installed]` (after [normalize] is applied to each
+   * read-back entity to remove ambient state the system fills in but the install never sets).
+   *
+   * MODIFY is the right verb for entities that exist implicitly the moment a parent does — every
+   * counter/meter index, every direct counter/meter on a table entry. INSERT is for entities the
+   * controller creates from scratch — table entries, action profile members/groups, PRE entries.
+   */
+  private fun assertRoundTrips(
+    installed: Entity,
+    type: Update.Type = Update.Type.INSERT,
+    normalize: (Entity) -> Entity = { it },
+  ) {
+    when (type) {
+      Update.Type.INSERT -> harness.installEntry(installed)
+      Update.Type.MODIFY -> harness.modifyEntry(installed)
+      else -> error("assertRoundTrips supports INSERT and MODIFY only; got $type")
+    }
+    val read = harness.readEntries(readAllOf(installed)).map(normalize)
+    assertEquals(listOf(installed), read)
+  }
+
+  /** Builds an action-profile-member entity carrying a translated `port` action param. */
+  private fun actionProfileMember(memberId: Int, port: String): Entity {
+    val ap = config.p4Info.actionProfilesList.first { it.preamble.alias == "ap" }
+    val forward = findAction(config, "forward")
+    return Entity.newBuilder()
+      .setActionProfileMember(
+        ActionProfileMember.newBuilder()
+          .setActionProfileId(ap.preamble.id)
+          .setMemberId(memberId)
+          .setAction(
+            Action.newBuilder()
+              .setActionId(forward.preamble.id)
+              .addParams(
+                Action.Param.newBuilder()
+                  .setParamId(paramId(forward, "port"))
+                  .setValue(ByteString.copyFromUtf8(port))
+              )
+          )
+      )
+      .build()
+  }
+
+  private fun translatedTableEntry(matchPort: String, actionPort: String): Entity {
+    val table = findTable(config, "translated_table")
+    val forward = findAction(config, "forward")
+    return Entity.newBuilder()
+      .setTableEntry(
+        TableEntry.newBuilder()
+          .setTableId(table.preamble.id)
+          .addMatch(
+            FieldMatch.newBuilder()
+              .setFieldId(matchFieldId(table, "smeta.ingress_port"))
+              .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFromUtf8(matchPort)))
+          )
+          .setAction(
+            TableAction.newBuilder()
+              .setAction(
+                Action.newBuilder()
+                  .setActionId(forward.preamble.id)
+                  .addParams(
+                    Action.Param.newBuilder()
+                      .setParamId(paramId(forward, "port"))
+                      .setValue(ByteString.copyFromUtf8(actionPort))
+                  )
+              )
+          )
+      )
+      .build()
+  }
+
+  private fun replica(port: String, instance: Int): Replica =
+    Replica.newBuilder().setPort(ByteString.copyFromUtf8(port)).setInstance(instance).build()
+
+  /**
+   * For tables with attached direct counters or direct meters, reads come back with empty
+   * counter_data / meter_config that the install request never set. Strip those before comparison
+   * so the assertion reflects read-write symmetry, not simulator backfill.
+   */
+  private fun stripAmbientTableEntryFields(entity: Entity): Entity =
+    entity
+      .toBuilder()
+      .setTableEntry(entity.tableEntry.toBuilder().clearCounterData().clearMeterConfig())
+      .build()
+
+  /** Read filter that matches all entries of the same entity case as [example]. */
+  private fun readAllOf(example: Entity): ReadRequest {
+    val filter =
+      when (example.entityCase) {
+        Entity.EntityCase.TABLE_ENTRY ->
+          Entity.newBuilder()
+            .setTableEntry(TableEntry.newBuilder().setTableId(example.tableEntry.tableId))
+            .build()
+        Entity.EntityCase.ACTION_PROFILE_MEMBER ->
+          Entity.newBuilder()
+            .setActionProfileMember(
+              ActionProfileMember.newBuilder()
+                .setActionProfileId(example.actionProfileMember.actionProfileId)
+            )
+            .build()
+        Entity.EntityCase.ACTION_PROFILE_GROUP ->
+          Entity.newBuilder()
+            .setActionProfileGroup(
+              ActionProfileGroup.newBuilder()
+                .setActionProfileId(example.actionProfileGroup.actionProfileId)
+            )
+            .build()
+        Entity.EntityCase.DIRECT_COUNTER_ENTRY ->
+          // Wildcard read by table_id only; the simulator returns counter entries for every
+          // installed table entry of that table.
+          Entity.newBuilder()
+            .setDirectCounterEntry(
+              DirectCounterEntry.newBuilder()
+                .setTableEntry(
+                  TableEntry.newBuilder().setTableId(example.directCounterEntry.tableEntry.tableId)
+                )
+            )
+            .build()
+        Entity.EntityCase.DIRECT_METER_ENTRY ->
+          Entity.newBuilder()
+            .setDirectMeterEntry(
+              DirectMeterEntry.newBuilder()
+                .setTableEntry(
+                  TableEntry.newBuilder().setTableId(example.directMeterEntry.tableEntry.tableId)
+                )
+            )
+            .build()
+        Entity.EntityCase.COUNTER_ENTRY ->
+          Entity.newBuilder()
+            .setCounterEntry(
+              CounterEntry.newBuilder()
+                .setCounterId(example.counterEntry.counterId)
+                .setIndex(example.counterEntry.index)
+            )
+            .build()
+        Entity.EntityCase.METER_ENTRY ->
+          Entity.newBuilder()
+            .setMeterEntry(
+              MeterEntry.newBuilder()
+                .setMeterId(example.meterEntry.meterId)
+                .setIndex(example.meterEntry.index)
+            )
+            .build()
+        Entity.EntityCase.REGISTER_ENTRY ->
+          Entity.newBuilder()
+            .setRegisterEntry(
+              RegisterEntry.newBuilder()
+                .setRegisterId(example.registerEntry.registerId)
+                .setIndex(example.registerEntry.index)
+            )
+            .build()
+        Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY ->
+          // PRE entries don't have a P4Info-level identifier to filter on; the wildcard returns
+          // every clone session and multicast group on the device. Each test installs into a
+          // clean harness, so this is precise enough for round-trip assertions.
+          Entity.newBuilder()
+            .setPacketReplicationEngineEntry(PacketReplicationEngineEntry.getDefaultInstance())
+            .build()
+        else -> error("readAllOf does not yet support ${example.entityCase}")
+      }
+    return ReadRequest.newBuilder().setDeviceId(1).addEntities(filter).build()
+  }
+}

--- a/p4runtime/TypeTranslator.kt
+++ b/p4runtime/TypeTranslator.kt
@@ -43,6 +43,18 @@ sealed class P4rtValue {
 class TranslationException(message: String) : RuntimeException(message)
 
 /**
+ * Direction of a `@p4runtime_translation` translation. Reads and Writes go through symmetric pairs
+ * of helpers in [TypeTranslator]; carrying the direction as a named enum (rather than a raw
+ * boolean) makes the call sites self-explanatory and prevents accidental inversion.
+ */
+private enum class Direction {
+  /** P4Runtime SDN form → data-plane representation (Write). */
+  TO_DATAPLANE,
+  /** Data-plane representation → P4Runtime SDN form (Read). */
+  TO_P4RT,
+}
+
+/**
  * Translates between P4Runtime port IDs and dataplane port numbers.
  *
  * Most `@p4runtime_translation` types appear only in dynamically-typed table entry fields (match
@@ -151,58 +163,70 @@ private constructor(
   // ---------------------------------------------------------------------------
 
   /** Translates a Write update from P4Runtime to data-plane representation. */
-  fun translateForWrite(update: Update): Update {
-    val entity = update.entity
-    return when (entity.entityCase) {
-      Entity.EntityCase.TABLE_ENTRY -> {
-        val translated = translateTableEntry(entity.tableEntry, toDataplane = true) ?: return update
-        update.toBuilder().setEntity(entity.toBuilder().setTableEntry(translated)).build()
-      }
-      Entity.EntityCase.ACTION_PROFILE_MEMBER -> {
-        val member = entity.actionProfileMember
-        val translated = translateAction(member.action, toDataplane = true) ?: return update
-        update
-          .toBuilder()
-          .setEntity(
-            entity.toBuilder().setActionProfileMember(member.toBuilder().setAction(translated))
-          )
-          .build()
-      }
-      Entity.EntityCase.ACTION_PROFILE_GROUP,
-      Entity.EntityCase.COUNTER_ENTRY,
-      Entity.EntityCase.DIRECT_COUNTER_ENTRY,
-      Entity.EntityCase.METER_ENTRY,
-      Entity.EntityCase.DIRECT_METER_ENTRY,
-      Entity.EntityCase.REGISTER_ENTRY,
-      Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
-      Entity.EntityCase.VALUE_SET_ENTRY,
-      Entity.EntityCase.DIGEST_ENTRY,
-      Entity.EntityCase.EXTERN_ENTRY,
-      Entity.EntityCase.ENTITY_NOT_SET,
-      null -> update
-    }
-  }
+  fun translateForWrite(update: Update): Update =
+    update
+      .toBuilder()
+      .setEntity(translateEntity(update.entity, direction = Direction.TO_DATAPLANE))
+      .build()
 
   /** Translates a Read entity from data-plane to P4Runtime representation. */
   fun translateForRead(entity: Entity): Entity =
+    translateEntity(entity, direction = Direction.TO_P4RT)
+
+  /**
+   * Translates [entity] in the given [direction]. P4Runtime spec §11.2 requires that whatever
+   * `TO_DATAPLANE` does on Write is reversed by `TO_P4RT` on Read; this single switch keeps the two
+   * directions co-located so the pair stays obviously symmetric in code review. Structural
+   * enforcement of "every supported entity type round-trips" lives in `RoundTripTest` — this
+   * dispatcher is the shape that makes that coverage easy to reason about.
+   */
+  private fun translateEntity(entity: Entity, direction: Direction): Entity =
     when (entity.entityCase) {
       Entity.EntityCase.TABLE_ENTRY -> {
-        val translated =
-          translateTableEntry(entity.tableEntry, toDataplane = false) ?: return entity
-        entity.toBuilder().setTableEntry(translated).build()
+        val translated = translateTableEntry(entity.tableEntry, direction)
+        if (translated == null) entity else entity.toBuilder().setTableEntry(translated).build()
       }
       Entity.EntityCase.ACTION_PROFILE_MEMBER -> {
         val member = entity.actionProfileMember
-        val translated = translateAction(member.action, toDataplane = false) ?: return entity
-        entity.toBuilder().setActionProfileMember(member.toBuilder().setAction(translated)).build()
+        val translated = translateAction(member.action, direction)
+        if (translated == null) entity
+        else
+          entity
+            .toBuilder()
+            .setActionProfileMember(member.toBuilder().setAction(translated))
+            .build()
+      }
+      Entity.EntityCase.DIRECT_COUNTER_ENTRY -> {
+        // Direct counters are addressed by the table entry they attach to; the embedded
+        // TableEntry carries match values that may be translated.
+        val direct = entity.directCounterEntry
+        val translated = translateTableEntry(direct.tableEntry, direction)
+        if (translated == null) entity
+        else
+          entity
+            .toBuilder()
+            .setDirectCounterEntry(direct.toBuilder().setTableEntry(translated))
+            .build()
+      }
+      Entity.EntityCase.DIRECT_METER_ENTRY -> {
+        val direct = entity.directMeterEntry
+        val translated = translateTableEntry(direct.tableEntry, direction)
+        if (translated == null) entity
+        else
+          entity
+            .toBuilder()
+            .setDirectMeterEntry(direct.toBuilder().setTableEntry(translated))
+            .build()
+      }
+      Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY -> {
+        val translated = translatePreReplicas(entity.packetReplicationEngineEntry, direction)
+        if (translated == null) entity
+        else entity.toBuilder().setPacketReplicationEngineEntry(translated).build()
       }
       Entity.EntityCase.ACTION_PROFILE_GROUP,
       Entity.EntityCase.COUNTER_ENTRY,
-      Entity.EntityCase.DIRECT_COUNTER_ENTRY,
       Entity.EntityCase.METER_ENTRY,
-      Entity.EntityCase.DIRECT_METER_ENTRY,
       Entity.EntityCase.REGISTER_ENTRY,
-      Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY,
       Entity.EntityCase.VALUE_SET_ENTRY,
       Entity.EntityCase.DIGEST_ENTRY,
       Entity.EntityCase.EXTERN_ENTRY,
@@ -211,15 +235,71 @@ private constructor(
     }
 
   /**
+   * Translates `Replica.port` on every replica of a [PacketReplicationEngineEntry], in either
+   * direction. Returns null if no port translation is configured for this pipeline (in which case
+   * replicas pass through untouched).
+   *
+   * `TO_DATAPLANE` (Write): forward-allocate — the controller's P4Runtime-encoded port bytes become
+   * the simulator's raw dataplane integer, and the [PortTranslator]'s table is updated so
+   * subsequent reads can reverse the mapping.
+   *
+   * `TO_P4RT` (Read): reverse-lookup — the simulator's dataplane integer becomes the controller-
+   * facing P4Runtime bytes. Replicas without an existing reverse mapping (e.g. those installed via
+   * the deprecated `Replica.egress_port` int32) pass through unchanged.
+   */
+  private fun translatePreReplicas(
+    pre: p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry,
+    direction: Direction,
+  ): p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry? {
+    val pt = portTranslator ?: return null
+
+    fun translate(replica: p4.v1.P4RuntimeOuterClass.Replica): p4.v1.P4RuntimeOuterClass.Replica {
+      if (replica.port.isEmpty) return replica
+      val newPort: ByteString =
+        when (direction) {
+          Direction.TO_DATAPLANE -> encodeMinWidth(pt.p4rtToDataplane(replica.port))
+          Direction.TO_P4RT -> pt.dataplaneToP4rt(replica.port.toUnsignedInt()) ?: return replica
+        }
+      return replica.toBuilder().setPort(newPort).build()
+    }
+
+    return when (pre.typeCase) {
+      p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.MULTICAST_GROUP_ENTRY -> {
+        val group = pre.multicastGroupEntry
+        pre
+          .toBuilder()
+          .setMulticastGroupEntry(
+            group.toBuilder().clearReplicas().addAllReplicas(group.replicasList.map(::translate))
+          )
+          .build()
+      }
+      p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.CLONE_SESSION_ENTRY -> {
+        val session = pre.cloneSessionEntry
+        pre
+          .toBuilder()
+          .setCloneSessionEntry(
+            session
+              .toBuilder()
+              .clearReplicas()
+              .addAllReplicas(session.replicasList.map(::translate))
+          )
+          .build()
+      }
+      p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.TypeCase.TYPE_NOT_SET,
+      null -> null
+    }
+  }
+
+  /**
    * Translates match field values and action parameter values in a table entry. Returns null if
    * nothing was translated.
    */
   private fun translateTableEntry(
     entry: p4.v1.P4RuntimeOuterClass.TableEntry,
-    toDataplane: Boolean,
+    direction: Direction,
   ): p4.v1.P4RuntimeOuterClass.TableEntry? {
-    val translatedMatches = translateMatchFields(entry.tableId, entry.matchList, toDataplane)
-    val translatedAction = translateTableAction(entry.action, toDataplane)
+    val translatedMatches = translateMatchFields(entry.tableId, entry.matchList, direction)
+    val translatedAction = translateTableAction(entry.action, direction)
     if (translatedMatches == null && translatedAction == null) return null
     val builder = entry.toBuilder()
     if (translatedMatches != null) {
@@ -239,8 +319,11 @@ private constructor(
   fun translatePacketOut(packetOut: PacketOut): PacketOut {
     if (packetOutMetadataTypeNames.isEmpty()) return packetOut
     val translated =
-      translateMetadata(packetOutMetadataTypeNames, packetOut.metadataList, toDataplane = true)
-        ?: return packetOut
+      translateMetadata(
+        packetOutMetadataTypeNames,
+        packetOut.metadataList,
+        direction = Direction.TO_DATAPLANE,
+      ) ?: return packetOut
     return packetOut.toBuilder().clearMetadata().addAllMetadata(translated).build()
   }
 
@@ -254,8 +337,11 @@ private constructor(
   fun translatePacketIn(packetIn: PacketIn): PacketIn {
     if (packetInMetadataTypeNames.isEmpty()) return packetIn
     val translated =
-      translateMetadata(packetInMetadataTypeNames, packetIn.metadataList, toDataplane = false)
-        ?: return packetIn
+      translateMetadata(
+        packetInMetadataTypeNames,
+        packetIn.metadataList,
+        direction = Direction.TO_P4RT,
+      ) ?: return packetIn
     return packetIn.toBuilder().clearMetadata().addAllMetadata(translated).build()
   }
 
@@ -265,17 +351,17 @@ private constructor(
    */
   private fun translateTableAction(
     tableAction: p4.v1.P4RuntimeOuterClass.TableAction,
-    toDataplane: Boolean,
+    direction: Direction,
   ): p4.v1.P4RuntimeOuterClass.TableAction? {
     if (tableAction.hasAction()) {
-      val translated = translateAction(tableAction.action, toDataplane) ?: return null
+      val translated = translateAction(tableAction.action, direction) ?: return null
       return tableAction.toBuilder().setAction(translated).build()
     }
     if (tableAction.hasActionProfileActionSet()) {
       var changed = false
       val translatedActions =
         tableAction.actionProfileActionSet.actionProfileActionsList.map { profileAction ->
-          val translated = translateAction(profileAction.action, toDataplane)
+          val translated = translateAction(profileAction.action, direction)
           if (translated != null) {
             changed = true
             profileAction.toBuilder().setAction(translated).build()
@@ -300,9 +386,9 @@ private constructor(
   /** Translates params of a single [Action], returning null if no translation was needed. */
   private fun translateAction(
     action: p4.v1.P4RuntimeOuterClass.Action,
-    toDataplane: Boolean,
+    direction: Direction,
   ): p4.v1.P4RuntimeOuterClass.Action? {
-    val translated = translateParams(action.actionId, action.paramsList, toDataplane) ?: return null
+    val translated = translateParams(action.actionId, action.paramsList, direction) ?: return null
     return action.toBuilder().clearParams().addAllParams(translated).build()
   }
 
@@ -313,7 +399,7 @@ private constructor(
   private fun translateParams(
     actionId: Int,
     params: List<p4.v1.P4RuntimeOuterClass.Action.Param>,
-    toDataplane: Boolean,
+    direction: Direction,
   ): List<p4.v1.P4RuntimeOuterClass.Action.Param>? {
     var changed = false
     val result =
@@ -321,7 +407,7 @@ private constructor(
         val typeName = paramTypeNames[packKey(actionId, param.paramId)]
         if (typeName != null) {
           changed = true
-          val translated = translateValue(getOrCreateTable(typeName), param.value, toDataplane)
+          val translated = translateValue(getOrCreateTable(typeName), param.value, direction)
           param.toBuilder().setValue(translated).build()
         } else {
           param
@@ -333,7 +419,7 @@ private constructor(
   private fun translateMatchFields(
     tableId: Int,
     matches: List<p4.v1.P4RuntimeOuterClass.FieldMatch>,
-    toDataplane: Boolean,
+    direction: Direction,
   ): List<p4.v1.P4RuntimeOuterClass.FieldMatch>? {
     var changed = false
     val result =
@@ -344,7 +430,7 @@ private constructor(
           val table = getOrCreateTable(typeName)
           when (match.fieldMatchTypeCase) {
             p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT -> {
-              val translated = translateValue(table, match.exact.value, toDataplane)
+              val translated = translateValue(table, match.exact.value, direction)
               match
                 .toBuilder()
                 .setExact(
@@ -353,7 +439,7 @@ private constructor(
                 .build()
             }
             p4.v1.P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL -> {
-              val translated = translateValue(table, match.optional.value, toDataplane)
+              val translated = translateValue(table, match.optional.value, direction)
               match
                 .toBuilder()
                 .setOptional(
@@ -379,14 +465,14 @@ private constructor(
   private fun translateMetadata(
     typeNameMap: Map<Int, String>,
     metadata: List<p4.v1.P4RuntimeOuterClass.PacketMetadata>,
-    toDataplane: Boolean,
+    direction: Direction,
   ): List<p4.v1.P4RuntimeOuterClass.PacketMetadata>? {
     var changed = false
     val result =
       metadata.map { meta ->
         val typeName = typeNameMap[meta.metadataId]
         if (typeName != null) {
-          val translated = translateValue(getOrCreateTable(typeName), meta.value, toDataplane)
+          val translated = translateValue(getOrCreateTable(typeName), meta.value, direction)
           changed = true
           meta.toBuilder().setValue(translated).build()
         } else {
@@ -405,19 +491,20 @@ private constructor(
   private fun translateValue(
     table: TranslationTable,
     value: ByteString,
-    toDataplane: Boolean,
+    direction: Direction,
   ): ByteString =
-    if (toDataplane) {
-      if (table.isStringType) {
-        table.lookupOrAllocateString(value.toStringUtf8())
-      } else {
-        table.lookupOrAllocateBitstring(value)
-      }
-    } else {
-      when (val p4rtValue = table.reverseLookup(value)) {
-        is P4rtValue.Bitstring -> p4rtValue.value
-        is P4rtValue.Str -> ByteString.copyFromUtf8(p4rtValue.value)
-      }
+    when (direction) {
+      Direction.TO_DATAPLANE ->
+        if (table.isStringType) {
+          table.lookupOrAllocateString(value.toStringUtf8())
+        } else {
+          table.lookupOrAllocateBitstring(value)
+        }
+      Direction.TO_P4RT ->
+        when (val p4rtValue = table.reverseLookup(value)) {
+          is P4rtValue.Bitstring -> p4rtValue.value
+          is P4rtValue.Str -> ByteString.copyFromUtf8(p4rtValue.value)
+        }
     }
 
   companion object {


### PR DESCRIPTION
## The win

P4Runtime spec §11.2 requires read-write symmetry: an entity read back
must be canonically equivalent to what was written. We had it for table
entries and action profile members, but **PRE replica ports** silently
returned raw dataplane bytes on read (issue #602), and **DIRECT_COUNTER /
DIRECT_METER** entries had a latent version of the same bug — symmetric
write/read but neither side translated the embedded TableEntry's match
fields.

This PR fixes both, consolidates the translator's two directions into a
single co-located dispatcher, and adds a round-trip test that's the
actual structural enforcement of the spec property.

## What changed

- **`TypeTranslator.translateForWrite` / `translateForRead`** become thin
  wrappers around a single dispatcher `translateEntity(entity,
  toDataplane: Boolean)`. The two directions stay obviously paired in
  code review — but the dispatcher itself isn't what guarantees
  read-write symmetry; that's the test layer's job (see below).
- **PRE replica-port translation moves into `TypeTranslator`.**
  `P4RuntimeService.translateReplicaPorts` is deleted; the new
  `translatePreReplicas` handles both directions in `TypeTranslator`,
  next to the table-entry / action-param translators.
- **`DIRECT_COUNTER_ENTRY` and `DIRECT_METER_ENTRY`** now translate their
  embedded `TableEntry` match fields via the existing
  `translateTableEntry` helper, in both directions.

## VALUE_SET_ENTRY

Considered, then dropped. P4-16 doesn't allow `select` over a translated
newtype, so a `value_set<port_id_t>` can be declared but never matched
against — the translation gap exists in theory but is unreachable from
compilable P4. Documented in the fixture comment.

## Tests — where the spec property is actually enforced

New `RoundTripTest` (in `p4runtime/`) drives a synthetic fixture
(`e2e_tests/translation_round_trip/round_trip.p4`) that declares one of
every P4Runtime-addressable construct 4ward supports: a translated-key
table with attached direct counter and direct meter, an action profile,
and indirect counters/meters/registers for the pass-through cases. Ten
test cases install one entity of every supported type with translated
values, read it back, and assert byte-equal (modulo ambient
counter_data/meter_config the table backfills).

The dispatcher style helps reviewers see write/read pairs at a glance,
but the real guarantee that "every supported entity type round-trips"
lives here: a missing read-side translation breaks one of these
assertions cleanly, and a new entity type that gets added to the
translator without its round-trip case stays uncovered until someone
extends this fixture.

## Verification

- `bazel test //p4runtime:RoundTripTest` — 10/10 pass.
- `bazel test //... --test_tag_filters=-heavy` — 71/71 pass.
- Format and lint clean.