### PR TITLE
Move cpplint to tools/ and exclude from BCR consumer check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,8 @@ jobs:
           bazel build "${FLAGS[@]}" -- \
             @fourward//... \
             -@fourward//e2e_tests/... \
-            -@fourward//examples/...
+            -@fourward//examples/... \
+            -@fourward//tools/...
 
       - name: Calculate build duration
         if: always()

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+py_console_script_binary(
+    name = "cpplint",
+    pkg = "@pip//cpplint",
+)

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -39,7 +39,7 @@ else
     cd "$REPO_ROOT" && git ls-files '*.cpp' '*.h' '*.cc'
   )
   if [[ ${#CPP_SOURCES[@]} -gt 0 ]]; then
-    (cd "$REPO_ROOT" && bazel run @pip//cpplint -- "${CPP_SOURCES[@]/#/$REPO_ROOT/}") \
+    (cd "$REPO_ROOT" && bazel run //tools:cpplint -- "${CPP_SOURCES[@]/#/$REPO_ROOT/}") \
       || rc=1
   fi
 fi


### PR DESCRIPTION
## Why

PR #614 removed the cpplint BUILD target and tried `bazel run @pip//cpplint`
directly, but pip wheel aliases aren't executable. This restores the
`py_console_script_binary` wrapper — but in `tools/BUILD.bazel` instead
of the root, and excludes `tools/` from the BCR consumer check.

## Changes

- `tools/BUILD.bazel` — new, contains the cpplint binary
- `tools/lint.sh` — invokes `//tools:cpplint` instead of `@pip//cpplint`
- `.github/workflows/ci.yml` — adds `-@fourward//tools/...` to BCR exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)