### PR TITLE
simulator: set egress_rid from clone session replica instance (closes #626)

### DIFF
--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -439,12 +439,11 @@ class SaiP4E2ETest {
     installCloneSessionDeprecated(COPY_TO_CPU_SESSION_ID, egressPort = 99)
 
     val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
-    // The clone outputs on dataplane port 99, which has no reverse mapping.
-    // toDualEncoded should fail loudly per invariant #5. The IllegalStateException
-    // is caught and converted to a proper INTERNAL StatusException.
-    FourwardTestHarness.assertGrpcError(Status.Code.INTERNAL) {
-      harness.injectPacket(ingressPort = 0, payload = packet)
-    }
+    // With egress_rid correctly set from the replica's instance field,
+    // packet_io.p4 recognises the clone as a PacketIn (instance_type==1 &&
+    // egress_rid==1) and delivers it to the CPU — the unmapped port 99 is
+    // never reached as a regular output.
+    harness.injectPacket(ingressPort = 0, payload = packet)
   }
 
   @Test

--- a/simulator/InterpreterTestDsl.kt
+++ b/simulator/InterpreterTestDsl.kt
@@ -95,6 +95,35 @@ fun assignField(target: String, fieldName: String, value: Long, width: Int): Stm
     )
     .build()
 
+/** Assignment statement: `lhsTarget.lhsField = rhsTarget.rhsField`. */
+fun assignFieldFromField(
+  lhsTarget: String,
+  lhsField: String,
+  lhsWidth: Int,
+  rhsTarget: String,
+  rhsField: String,
+  rhsWidth: Int,
+): Stmt =
+  Stmt.newBuilder()
+    .setAssignment(
+      AssignmentStmt.newBuilder()
+        .setLhs(
+          Expr.newBuilder()
+            .setFieldAccess(
+              FieldAccess.newBuilder().setExpr(nameRef(lhsTarget)).setFieldName(lhsField)
+            )
+            .setType(bitType(lhsWidth))
+        )
+        .setRhs(
+          Expr.newBuilder()
+            .setFieldAccess(
+              FieldAccess.newBuilder().setExpr(nameRef(rhsTarget)).setFieldName(rhsField)
+            )
+            .setType(bitType(rhsWidth))
+        )
+    )
+    .build()
+
 /** Assignment statement: `varName = rhs`. */
 fun assign(varName: String, rhs: Expr): Stmt =
   Stmt.newBuilder()

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -367,6 +367,7 @@ class V1ModelArchitecture(
         configure = { s ->
           s.standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
           s.standardMetadata.setBitField("egress_port", fork.clonePort)
+          s.standardMetadata.setBitField("egress_rid", fork.egressRid.toLong())
           applyPreservedMetadata(ctx, s.env, fork.preservedMetadata)
         },
         pipelineTail = { c, s -> runEgressAndDeparser(c, s) },
@@ -410,6 +411,7 @@ class V1ModelArchitecture(
           s.pendingOps.egressCloneSessionId = null
           s.standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
           s.standardMetadata.setBitField("egress_port", fork.clonePort)
+          s.standardMetadata.setBitField("egress_rid", fork.egressRid.toLong())
           applyPreservedMetadata(ctx, s.env, fork.preservedMetadata)
         },
         pipelineTail = { _, s ->
@@ -731,10 +733,11 @@ class V1ModelArchitecture(
   private fun ingressEgressBoundary(ctx: PipelineContext, s: PipelineState) {
     val pendingClone = s.pendingOps.cloneSessionId
     if (pendingClone != null) {
-      resolveCloneSession(ctx, s, pendingClone)?.let { clonePort ->
+      resolveCloneSession(ctx, s, pendingClone)?.let { replica ->
         throw CloneFork(
           pendingClone,
-          clonePort,
+          replica.port.toLong(),
+          replica.rid,
           s.packetCtx.getEvents(),
           snapshotPreservedMetadata(s, s.pendingOps.cloneFieldListId),
           s.env.deepCopy(),
@@ -777,10 +780,11 @@ class V1ModelArchitecture(
   private fun postEgressBoundary(ctx: PipelineContext, s: PipelineState) {
     val pendingE2EClone = s.pendingOps.egressCloneSessionId
     if (pendingE2EClone != null) {
-      resolveCloneSession(ctx, s, pendingE2EClone)?.let { clonePort ->
+      resolveCloneSession(ctx, s, pendingE2EClone)?.let { replica ->
         throw EgressCloneFork(
           pendingE2EClone,
-          clonePort,
+          replica.port.toLong(),
+          replica.rid,
           s.packetCtx.getEvents(),
           snapshotPreservedMetadata(s, s.pendingOps.egressCloneFieldListId),
           s.env.deepCopy(),
@@ -833,27 +837,35 @@ class V1ModelArchitecture(
     (s.standardMetadata.fields["egress_spec"] as? BitVal)?.bits?.value?.toLong() == s.dropPort
 
   /**
-   * Resolves a pending clone session: emits a [CloneSessionLookupEvent] and returns the clone port,
-   * or emits a miss event and returns null if the session doesn't exist.
+   * Resolves a pending clone session: emits a [CloneSessionLookupEvent] and returns the first
+   * replica, or emits a miss event and returns null if the session doesn't exist.
    */
-  private fun resolveCloneSession(ctx: PipelineContext, s: PipelineState, sessionId: Int): Long? {
+  private fun resolveCloneSession(
+    ctx: PipelineContext,
+    s: PipelineState,
+    sessionId: Int,
+  ): Replica? {
     val session = ctx.tableStore.getCloneSession(sessionId)
     if (session != null) {
-      val egressPort = replicaPort(session.replicasList.first())
-      s.packetCtx.addTraceEvent(cloneSessionLookupEvent(sessionId, egressPort))
-      return egressPort.toLong()
+      val firstReplica = session.replicasList.first()
+      val egressPort = replicaPort(firstReplica)
+      s.packetCtx.addTraceEvent(
+        cloneSessionLookupEvent(sessionId, egressPort, firstReplica.instance)
+      )
+      return Replica(firstReplica.instance, egressPort)
     }
     s.packetCtx.addTraceEvent(cloneSessionMissEvent(sessionId))
     return null
   }
 
-  private fun cloneSessionLookupEvent(sessionId: Int, egressPort: Int): TraceEvent =
+  private fun cloneSessionLookupEvent(sessionId: Int, egressPort: Int, egressRid: Int): TraceEvent =
     TraceEvent.newBuilder()
       .setCloneSessionLookup(
         CloneSessionLookupEvent.newBuilder()
           .setSessionId(sessionId)
           .setSessionFound(true)
           .setDataplaneEgressPort(egressPort)
+          .setEgressRid(egressRid)
       )
       .build()
 
@@ -1202,6 +1214,7 @@ internal class V1ModelSelectorFork(
 internal class CloneFork(
   val sessionId: Int,
   val clonePort: Long,
+  val egressRid: Int,
   eventsBeforeFork: List<TraceEvent>,
   val preservedMetadata: Map<String, Value>? = null,
   /** Deep copy of the post-ingress environment (for the "original" branch). */
@@ -1221,6 +1234,7 @@ internal class CloneFork(
 internal class EgressCloneFork(
   val sessionId: Int,
   val clonePort: Long,
+  val egressRid: Int,
   eventsBeforeFork: List<TraceEvent>,
   val preservedMetadata: Map<String, Value>? = null,
   /** Deep copy of the post-egress environment (for both branches). */

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -240,6 +240,7 @@ class V1ModelArchitectureTest {
     store: TableStore,
     sessionId: Int,
     egressPort: Int,
+    instance: Int = 0,
     usePortBytes: Boolean = false,
   ) {
     store.write(
@@ -252,7 +253,7 @@ class V1ModelArchitectureTest {
                 .setCloneSessionEntry(
                   P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
                     .setSessionId(sessionId)
-                    .addReplicas(buildReplica(egressPort, usePortBytes = usePortBytes))
+                    .addReplicas(buildReplica(egressPort, instance, usePortBytes = usePortBytes))
                 )
             )
         )
@@ -454,6 +455,44 @@ class V1ModelArchitectureTest {
   }
 
   @Test
+  fun `I2E clone sets egress_rid from clone session replica instance`() {
+    // Egress copies egress_rid into a user metadata field, then uses it to
+    // decide whether to drop. Verifies the replica's instance field flows
+    // through to standard_metadata.egress_rid in the clone branch.
+    val config =
+      v1modelConfig(
+        ingressStmts =
+          listOf(
+            externCall("clone", enumArg("I2E"), intArg(1, 32)),
+            assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+          ),
+        egressStmts =
+          listOf(
+            // In the clone branch, drop if egress_rid == 0 (the default / unfixed value).
+            ifFieldEquals(
+              "sm",
+              "instance_type",
+              1,
+              32,
+              ifFieldEquals("sm", "egress_rid", 0, 16, markToDrop),
+            )
+          ),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, egressPort = 7, instance = 42)
+
+    val result =
+      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(2, outputs.size)
+    // Original: egress_spec=2, not a clone so egress doesn't drop.
+    assertEquals(2, outputs[0].dataplaneEgressPort)
+    // Clone: if egress_rid is correctly set to 42 (not 0), the clone survives.
+    assertEquals(7, outputs[1].dataplaneEgressPort)
+  }
+
+  @Test
   fun `I2E clone works with multi-byte Replica port`() {
     val config =
       v1modelConfig(
@@ -516,6 +555,64 @@ class V1ModelArchitectureTest {
     assertEquals(2, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
     assertEquals(8, outputs[1].dataplaneEgressPort)
+  }
+
+  @Test
+  fun `E2E clone sets egress_rid from clone session replica instance`() {
+    val config =
+      v1modelConfig(
+        ingressStmts =
+          listOf(assignField("sm", "egress_spec", 3, V1ModelArchitecture.DEFAULT_PORT_BITS)),
+        egressStmts =
+          listOf(
+            // First egress pass (instance_type == 0): trigger E2E clone.
+            ifFieldEquals(
+              "sm",
+              "instance_type",
+              0,
+              32,
+              externCall("clone", enumArg("E2E"), intArg(1, 32)),
+            ),
+            // Clone pass (instance_type == 2): drop if egress_rid == 0.
+            ifFieldEquals(
+              "sm",
+              "instance_type",
+              2,
+              32,
+              ifFieldEquals("sm", "egress_rid", 0, 16, markToDrop),
+            ),
+          ),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, egressPort = 8, instance = 7)
+
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(2, outputs.size)
+    assertEquals(3, outputs[0].dataplaneEgressPort)
+    // Clone survives because egress_rid=7, not 0.
+    assertEquals(8, outputs[1].dataplaneEgressPort)
+  }
+
+  @Test
+  fun `clone session trace event includes egress_rid`() {
+    val config =
+      v1modelConfig(
+        externCall("clone", enumArg("I2E"), intArg(1, 32)),
+        assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, egressPort = 7, instance = 42)
+
+    val result =
+      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+    val cloneEvent = result.trace.eventsList.first { it.hasCloneSessionLookup() }.cloneSessionLookup
+
+    assertTrue(cloneEvent.sessionFound)
+    assertEquals(1, cloneEvent.sessionId)
+    assertEquals(7, cloneEvent.dataplaneEgressPort)
+    assertEquals(42, cloneEvent.egressRid)
   }
 
   @Test

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -204,6 +204,8 @@ message CloneSessionLookupEvent {
       3;  // clone destination; only meaningful when session_found
   // P4Runtime port ID. Populated by enrichment layers, never by the simulator.
   bytes p4rt_egress_port = 4;
+  // Replica instance from the clone session entry, mapped to egress_rid.
+  uint32 egress_rid = 5;
 }
 
 // Fired when a packet arrives at the pipeline — the very first event in any


### PR DESCRIPTION
## Why

Clone sessions carry a replica `instance` field that maps to
`standard_metadata.egress_rid` in v1model. The simulator set
`instance_type` and `egress_port` for cloned copies but never
`egress_rid` — it was always 0. Programs that gate PacketIn on
`egress_rid == 1` (like SAI P4's `packet_io.p4`) silently dropped the
cloned packet, causing missing PacketIn responses (#626).

The multicast path already set `egress_rid` correctly.

## Fix

`resolveCloneSession` now returns the full `Replica` (port + rid)
instead of just the port. Both I2E and E2E clone configure lambdas set
`egress_rid` from the replica's instance field.

## Test

New test: `I2E clone sets egress_rid from clone session replica instance`
— egress drops the clone if `egress_rid == 0`, verifying the fix by
observing that the clone survives when `instance = 42`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)