### PR TITLE
p4runtime: flags to disable @refers_to and p4-constraints checking

### DIFF
--- a/p4runtime/BUILD.bazel
+++ b/p4runtime/BUILD.bazel
@@ -437,6 +437,39 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "DisableCheckingTest",
+    srcs = [
+        "DisableCheckingTest.kt",
+        "P4RuntimeTestHarness.kt",
+    ],
+    data = [
+        ":constraint_validator",
+        "//e2e_tests/constrained_table",
+        "//e2e_tests/golden_errors:refers_to",
+    ],
+    test_class = "fourward.p4runtime.DisableCheckingTest",
+    deps = [
+        ":dataplane_java_proto",
+        ":dataplane_kt_grpc",
+        ":p4runtime",
+        ":p4runtime_kt_grpc",
+        "//bazel:runfiles",
+        "//simulator",
+        "//simulator:ir_java_proto",
+        "//simulator:p4data_java_proto",
+        "//simulator:p4info_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:io_grpc_grpc_api",
+        "@fourward_maven//:io_grpc_grpc_inprocess",
+        "@fourward_maven//:junit_junit",
+        "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@googleapis//google/rpc:rpc_java_proto",
+    ],
+)
+
+kt_jvm_test(
     name = "P4RuntimeConstraintTest",
     srcs = [
         "P4RuntimeConstraintTest.kt",

--- a/p4runtime/DisableCheckingTest.kt
+++ b/p4runtime/DisableCheckingTest.kt
@@ -1,0 +1,172 @@
+package fourward.p4runtime
+
+import com.google.protobuf.ByteString
+import fourward.ir.PipelineConfig
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.assertGrpcError
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.findAction
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.findTable
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.loadConfig
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.longToBytes
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.matchFieldId
+import fourward.p4runtime.P4RuntimeTestHarness.Companion.paramId
+import io.grpc.Status
+import java.nio.file.Path
+import org.junit.Test
+import p4.v1.P4RuntimeOuterClass
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.TableEntry
+
+/**
+ * Tests that `disableRefersToChecking` and `disableP4ConstraintsChecking` flags suppress
+ * annotation-based validation on Write RPCs. Each test first proves the violation is normally
+ * rejected, then shows it succeeds with the flag set.
+ */
+class DisableCheckingTest {
+
+  // ===========================================================================
+  // @refers_to
+  // ===========================================================================
+
+  @Test
+  fun `refers_to violation is rejected by default`() {
+    P4RuntimeTestHarness().use { harness ->
+      val config = loadRefersTo()
+      harness.loadPipeline(config)
+      assertGrpcError(Status.Code.INVALID_ARGUMENT) {
+        harness.installEntry(refersToViolatingEntry(config))
+      }
+    }
+  }
+
+  @Test
+  fun `refers_to violation is accepted when checking is disabled`() {
+    P4RuntimeTestHarness(disableRefersToChecking = true).use { harness ->
+      val config = loadRefersTo()
+      harness.loadPipeline(config)
+      harness.installEntry(refersToViolatingEntry(config))
+    }
+  }
+
+  // ===========================================================================
+  // @entry_restriction / @action_restriction
+  // ===========================================================================
+
+  @Test
+  fun `constraint violation is rejected by default`() {
+    P4RuntimeTestHarness(constraintValidatorBinary = VALIDATOR_BINARY).use { harness ->
+      val config = loadConstrained()
+      harness.loadPipeline(config)
+      assertGrpcError(Status.Code.INVALID_ARGUMENT) {
+        harness.installEntry(constraintViolatingEntry(config))
+      }
+    }
+  }
+
+  @Test
+  fun `constraint violation is accepted when checking is disabled`() {
+    P4RuntimeTestHarness(
+      constraintValidatorBinary = VALIDATOR_BINARY,
+      disableP4ConstraintsChecking = true,
+    )
+      .use { harness ->
+        val config = loadConstrained()
+        harness.loadPipeline(config)
+        harness.installEntry(constraintViolatingEntry(config))
+      }
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  private fun loadRefersTo(): PipelineConfig =
+    loadConfig("e2e_tests/golden_errors/refers_to.txtpb")
+
+  private fun loadConstrained(): PipelineConfig =
+    loadConfig("e2e_tests/constrained_table/constrained_table.txtpb")
+
+  /** INSERT into ref_table without a matching entry in target_table. */
+  @Suppress("MagicNumber")
+  private fun refersToViolatingEntry(config: PipelineConfig): Entity {
+    val refTable = findTable(config, "ref_table")
+    val forwardAction = findAction(config, "forward")
+    return Entity.newBuilder()
+      .setTableEntry(
+        TableEntry.newBuilder()
+          .setTableId(refTable.preamble.id)
+          .addMatch(
+            FieldMatch.newBuilder()
+              .setFieldId(matchFieldId(refTable, "hdr.ethernet.srcAddr"))
+              .setExact(
+                FieldMatch.Exact.newBuilder()
+                  .setValue(ByteString.copyFrom(longToBytes(0xAABBCCDDEEFFL, 6)))
+              )
+          )
+          .setAction(
+            P4RuntimeOuterClass.TableAction.newBuilder()
+              .setAction(
+                P4RuntimeOuterClass.Action.newBuilder()
+                  .setActionId(forwardAction.preamble.id)
+                  .addParams(
+                    P4RuntimeOuterClass.Action.Param.newBuilder()
+                      .setParamId(paramId(forwardAction, "port"))
+                      .setValue(ByteString.copyFrom(longToBytes(1, 2)))
+                  )
+              )
+          )
+      )
+      .build()
+  }
+
+  /** Ternary ACL entry matching ipv4_dst with wrong ether_type — violates the constraint. */
+  @Suppress("MagicNumber")
+  private fun constraintViolatingEntry(config: PipelineConfig): Entity {
+    val table = config.p4Info.tablesList.first { it.preamble.name.contains("acl") }
+    val forwardAction = config.p4Info.actionsList.first { it.preamble.name.contains("forward") }
+    fun fieldId(name: String) = table.matchFieldsList.first { it.name.contains(name) }.id
+
+    return Entity.newBuilder()
+      .setTableEntry(
+        TableEntry.newBuilder()
+          .setTableId(table.preamble.id)
+          .setPriority(10)
+          .addMatch(
+            FieldMatch.newBuilder()
+              .setFieldId(fieldId("ether_type"))
+              .setTernary(
+                FieldMatch.Ternary.newBuilder()
+                  .setValue(ByteString.copyFrom(longToBytes(0x0806L, 2)))
+                  .setMask(ByteString.copyFrom(longToBytes(0xFFFFL, 2)))
+              )
+          )
+          .addMatch(
+            FieldMatch.newBuilder()
+              .setFieldId(fieldId("ipv4_dst"))
+              .setTernary(
+                FieldMatch.Ternary.newBuilder()
+                  .setValue(ByteString.copyFrom(longToBytes(0x0A000001L, 4)))
+                  .setMask(ByteString.copyFrom(longToBytes(0xFFFFFFFFL, 4)))
+              )
+          )
+          .setAction(
+            P4RuntimeOuterClass.TableAction.newBuilder()
+              .setAction(
+                P4RuntimeOuterClass.Action.newBuilder()
+                  .setActionId(forwardAction.preamble.id)
+                  .addParams(
+                    P4RuntimeOuterClass.Action.Param.newBuilder()
+                      .setParamId(1)
+                      .setValue(ByteString.copyFrom(longToBytes(1L, 2)))
+                  )
+              )
+          )
+      )
+      .build()
+  }
+
+  companion object {
+    private val VALIDATOR_BINARY: Path =
+      fourward.bazel.repoRoot.resolve("p4runtime/constraint_validator")
+  }
+}

--- a/p4runtime/DisableCheckingTest.kt
+++ b/p4runtime/DisableCheckingTest.kt
@@ -77,6 +77,36 @@ class DisableCheckingTest {
   }
 
   // ===========================================================================
+  // Independence: disabling one does not affect the other
+  // ===========================================================================
+
+  @Test
+  fun `disabling refers_to still rejects constraint violations`() {
+    P4RuntimeTestHarness(
+      constraintValidatorBinary = VALIDATOR_BINARY,
+      disableRefersToChecking = true,
+    )
+      .use { harness ->
+        val config = loadConstrained()
+        harness.loadPipeline(config)
+        assertGrpcError(Status.Code.INVALID_ARGUMENT) {
+          harness.installEntry(constraintViolatingEntry(config))
+        }
+      }
+  }
+
+  @Test
+  fun `disabling p4-constraints still rejects refers_to violations`() {
+    P4RuntimeTestHarness(disableP4ConstraintsChecking = true).use { harness ->
+      val config = loadRefersTo()
+      harness.loadPipeline(config)
+      assertGrpcError(Status.Code.INVALID_ARGUMENT) {
+        harness.installEntry(refersToViolatingEntry(config))
+      }
+    }
+  }
+
+  // ===========================================================================
   // Helpers
   // ===========================================================================
 

--- a/p4runtime/DisableCheckingTest.kt
+++ b/p4runtime/DisableCheckingTest.kt
@@ -152,18 +152,17 @@ class DisableCheckingTest {
   /** Ternary ACL entry matching ipv4_dst with wrong ether_type — violates the constraint. */
   @Suppress("MagicNumber")
   private fun constraintViolatingEntry(config: PipelineConfig): Entity {
-    val table = config.p4Info.tablesList.first { it.preamble.name.contains("acl") }
-    val forwardAction = config.p4Info.actionsList.first { it.preamble.name.contains("forward") }
-    fun fieldId(name: String) = table.matchFieldsList.first { it.name.contains(name) }.id
+    val aclTable = findTable(config, "acl")
+    val forwardAction = findAction(config, "forward")
 
     return Entity.newBuilder()
       .setTableEntry(
         TableEntry.newBuilder()
-          .setTableId(table.preamble.id)
+          .setTableId(aclTable.preamble.id)
           .setPriority(10)
           .addMatch(
             FieldMatch.newBuilder()
-              .setFieldId(fieldId("ether_type"))
+              .setFieldId(matchFieldId(aclTable, "ether_type"))
               .setTernary(
                 FieldMatch.Ternary.newBuilder()
                   .setValue(ByteString.copyFrom(longToBytes(0x0806L, 2)))
@@ -172,7 +171,7 @@ class DisableCheckingTest {
           )
           .addMatch(
             FieldMatch.newBuilder()
-              .setFieldId(fieldId("ipv4_dst"))
+              .setFieldId(matchFieldId(aclTable, "ipv4_dst"))
               .setTernary(
                 FieldMatch.Ternary.newBuilder()
                   .setValue(ByteString.copyFrom(longToBytes(0x0A000001L, 4)))
@@ -186,7 +185,7 @@ class DisableCheckingTest {
                   .setActionId(forwardAction.preamble.id)
                   .addParams(
                     P4RuntimeOuterClass.Action.Param.newBuilder()
-                      .setParamId(1)
+                      .setParamId(paramId(forwardAction, "port"))
                       .setValue(ByteString.copyFrom(longToBytes(1L, 2)))
                   )
               )

--- a/p4runtime/P4RuntimeServer.kt
+++ b/p4runtime/P4RuntimeServer.kt
@@ -15,6 +15,8 @@ class P4RuntimeServer(
   private val deviceId: Long = P4RuntimeService.DEFAULT_DEVICE_ID,
   dropPortOverride: Int? = null,
   cpuPortConfig: CpuPortConfig = CpuPortConfig.Auto,
+  private val disableRefersToChecking: Boolean = false,
+  private val disableP4ConstraintsChecking: Boolean = false,
 ) {
 
   /**
@@ -31,6 +33,8 @@ class P4RuntimeServer(
       writeMutex = writeMutex,
       deviceId = deviceId,
       cpuPortConfig = cpuPortConfig,
+      disableRefersToChecking = disableRefersToChecking,
+      disableP4ConstraintsChecking = disableP4ConstraintsChecking,
     )
   private val dataplaneService =
     DataplaneService(broker, typeTranslator = { service.typeTranslator })
@@ -84,8 +88,19 @@ fun main(args: Array<String>) {
   val dropPort = flagValue(args, "--drop-port")?.toIntOrNull()
   val cpuPortConfig = CpuPortConfig.fromFlag(flagValue(args, "--cpu-port"))
   val portFile = flagValue(args, "--port-file")?.let(Path::of)
+  val disableRefersToChecking = flagPresent(args, "--disable-refers-to-checking")
+  val disableP4ConstraintsChecking = flagPresent(args, "--disable-p4-constraints-checking")
 
-  val server = P4RuntimeServer(port, deviceId, dropPort, cpuPortConfig).start()
+  val server =
+    P4RuntimeServer(
+        port,
+        deviceId,
+        dropPort,
+        cpuPortConfig,
+        disableRefersToChecking = disableRefersToChecking,
+        disableP4ConstraintsChecking = disableP4ConstraintsChecking,
+      )
+      .start()
   println("P4Runtime server listening on port ${server.port()}")
 
   // Machine-readable readiness signal for embedders. Write the port to a temp
@@ -104,3 +119,5 @@ private fun writePortFileAtomic(path: Path, port: Int) {
 
 private fun flagValue(args: Array<String>, flag: String): String? =
   args.find { it.startsWith("$flag=") }?.substringAfter("=")
+
+private fun flagPresent(args: Array<String>, flag: String): Boolean = args.any { it == flag }

--- a/p4runtime/P4RuntimeService.kt
+++ b/p4runtime/P4RuntimeService.kt
@@ -77,6 +77,8 @@ class P4RuntimeService(
   private val writeMutex: Mutex = Mutex(),
   private val deviceId: Long = DEFAULT_DEVICE_ID,
   private val cpuPortConfig: CpuPortConfig = CpuPortConfig.Auto,
+  private val disableRefersToChecking: Boolean = false,
+  private val disableP4ConstraintsChecking: Boolean = false,
 ) : P4RuntimeGrpcKt.P4RuntimeCoroutineImplBase(), Closeable {
 
   /** Bundled pipeline state — atomically swapped on pipeline load to avoid torn reads. */
@@ -228,15 +230,20 @@ class P4RuntimeService(
       cookie = fwdConfig.cookie,
       typeTranslator = typeTranslator,
       writeValidator = WriteValidator(pipelineConfig.p4Info),
-      referenceValidator = ReferenceValidator.create(fwdConfig.p4Info),
+      referenceValidator =
+        if (disableRefersToChecking) null else ReferenceValidator.create(fwdConfig.p4Info),
       constraintValidator =
-        constraintValidatorBinary?.let {
-          try {
-            ConstraintValidator.create(fwdConfig.p4Info, it)
-          } catch (e: ConstraintValidatorException) {
-            throw Status.INTERNAL.withDescription("constraint validation failed: ${e.message}")
-              .withCause(e)
-              .asException()
+        if (disableP4ConstraintsChecking) {
+          null
+        } else {
+          constraintValidatorBinary?.let {
+            try {
+              ConstraintValidator.create(fwdConfig.p4Info, it)
+            } catch (e: ConstraintValidatorException) {
+              throw Status.INTERNAL.withDescription("constraint validation failed: ${e.message}")
+                .withCause(e)
+                .asException()
+            }
           }
         },
       packetHeaderCodec =

--- a/p4runtime/P4RuntimeTestHarness.kt
+++ b/p4runtime/P4RuntimeTestHarness.kt
@@ -56,6 +56,8 @@ class P4RuntimeTestHarness(
   constraintValidatorBinary: Path? = null,
   dropPortOverride: Int? = null,
   cpuPortConfig: CpuPortConfig = CpuPortConfig.Auto,
+  disableRefersToChecking: Boolean = false,
+  disableP4ConstraintsChecking: Boolean = false,
 ) : Closeable {
 
   private val serverName = InProcessServerBuilder.generateName()
@@ -69,6 +71,8 @@ class P4RuntimeTestHarness(
       constraintValidatorBinary,
       writeMutex = writeMutex,
       cpuPortConfig = cpuPortConfig,
+      disableRefersToChecking = disableRefersToChecking,
+      disableP4ConstraintsChecking = disableP4ConstraintsChecking,
     )
   private val dataplaneService =
     DataplaneService(broker, typeTranslator = { service.typeTranslator })

--- a/p4runtime_cc/fourward_server.cc
+++ b/p4runtime_cc/fourward_server.cc
@@ -59,6 +59,9 @@ constexpr char kFlagPortFile[] = "--port-file=";
 constexpr char kFlagDropPort[] = "--drop-port=";
 constexpr char kFlagCpuPort[] = "--cpu-port=";
 constexpr char kCpuPortNoneValue[] = "none";
+constexpr char kFlagDisableRefersToChecking[] = "--disable-refers-to-checking";
+constexpr char kFlagDisableP4ConstraintsChecking[] =
+    "--disable-p4-constraints-checking";
 
 // Creates a unique scratch directory under $TEST_TMPDIR (honored by Bazel
 // test shards) or /tmp.
@@ -206,6 +209,12 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
     case CpuPort::Kind::kOverride:
       args.push_back(absl::StrCat(kFlagCpuPort, options.cpu_port.port));
       break;
+  }
+  if (options.disable_refers_to_checking) {
+    args.push_back(kFlagDisableRefersToChecking);
+  }
+  if (options.disable_p4_constraints_checking) {
+    args.push_back(kFlagDisableP4ConstraintsChecking);
   }
   std::vector<char*> argv;
   argv.reserve(args.size() + 1);

--- a/p4runtime_cc/fourward_server.h
+++ b/p4runtime_cc/fourward_server.h
@@ -74,6 +74,12 @@ struct FourwardServerOptions {
   // CPU port configuration (the `--cpu-port` flag).
   CpuPort cpu_port = CpuPort::Auto();
 
+  // Skip @refers_to referential integrity checking on Write RPCs.
+  bool disable_refers_to_checking = false;
+
+  // Skip @entry_restriction / @action_restriction checking on Write RPCs.
+  bool disable_p4_constraints_checking = false;
+
   // Maximum time to wait for Start() to complete.
   absl::Duration startup_timeout = absl::Seconds(5);
 };

--- a/p4runtime_cc/fourward_server_test.cc
+++ b/p4runtime_cc/fourward_server_test.cc
@@ -151,6 +151,14 @@ TEST(FourwardServerTest, DropAndCpuPortFlagsAcceptedByServer) {
   ExpectHealthy(*cpu_override);
 }
 
+TEST(FourwardServerTest, DisableCheckingFlagsAcceptedByServer) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start(
+      {.disable_refers_to_checking = true,
+       .disable_p4_constraints_checking = true});
+  ASSERT_TRUE(server.ok()) << server.status();
+  ExpectHealthy(*server);
+}
+
 TEST(FourwardServerTest, StartupTimeoutYieldsDeadlineExceeded) {
   // A 1-nanosecond timeout is unreachable: even if the JVM had booted
   // instantly the port file poll loop cannot observe it that fast. The


### PR DESCRIPTION
Closes #611.

Two independent flags let users selectively bypass annotation-based Write RPC
validation — useful for testing scenarios where you want to shove entries in
without worrying about dependency ordering or constraint satisfaction.

- `--disable-refers-to-checking` — skips `@refers_to` referential integrity
- `--disable-p4-constraints-checking` — skips `@entry_restriction` / `@action_restriction`

Both flags are plumbed through:
- Kotlin server CLI (`P4RuntimeServer`)
- C++ embedding API (`FourwardServerOptions`)
- In-process test harness (`P4RuntimeTestHarness`)

## Test plan
- [x] `DisableCheckingTest`: 6 new tests — default rejection (2), flag disables validation (2), flags are independent (2)
- [x] `FourwardServerTest`: C++ smoke test — server starts with both flags set
- [x] Existing `P4RuntimeConstraintTest` and `ReferenceValidatorTest` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)