### PR TITLE
C++ DataplaneClient

### DIFF
--- a/e2e_tests/passthrough/BUILD.bazel
+++ b/e2e_tests/passthrough/BUILD.bazel
@@ -14,6 +14,14 @@ fourward_pipeline(
     visibility = ["//p4runtime:__pkg__"],
 )
 
+fourward_pipeline(
+    name = "passthrough_p4runtime",
+    src = "passthrough.p4",
+    out = "passthrough_p4runtime.binpb",
+    out_format = "p4runtime",
+    visibility = ["//p4runtime_cc:__pkg__"],
+)
+
 # Runs the passthrough STF test against the 4ward simulator.
 kt_jvm_test(
     name = "passthrough_test",

--- a/p4runtime_cc/BUILD.bazel
+++ b/p4runtime_cc/BUILD.bazel
@@ -33,6 +33,66 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "dataplane_client",
+    srcs = ["dataplane_client.cc"],
+    hdrs = ["dataplane_client.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":fourward_server",
+        "//p4runtime:dataplane_cc_grpc",
+        "//p4runtime:dataplane_cc_proto",
+        "@abseil-cpp//absl/base:core_headers",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/synchronization",
+        "@abseil-cpp//absl/time",
+        "@abseil-cpp//absl/types:span",
+        "@grpc//:grpc++",
+    ],
+)
+
+cc_test(
+    name = "dataplane_client_test",
+    srcs = ["dataplane_client_test.cc"],
+    deps = [
+        ":dataplane_client",
+        ":fourward_server",
+        "//p4runtime:dataplane_cc_proto",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/time",
+        "@abseil-cpp//absl/types:span",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "dataplane_client_e2e_test",
+    srcs = ["dataplane_client_e2e_test.cc"],
+    data = ["//e2e_tests/passthrough:passthrough_p4runtime"],
+    local_defines = [
+        'PASSTHROUGH_PIPELINE_RLOCATION=\\"$(rlocationpath //e2e_tests/passthrough:passthrough_p4runtime)\\"',
+    ],
+    deps = [
+        ":dataplane_client",
+        ":fourward_server",
+        "//p4runtime:dataplane_cc_proto",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/time",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@grpc//:grpc++",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+    ],
+)
+
 cc_test(
     name = "fourward_server_test",
     srcs = ["fourward_server_test.cc"],

--- a/p4runtime_cc/dataplane_client.cc
+++ b/p4runtime_cc/dataplane_client.cc
@@ -1,0 +1,264 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "p4runtime_cc/dataplane_client.h"
+
+#include <chrono>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <variant>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "grpcpp/client_context.h"
+#include "grpcpp/support/status.h"
+#include "grpcpp/support/sync_stream.h"
+#include "p4runtime/dataplane.grpc.pb.h"
+#include "p4runtime/dataplane.pb.h"
+#include "p4runtime_cc/fourward_server.h"
+
+namespace fourward {
+namespace {
+
+absl::Status ToAbsl(const grpc::Status& s) {
+  if (s.ok()) return absl::OkStatus();
+  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
+                      s.error_message());
+}
+
+std::chrono::system_clock::time_point AbsoluteDeadline(
+    absl::Duration relative) {
+  // time_point_cast: macOS system_clock uses microseconds, not nanoseconds.
+  return std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+      std::chrono::system_clock::now() + absl::ToChronoNanoseconds(relative));
+}
+
+template <class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+fourward::dataplane::InjectPacketRequest ToProto(
+    const InjectPacketArgs& args) {
+  fourward::dataplane::InjectPacketRequest req;
+  std::visit(overloaded{
+                 [&](const DataplanePort& p) {
+                   req.set_dataplane_ingress_port(p.port);
+                 },
+                 [&](const P4RuntimePort& p) {
+                   req.set_p4rt_ingress_port(p.port);
+                 },
+             },
+             args.ingress_port);
+  req.set_payload(args.payload);
+  return req;
+}
+
+}  // namespace
+
+DataplaneClient::DataplaneClient(const FourwardServer& server,
+                                 absl::Duration default_timeout)
+    : DataplaneClient(server.NewDataplaneStub(), default_timeout) {}
+
+DataplaneClient::DataplaneClient(
+    std::unique_ptr<fourward::dataplane::Dataplane::Stub> stub,
+    absl::Duration default_timeout)
+    : stub_(std::move(stub)), default_timeout_(default_timeout) {}
+
+DataplaneClient::~DataplaneClient() = default;
+DataplaneClient::DataplaneClient(DataplaneClient&&) = default;
+DataplaneClient& DataplaneClient::operator=(DataplaneClient&&) =
+    default;
+
+absl::StatusOr<fourward::dataplane::InjectPacketResponse>
+DataplaneClient::InjectPacket(const InjectPacketArgs& args,
+                              std::optional<absl::Duration> deadline) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(deadline)));
+  fourward::dataplane::InjectPacketRequest req = ToProto(args);
+  fourward::dataplane::InjectPacketResponse resp;
+  grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
+  if (!status.ok()) return ToAbsl(status);
+  return resp;
+}
+
+absl::Status DataplaneClient::InjectPackets(
+    absl::Span<const InjectPacketArgs> args,
+    std::optional<absl::Duration> deadline) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(deadline)));
+  fourward::dataplane::InjectPacketsResponse resp;
+  std::unique_ptr<
+      grpc::ClientWriter<fourward::dataplane::InjectPacketRequest>>
+      writer = stub_->InjectPackets(&ctx, &resp);
+  for (const InjectPacketArgs& arg : args) {
+    fourward::dataplane::InjectPacketRequest req = ToProto(arg);
+    if (!writer->Write(req)) {
+      return ToAbsl(writer->Finish());
+    }
+  }
+  writer->WritesDone();
+  return ToAbsl(writer->Finish());
+}
+
+class ResultStream::Impl {
+ public:
+  static absl::StatusOr<std::unique_ptr<Impl>> Create(
+      fourward::dataplane::Dataplane::Stub* stub,
+      absl::Duration startup_timeout);
+
+  ~Impl();
+
+  Impl(const Impl&) = delete;
+  Impl& operator=(const Impl&) = delete;
+
+  absl::StatusOr<fourward::dataplane::ProcessPacketResult> Next(
+      absl::Duration timeout);
+
+ private:
+  Impl() = default;
+  void ReadLoop();
+
+  enum class State { kStarting, kSubscribed, kFinished };
+
+  bool StartupSettled() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    return state_ != State::kStarting;
+  }
+  bool QueueOrFinished() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    return !queue_.empty() || state_ == State::kFinished;
+  }
+
+  std::unique_ptr<grpc::ClientContext> context_;
+  std::unique_ptr<
+      grpc::ClientReader<fourward::dataplane::SubscribeResultsResponse>>
+      reader_;
+  std::thread thread_;
+
+  absl::Mutex mu_;
+  State state_ ABSL_GUARDED_BY(mu_) = State::kStarting;
+  std::deque<fourward::dataplane::ProcessPacketResult> queue_
+      ABSL_GUARDED_BY(mu_);
+  absl::Status final_status_ ABSL_GUARDED_BY(mu_);
+};
+
+absl::StatusOr<std::unique_ptr<ResultStream::Impl>> ResultStream::Impl::Create(
+    fourward::dataplane::Dataplane::Stub* stub,
+    absl::Duration startup_timeout) {
+  std::unique_ptr<Impl> impl(new Impl);
+  impl->context_ = std::make_unique<grpc::ClientContext>();
+  fourward::dataplane::SubscribeResultsRequest req;
+  impl->reader_ = stub->SubscribeResults(impl->context_.get(), req);
+
+  Impl* raw = impl.get();
+  impl->thread_ = std::thread([raw] { raw->ReadLoop(); });
+
+  bool subscribed = false;
+  absl::Status finished_status;
+  {
+    absl::MutexLock lock(&impl->mu_);
+    if (!impl->mu_.AwaitWithTimeout(
+            absl::Condition(impl.get(), &Impl::StartupSettled),
+            startup_timeout)) {
+      impl->context_->TryCancel();
+    }
+    subscribed = impl->state_ == State::kSubscribed;
+    if (impl->state_ == State::kFinished) finished_status = impl->final_status_;
+  }
+
+  if (subscribed) return impl;
+
+  impl->thread_.join();
+  if (finished_status.ok()) {
+    return absl::DeadlineExceededError(absl::StrCat(
+        "SubscribeResults: server did not send SubscriptionActive within ",
+        absl::FormatDuration(startup_timeout)));
+  }
+  return finished_status;
+}
+
+ResultStream::Impl::~Impl() {
+  if (context_ != nullptr) context_->TryCancel();
+  if (thread_.joinable()) thread_.join();
+}
+
+void ResultStream::Impl::ReadLoop() {
+  fourward::dataplane::SubscribeResultsResponse first;
+  if (!reader_->Read(&first) || !first.has_active()) {
+    grpc::Status status = reader_->Finish();
+    absl::MutexLock lock(&mu_);
+    state_ = State::kFinished;
+    // Distinguish protocol violation (clean close without sentinel) from
+    // actual RPC errors.
+    if (status.ok()) {
+      final_status_ = absl::InternalError(
+          "SubscribeResults: stream closed before SubscriptionActive");
+    } else {
+      final_status_ = ToAbsl(status);
+    }
+    return;
+  }
+  {
+    absl::MutexLock lock(&mu_);
+    state_ = State::kSubscribed;
+  }
+
+  fourward::dataplane::SubscribeResultsResponse resp;
+  while (reader_->Read(&resp)) {
+    if (!resp.has_result()) continue;
+    absl::MutexLock lock(&mu_);
+    queue_.push_back(std::move(*resp.mutable_result()));
+  }
+  grpc::Status status = reader_->Finish();
+  absl::MutexLock lock(&mu_);
+  state_ = State::kFinished;
+  final_status_ = ToAbsl(status);
+}
+
+absl::StatusOr<fourward::dataplane::ProcessPacketResult>
+ResultStream::Impl::Next(absl::Duration timeout) {
+  absl::MutexLock lock(&mu_);
+  if (!mu_.AwaitWithTimeout(absl::Condition(this, &Impl::QueueOrFinished),
+                            timeout)) {
+    return absl::DeadlineExceededError(absl::StrCat(
+        "ResultStream::Next: no result within ", absl::FormatDuration(timeout)));
+  }
+  if (!queue_.empty()) {
+    fourward::dataplane::ProcessPacketResult result = std::move(queue_.front());
+    queue_.pop_front();
+    return result;
+  }
+  if (final_status_.ok()) {
+    return absl::CancelledError(
+        "ResultStream::Next: server closed the stream");
+  }
+  return final_status_;
+}
+
+ResultStream::~ResultStream() = default;
+ResultStream::ResultStream(ResultStream&&) = default;
+ResultStream& ResultStream::operator=(ResultStream&&) = default;
+ResultStream::ResultStream(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+
+absl::StatusOr<fourward::dataplane::ProcessPacketResult> ResultStream::Next(
+    absl::Duration timeout) {
+  return impl_->Next(timeout);
+}
+
+absl::StatusOr<ResultStream> DataplaneClient::SubscribeResults(
+    std::optional<absl::Duration> startup_timeout) {
+  absl::StatusOr<std::unique_ptr<ResultStream::Impl>> impl =
+      ResultStream::Impl::Create(stub_.get(), ResolveTimeout(startup_timeout));
+  if (!impl.ok()) return impl.status();
+  return ResultStream(*std::move(impl));
+}
+
+}  // namespace fourward

--- a/p4runtime_cc/dataplane_client.h
+++ b/p4runtime_cc/dataplane_client.h
@@ -1,0 +1,131 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FOURWARD_P4RUNTIME_CC_DATAPLANE_CLIENT_H_
+#define FOURWARD_P4RUNTIME_CC_DATAPLANE_CLIENT_H_
+
+// Convenience wrapper for the Dataplane gRPC service (dataplane.proto).
+//
+// Example:
+//
+//   ASSIGN_OR_RETURN(fourward::FourwardServer server,
+//                    fourward::FourwardServer::Start());
+//
+//   // Use default 10s timeout for everything:
+//   fourward::DataplaneClient dataplane(server);
+//
+//   // Or configure a longer default for slow networks:
+//   fourward::DataplaneClient dataplane(server, absl::Seconds(30));
+//
+//   ASSIGN_OR_RETURN(auto response,
+//                    dataplane.InjectPacket({
+//                        .ingress_port = fourward::DataplanePort{.port = 0},
+//                        .payload = "...",
+//                    }));
+//
+//   // Override timeout per-call when needed:
+//   dataplane.InjectPacket(args, absl::Seconds(1));
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "p4runtime/dataplane.grpc.pb.h"
+#include "p4runtime/dataplane.pb.h"
+#include "p4runtime_cc/fourward_server.h"
+
+namespace fourward {
+
+struct DataplanePort {
+  uint32_t port = 0;
+};
+
+// P4Runtime port ID — opaque bytes whose encoding depends on
+// @p4runtime_translation. Requires a loaded pipeline with port translation.
+struct P4RuntimePort {
+  std::string port;
+};
+
+// Mirrors fourward.dataplane.InjectPacketRequest with the proto's
+// `ingress_port` oneof modeled as a std::variant.
+struct InjectPacketArgs {
+  std::variant<DataplanePort, P4RuntimePort> ingress_port;
+  std::string payload;
+};
+
+// RAII handle for an open SubscribeResults stream. Destructor cancels and
+// joins the reader thread.
+//
+// Thread-safe: concurrent Next() calls each receive a distinct result.
+class ResultStream {
+ public:
+  ~ResultStream();
+  ResultStream(ResultStream&&);
+  ResultStream& operator=(ResultStream&&);
+  ResultStream(const ResultStream&) = delete;
+  ResultStream& operator=(const ResultStream&) = delete;
+
+  // Blocks up to `timeout` for the next result. Returns
+  // DeadlineExceededError on timeout, CancelledError when the stream ends.
+  absl::StatusOr<fourward::dataplane::ProcessPacketResult> Next(
+      absl::Duration timeout = absl::Seconds(10));
+
+ private:
+  friend class DataplaneClient;
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+  explicit ResultStream(std::unique_ptr<Impl> impl);
+};
+
+// Ergonomic C++ client for the 4ward Dataplane gRPC service. Wraps the
+// InjectPacket, InjectPackets, and SubscribeResults RPCs; names mirror
+// dataplane.proto one-to-one. RegisterPrePacketHook is intentionally not
+// wrapped — use the raw stub for advanced use cases.
+//
+// Thread-safe: each method uses its own ClientContext.
+class DataplaneClient {
+ public:
+  explicit DataplaneClient(const FourwardServer& server,
+                           absl::Duration default_timeout = absl::Seconds(10));
+  explicit DataplaneClient(
+      std::unique_ptr<fourward::dataplane::Dataplane::Stub> stub,
+      absl::Duration default_timeout = absl::Seconds(10));
+
+  ~DataplaneClient();
+  DataplaneClient(DataplaneClient&&);
+  DataplaneClient& operator=(DataplaneClient&&);
+  DataplaneClient(const DataplaneClient&) = delete;
+  DataplaneClient& operator=(const DataplaneClient&) = delete;
+
+  absl::StatusOr<fourward::dataplane::InjectPacketResponse> InjectPacket(
+      const InjectPacketArgs& args,
+      std::optional<absl::Duration> deadline = std::nullopt);
+
+  // Results are delivered via SubscribeResults, not in the response.
+  absl::Status InjectPackets(
+      absl::Span<const InjectPacketArgs> args,
+      std::optional<absl::Duration> deadline = std::nullopt);
+
+  // Blocks until the server confirms the subscription is active. The
+  // ResultStream is then long-lived; cancel via destruction.
+  absl::StatusOr<ResultStream> SubscribeResults(
+      std::optional<absl::Duration> startup_timeout = std::nullopt);
+
+ private:
+  absl::Duration ResolveTimeout(std::optional<absl::Duration> override) const {
+    return override.value_or(default_timeout_);
+  }
+
+  std::unique_ptr<fourward::dataplane::Dataplane::Stub> stub_;
+  absl::Duration default_timeout_;
+};
+
+}  // namespace fourward
+
+#endif  // FOURWARD_P4RUNTIME_CC_DATAPLANE_CLIENT_H_

--- a/p4runtime_cc/dataplane_client_e2e_test.cc
+++ b/p4runtime_cc/dataplane_client_e2e_test.cc
@@ -1,0 +1,199 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// End-to-end tests for DataplaneClient against a live FourwardServer with a
+// loaded P4 pipeline. Uses the passthrough program (always forwards to port 1)
+// so results are deterministic without any table entries.
+
+#include "p4runtime_cc/dataplane_client.h"
+
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/time/time.h"
+#include "gtest/gtest.h"
+#include "grpcpp/client_context.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4runtime/dataplane.pb.h"
+#include "p4runtime_cc/fourward_server.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+#ifndef PASSTHROUGH_PIPELINE_RLOCATION
+#error "PASSTHROUGH_PIPELINE_RLOCATION must be set by the BUILD rule"
+#endif
+
+namespace fourward {
+namespace {
+
+using ::bazel::tools::cpp::runfiles::Runfiles;
+
+absl::Status ToAbsl(const grpc::Status& s) {
+  if (s.ok()) return absl::OkStatus();
+  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
+                      s.error_message());
+}
+
+absl::StatusOr<std::string> ReadRunfile(const std::string& rlocation) {
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", &error));
+  if (runfiles == nullptr) {
+    return absl::InternalError(absl::StrCat("runfiles: ", error));
+  }
+  std::string path = runfiles->Rlocation(rlocation);
+  if (path.empty()) {
+    return absl::NotFoundError(
+        absl::StrCat("not found in runfiles: ", rlocation));
+  }
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    return absl::NotFoundError(absl::StrCat("cannot open: ", path));
+  }
+  return std::string(std::istreambuf_iterator<char>(file),
+                     std::istreambuf_iterator<char>());
+}
+
+// Pushes a ForwardingPipelineConfig to the server via the P4Runtime API.
+// Handles the arbitration handshake.
+absl::Status PushPipeline(const FourwardServer& server,
+                          const p4::v1::ForwardingPipelineConfig& config) {
+  auto stub = server.NewP4RuntimeStub();
+
+  // Establish master arbitration.
+  grpc::ClientContext stream_ctx;
+  auto stream = stub->StreamChannel(&stream_ctx);
+  p4::v1::StreamMessageRequest arb_req;
+  arb_req.mutable_arbitration()->set_device_id(server.DeviceId());
+  arb_req.mutable_arbitration()->mutable_election_id()->set_low(1);
+  if (!stream->Write(arb_req)) {
+    return absl::InternalError("failed to write arbitration request");
+  }
+  p4::v1::StreamMessageResponse arb_resp;
+  if (!stream->Read(&arb_resp)) {
+    return absl::InternalError("failed to read arbitration response");
+  }
+
+  // Push pipeline.
+  grpc::ClientContext set_ctx;
+  p4::v1::SetForwardingPipelineConfigRequest req;
+  req.set_device_id(server.DeviceId());
+  req.mutable_election_id()->set_low(1);
+  req.set_action(
+      p4::v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT);
+  *req.mutable_config() = config;
+  p4::v1::SetForwardingPipelineConfigResponse resp;
+  grpc::Status status =
+      stub->SetForwardingPipelineConfig(&set_ctx, req, &resp);
+  if (!status.ok()) return ToAbsl(status);
+
+  stream_ctx.TryCancel();
+  return absl::OkStatus();
+}
+
+// A minimal Ethernet frame: dst=00:00:00:00:00:01, src=00:00:00:00:00:02,
+// ethertype=0x0800, plus 46 zero bytes of payload to reach the 64-byte
+// minimum.
+std::string MakeEthernetFrame() {
+  std::string frame(64, '\0');
+  frame[5] = 0x01;   // dst
+  frame[11] = 0x02;  // src
+  frame[12] = 0x08;  // ethertype high
+  return frame;
+}
+
+class DataplaneClientE2ETest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    absl::StatusOr<FourwardServer> s = FourwardServer::Start();
+    ASSERT_TRUE(s.ok()) << s.status();
+    server_ = std::make_unique<FourwardServer>(*std::move(s));
+
+    // Load the passthrough pipeline.
+    absl::StatusOr<std::string> binpb =
+        ReadRunfile(PASSTHROUGH_PIPELINE_RLOCATION);
+    ASSERT_TRUE(binpb.ok()) << binpb.status();
+    p4::v1::ForwardingPipelineConfig config;
+    ASSERT_TRUE(config.ParseFromString(*binpb))
+        << "failed to parse ForwardingPipelineConfig";
+    absl::Status push = PushPipeline(*server_, config);
+    ASSERT_TRUE(push.ok()) << push;
+  }
+
+  std::unique_ptr<FourwardServer> server_;
+};
+
+TEST_F(DataplaneClientE2ETest, InjectPacketReturnsTraceAndOutputs) {
+  DataplaneClient client(*server_);
+
+  absl::StatusOr<fourward::dataplane::InjectPacketResponse> resp =
+      client.InjectPacket({
+          .ingress_port = DataplanePort{.port = 0},
+          .payload = MakeEthernetFrame(),
+      });
+  ASSERT_TRUE(resp.ok()) << resp.status();
+
+  // Passthrough forwards every packet to port 1.
+  ASSERT_EQ(resp->possible_outcomes_size(), 1);
+  ASSERT_EQ(resp->possible_outcomes(0).packets_size(), 1);
+  EXPECT_EQ(resp->possible_outcomes(0).packets(0).dataplane_egress_port(), 1u);
+  EXPECT_FALSE(resp->trace().DebugString().empty());
+}
+
+TEST_F(DataplaneClientE2ETest, SubscribeResultsDeliversInjectedPacket) {
+  DataplaneClient client(*server_);
+
+  absl::StatusOr<ResultStream> stream = client.SubscribeResults();
+  ASSERT_TRUE(stream.ok()) << stream.status();
+
+  // Inject via the unary RPC; the result should also appear on the stream.
+  absl::StatusOr<fourward::dataplane::InjectPacketResponse> inject =
+      client.InjectPacket({
+          .ingress_port = DataplanePort{.port = 0},
+          .payload = MakeEthernetFrame(),
+      });
+  ASSERT_TRUE(inject.ok()) << inject.status();
+
+  absl::StatusOr<fourward::dataplane::ProcessPacketResult> result =
+      stream->Next();
+  ASSERT_TRUE(result.ok()) << result.status();
+  ASSERT_EQ(result->possible_outcomes_size(), 1);
+  ASSERT_EQ(result->possible_outcomes(0).packets_size(), 1);
+  EXPECT_EQ(result->possible_outcomes(0).packets(0).dataplane_egress_port(),
+            1u);
+  EXPECT_EQ(result->input_packet().dataplane_ingress_port(), 0u);
+}
+
+TEST_F(DataplaneClientE2ETest, InjectPacketsResultsDeliveredViaSubscribe) {
+  DataplaneClient client(*server_);
+
+  absl::StatusOr<ResultStream> stream = client.SubscribeResults();
+  ASSERT_TRUE(stream.ok()) << stream.status();
+
+  std::vector<InjectPacketArgs> batch = {
+      {.ingress_port = DataplanePort{.port = 0},
+       .payload = MakeEthernetFrame()},
+      {.ingress_port = DataplanePort{.port = 2},
+       .payload = MakeEthernetFrame()},
+  };
+  absl::Status status = client.InjectPackets(absl::MakeConstSpan(batch));
+  ASSERT_TRUE(status.ok()) << status;
+
+  // Both results should arrive.
+  for (int i = 0; i < 2; ++i) {
+    absl::StatusOr<fourward::dataplane::ProcessPacketResult> result =
+        stream->Next();
+    ASSERT_TRUE(result.ok()) << "result " << i << ": " << result.status();
+    ASSERT_EQ(result->possible_outcomes_size(), 1);
+    EXPECT_EQ(result->possible_outcomes(0).packets(0).dataplane_egress_port(),
+              1u);
+  }
+}
+
+}  // namespace
+}  // namespace fourward

--- a/p4runtime_cc/dataplane_client_test.cc
+++ b/p4runtime_cc/dataplane_client_test.cc
@@ -1,0 +1,134 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "p4runtime_cc/dataplane_client.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "gtest/gtest.h"
+#include "p4runtime/dataplane.pb.h"
+#include "p4runtime_cc/fourward_server.h"
+
+namespace fourward {
+namespace {
+
+class DataplaneClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    absl::StatusOr<FourwardServer> s = FourwardServer::Start();
+    ASSERT_TRUE(s.ok()) << s.status();
+    server_ = std::make_unique<FourwardServer>(*std::move(s));
+  }
+
+  std::unique_ptr<FourwardServer> server_;
+};
+
+TEST_F(DataplaneClientTest, ConstructAndDestroy) {
+  DataplaneClient client(*server_);
+}
+
+TEST_F(DataplaneClientTest, SubscribeResultsConfirmsActiveAndCancelsCleanly) {
+  DataplaneClient client(*server_);
+
+  absl::StatusOr<ResultStream> stream = client.SubscribeResults();
+  ASSERT_TRUE(stream.ok()) << stream.status();
+
+  // No pipeline loaded — no results will arrive.
+  absl::StatusOr<fourward::dataplane::ProcessPacketResult> next =
+      stream->Next(absl::Milliseconds(50));
+  ASSERT_FALSE(next.ok());
+  EXPECT_EQ(next.status().code(), absl::StatusCode::kDeadlineExceeded)
+      << next.status();
+
+  // Destruction must cancel the RPC and join the reader thread.
+}
+
+TEST_F(DataplaneClientTest, SubscribeResultsRespectsStartupTimeout) {
+  DataplaneClient client(*server_);
+
+  absl::StatusOr<ResultStream> stream =
+      client.SubscribeResults(absl::Nanoseconds(1));
+  ASSERT_FALSE(stream.ok());
+  EXPECT_EQ(stream.status().code(), absl::StatusCode::kDeadlineExceeded)
+      << stream.status();
+}
+
+TEST_F(DataplaneClientTest, InjectPacketDataplanePortDeadlinePropagated) {
+  DataplaneClient client(*server_);
+
+  absl::StatusOr<fourward::dataplane::InjectPacketResponse> resp =
+      client.InjectPacket(
+          {.ingress_port = DataplanePort{.port = 0}, .payload = "x"},
+          absl::Nanoseconds(1));
+  ASSERT_FALSE(resp.ok());
+  EXPECT_EQ(resp.status().code(), absl::StatusCode::kDeadlineExceeded)
+      << resp.status();
+}
+
+TEST_F(DataplaneClientTest, InjectPacketP4RuntimePortDeadlinePropagated) {
+  DataplaneClient client(*server_);
+
+  absl::StatusOr<fourward::dataplane::InjectPacketResponse> resp =
+      client.InjectPacket(
+          {.ingress_port = P4RuntimePort{.port = std::string("\x00\x01", 2)},
+           .payload = "x"},
+          absl::Nanoseconds(1));
+  ASSERT_FALSE(resp.ok());
+  EXPECT_EQ(resp.status().code(), absl::StatusCode::kDeadlineExceeded)
+      << resp.status();
+}
+
+TEST_F(DataplaneClientTest, InjectPacketsAcceptsEmptyBatch) {
+  DataplaneClient client(*server_);
+
+  std::vector<InjectPacketArgs> empty;
+  absl::Status status = client.InjectPackets(absl::MakeConstSpan(empty));
+  EXPECT_TRUE(status.ok()) << status;
+}
+
+TEST_F(DataplaneClientTest, InjectPacketsNonEmptyBatchDeadlinePropagated) {
+  DataplaneClient client(*server_);
+
+  std::vector<InjectPacketArgs> batch = {
+      {.ingress_port = DataplanePort{.port = 0}, .payload = "a"},
+      {.ingress_port = DataplanePort{.port = 1}, .payload = "b"},
+      {.ingress_port = P4RuntimePort{.port = std::string("\x00\x02", 2)},
+       .payload = "c"},
+  };
+  absl::Status status =
+      client.InjectPackets(absl::MakeConstSpan(batch), absl::Nanoseconds(1));
+  ASSERT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kDeadlineExceeded) << status;
+}
+
+TEST_F(DataplaneClientTest, MoveConstructionPreservesStub) {
+  DataplaneClient original(*server_);
+  DataplaneClient moved = std::move(original);
+
+  absl::StatusOr<ResultStream> stream = moved.SubscribeResults();
+  EXPECT_TRUE(stream.ok()) << stream.status();
+}
+
+TEST_F(DataplaneClientTest, ResultStreamMoveConstructionPreservesStream) {
+  DataplaneClient client(*server_);
+  absl::StatusOr<ResultStream> original = client.SubscribeResults();
+  ASSERT_TRUE(original.ok()) << original.status();
+
+  ResultStream moved = *std::move(original);
+
+  absl::StatusOr<fourward::dataplane::ProcessPacketResult> next =
+      moved.Next(absl::Milliseconds(50));
+  ASSERT_FALSE(next.ok());
+  EXPECT_EQ(next.status().code(), absl::StatusCode::kDeadlineExceeded)
+      << next.status();
+}
+
+}  // namespace
+}  // namespace fourward


### PR DESCRIPTION
## Why

Customers driving the 4ward Dataplane gRPC service from C++ today repeat
the same boilerplate per integration: stream lifecycle, sentinel waits for
`SubscriptionActive`, and proto-oneof field selection.

`DataplaneClient` collapses each RPC into a single method call with RAII
stream handles that cancel on destruction. Every blocking method takes a
deadline so a wedged server can't hang the caller.

## Surface

```cpp
class DataplaneClient {
 public:
  explicit DataplaneClient(const FourwardServer& server);
  explicit DataplaneClient(std::unique_ptr<dataplane::Dataplane::Stub>);

  StatusOr<InjectPacketResponse> InjectPacket(const InjectPacketArgs&, Duration = 10s);
  Status                         InjectPackets(Span<const InjectPacketArgs>, Duration = 10s);
  StatusOr<ResultStream>         SubscribeResults(Duration startup_timeout = 10s);
};
```

Method names mirror `dataplane.proto`. Inputs use C++ structs with
`std::variant` for proto oneofs, designed for designated-init call sites:

```cpp
client.InjectPacket({.ingress_port = DataplanePort{.port = 0}, .payload = "..."});
```

Outputs come back as protos directly — they are tree-shaped, evolve with
the simulator, and callers typically need the proto for logging or
comparison anyway.

## Design choices

- **Two constructors.** `DataplaneClient(server)` for the common case;
  `DataplaneClient(stub)` for custom stub construction / testing.
- **`RegisterPrePacketHook` intentionally not wrapped.** Advanced use case;
  use the raw stub.
- **PIMPL on `ResultStream`, not the client.** Streaming handle hides
  threads + queue; the client is just a stub holder.
- **10s default deadline everywhere.** Bounded to prevent silent hangs;
  pass `InfiniteDuration()` if you truly want to wait forever.

## Test coverage

**Smoke tests** (9 tests, no pipeline required):
- Both `DataplanePort` and `P4RuntimePort` variant dispatch at runtime
- Deadline propagation on every method
- `ResultStream::Next()` timeout, startup timeout
- Empty and non-empty batch injection
- Subscribe → cancel lifecycle
- Move semantics for `DataplaneClient` and `ResultStream`

**E2E tests** (3 tests, passthrough pipeline loaded):
- `InjectPacket` returns trace + correct egress port
- `SubscribeResults` delivers results from unary injection
- `InjectPackets` batch results delivered via stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)