### PR TITLE
simulator: include type and field name in setBitField overflow errors

### DIFF
--- a/p4runtime/DataplaneService.kt
+++ b/p4runtime/DataplaneService.kt
@@ -59,9 +59,11 @@ class DataplaneService(
         .build()
     } catch (e: StatusException) {
       throw e // already has a proper status; don't rewrap.
+    } catch (e: IllegalArgumentException) {
+      val detail = listOfNotNull("InjectPacket failed", e.message).joinToString(": ")
+      throw Status.INVALID_ARGUMENT.withDescription(detail).withCause(e).asException()
     } catch (e: Exception) {
-      val detail =
-        listOfNotNull("InjectPacket failed", e.javaClass.simpleName, e.message).joinToString(": ")
+      val detail = listOfNotNull("InjectPacket failed", e.message).joinToString(": ")
       throw Status.INTERNAL.withDescription(detail).withCause(e).asException()
     }
   }

--- a/p4runtime/GoldenErrorTest.kt
+++ b/p4runtime/GoldenErrorTest.kt
@@ -175,6 +175,7 @@ class GoldenErrorTest(private val testName: String) {
       "inject-packet-no-pipeline" -> triggerInjectPacketNoPipeline()
       "inject-packet-no-port-translation" -> triggerInjectPacketNoPortTranslation()
       "inject-packet-simulator-throws" -> triggerInjectPacketSimulatorThrows()
+      "inject-packet-port-overflow" -> triggerInjectPacketPortOverflow()
       else -> error("unknown test: $name")
     }
   }
@@ -187,7 +188,7 @@ class GoldenErrorTest(private val testName: String) {
     // reproduce here; what this golden protects is the *translation format*.
     val throwingBroker =
       PacketBroker(
-        simulatorFn = { _, _ -> throw IllegalArgumentException("simulated failure") },
+        simulatorFn = { _, _ -> throw ArithmeticException("simulated failure") },
         writeMutex = kotlinx.coroutines.sync.Mutex(),
       )
     val service = DataplaneService(throwingBroker)
@@ -207,6 +208,14 @@ class GoldenErrorTest(private val testName: String) {
   private fun triggerInjectPacketNoPipeline() {
     val p4rtPort = ByteString.copyFrom(byteArrayOf(0, 0, 0, 1))
     harness.injectPacketP4rt(p4rtPort, byteArrayOf(0x01))
+  }
+
+  @Suppress("MagicNumber")
+  private fun triggerInjectPacketPortOverflow() {
+    // v1model's ingress_port is bit<9> (max 511). Injecting port 512 triggers
+    // a setBitField overflow in the simulator.
+    harness.loadPipeline(loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.injectPacket(512, P4RuntimeTestHarness.buildEthernetFrame(0x0800))
   }
 
   private fun triggerInjectPacketNoPortTranslation() {
@@ -1716,6 +1725,7 @@ class GoldenErrorTest(private val testName: String) {
         "inject-packet-no-pipeline",
         "inject-packet-no-port-translation",
         "inject-packet-simulator-throws",
+        "inject-packet-port-overflow",
       )
 
     private val VALIDATOR_BINARY: Path =

--- a/p4runtime/golden_errors/inject-packet-port-overflow.golden.txt
+++ b/p4runtime/golden_errors/inject-packet-port-overflow.golden.txt
@@ -1,0 +1,1 @@
+INVALID_ARGUMENT: InjectPacket failed: standard_metadata_t.ingress_port: value 512 does not fit in 9 bits

--- a/p4runtime/golden_errors/inject-packet-simulator-throws.golden.txt
+++ b/p4runtime/golden_errors/inject-packet-simulator-throws.golden.txt
@@ -1,1 +1,1 @@
-INTERNAL: InjectPacket failed: IllegalArgumentException: simulated failure
+INTERNAL: InjectPacket failed: simulated failure

--- a/simulator/BitVectorTest.kt
+++ b/simulator/BitVectorTest.kt
@@ -188,4 +188,18 @@ class BitVectorTest {
     assertEquals(SignedBitVector(BigInteger.valueOf(30), 16), a.addSat(b))
     assertEquals(SignedBitVector(BigInteger.valueOf(-10), 16), a.subSat(b))
   }
+
+  // ===========================================================================
+  // StructVal.setBitField error context
+  // ===========================================================================
+
+  @Test
+  fun `setBitField overflow error includes type and field name`() {
+    val s = StructVal("standard_metadata_t", mutableMapOf("ingress_port" to BitVal(0L, 8)))
+    val e =
+      assertThrows(IllegalArgumentException::class.java) { s.setBitField("ingress_port", 4095) }
+    assert(e.message!!.contains("standard_metadata_t.ingress_port")) {
+      "expected type-qualified field name, got: ${e.message}"
+    }
+  }
 }

--- a/simulator/Values.kt
+++ b/simulator/Values.kt
@@ -166,7 +166,11 @@ data class StructVal(val typeName: String, val fields: MutableMap<String, Value>
   /** Overwrites a bit-valued field, preserving its IR-defined width. */
   fun setBitField(name: String, value: Long) {
     val existing = checkNotNull(fields[name] as? BitVal) { "$typeName.$name is not a bit field" }
-    fields[name] = BitVal(value, existing.bits.width)
+    try {
+      fields[name] = BitVal(value, existing.bits.width)
+    } catch (e: IllegalArgumentException) {
+      throw IllegalArgumentException("$typeName.$name: ${e.message}", e)
+    }
   }
 
   /** Returns the bit width of a bit-valued field, as defined by the IR. */


### PR DESCRIPTION
Ref #616.

Three improvements to errors when a value overflows a bit field during
packet processing:

1. `setBitField` now includes the struct type and field name in the error.
2. `InjectPacket` maps `IllegalArgumentException` to `INVALID_ARGUMENT`
   instead of `INTERNAL` — it's a user input error, not a server bug.
3. Drop the Java exception class name from the gRPC error description.

Before:
```
INTERNAL: InjectPacket failed: IllegalArgumentException: value 4095 does not fit in 8 bits
```

After:
```
INVALID_ARGUMENT: InjectPacket failed: standard_metadata_t.ingress_port: value 4095 does not fit in 8 bits
```

## Test plan
- [x] Unit test: `setBitField overflow error includes type and field name`
- [x] Golden error test: `inject-packet-port-overflow` pins the full gRPC error
- [x] Updated golden: `inject-packet-simulator-throws` reflects new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)