### PR TITLE
p4runtime_cc: update embedding docs + P4RuntimePort error-path test

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ ergonomics (sealed classes, pattern matching).
 > [!IMPORTANT]
 > **You don't need Kotlin to contribute to — or use — 4ward.**
 > [AI writes the code](docs/AI_WORKFLOW.md); C++ projects embed via
-> [`//p4runtime_cc:fourward_server`](https://smolkaj.github.io/4ward/reference/embedding-cc/);
+> [`//p4runtime_cc:dataplane_client`](https://smolkaj.github.io/4ward/reference/embedding-cc/);
 > any gRPC client works in any language.
 
 ## Project structure

--- a/p4runtime_cc/dataplane_client_e2e_test.cc
+++ b/p4runtime_cc/dataplane_client_e2e_test.cc
@@ -195,5 +195,21 @@ TEST_F(DataplaneClientE2ETest, InjectPacketsResultsDeliveredViaSubscribe) {
   }
 }
 
+TEST_F(DataplaneClientE2ETest,
+       InjectPacketWithP4RuntimePortFailsWithoutTranslation) {
+  DataplaneClient client(*server_);
+
+  // The passthrough program has no @p4runtime_translation on its port type.
+  // Injecting via P4RuntimePort must fail with FAILED_PRECONDITION.
+  absl::StatusOr<fourward::dataplane::InjectPacketResponse> resp =
+      client.InjectPacket({
+          .ingress_port = P4RuntimePort{.port = std::string("\x00\x01", 2)},
+          .payload = MakeEthernetFrame(),
+      });
+  ASSERT_FALSE(resp.ok());
+  EXPECT_EQ(resp.status().code(), absl::StatusCode::kFailedPrecondition)
+      << resp.status();
+}
+
 }  // namespace
 }  // namespace fourward

--- a/userdocs/reference/embedding-cc.md
+++ b/userdocs/reference/embedding-cc.md
@@ -5,14 +5,10 @@ description: "Treat 4ward like a native C++ library — Bazel setup, example usa
 # Embedding the server in C++
 
 **Treat 4ward like a native C++ library.** Depend on
-`//p4runtime_cc:fourward_server`, construct a `FourwardServer`, and
-you have factories for P4Runtime and Dataplane stubs on a shared gRPC
-channel. Your project sees a C++ API and a Bazel target; the server's
-implementation language never enters the picture.
-
-Under the hood, `Start()` spawns the server as a subprocess, blocks
-until it is accepting RPCs, and returns an RAII handle. Destruction
-kills the subprocess.
+`//p4runtime_cc:dataplane_client` for the ergonomic wrapper, or
+`//p4runtime_cc:fourward_server` for raw stub access. Your project sees
+a C++ API and a Bazel target; the server's implementation language never
+enters the picture.
 
 ## Bazel dependency
 
@@ -21,17 +17,58 @@ cc_test(
     name = "my_test",
     srcs = ["my_test.cc"],
     deps = [
+        "@fourward//p4runtime_cc:dataplane_client",
         "@fourward//p4runtime_cc:fourward_server",
-        # ... your gRPC / P4Runtime deps ...
+        # ... your other deps ...
     ],
 )
 ```
 
-The library propagates the server binary through its `data` attribute, so
-consumers do not need to list `@fourward//p4runtime:p4runtime_server`
-themselves.
 
-## Example
+## DataplaneClient
+
+The recommended entry point for packet injection and result observation:
+
+```cpp
+#include "p4runtime_cc/dataplane_client.h"
+
+absl::Status RunAgainstFourward() {
+  ASSIGN_OR_RETURN(fourward::FourwardServer server,
+                   fourward::FourwardServer::Start());
+
+  // Use default 10s timeout for everything:
+  fourward::DataplaneClient dataplane(server);
+
+  // Or configure a longer default for slow networks:
+  fourward::DataplaneClient dataplane(server, absl::Seconds(30));
+
+  // Inject a single packet — returns trace + outputs inline.
+  ASSIGN_OR_RETURN(auto response,
+                   dataplane.InjectPacket({
+                       .ingress_port = fourward::DataplanePort{.port = 0},
+                       .payload = raw_ethernet_bytes,
+                   }));
+
+  // Override timeout per-call when needed:
+  ASSIGN_OR_RETURN(auto fast,
+                   dataplane.InjectPacket(args, absl::Seconds(1)));
+
+  // Subscribe to results from all injection sources.
+  ASSIGN_OR_RETURN(fourward::ResultStream stream,
+                   dataplane.SubscribeResults());
+  ASSIGN_OR_RETURN(auto result, stream.Next());
+
+  return absl::OkStatus();
+}
+```
+
+Method names mirror `dataplane.proto` one-to-one: `InjectPacket`,
+`InjectPackets`, `SubscribeResults`. `RegisterPrePacketHook` is
+intentionally not wrapped — use the raw stub for advanced use cases.
+
+## FourwardServer (low-level)
+
+For direct stub access or when you need the P4Runtime service:
 
 ```cpp
 #include "p4runtime_cc/fourward_server.h"
@@ -45,13 +82,9 @@ absl::Status RunAgainstFourward() {
   // ... drive the server via gRPC ...
 
   return absl::OkStatus();
-  // `server` is killed here via SIGTERM; the scratch directory holding its
-  // port-file is removed on the same path.
+  // `server` destructor kills the subprocess.
 }
 ```
-
-Both stubs share a single insecure channel to `localhost:<port>` managed
-by the wrapper.
 
 Options cover `device_id`, the listening `port` (unset by default — the
 kernel picks an ephemeral port), `drop_port`, `cpu_port`, and


### PR DESCRIPTION
## Summary

- Rewrite `userdocs/reference/embedding-cc.md` to lead with
  `DataplaneClient` (the recommended entry point), show timeout
  configuration patterns, and move raw-stub usage to a "low-level"
  section.
- Add e2e test verifying `P4RuntimePort` returns `FAILED_PRECONDITION`
  when the loaded pipeline has no `@p4runtime_translation`. Exercises the
  P4RuntimePort std::visit branch at runtime against a real server.
- BCR consumer check already covers `dataplane_client` (builds
  `@fourward//...`), so no separate consumer BUILD needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)