### PR TITLE
Remove cpplint BUILD target; run directly from pip (fixes BCR)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
 
 package(
     default_applicable_licenses = [":license"],
@@ -33,12 +32,4 @@ kt_jvm_binary(
     name = "detekt",
     main_class = "io.gitlab.arturbosch.detekt.cli.Main",
     runtime_deps = ["@fourward_maven//:io_gitlab_arturbosch_detekt_detekt_cli"],
-)
-
-# cpplint: enforces Google C++ Style Guide rules that clang-tidy doesn't
-# (header guards, IWYU hygiene, copyright, etc.). Invoked from
-# tools/lint.sh; CPPLINT.cfg at repo root configures filters.
-py_console_script_binary(
-    name = "cpplint",
-    pkg = "@pip//cpplint",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -126,7 +126,7 @@ maven.install(
 )
 use_repo(maven, "maven")
 
-# --- Python (cram test runner) ---
+# --- Python (cram test runner, cpplint) ---
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.12")

--- a/p4runtime/DisableCheckingTest.kt
+++ b/p4runtime/DisableCheckingTest.kt
@@ -66,9 +66,9 @@ class DisableCheckingTest {
   @Test
   fun `constraint violation is accepted when checking is disabled`() {
     P4RuntimeTestHarness(
-      constraintValidatorBinary = VALIDATOR_BINARY,
-      disableP4ConstraintsChecking = true,
-    )
+        constraintValidatorBinary = VALIDATOR_BINARY,
+        disableP4ConstraintsChecking = true,
+      )
       .use { harness ->
         val config = loadConstrained()
         harness.loadPipeline(config)
@@ -83,9 +83,9 @@ class DisableCheckingTest {
   @Test
   fun `disabling refers_to still rejects constraint violations`() {
     P4RuntimeTestHarness(
-      constraintValidatorBinary = VALIDATOR_BINARY,
-      disableRefersToChecking = true,
-    )
+        constraintValidatorBinary = VALIDATOR_BINARY,
+        disableRefersToChecking = true,
+      )
       .use { harness ->
         val config = loadConstrained()
         harness.loadPipeline(config)
@@ -110,8 +110,7 @@ class DisableCheckingTest {
   // Helpers
   // ===========================================================================
 
-  private fun loadRefersTo(): PipelineConfig =
-    loadConfig("e2e_tests/golden_errors/refers_to.txtpb")
+  private fun loadRefersTo(): PipelineConfig = loadConfig("e2e_tests/golden_errors/refers_to.txtpb")
 
   private fun loadConstrained(): PipelineConfig =
     loadConfig("e2e_tests/constrained_table/constrained_table.txtpb")

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -39,7 +39,7 @@ else
     cd "$REPO_ROOT" && git ls-files '*.cpp' '*.h' '*.cc'
   )
   if [[ ${#CPP_SOURCES[@]} -gt 0 ]]; then
-    (cd "$REPO_ROOT" && bazel run //:cpplint -- "${CPP_SOURCES[@]/#/$REPO_ROOT/}") \
+    (cd "$REPO_ROOT" && bazel run @pip//cpplint -- "${CPP_SOURCES[@]/#/$REPO_ROOT/}") \
       || rc=1
   fi
 fi


### PR DESCRIPTION
## Why

PR #609 added a cpplint `py_console_script_binary`. Its implicit
`cpplint_gen__` target is visible in `@fourward//...` and fails for BCR
consumers whose Python version doesn't match the pip wheel. `tags =
["manual"]` didn't help — the generated target doesn't inherit it.

## Fix

Remove the wrapper target entirely and invoke `@pip//cpplint` directly
in `tools/lint.sh`. Same behavior, no generated targets in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)