### PR TITLE
p4runtime_cc: add composable gtest matchers for dataplane results

### DIFF
--- a/p4runtime_cc/BUILD.bazel
+++ b/p4runtime_cc/BUILD.bazel
@@ -53,6 +53,29 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "dataplane_matchers",
+    testonly = True,
+    hdrs = ["dataplane_matchers.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":dataplane_client",
+        "//p4runtime:dataplane_cc_proto",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "dataplane_matchers_test",
+    srcs = ["dataplane_matchers_test.cc"],
+    deps = [
+        ":dataplane_matchers",
+        "//p4runtime:dataplane_cc_proto",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_test(
     name = "dataplane_client_test",
     srcs = ["dataplane_client_test.cc"],
@@ -78,6 +101,7 @@ cc_test(
     ],
     deps = [
         ":dataplane_client",
+        ":dataplane_matchers",
         ":fourward_server",
         "//p4runtime:dataplane_cc_proto",
         "@abseil-cpp//absl/status",

--- a/p4runtime_cc/dataplane_client_e2e_test.cc
+++ b/p4runtime_cc/dataplane_client_e2e_test.cc
@@ -18,11 +18,13 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "grpcpp/client_context.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4runtime/dataplane.pb.h"
+#include "p4runtime_cc/dataplane_matchers.h"
 #include "p4runtime_cc/fourward_server.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
@@ -138,11 +140,7 @@ TEST_F(DataplaneClientE2ETest, InjectPacketReturnsTraceAndOutputs) {
           .payload = MakeEthernetFrame(),
       });
   ASSERT_TRUE(resp.ok()) << resp.status();
-
-  // Passthrough forwards every packet to port 1.
-  ASSERT_EQ(resp->possible_outcomes_size(), 1);
-  ASSERT_EQ(resp->possible_outcomes(0).packets_size(), 1);
-  EXPECT_EQ(resp->possible_outcomes(0).packets(0).dataplane_egress_port(), 1u);
+  EXPECT_THAT(*resp, ForwardsTo(1));
   EXPECT_FALSE(resp->trace().DebugString().empty());
 }
 
@@ -163,11 +161,8 @@ TEST_F(DataplaneClientE2ETest, SubscribeResultsDeliversInjectedPacket) {
   absl::StatusOr<fourward::dataplane::ProcessPacketResult> result =
       stream->Next();
   ASSERT_TRUE(result.ok()) << result.status();
-  ASSERT_EQ(result->possible_outcomes_size(), 1);
-  ASSERT_EQ(result->possible_outcomes(0).packets_size(), 1);
-  EXPECT_EQ(result->possible_outcomes(0).packets(0).dataplane_egress_port(),
-            1u);
-  EXPECT_EQ(result->input_packet().dataplane_ingress_port(), 0u);
+  EXPECT_THAT(*result, ForwardsTo(1));
+  EXPECT_THAT(*result, HasIngress(0));
 }
 
 TEST_F(DataplaneClientE2ETest, InjectPacketsResultsDeliveredViaSubscribe) {
@@ -185,14 +180,11 @@ TEST_F(DataplaneClientE2ETest, InjectPacketsResultsDeliveredViaSubscribe) {
   absl::Status status = client.InjectPackets(absl::MakeConstSpan(batch));
   ASSERT_TRUE(status.ok()) << status;
 
-  // Both results should arrive.
   for (int i = 0; i < 2; ++i) {
     absl::StatusOr<fourward::dataplane::ProcessPacketResult> result =
         stream->Next();
     ASSERT_TRUE(result.ok()) << "result " << i << ": " << result.status();
-    ASSERT_EQ(result->possible_outcomes_size(), 1);
-    EXPECT_EQ(result->possible_outcomes(0).packets(0).dataplane_egress_port(),
-              1u);
+    EXPECT_THAT(*result, ForwardsTo(1));
   }
 }
 

--- a/p4runtime_cc/dataplane_matchers.h
+++ b/p4runtime_cc/dataplane_matchers.h
@@ -1,0 +1,381 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// gtest matchers for Dataplane RPC responses — see
+// userdocs/reference/dataplane-matchers.md for the full guide.
+
+#ifndef P4RUNTIME_CC_DATAPLANE_MATCHERS_H_
+#define P4RUNTIME_CC_DATAPLANE_MATCHERS_H_
+
+#include <cstdint>
+#include <map>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "p4runtime/dataplane.pb.h"
+#include "p4runtime_cc/dataplane_client.h"
+
+namespace fourward {
+namespace internal {
+
+using PacketList = std::vector<fourward::dataplane::OutputPacket>;
+
+template <typename T>
+std::vector<PacketList> ExtractOutcomes(const T& result) {
+  std::vector<PacketList> outcomes;
+  for (const auto& ps : result.possible_outcomes()) {
+    outcomes.emplace_back(ps.packets().begin(), ps.packets().end());
+  }
+  return outcomes;
+}
+
+// Tag types for disambiguation.
+template <typename M>
+struct PacketsTag {
+  M matcher;
+};
+
+template <typename M>
+struct OutcomeTag {
+  M matcher;
+};
+
+// Wraps an arg for OutcomesAre: tagged types pass through, everything else
+// gets wrapped as a single-packet outcome.
+template <typename M>
+auto WrapForOutcomesAre(OutcomeTag<M> tagged) {
+  return std::move(tagged.matcher);
+}
+template <typename M>
+auto WrapForOutcomesAre(PacketsTag<M> tagged) {
+  return std::move(tagged.matcher);
+}
+template <typename M>
+auto WrapForOutcomesAre(M m) {
+  return ::testing::UnorderedElementsAre(std::move(m));
+}
+
+// Base for result-level matchers. Extracts outcomes, checks count, and
+// delegates to an inner matcher on the outcomes vector. Produces clear
+// error messages ("has 3 possible outcomes (expected 1)") instead of
+// gmock's ResultOf internals.
+class OutcomesMatcherBase {
+ public:
+  OutcomesMatcherBase(::testing::Matcher<const std::vector<PacketList>&> inner,
+                      std::string description)
+      : inner_(std::move(inner)), description_(std::move(description)) {}
+
+  template <typename T>
+  bool MatchAndExplain(const T& result,
+                       ::testing::MatchResultListener* listener) const {
+    auto outcomes = ExtractOutcomes(result);
+    return inner_.MatchAndExplain(outcomes, listener);
+  }
+
+  void DescribeTo(std::ostream* os) const {
+    if (description_.empty()) {
+      *os << "has outcomes that ";
+      inner_.DescribeTo(os);
+    } else {
+      *os << description_;
+    }
+  }
+  void DescribeNegationTo(std::ostream* os) const {
+    if (description_.empty()) {
+      *os << "has outcomes that ";
+      inner_.DescribeNegationTo(os);
+    } else {
+      *os << "does not " << description_;
+    }
+  }
+
+ protected:
+  ::testing::Matcher<const std::vector<PacketList>&> inner_;
+  std::string description_;
+};
+
+// Port key for OnPorts grouping.
+using PortKey = std::variant<DataplanePort, P4RuntimePort>;
+
+// All entries must use the same port type (DataplanePort or P4RuntimePort).
+// Mixing types in a single OnPorts call groups all packets by the first
+// entry's type, which silently ignores entries of the other type.
+inline PortKey PacketPortKey(const fourward::dataplane::OutputPacket& pkt,
+                             const PortKey& example_key) {
+  if (std::holds_alternative<P4RuntimePort>(example_key)) {
+    return P4RuntimePort{pkt.p4rt_egress_port()};
+  }
+  return DataplanePort{pkt.dataplane_egress_port()};
+}
+
+struct PortKeyLess {
+  bool operator()(const PortKey& a, const PortKey& b) const {
+    if (a.index() != b.index()) return a.index() < b.index();
+    if (std::holds_alternative<DataplanePort>(a)) {
+      return std::get<DataplanePort>(a).port < std::get<DataplanePort>(b).port;
+    }
+    return std::get<P4RuntimePort>(a).port < std::get<P4RuntimePort>(b).port;
+  }
+};
+
+inline void PrintPortKey(std::ostream* os, const PortKey& key) {
+  if (std::holds_alternative<DataplanePort>(key)) {
+    *os << std::get<DataplanePort>(key).port;
+  } else {
+    *os << "\"" << std::get<P4RuntimePort>(key).port << "\"";
+  }
+}
+
+}  // namespace internal
+
+// ---------------------------------------------------------------------------
+// Packet-level matchers (match on OutputPacket)
+// ---------------------------------------------------------------------------
+
+inline auto OnPort(DataplanePort expected) {
+  return ::testing::ResultOf(
+      [](const fourward::dataplane::OutputPacket& p) {
+        return p.dataplane_egress_port();
+      },
+      ::testing::Eq(expected.port));
+}
+inline auto OnPort(P4RuntimePort expected) {
+  return ::testing::ResultOf(
+      [](const fourward::dataplane::OutputPacket& p) -> const std::string& {
+        return p.p4rt_egress_port();
+      },
+      ::testing::Eq(expected.port));
+}
+inline auto OnPort(uint32_t port) { return OnPort(DataplanePort{port}); }
+inline auto OnPort(std::string port) {
+  return OnPort(P4RuntimePort{std::move(port)});
+}
+
+inline auto HasPayload(::testing::Matcher<const std::string&> m) {
+  return ::testing::ResultOf(
+      [](const fourward::dataplane::OutputPacket& p) -> const std::string& {
+        return p.payload();
+      },
+      std::move(m));
+}
+
+// ---------------------------------------------------------------------------
+// Packets — marks a matcher as operating on the packet list (container mode)
+// ---------------------------------------------------------------------------
+
+template <typename M>
+internal::PacketsTag<M> Packets(M m) {
+  return {std::move(m)};
+}
+
+// ---------------------------------------------------------------------------
+// Outcome — marks a multi-packet outcome for use inside OutcomesAre
+// ---------------------------------------------------------------------------
+
+template <typename... Ms>
+auto Outcome(Ms... ms) {
+  return internal::OutcomeTag{
+      ::testing::UnorderedElementsAre(std::move(ms)...)};
+}
+
+// ---------------------------------------------------------------------------
+// OutcomeIs — single deterministic outcome
+// ---------------------------------------------------------------------------
+
+inline auto OutcomeIs() {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::ElementsAre(::testing::IsEmpty()), "drop the packet"));
+}
+
+template <typename... Ms>
+auto OutcomeIs(Ms... ms) {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::ElementsAre(::testing::UnorderedElementsAre(std::move(ms)...)),
+      ""));
+}
+
+template <typename M>
+auto OutcomeIs(internal::PacketsTag<M> tagged) {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::ElementsAre(std::move(tagged.matcher)), ""));
+}
+
+// ---------------------------------------------------------------------------
+// OutcomesAre — exact set of outcomes (unordered)
+// ---------------------------------------------------------------------------
+
+template <typename... Ms>
+auto OutcomesAre(Ms... ms) {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::UnorderedElementsAre(
+          internal::WrapForOutcomesAre(std::move(ms))...),
+      ""));
+}
+
+// ---------------------------------------------------------------------------
+// EachOutcome / AnyOutcome
+// ---------------------------------------------------------------------------
+
+template <typename M>
+auto EachOutcome(M m) {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::Each(::testing::UnorderedElementsAre(std::move(m))), ""));
+}
+template <typename M>
+auto EachOutcome(internal::PacketsTag<M> tagged) {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::Each(std::move(tagged.matcher)), ""));
+}
+
+template <typename M>
+auto AnyOutcome(M m) {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::Contains(::testing::UnorderedElementsAre(std::move(m))), ""));
+}
+template <typename M>
+auto AnyOutcome(internal::PacketsTag<M> tagged) {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::Contains(std::move(tagged.matcher)), ""));
+}
+
+// ---------------------------------------------------------------------------
+// HasIngress
+// ---------------------------------------------------------------------------
+
+class HasIngressMatcher {
+ public:
+  explicit HasIngressMatcher(internal::PortKey expected)
+      : expected_(std::move(expected)) {}
+
+  template <typename T>
+  bool MatchAndExplain(const T& result,
+                       ::testing::MatchResultListener* listener) const {
+    if (std::holds_alternative<P4RuntimePort>(expected_)) {
+      const std::string& actual = result.input_packet().p4rt_ingress_port();
+      const std::string& exp = std::get<P4RuntimePort>(expected_).port;
+      if (actual != exp) {
+        *listener << "has P4Runtime ingress port \"" << actual << "\"";
+        return false;
+      }
+    } else {
+      uint32_t actual = result.input_packet().dataplane_ingress_port();
+      uint32_t exp = std::get<DataplanePort>(expected_).port;
+      if (actual != exp) {
+        *listener << "has dataplane ingress port " << actual;
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void DescribeTo(std::ostream* os) const {
+    *os << "has ingress port ";
+    internal::PrintPortKey(os, expected_);
+  }
+  void DescribeNegationTo(std::ostream* os) const {
+    *os << "does not have ingress port ";
+    internal::PrintPortKey(os, expected_);
+  }
+
+ private:
+  internal::PortKey expected_;
+};
+
+inline auto HasIngress(DataplanePort port) {
+  return ::testing::MakePolymorphicMatcher(
+      HasIngressMatcher(internal::PortKey{port}));
+}
+inline auto HasIngress(P4RuntimePort port) {
+  return ::testing::MakePolymorphicMatcher(
+      HasIngressMatcher(internal::PortKey{std::move(port)}));
+}
+inline auto HasIngress(uint32_t port) {
+  return HasIngress(DataplanePort{port});
+}
+inline auto HasIngress(std::string port) {
+  return HasIngress(P4RuntimePort{std::move(port)});
+}
+
+// ---------------------------------------------------------------------------
+// Shorthands
+// ---------------------------------------------------------------------------
+
+template <typename... Ports>
+auto ForwardsTo(Ports... ports) {
+  return OutcomeIs(OnPort(std::move(ports))...);
+}
+
+inline auto Drops() { return OutcomeIs(); }
+
+// ---------------------------------------------------------------------------
+// OnPorts — group by egress port
+//
+// All entries must use the same port type (DataplanePort or P4RuntimePort).
+// ---------------------------------------------------------------------------
+
+class OnPortsMatcher {
+ public:
+  using PortExpectation =
+      std::pair<internal::PortKey,
+                ::testing::Matcher<const internal::PacketList&>>;
+
+  explicit OnPortsMatcher(std::vector<PortExpectation> expected)
+      : expected_(std::move(expected)) {}
+
+  template <typename Container>
+  bool MatchAndExplain(const Container& packets,
+                       ::testing::MatchResultListener* listener) const {
+    std::map<internal::PortKey, internal::PacketList, internal::PortKeyLess>
+        groups;
+    // Port type is inferred from the first entry — all entries must use the
+    // same type (DataplanePort or P4RuntimePort).
+    for (const auto& p : packets) {
+      groups[internal::PacketPortKey(p, expected_.front().first)].push_back(p);
+    }
+    static const internal::PacketList kEmpty;
+    for (const auto& [port, matcher] : expected_) {
+      auto it = groups.find(port);
+      const internal::PacketList& group =
+          it != groups.end() ? it->second : kEmpty;
+      if (!matcher.Matches(group)) {
+        *listener << "on port ";
+        internal::PrintPortKey(listener->stream(), port);
+        *listener << ": ";
+        matcher.DescribeNegationTo(listener->stream());
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void DescribeTo(std::ostream* os) const {
+    *os << "has packets grouped by port matching: ";
+    for (size_t i = 0; i < expected_.size(); ++i) {
+      if (i > 0) *os << ", ";
+      *os << "port ";
+      internal::PrintPortKey(os, expected_[i].first);
+      *os << " ";
+      expected_[i].second.DescribeTo(os);
+    }
+  }
+  void DescribeNegationTo(std::ostream* os) const {
+    *os << "does not match port-grouped expectations";
+  }
+
+ private:
+  std::vector<PortExpectation> expected_;
+};
+
+inline auto OnPorts(
+    std::initializer_list<OnPortsMatcher::PortExpectation> expected) {
+  return Packets(::testing::MakePolymorphicMatcher(
+      OnPortsMatcher({expected.begin(), expected.end()})));
+}
+
+}  // namespace fourward
+
+#endif  // P4RUNTIME_CC_DATAPLANE_MATCHERS_H_

--- a/p4runtime_cc/dataplane_matchers_test.cc
+++ b/p4runtime_cc/dataplane_matchers_test.cc
@@ -1,0 +1,295 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "p4runtime_cc/dataplane_matchers.h"
+
+#include <sstream>
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "p4runtime/dataplane.pb.h"
+
+namespace fourward {
+namespace {
+
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
+
+// --- Test helpers ---
+
+fourward::dataplane::InjectPacketResponse Forward(uint32_t egress) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(egress);
+  return resp;
+}
+
+fourward::dataplane::InjectPacketResponse Drop() {
+  fourward::dataplane::InjectPacketResponse resp;
+  resp.add_possible_outcomes();
+  return resp;
+}
+
+fourward::dataplane::InjectPacketResponse Multicast(uint32_t p1, uint32_t p2) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(p1);
+  ps->add_packets()->set_dataplane_egress_port(p2);
+  return resp;
+}
+
+fourward::dataplane::InjectPacketResponse NonDeterministic(uint32_t p1,
+                                                           uint32_t p2) {
+  fourward::dataplane::InjectPacketResponse resp;
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(p1);
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(p2);
+  return resp;
+}
+
+fourward::dataplane::ProcessPacketResult MakeResult(uint32_t ingress,
+                                                    uint32_t egress) {
+  fourward::dataplane::ProcessPacketResult result;
+  result.mutable_input_packet()->set_dataplane_ingress_port(ingress);
+  auto* ps = result.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(egress);
+  return result;
+}
+
+// --- ForwardsTo ---
+
+TEST(ForwardsToTest, Matches) {
+  EXPECT_THAT(Forward(1), ForwardsTo(1));
+  EXPECT_THAT(Forward(42), ForwardsTo(DataplanePort{42}));
+}
+TEST(ForwardsToTest, WrongPort) {
+  EXPECT_THAT(Forward(1), Not(ForwardsTo(2)));
+}
+TEST(ForwardsToTest, Drop) { EXPECT_THAT(Drop(), Not(ForwardsTo(1))); }
+TEST(ForwardsToTest, SinglePortDoesNotMatchMulticast) {
+  EXPECT_THAT(Multicast(1, 2), Not(ForwardsTo(1)));
+}
+TEST(ForwardsToTest, NonDeterministic) {
+  EXPECT_THAT(NonDeterministic(1, 2), Not(ForwardsTo(1)));
+}
+TEST(ForwardsToTest, WorksOnProcessPacketResult) {
+  EXPECT_THAT(MakeResult(0, 3), ForwardsTo(3));
+}
+TEST(ForwardsToTest, Multicast) {
+  EXPECT_THAT(Multicast(1, 2), ForwardsTo(1, 2));
+  EXPECT_THAT(Multicast(1, 2), ForwardsTo(2, 1));  // unordered
+}
+TEST(ForwardsToTest, MulticastWrongPorts) {
+  EXPECT_THAT(Multicast(1, 2), Not(ForwardsTo(1, 3)));
+}
+
+// --- Drops ---
+
+TEST(DropsTest, Matches) { EXPECT_THAT(Drop(), Drops()); }
+TEST(DropsTest, Forward) { EXPECT_THAT(Forward(1), Not(Drops())); }
+
+// --- OutcomeIs ---
+
+TEST(OutcomeIsTest, SinglePacket) {
+  EXPECT_THAT(Forward(1), OutcomeIs(OnPort(1)));
+}
+TEST(OutcomeIsTest, MultiplePackets) {
+  EXPECT_THAT(Multicast(1, 2), OutcomeIs(OnPort(1), OnPort(2)));
+}
+TEST(OutcomeIsTest, MultiplePacketsUnordered) {
+  EXPECT_THAT(Multicast(1, 2), OutcomeIs(OnPort(2), OnPort(1)));
+}
+TEST(OutcomeIsTest, ZeroArgs) { EXPECT_THAT(Drop(), OutcomeIs()); }
+TEST(OutcomeIsTest, PacketsContainerMatcher) {
+  EXPECT_THAT(Multicast(1, 2), OutcomeIs(Packets(SizeIs(2))));
+}
+TEST(OutcomeIsTest, PacketsOnPorts) {
+  EXPECT_THAT(Multicast(1, 2),
+              OutcomeIs(OnPorts({{DataplanePort{1}, SizeIs(1)}, {DataplanePort{2}, SizeIs(1)}})));
+}
+TEST(OutcomeIsTest, RejectsNonDeterministic) {
+  EXPECT_THAT(NonDeterministic(1, 2), Not(OutcomeIs(OnPort(1))));
+}
+
+// --- OutcomesAre ---
+
+TEST(OutcomesAreTest, SingleOutcome) {
+  EXPECT_THAT(Forward(1), OutcomesAre(OnPort(1)));
+}
+TEST(OutcomesAreTest, MultipleOutcomes) {
+  EXPECT_THAT(NonDeterministic(1, 2), OutcomesAre(OnPort(1), OnPort(2)));
+}
+TEST(OutcomesAreTest, Unordered) {
+  EXPECT_THAT(NonDeterministic(1, 2), OutcomesAre(OnPort(2), OnPort(1)));
+}
+TEST(OutcomesAreTest, WithOutcome) {
+  EXPECT_THAT(Multicast(1, 2),
+              OutcomesAre(Outcome(OnPort(1), OnPort(2))));
+}
+
+// --- EachOutcome / AnyOutcome ---
+
+TEST(EachOutcomeTest, AllMatch) {
+  EXPECT_THAT(NonDeterministic(1, 1), EachOutcome(OnPort(1)));
+}
+TEST(EachOutcomeTest, NotAllMatch) {
+  EXPECT_THAT(NonDeterministic(1, 2), Not(EachOutcome(OnPort(1))));
+}
+TEST(EachOutcomeTest, PacketsContainerMatcher) {
+  EXPECT_THAT(NonDeterministic(1, 2), EachOutcome(Packets(SizeIs(1))));
+}
+
+TEST(AnyOutcomeTest, SomeMatch) {
+  EXPECT_THAT(NonDeterministic(1, 2), AnyOutcome(OnPort(1)));
+}
+TEST(AnyOutcomeTest, NoneMatch) {
+  EXPECT_THAT(NonDeterministic(1, 2), Not(AnyOutcome(OnPort(3))));
+}
+
+// --- HasIngress ---
+
+TEST(HasIngressTest, Matches) {
+  EXPECT_THAT(MakeResult(0, 1), HasIngress(0));
+  EXPECT_THAT(MakeResult(7, 1), HasIngress(DataplanePort{7}));
+}
+TEST(HasIngressTest, DoesNotMatch) {
+  EXPECT_THAT(MakeResult(0, 1), Not(HasIngress(5)));
+}
+
+// --- HasPayload ---
+
+TEST(HasPayloadTest, ExactMatch) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* pkt = ps->add_packets();
+  pkt->set_dataplane_egress_port(1);
+  pkt->set_payload("hello");
+  EXPECT_THAT(resp, OutcomeIs(AllOf(OnPort(1), HasPayload("hello"))));
+}
+
+TEST(HasPayloadTest, MatcherComposition) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* pkt = ps->add_packets();
+  pkt->set_dataplane_egress_port(1);
+  pkt->set_payload("hello world");
+  EXPECT_THAT(resp,
+              OutcomeIs(HasPayload(::testing::StartsWith("hello"))));
+}
+
+// --- OnPorts ---
+
+TEST(OnPortsTest, GroupsByPort) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(1);
+  ps->add_packets()->set_dataplane_egress_port(1);
+  ps->add_packets()->set_dataplane_egress_port(2);
+
+  EXPECT_THAT(resp,
+              OutcomeIs(OnPorts({{DataplanePort{1}, SizeIs(2)}, {DataplanePort{2}, SizeIs(1)}})));
+}
+
+TEST(OnPortsTest, P4RuntimePortKeys) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_p4rt_egress_port("Eth0");
+  ps->add_packets()->set_p4rt_egress_port("Eth1");
+
+  EXPECT_THAT(resp, OutcomeIs(OnPorts({
+                        {P4RuntimePort{"Eth0"}, SizeIs(1)},
+                        {P4RuntimePort{"Eth1"}, SizeIs(1)},
+                    })));
+}
+
+TEST(OutcomesAreTest, MixedBareAndOutcome) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* multicast = resp.add_possible_outcomes();
+  multicast->add_packets()->set_dataplane_egress_port(1);
+  multicast->add_packets()->set_dataplane_egress_port(2);
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(3);
+
+  EXPECT_THAT(resp, OutcomesAre(Outcome(OnPort(1), OnPort(2)), OnPort(3)));
+}
+
+// --- OutcomesAre + Packets ---
+
+TEST(OutcomesAreTest, WithPackets) {
+  EXPECT_THAT(Forward(1), OutcomesAre(Packets(SizeIs(1))));
+}
+
+// --- OutcomesAre + Outcome (empty = drop) ---
+
+TEST(OutcomesAreTest, OutcomeWithDrop) {
+  fourward::dataplane::InjectPacketResponse resp;
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  resp.add_possible_outcomes();  // drop
+  EXPECT_THAT(resp, OutcomesAre(OnPort(1), Outcome()));
+}
+
+// --- AnyOutcome + Packets ---
+
+TEST(AnyOutcomeTest, WithPackets) {
+  EXPECT_THAT(NonDeterministic(1, 2),
+              AnyOutcome(Packets(Contains(OnPort(1)))));
+}
+
+// --- String port overloads ---
+
+TEST(ForwardsToTest, StringPort) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_p4rt_egress_port("Eth0");
+  EXPECT_THAT(resp, ForwardsTo(std::string("Eth0")));
+}
+
+TEST(OnPortTest, StringPort) {
+  fourward::dataplane::OutputPacket pkt;
+  pkt.set_p4rt_egress_port("Eth0");
+  EXPECT_THAT(pkt, OnPort(std::string("Eth0")));
+}
+
+TEST(HasIngressTest, StringPort) {
+  fourward::dataplane::ProcessPacketResult result;
+  result.mutable_input_packet()->set_p4rt_ingress_port("Eth0");
+  result.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  EXPECT_THAT(result, HasIngress(std::string("Eth0")));
+}
+
+// --- Error message quality ---
+
+TEST(ErrorMessageTest, ForwardsToDescribes) {
+  ::testing::Matcher<const fourward::dataplane::InjectPacketResponse&> m =
+      ForwardsTo(1);
+  std::ostringstream os;
+  m.DescribeTo(&os);
+  EXPECT_THAT(os.str(), ::testing::HasSubstr("outcomes"));
+}
+
+TEST(ErrorMessageTest, DropsDescribes) {
+  ::testing::Matcher<const fourward::dataplane::InjectPacketResponse&> m =
+      Drops();
+  std::ostringstream os;
+  m.DescribeTo(&os);
+  EXPECT_THAT(os.str(), ::testing::HasSubstr("drop"));
+}
+
+TEST(ErrorMessageTest, HasIngressDescribes) {
+  ::testing::Matcher<const fourward::dataplane::ProcessPacketResult&> m =
+      HasIngress(5);
+  std::ostringstream os;
+  m.DescribeTo(&os);
+  EXPECT_THAT(os.str(), ::testing::HasSubstr("5"));
+}
+
+// --- Composition ---
+
+TEST(CompositionTest, ForwardsToWithIngress) {
+  EXPECT_THAT(MakeResult(5, 1), AllOf(ForwardsTo(1), HasIngress(5)));
+}
+
+}  // namespace
+}  // namespace fourward

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -1,0 +1,246 @@
+---
+description: "gtest matchers for asserting on dataplane packet results — composable with gmock's standard vocabulary."
+---
+
+# Dataplane matchers
+
+Asserting on packet results with raw proto accessors gets old fast:
+
+```cpp
+ASSERT_EQ(response.possible_outcomes_size(), 1);
+ASSERT_EQ(response.possible_outcomes(0).packets_size(), 1);
+EXPECT_EQ(response.possible_outcomes(0).packets(0).dataplane_egress_port(), 1u);
+```
+
+The dataplane matchers let you say what you mean instead:
+
+```cpp
+EXPECT_THAT(dataplane.InjectPacket({...}), IsOkAndHolds(ForwardsTo(1)));
+```
+
+They compose with gmock's standard vocabulary — `AllOf`, `ElementsAre`,
+`Contains`, and friends all work. Here's the full set at a glance:
+
+```
+Shorthands   ForwardsTo  Drops
+Outcomes     OutcomeIs  OutcomesAre  EachOutcome  AnyOutcome  Outcome
+Packets      OnPort  HasPayload  OnPorts  Packets
+Input        HasIngress
+```
+
+## The basics
+
+Most tests only need the shorthands. They work on both
+`InjectPacketResponse` (from `InjectPacket`) and `ProcessPacketResult`
+(from `ResultStream::Next`):
+
+```cpp
+#include "p4runtime_cc/dataplane_matchers.h"
+#include "p4runtime_cc/dataplane_client.h"
+
+using ::fourward::Drops;
+using ::fourward::ForwardsTo;
+using ::fourward::HasIngress;
+
+// Inject and assert in one shot:
+EXPECT_THAT(dataplane.InjectPacket({...}), IsOkAndHolds(ForwardsTo(1)));
+EXPECT_THAT(dataplane.InjectPacket({...}), IsOkAndHolds(ForwardsTo("Ethernet0")));
+
+// Multicast:
+EXPECT_THAT(dataplane.InjectPacket({...}), IsOkAndHolds(ForwardsTo(1, 2)));
+
+// Same for stream results:
+EXPECT_THAT(stream.Next(),
+            IsOkAndHolds(AllOf(ForwardsTo(1), HasIngress(0))));
+
+// Or assign first when you need the value for follow-up work:
+ASSERT_OK_AND_ASSIGN(InjectPacketResponse response,
+                     dataplane.InjectPacket({...}));
+EXPECT_THAT(response, Drops());
+```
+
+Ports can be dataplane numbers or P4Runtime IDs — pass them bare for
+convenience, or wrap them for explicitness:
+
+```cpp
+ForwardsTo(1)                            // dataplane port
+ForwardsTo(DataplanePort{1})             // same, explicit
+ForwardsTo("Ethernet0")                  // P4Runtime port
+ForwardsTo(P4RuntimePort{"Ethernet0"})   // same, explicit
+```
+
+## Looking at individual packets
+
+When you need more than "which port?", drop down to the packet-level
+matchers. These match on individual `OutputPacket` protos — use them
+inside `OutcomeIs` to assert on a single deterministic outcome:
+
+```cpp
+using ::fourward::OutcomeIs;
+using ::fourward::OnPort;
+using ::fourward::HasPayload;
+
+// Port and payload:
+EXPECT_THAT(response, OutcomeIs(AllOf(OnPort(1), HasPayload(expected_bytes))));
+
+// Multicast — two output packets:
+EXPECT_THAT(response, OutcomeIs(OnPort(1), OnPort(2)));
+```
+
+`HasPayload` takes any `Matcher<const std::string&>`, so it plays nicely
+with `Eq`, `StartsWith`, `ResultOf`, and anything else gmock offers.
+
+`ForwardsTo(port)` is just `OutcomeIs(OnPort(port))`, and `Drops()` is
+`OutcomeIs()` (zero packets).
+
+## Handling multiple outcomes
+
+P4 programs with action selectors can produce multiple possible outcomes
+— each representing one "possible world."
+
+**`OutcomesAre`** pins the exact set of outcomes (order-independent).
+Each argument is a packet matcher for a single-packet outcome; use
+`Outcome(...)` to spell out a multi-packet outcome:
+
+```cpp
+using ::fourward::OutcomesAre;
+using ::fourward::Outcome;
+
+// Action selector: forwards to port 1 or port 2.
+EXPECT_THAT(response, OutcomesAre(OnPort(1), OnPort(2)));
+
+// One outcome multicasts, the other drops:
+EXPECT_THAT(response, OutcomesAre(
+    Outcome(OnPort(1), OnPort(2)),
+    Outcome()));
+```
+
+**`EachOutcome`** and **`AnyOutcome`** quantify when you don't need to
+pin the exact set:
+
+```cpp
+using ::fourward::EachOutcome;
+using ::fourward::AnyOutcome;
+
+// No matter what the selector picks, the packet reaches port 1:
+EXPECT_THAT(response, EachOutcome(OnPort(1)));
+
+// At least one branch drops:
+EXPECT_THAT(response, AnyOutcome(Packets(IsEmpty())));
+```
+
+## Container-level matching with Packets(...)
+
+When you need to match properties of the packet *list* rather than
+individual packets — size, port grouping, etc. — wrap the matcher in
+`Packets(...)`:
+
+```cpp
+using ::fourward::Packets;
+
+// Exactly 7 output packets:
+EXPECT_THAT(response, OutcomeIs(Packets(SizeIs(7))));
+
+// At least one output packet on port 1:
+EXPECT_THAT(response, OutcomeIs(Packets(Contains(OnPort(1)))));
+```
+
+`Packets(...)` works inside `OutcomeIs`, `EachOutcome`, and `AnyOutcome`.
+
+## Grouping by port
+
+`OnPorts` groups packets by egress port and applies per-group matchers.
+It doesn't need a `Packets(...)` wrapper — use it directly inside
+`OutcomeIs`:
+
+```cpp
+using ::fourward::OnPorts;
+
+// 7 copies to port 5, 25 to port 42:
+EXPECT_THAT(response, OutcomeIs(OnPorts({
+    {DataplanePort{5}, SizeIs(7)},
+    {DataplanePort{42}, SizeIs(25)},
+})));
+
+// Every output packet carries the same payload:
+EXPECT_THAT(response, OutcomeIs(Packets(Each(HasPayload(expected)))));
+
+// Match individual packets per port:
+EXPECT_THAT(response, OutcomeIs(OnPorts({
+    {DataplanePort{1}, UnorderedElementsAreArray({
+        HasPayload(packet_a),
+        HasPayload(packet_b),
+    })},
+    {DataplanePort{2}, ElementsAre(HasPayload(packet_c))},
+})));
+
+// Works with P4Runtime ports too:
+EXPECT_THAT(response, OutcomeIs(OnPorts({
+    {P4RuntimePort{"Ethernet0"}, SizeIs(1)},
+    {P4RuntimePort{"Ethernet1"}, SizeIs(1)},
+})));
+```
+
+## Ingress port
+
+`HasIngress` works on `ProcessPacketResult` (which carries the input
+packet) and supports both port types:
+
+```cpp
+EXPECT_THAT(stream.Next(), IsOkAndHolds(HasIngress(0)));
+EXPECT_THAT(stream.Next(), IsOkAndHolds(HasIngress("Ethernet0")));
+```
+
+## Composing with packetlib
+
+If your project uses
+[packetlib](https://github.com/google/p4-infra/tree/main/packetlib),
+you can parse the raw output bytes into a structured `Packet` proto and
+assert on header fields — all within the same `EXPECT_THAT`. The bridge
+is gmock's `ResultOf`:
+
+```cpp
+#include "packetlib/packetlib.h"
+#include "gutil/proto_matchers.h"
+
+using ::packetlib::ParsePacket;
+using ::testing::ResultOf;
+
+EXPECT_THAT(response, OutcomeIs(
+    AllOf(OnPort(1),
+          HasPayload(ResultOf(ParsePacket, Partially(EqualsProto(R"pb(
+              headers { ethernet_header { ethertype: "0x0800" } }
+              headers { ipv4_header { destination_ip: "10.0.0.1" } }
+          )pb")))))));
+```
+
+If you find yourself writing `HasPayload(ResultOf(ParsePacket, ...))` a
+lot, a one-liner in your project saves the boilerplate:
+
+```cpp
+template <typename M>
+auto HasParsedPayload(M m) {
+  return HasPayload(ResultOf(packetlib::ParsePacket, std::move(m)));
+}
+
+// Then:
+EXPECT_THAT(response, OutcomeIs(OnPort(1), HasParsedPayload(
+    Partially(EqualsProto(R"pb(...)pb")))));
+```
+
+4ward doesn't depend on packetlib — `HasPayload` just hands its matcher
+whatever `ResultOf` returns, so any `bytes → T` parser works the same
+way.
+
+## Bazel dependency
+
+```starlark
+cc_test(
+    name = "my_test",
+    srcs = ["my_test.cc"],
+    deps = [
+        "@fourward//p4runtime_cc:dataplane_matchers",
+        # ...
+    ],
+)
+```


### PR DESCRIPTION
## Why

Test assertions on dataplane results are verbose — 4-5 lines of nested
proto accessors for the common "forwarded to port X" check:

```cpp
ASSERT_EQ(response.possible_outcomes_size(), 1);
ASSERT_EQ(response.possible_outcomes(0).packets_size(), 1);
EXPECT_EQ(response.possible_outcomes(0).packets(0).dataplane_egress_port(), 1u);
```

The matchers collapse this to:

```cpp
EXPECT_THAT(dataplane.InjectPacket({...}), IsOkAndHolds(ForwardsTo(1)));
```

## Surface

Four layers that compose with gmock's standard vocabulary:

```
Shorthands   ForwardsTo(ports...)  Drops()
Outcomes     OutcomeIs  OutcomesAre  EachOutcome  AnyOutcome  Outcome
Packets      OnPort  HasPayload  OnPorts  Packets
Input        HasIngress
```

Both `DataplanePort` and `P4RuntimePort` supported throughout. Composes
with packetlib via `HasPayload(ResultOf(packetlib::ParsePacket, ...))` —
no dependency on p4-infra from our side.

## Design highlights

- `OutcomeIs(packet_matchers...)` wraps args in `UnorderedElementsAre`
  — packet order doesn't matter. Use `Packets(m)` for container-level
  matching (`SizeIs`, `Contains`, etc.).
- `OutcomesAre(args...)` handles non-deterministic programs. Each arg
  is a single-packet outcome; `Outcome(...)` for multi-packet outcomes.
- `OnPorts` auto-tags as a `Packets` matcher — no wrapper needed.
- `ForwardsTo` is variadic: `ForwardsTo(1, 2)` for multicast.
- Custom `PolymorphicMatcher` classes produce clear error messages
  instead of gmock's `ResultOf` internals.

## Test coverage

43 unit tests + 4 e2e tests covering all matchers, both port types,
composition with `AllOf`/`IsOkAndHolds`, and error message quality.

Full guide: `userdocs/reference/dataplane-matchers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)