### PR TITLE
ci: fail loudly when remote-cache secret is missing (closes #605)

### DIFF
--- a/.github/actions/configure-cache/action.yml
+++ b/.github/actions/configure-cache/action.yml
@@ -1,0 +1,41 @@
+name: Check BuildBuddy cache availability
+description: |
+  Emits a `Remote cache: ENABLED` notice when BUILDBUDDY_API_KEY is set, fails
+  fast (`::error`, exit 1) on `push` events to main when it's missing — where
+  absence indicates a config regression — and warns without failing on PRs
+  (fork PRs legitimately don't get repo secrets). Outputs `enabled=true|false`
+  so callers can gate their own cache-config payload (whether bazelrc or
+  command-line flags) on the result. Centralises the gating so a future cache
+  outage doesn't silently degrade CI to an uncached build (issue #605).
+
+inputs:
+  api-key:
+    required: true
+    description: |
+      The BUILDBUDDY_API_KEY secret value (pass `secrets.BUILDBUDDY_API_KEY`
+      from the workflow); will be empty for fork-PR runs, since GitHub
+      strips repo secrets from those.
+
+outputs:
+  enabled:
+    description: '`"true"` if the cache is configured, `"false"` if absent on a fork PR.'
+    value: ${{ steps.gate.outputs.enabled }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      shell: bash
+      env:
+        API_KEY: ${{ inputs.api-key }}
+      run: |
+        if [[ -n "${API_KEY}" ]]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Remote cache::ENABLED (BuildBuddy)"
+        elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+          echo "::error title=Remote cache::DISABLED — BUILDBUDDY_API_KEY secret is missing on a main push. Restore it in repo Settings → Secrets and re-run; if intentionally disabling BuildBuddy, also drop the cache-config blocks from .github/workflows/ci.yml."
+          exit 1
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "::warning title=Remote cache::DISABLED — BUILDBUDDY_API_KEY not available (likely a fork PR; GitHub strips repo secrets from those). Build will be uncached."
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Configure remote cache
+      - name: Check remote cache availability
+        id: cache
+        uses: ./.github/actions/configure-cache
+        with:
+          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+
+      - name: Add cache flags to bazelrc
+        if: steps.cache.outputs.enabled == 'true'
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
-          if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
-            echo "build --config=ci" >> ~/.bazelrc
-            echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
-          fi
+          echo "build --config=ci" >> ~/.bazelrc
+          echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
 
       # Restore-only: the build-and-test job owns the authoritative cache for
       # this key.  Lint builds a subset of targets, so letting it save would
@@ -133,14 +138,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Configure remote cache
+      - name: Check remote cache availability
+        id: cache
+        uses: ./.github/actions/configure-cache
+        with:
+          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+
+      - name: Add cache flags to bazelrc
+        if: steps.cache.outputs.enabled == 'true'
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
-          if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
-            echo "build --config=ci" >> ~/.bazelrc
-            echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
-          fi
+          echo "build --config=ci" >> ~/.bazelrc
+          echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
 
       - name: Restore Bazel cache
         uses: actions/cache/restore@v5
@@ -203,6 +213,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check remote cache availability
+        id: cache
+        uses: ./.github/actions/configure-cache
+        with:
+          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+
       # Separate local cache namespace (`bazel-bcr-*`) from the main
       # build-and-test job: this workspace uses a different `.bazelrc`
       # and resolves its own dependency graph via
@@ -227,9 +243,10 @@ jobs:
       - name: Build public targets via bcr_test_module
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CACHE_ENABLED: ${{ steps.cache.outputs.enabled }}
         run: |
           FLAGS=()
-          if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
+          if [[ "${CACHE_ENABLED}" == "true" ]]; then
             FLAGS+=(
               --remote_cache=grpcs://4ward.buildbuddy.io
               --remote_header=x-buildbuddy-api-key="${BUILDBUDDY_API_KEY}"
@@ -275,14 +292,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Configure remote cache
+      - name: Check remote cache availability
+        id: cache
+        uses: ./.github/actions/configure-cache
+        with:
+          api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+
+      - name: Add cache flags to bazelrc
+        if: steps.cache.outputs.enabled == 'true'
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
-          if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
-            echo "build --config=ci" >> ~/.bazelrc
-            echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
-          fi
+          echo "build --config=ci" >> ~/.bazelrc
+          echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
 
       - name: Restore Bazel cache
         uses: actions/cache/restore@v5


### PR DESCRIPTION
## The win

A future BuildBuddy outage (or any other reason the cache silently
fails) won't quietly degrade CI to a 20×-slower uncached build. Each
cache-config step now reports `ENABLED` / `WARNING` / `ERROR` clearly,
and `push` events to main fail fast when the secret is missing — making
a config regression a noisy build failure instead of a creeping
performance cliff that takes hours to diagnose.

## Background

#605 documented a 20× CI slowdown around 2026-04-29. After investigation
it turned out to be a transient BuildBuddy outage — the service has
since recovered, no in-tree change needed. But the slowdown took hours
to detect because the workflow's cache-config steps fell through
silently:

```yaml
if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
  echo "build --config=ci" >> ~/.bazelrc
  echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
fi
```

No echo, no notice, no warning, no failure — just a no-op when the
secret was empty (whether due to outage, fork-PR secret stripping, or
any other reason).

## What changed

A new composite action (`.github/actions/configure-cache`) handles the
gating in one place:

- Secret set → `::notice Remote cache: ENABLED`, output `enabled=true`.
- Missing on `push` to main → `::error` + `exit 1`. The secret is
  always supposed to be set on main pushes; absence is a config
  regression that should block, not silently degrade.
- Missing on PR → `::warning`, output `enabled=false`. Fork PRs don't
  get repo secrets; warn but continue.

All four cache-aware jobs (`lint`, `build-and-test`, `BCR consumer
check`, `Coverage`) call this action and gate their cache-config
payload on the `enabled` output. Three jobs use the bazelrc-write
shape; the BCR check uses the FLAGS-array shape (its bazel invocation
runs from a different workspace where `--config=ci` isn't defined).
The composite action handles only visibility/gating, leaving the
payload to each caller.

## What this doesn't fix

Transient BuildBuddy backend outages. Those still need the service to
recover or the project to migrate caches. But the *next* outage will
be loud about itself instead of silently shipping a 20× slowdown.