### PR TITLE
docs: add C++ Library to navigation and entry point table

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,8 @@ report in about 5. No flakes, no "works on my machine." See for yourself on the
 
 **[User documentation](https://smolkaj.github.io/4ward/)** — getting started
 guides, reference pages, and concept explainers for the web playground, CLI,
-and gRPC API. Working in a C++ codebase?
-**[Embedding in C++](https://smolkaj.github.io/4ward/reference/embedding-cc/)**
-lets you treat 4ward like a native C++ library.
+gRPC API, and [C++ library](https://smolkaj.github.io/4ward/reference/embedding-cc/)
+(including composable [gtest matchers](https://smolkaj.github.io/4ward/reference/dataplane-matchers/)).
 
 **[Tutorial](examples/tutorial.t)** — a hands-on walkthrough from hello
 world to machine-readable trace output. Doubles as a regression test (cram

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,9 @@ nav:
   - gRPC API:
       - Getting Started: getting-started/grpc.md
       - Reference: reference/grpc.md
-      - Embedding in C++: reference/embedding-cc.md
+  - C++ Library:
+      - Getting Started: reference/embedding-cc.md
+      - Dataplane Matchers: reference/dataplane-matchers.md
   - Concepts:
       - Trace Trees: concepts/traces.md
       - Type Translation: concepts/type-translation.md

--- a/userdocs/index.md
+++ b/userdocs/index.md
@@ -27,6 +27,7 @@ all possible outcomes in a single pass.
 | **[Web Playground](getting-started/playground.md)** | Edit P4 in the browser, install table entries, send packets, step through traces visually. |
 | **[CLI](getting-started/cli.md)** | Compile a P4 program, run an STF test, read the trace — all from the terminal. |
 | **[gRPC API](getting-started/grpc.md)** | Load pipelines and inject packets programmatically via the DataplaneService and P4Runtime gRPC services. |
+| **[C++ Library](reference/embedding-cc.md)** | Embed 4ward in a C++ project via Bazel, inject packets with designated-init call sites, assert with composable [gtest matchers](reference/dataplane-matchers.md). |
 
 ## Who is this for?
 


### PR DESCRIPTION
## Why

The dataplane matchers page existed but wasn't in the mkdocs nav —
completely invisible on the site. The embedding-cc page was buried under
"gRPC API" which doesn't suggest "C++ library."

## Changes

- **mkdocs.yml**: New top-level "C++ Library" section with "Getting Started"
  (embedding-cc.md) and "Dataplane Matchers" (dataplane-matchers.md).
  Removed embedding-cc from the gRPC section.
- **index.md**: Added C++ row to the "Pick your entry point" table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)