### PR TITLE
Add inline P4 compiler for Kotlin tests

### DIFF
--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -97,6 +97,7 @@ kt_jvm_library(
         exclude = [
             "*Test.kt",
             "*TestHarness.kt",
+            "InlineP4Compiler.kt",
             "*Benchmark.kt",
         ],
     ),
@@ -207,6 +208,44 @@ kt_jvm_test(
         "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
         "@googleapis//google/rpc:rpc_java_proto",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
+    ],
+)
+
+kt_jvm_test(
+    name = "InlineP4CompilerTest",
+    srcs = [
+        "FourwardTestHarness.kt",
+        "InlineP4Compiler.kt",
+        "InlineP4CompilerTest.kt",
+    ],
+    data = [
+        "//p4c_backend:p4c-4ward",
+        "@p4c//p4include",
+        "@p4c//p4include:core.p4",
+    ],
+    jvm_flags = [
+        "-Dp4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
+        "-Dp4include=$(rlocationpath @p4c//p4include:core.p4)",
+    ],
+    test_class = "fourward.grpc.InlineP4CompilerTest",
+    deps = [
+        ":dataplane_java_proto",
+        ":dataplane_kt_grpc",
+        ":grpc",
+        ":p4runtime_kt_grpc",
+        "//bazel:runfiles",
+        "//simulator",
+        "//simulator:ir_java_proto",
+        "//simulator:p4data_java_proto",
+        "//simulator:p4info_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:io_grpc_grpc_api",
+        "@fourward_maven//:io_grpc_grpc_inprocess",
+        "@fourward_maven//:junit_junit",
+        "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@googleapis//google/rpc:rpc_java_proto",
     ],
 )
 

--- a/grpc/InlineP4Compiler.kt
+++ b/grpc/InlineP4Compiler.kt
@@ -1,0 +1,63 @@
+package fourward.grpc
+
+import com.google.protobuf.TextFormat
+import fourward.PipelineConfig
+import java.nio.file.Files
+
+/**
+ * Compiles a P4 source string at test time using p4c-4ward. Useful for tests that need a custom P4
+ * program without a dedicated BUILD target.
+ *
+ * Example:
+ * ```
+ * val config = compileInlineP4("""
+ *   #include <core.p4>
+ *   #include <v1model.p4>
+ *   // ... minimal program ...
+ * """)
+ * val harness = FourwardTestHarness()
+ * harness.loadPipeline(config)
+ * ```
+ *
+ * Requires the test's BUILD target to include:
+ * ```
+ * data = ["//p4c_backend:p4c-4ward", "@p4c//p4include"],
+ * jvm_flags = [
+ *     "-Dp4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
+ *     "-Dp4include=$(rlocationpath @p4c//p4include:core.p4)",
+ * ],
+ * ```
+ */
+fun compileInlineP4(source: String): PipelineConfig {
+  val p4cBinary = fourward.bazel.resolveRunfileProperty("p4c_4ward")
+  val p4includeDir = fourward.bazel.resolveRunfileProperty("p4include").parent
+
+  val tmpDir = Files.createTempDirectory("inline-p4")
+  try {
+    val srcFile = tmpDir.resolve("program.p4")
+    val outFile = tmpDir.resolve("pipeline.txtpb")
+    Files.writeString(srcFile, source)
+
+    val process =
+      ProcessBuilder(
+          p4cBinary.toString(),
+          srcFile.toString(),
+          "-o",
+          outFile.toString(),
+          "-I",
+          p4includeDir.toString(),
+        )
+        .redirectErrorStream(true)
+        .start()
+
+    val output = process.inputStream.bufferedReader().readText()
+    val exitCode = process.waitFor()
+    check(exitCode == 0) { "p4c-4ward failed (exit $exitCode):\n$output" }
+
+    val builder = PipelineConfig.newBuilder()
+    TextFormat.merge(Files.readString(outFile), builder)
+    return builder.build()
+  } finally {
+    tmpDir.toFile().deleteRecursively()
+  }
+}

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -1,0 +1,73 @@
+package fourward.grpc
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InlineP4CompilerTest {
+
+  @Test
+  fun `compiles minimal passthrough program`() {
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 1; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    assertTrue(config.hasP4Info())
+    assertTrue(config.hasDevice())
+  }
+
+  @Test
+  fun `compiled program runs in simulator`() {
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 1; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+      val packet = ByteArray(14) { 0xFF.toByte() }
+      val response = it.injectPacket(ingressPort = 0, payload = packet)
+      val outputs = response.possibleOutcomesList.flatMap { it.packetsList }
+      assertTrue("expected output on port 1", outputs.any { it.dataplaneEgressPort == 1 })
+    }
+  }
+}


### PR DESCRIPTION
## Why

Writing a test for a specific P4 behavior currently requires a
dedicated `fourward_pipeline` BUILD target, a `.p4` source file, and
runfiles wiring. For one-off tests (error golden tests, edge cases),
this is heavy overhead.

## What

`compileInlineP4(source)` compiles a P4 program string at test time
using `p4c-4ward` as a subprocess, returning a `PipelineConfig` ready
to load into the simulator:

```kotlin
val config = compileInlineP4("""
  #include <core.p4>
  #include <v1model.p4>
  header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
  struct headers_t { ethernet_t eth; }
  struct meta_t {}
  // ... minimal program ...
  V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
""")
harness.loadPipeline(config)
```

No BUILD target per program. Tests declare `p4c-4ward` and `p4include`
in `data`/`jvm_flags` once.

## Tests

- `compiles minimal passthrough program` — verifies output has p4info + device config
- `compiled program runs in simulator` — inject → output end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)