### PR TITLE
Move InlineP4Compiler to e2e_tests/ and document in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,9 @@ in low-level details; the diff already has those.
 
 Before submitting:
 
-- Proactively add unit test.
+- Proactively add unit test. For one-off P4 programs, use
+  `compileInlineP4()` (`e2e_tests/InlineP4Compiler.kt`) to compile P4
+  source at test time without a dedicated BUILD target.
 - Run `./tools/format.sh` and `./tools/lint.sh`. Fix all warnings, even
   pre-existing ones.
 - Check whether your change affects [LIMITATIONS.md](docs/LIMITATIONS.md) or

--- a/e2e_tests/BUILD.bazel
+++ b/e2e_tests/BUILD.bazel
@@ -42,6 +42,17 @@ bzl_library(
 )
 
 kt_jvm_library(
+    name = "inline_p4_compiler",
+    srcs = ["InlineP4Compiler.kt"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bazel:runfiles",
+        "//simulator:ir_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+    ],
+)
+
+kt_jvm_library(
     name = "golden_file",
     srcs = ["GoldenFile.kt"],
     visibility = ["//visibility:public"],

--- a/e2e_tests/InlineP4Compiler.kt
+++ b/e2e_tests/InlineP4Compiler.kt
@@ -1,4 +1,4 @@
-package fourward.grpc
+package fourward.e2e
 
 import com.google.protobuf.TextFormat
 import fourward.PipelineConfig

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -97,7 +97,6 @@ kt_jvm_library(
         exclude = [
             "*Test.kt",
             "*TestHarness.kt",
-            "InlineP4Compiler.kt",
             "*Benchmark.kt",
         ],
     ),
@@ -215,7 +214,6 @@ kt_jvm_test(
     name = "InlineP4CompilerTest",
     srcs = [
         "FourwardTestHarness.kt",
-        "InlineP4Compiler.kt",
         "InlineP4CompilerTest.kt",
     ],
     data = [
@@ -234,6 +232,7 @@ kt_jvm_test(
         ":grpc",
         ":p4runtime_kt_grpc",
         "//bazel:runfiles",
+        "//e2e_tests:inline_p4_compiler",
         "//simulator",
         "//simulator:ir_java_proto",
         "//simulator:p4data_java_proto",

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -1,5 +1,6 @@
 package fourward.grpc
 
+import fourward.e2e.compileInlineP4
 import org.junit.Assert.assertTrue
 import org.junit.Test
 


### PR DESCRIPTION
## Why

`InlineP4Compiler.kt` was in `grpc/` but has nothing to do with gRPC —
it compiles P4 source strings at test time. Moved to `e2e_tests/`
alongside `GoldenFile.kt` and other test utilities.

Added a one-liner to AGENTS.md so agents discover `compileInlineP4()`
when writing tests that need one-off P4 programs.

## Changes

- `e2e_tests/InlineP4Compiler.kt` — moved, package changed to `fourward.e2e`
- `e2e_tests/BUILD.bazel` — new `inline_p4_compiler` library target
- `grpc/BUILD.bazel` — removed from glob exclude, added dep on `//e2e_tests:inline_p4_compiler`
- `grpc/InlineP4CompilerTest.kt` — updated import
- `AGENTS.md` — documented `compileInlineP4()` in test guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)