### PR TITLE
p4runtime_cc: add string_view overloads and OnPort with payload

### DIFF
--- a/p4runtime_cc/dataplane_matchers.h
+++ b/p4runtime_cc/dataplane_matchers.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -154,6 +155,9 @@ inline auto OnPort(uint32_t port) { return OnPort(DataplanePort{port}); }
 inline auto OnPort(std::string port) {
   return OnPort(P4RuntimePort{std::move(port)});
 }
+inline auto OnPort(std::string_view port) {
+  return OnPort(P4RuntimePort{std::string(port)});
+}
 
 inline auto HasPayload(::testing::Matcher<const std::string&> m) {
   return ::testing::ResultOf(
@@ -161,6 +165,13 @@ inline auto HasPayload(::testing::Matcher<const std::string&> m) {
         return p.payload();
       },
       std::move(m));
+}
+
+// OnPort with payload: "a packet on this port with this payload."
+template <typename Port, typename Payload>
+auto OnPort(Port port, Payload payload) {
+  return ::testing::AllOf(OnPort(std::move(port)),
+                          HasPayload(std::move(payload)));
 }
 
 // ---------------------------------------------------------------------------
@@ -298,6 +309,9 @@ inline auto HasIngress(uint32_t port) {
 }
 inline auto HasIngress(std::string port) {
   return HasIngress(P4RuntimePort{std::move(port)});
+}
+inline auto HasIngress(std::string_view port) {
+  return HasIngress(P4RuntimePort{std::string(port)});
 }
 
 // ---------------------------------------------------------------------------

--- a/p4runtime_cc/dataplane_matchers_test.cc
+++ b/p4runtime_cc/dataplane_matchers_test.cc
@@ -5,6 +5,7 @@
 
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -257,6 +258,56 @@ TEST(HasIngressTest, StringPort) {
   result.mutable_input_packet()->set_p4rt_ingress_port("Eth0");
   result.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
   EXPECT_THAT(result, HasIngress(std::string("Eth0")));
+}
+
+// --- string_view overloads ---
+
+TEST(OnPortTest, StringView) {
+  fourward::dataplane::OutputPacket pkt;
+  pkt.set_p4rt_egress_port("Eth0");
+  std::string_view sv = "Eth0";
+  EXPECT_THAT(pkt, OnPort(sv));
+}
+
+TEST(HasIngressTest, StringView) {
+  fourward::dataplane::ProcessPacketResult result;
+  result.mutable_input_packet()->set_p4rt_ingress_port("Eth0");
+  result.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  std::string_view sv = "Eth0";
+  EXPECT_THAT(result, HasIngress(sv));
+}
+
+TEST(ForwardsToTest, StringView) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_p4rt_egress_port("Eth0");
+  std::string_view sv = "Eth0";
+  EXPECT_THAT(resp, ForwardsTo(sv));
+}
+
+// --- OnPort with payload ---
+
+TEST(OnPortTest, WithPayload) {
+  fourward::dataplane::OutputPacket pkt;
+  pkt.set_dataplane_egress_port(1);
+  pkt.set_payload("hello");
+  EXPECT_THAT(pkt, OnPort(1, "hello"));
+}
+
+TEST(OnPortTest, WithPayloadMatcher) {
+  fourward::dataplane::OutputPacket pkt;
+  pkt.set_dataplane_egress_port(1);
+  pkt.set_payload("hello world");
+  EXPECT_THAT(pkt, OnPort(1, ::testing::StartsWith("hello")));
+}
+
+TEST(OnPortTest, WithPayloadInOutcomeIs) {
+  fourward::dataplane::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* pkt = ps->add_packets();
+  pkt->set_dataplane_egress_port(1);
+  pkt->set_payload("data");
+  EXPECT_THAT(resp, OutcomeIs(OnPort(1, "data")));
 }
 
 // --- Error message quality ---

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -81,7 +81,10 @@ using ::fourward::OnPort;
 using ::fourward::HasPayload;
 
 // Port and payload:
-EXPECT_THAT(response, OutcomeIs(AllOf(OnPort(1), HasPayload(expected_bytes))));
+EXPECT_THAT(response, OutcomeIs(OnPort(1, expected_bytes)));
+
+// With a payload matcher:
+EXPECT_THAT(response, OutcomeIs(OnPort(1, HasPayload(StartsWith("hello")))));
 
 // Multicast — two output packets:
 EXPECT_THAT(response, OutcomeIs(OnPort(1), OnPort(2)));


### PR DESCRIPTION
## Why

Two ergonomics issues surfaced in real SAI P4 test usage:

1. Port constants are often `string_view` — requiring `std::string(sv)`
   at every call site since `string_view → string` is explicit in C++.

2. Matching on both egress port and payload is the most common assertion,
   but requires `AllOf(OnPort(...), HasPayload(...))` every time.

## Changes

**string_view overloads** for `OnPort`, `HasIngress`, and (transitively)
`ForwardsTo`:

```cpp
std::string_view kPort = "Ethernet0";
EXPECT_THAT(response, ForwardsTo(kPort));  // just works
```

**OnPort with payload** — optional second argument combines port + payload:

```cpp
// Before:
OutcomeIs(AllOf(OnPort(kEgressPort), HasPayload(raw_packet)))

// After:
OutcomeIs(OnPort(kEgressPort, HasPayload(raw_packet)))

// Or with raw string (implicit Eq):
OutcomeIs(OnPort(kEgressPort, raw_packet))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)