### PR TITLE
Normalize translation table keys to minimum-width encoding (closes #632)

### DIFF
--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -220,10 +220,8 @@ private fun enrichTrace(trace: TraceTree, translator: TypeTranslator?): TraceTre
 /**
  * Returns a copy of this [OutputPacket] enriched with the P4Runtime port ID.
  *
- * When a [PortTranslator] is present, every egress port must be reverse-translatable — either
- * forward-allocated by a controller Write or installed via `Replica.port` (bytes). A missing
- * mapping means the clone session or multicast group used the deprecated `Replica.egress_port`
- * (int32), which bypasses port translation.
+ * When a [PortTranslator] is present, every egress port must have a reverse mapping — either from
+ * an explicit `@p4runtime_translation_mappings` entry or auto-allocated by a prior P4Runtime Write.
  */
 private fun OutputPacket.toDualEncoded(pt: PortTranslator?): OutputPacket =
   OutputPacket.newBuilder()
@@ -233,10 +231,9 @@ private fun OutputPacket.toDualEncoded(pt: PortTranslator?): OutputPacket =
         val p4rtPort =
           pt.dataplaneToP4rt(dataplaneEgressPort)
             ?: error(
-              "PortTranslator has no reverse mapping for dataplane egress port " +
-                "$dataplaneEgressPort. Use Replica.port (bytes) instead of the deprecated " +
-                "Replica.egress_port (int32) to enable port translation for clone sessions " +
-                "and multicast groups."
+              "No P4Runtime port name for dataplane egress port $dataplaneEgressPort. " +
+                "Ensure the port has a @p4runtime_translation_mappings entry or was " +
+                "auto-allocated via a prior P4Runtime Write."
             )
         setP4RtEgressPort(p4rtPort)
       }

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -429,20 +429,17 @@ class SaiP4E2ETest {
   }
 
   @Test
-  fun `deprecated Replica egress_port causes loud error on unmapped port`() {
+  fun `deprecated Replica egress_port with egress_rid delivers PacketIn via CPU`() {
     installRoutingChain()
     installAclEntry(findAction("acl_trap"))
-    // Install the ingress_clone_table entry that triggers clone3() with session 255.
     installIngressCloneTableEntry()
-    // Install clone session using the deprecated Replica.egress_port (int32) which bypasses
-    // port translation. Port 99 has no P4RT reverse mapping.
+    // Port 99 has no P4RT mapping, but with egress_rid correctly set from the
+    // replica's instance field, packet_io.p4 recognises the clone as a
+    // PacketIn (instance_type==1 && egress_rid==1) and delivers it to the
+    // CPU — the unmapped port 99 is never reached as a regular output.
     installCloneSessionDeprecated(COPY_TO_CPU_SESSION_ID, egressPort = 99)
 
     val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
-    // With egress_rid correctly set from the replica's instance field,
-    // packet_io.p4 recognises the clone as a PacketIn (instance_type==1 &&
-    // egress_rid==1) and delivers it to the CPU — the unmapped port 99 is
-    // never reached as a regular output.
     harness.injectPacket(ingressPort = 0, payload = packet)
   }
 

--- a/grpc/TypeTranslator.kt
+++ b/grpc/TypeTranslator.kt
@@ -773,6 +773,10 @@ internal class TranslationTable(
       "no mapping for P4Runtime string '$p4rtStr' (auto-allocate off)",
     )
 
+  private fun putReverse(dataplaneValue: ByteString, p4rtValue: P4rtValue) {
+    reverse[encodeMinWidth(dataplaneValue.toUnsignedInt())] = p4rtValue
+  }
+
   /** Reverse-translates a data-plane value to its P4Runtime representation. */
   @Synchronized
   fun reverseLookup(dataplaneValue: ByteString): P4rtValue =
@@ -799,7 +803,7 @@ internal class TranslationTable(
     if (!autoAllocate) throw TranslationException(errorMsg)
     val dp = allocateNext()
     forward[key] = dp
-    reverse[dp] = wrapP4rt(key)
+    putReverse(dp, wrapP4rt(key))
     return dp
   }
 
@@ -817,19 +821,24 @@ internal class TranslationTable(
       val table = TranslationTable(autoAllocate = proto.autoAllocate, isStringType = isStringType)
       for (entry in proto.entriesList) {
         val dp = entry.dataplaneValue
+        // Normalize to minimum-width so reverse lookups (which use
+        // encodeMinWidth) match regardless of the config's byte width.
+        val dpNorm = encodeMinWidth(dp.toUnsignedInt())
         table.reservedValues.add(dp.toUnsignedInt())
-        table.reverse[dp] =
+        table.putReverse(
+          dpNorm,
           when (entry.sdnValueCase) {
             TranslationEntry.SdnValueCase.SDN_BITSTRING -> {
-              table.bitstringForward[entry.sdnBitstring] = dp
+              table.bitstringForward[entry.sdnBitstring] = dpNorm
               P4rtValue.Bitstring(entry.sdnBitstring)
             }
             TranslationEntry.SdnValueCase.SDN_STR -> {
-              table.stringForward[entry.sdnStr] = dp
+              table.stringForward[entry.sdnStr] = dpNorm
               P4rtValue.Str(entry.sdnStr)
             }
             else -> throw IllegalArgumentException("TranslationEntry must have an sdn_value")
-          }
+          },
+        )
       }
       return table
     }

--- a/grpc/TypeTranslatorTest.kt
+++ b/grpc/TypeTranslatorTest.kt
@@ -150,6 +150,24 @@ class TypeTranslatorTest {
   }
 
   @Test
+  fun `reverse lookup works when config dataplane value is wider than minimum encoding`() {
+    // Config stores dataplane value as 4 bytes (bit<32>): \x00\x00\x01\xfe = 510.
+    // Reverse lookup encodes port 510 in minimum width: \x01\xfe (2 bytes).
+    // These must match despite different byte widths.
+    val translator =
+      buildTranslator(
+        translation {
+          typeName = "port_id_t"
+          autoAllocate = true
+          addEntries(stringEntry("510", byteArrayOf(0, 0, 0x01, 0xfe.toByte())))
+        }
+      )
+
+    val result = translator.dataplaneToP4rt("port_id_t", dpBytes(510))
+    assertEquals(P4rtValue.Str("510"), result)
+  }
+
+  @Test
   fun `auto-allocate reverse lookup works after allocation`() {
     val translator =
       buildTranslator(


### PR DESCRIPTION
## Why

Overriding the CPU port with `CpuPort::Override(510)` failed with
"no reverse mapping for dataplane egress port 510" despite the
translation config having an explicit entry for port 510 (#632).

Root cause: the translation table's reverse map stored config entries
at their original byte width (4 bytes for `bit<32>`: `\x00\x00\x01\xfe`),
but reverse lookups used `encodeMinWidth` (2 bytes: `\x01\xfe`). Same
integer, different byte representation — lookup missed.

## Fix

1. **Normalize keys via `putReverse()`** — all reverse map insertions
   go through one method that normalizes to minimum-width encoding.
   Impossible to insert a non-normalized key.

2. **Fix misleading error message** — the old message blamed the
   `Replica.egress_port` field, but the user was likely already using
   `Replica.port`. The real issue was the byte-width mismatch.
   New message: "Ensure the port has a @p4runtime_translation_mappings
   entry or was auto-allocated via a prior P4Runtime Write."

3. **Rename stale test** — `deprecated Replica egress_port causes loud
   error on unmapped port` → `deprecated Replica egress_port with
   egress_rid delivers PacketIn via CPU` (behavior changed in #628).

## Test

New test: explicit entry with 4-byte config value, reverse lookup with
2-byte minimum encoding — verifies they match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)