### PR TITLE
fourward_cc: add Forwards() matcher

### DIFF
--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -75,7 +75,11 @@ class OutcomesMatcherBase {
   bool MatchAndExplain(const T& result,
                        ::testing::MatchResultListener* listener) const {
     auto outcomes = ExtractOutcomes(result);
-    return inner_.MatchAndExplain(outcomes, listener);
+    if (inner_.MatchAndExplain(outcomes, listener)) return true;
+    if (result.has_trace()) {
+      *listener << "\nfull trace:\n" << result.trace().DebugString();
+    }
+    return false;
   }
 
   void DescribeTo(std::ostream* os) const {

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -322,6 +322,12 @@ auto ForwardsTo(Ports... ports) {
   return OutcomeIs(OnPort(std::move(ports))...);
 }
 
+inline auto Forwards() {
+  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
+      ::testing::ElementsAre(::testing::Not(::testing::IsEmpty())),
+      "forward the packet"));
+}
+
 inline auto Drops() { return OutcomeIs(); }
 
 // ---------------------------------------------------------------------------

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -87,6 +87,18 @@ TEST(ForwardsToTest, MulticastWrongPorts) {
   EXPECT_THAT(Multicast(1, 2), Not(ForwardsTo(1, 3)));
 }
 
+// --- Forwards ---
+
+TEST(ForwardsTest, Matches) { EXPECT_THAT(Forward(1), Forwards()); }
+TEST(ForwardsTest, Multicast) { EXPECT_THAT(Multicast(1, 2), Forwards()); }
+TEST(ForwardsTest, Drop) { EXPECT_THAT(Drop(), Not(Forwards())); }
+TEST(ForwardsTest, NonDeterministic) {
+  EXPECT_THAT(NonDeterministic(1, 2), Not(Forwards()));
+}
+TEST(ForwardsTest, WorksOnProcessPacketResult) {
+  EXPECT_THAT(MakeResult(0, 3), Forwards());
+}
+
 // --- Drops ---
 
 TEST(DropsTest, Matches) { EXPECT_THAT(Drop(), Drops()); }
@@ -318,6 +330,14 @@ TEST(ErrorMessageTest, ForwardsToDescribes) {
   std::ostringstream os;
   m.DescribeTo(&os);
   EXPECT_THAT(os.str(), ::testing::HasSubstr("outcomes"));
+}
+
+TEST(ErrorMessageTest, ForwardsDescribes) {
+  ::testing::Matcher<const fourward::InjectPacketResponse&> m =
+      Forwards();
+  std::ostringstream os;
+  m.DescribeTo(&os);
+  EXPECT_THAT(os.str(), ::testing::HasSubstr("forward"));
 }
 
 TEST(ErrorMessageTest, DropsDescribes) {

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -60,6 +60,14 @@ fourward::ProcessPacketResult MakeResult(uint32_t ingress,
   return result;
 }
 
+template <typename M, typename T>
+std::string ExplainMatch(M polymorphic_matcher, const T& value) {
+  ::testing::Matcher<const T&> matcher = polymorphic_matcher;
+  ::testing::StringMatchResultListener listener;
+  matcher.MatchAndExplain(value, &listener);
+  return listener.str();
+}
+
 // --- ForwardsTo ---
 
 TEST(ForwardsToTest, Matches) {
@@ -359,13 +367,10 @@ TEST(ErrorMessageTest, HasIngressDescribes) {
 TEST(ErrorMessageTest, FailureIncludesTrace) {
   fourward::InjectPacketResponse resp;
   resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
-  auto* event = resp.mutable_trace()->add_events();
-  event->mutable_table_lookup()->set_table_name("my_table");
-
-  ::testing::Matcher<const fourward::InjectPacketResponse&> m = Drops();
-  ::testing::StringMatchResultListener listener;
-  EXPECT_FALSE(m.MatchAndExplain(resp, &listener));
-  EXPECT_THAT(listener.str(), ::testing::HasSubstr("my_table"));
+  resp.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
+      "my_table");
+  EXPECT_THAT(ExplainMatch(Drops(), resp),
+              ::testing::HasSubstr("my_table"));
 }
 
 TEST(ErrorMessageTest, FailureIncludesTraceOnProcessPacketResult) {
@@ -373,18 +378,13 @@ TEST(ErrorMessageTest, FailureIncludesTraceOnProcessPacketResult) {
   result.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
   result.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
       "ingress_table");
-
-  ::testing::Matcher<const fourward::ProcessPacketResult&> m = Drops();
-  ::testing::StringMatchResultListener listener;
-  EXPECT_FALSE(m.MatchAndExplain(result, &listener));
-  EXPECT_THAT(listener.str(), ::testing::HasSubstr("ingress_table"));
+  EXPECT_THAT(ExplainMatch(Drops(), result),
+              ::testing::HasSubstr("ingress_table"));
 }
 
 TEST(ErrorMessageTest, FailureOmitsTraceWhenAbsent) {
-  ::testing::Matcher<const fourward::InjectPacketResponse&> m = Drops();
-  ::testing::StringMatchResultListener listener;
-  EXPECT_FALSE(m.MatchAndExplain(Forward(1), &listener));
-  EXPECT_THAT(listener.str(), Not(::testing::HasSubstr("trace")));
+  EXPECT_THAT(ExplainMatch(Drops(), Forward(1)),
+              Not(::testing::HasSubstr("trace")));
 }
 
 TEST(ErrorMessageTest, NoTraceWhenMatches) {
@@ -392,11 +392,8 @@ TEST(ErrorMessageTest, NoTraceWhenMatches) {
   resp.add_possible_outcomes();
   resp.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
       "my_table");
-
-  ::testing::Matcher<const fourward::InjectPacketResponse&> m = Drops();
-  ::testing::StringMatchResultListener listener;
-  EXPECT_TRUE(m.MatchAndExplain(resp, &listener));
-  EXPECT_THAT(listener.str(), Not(::testing::HasSubstr("my_table")));
+  EXPECT_THAT(ExplainMatch(Drops(), resp),
+              Not(::testing::HasSubstr("my_table")));
 }
 
 // --- Composition ---

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -356,6 +356,30 @@ TEST(ErrorMessageTest, HasIngressDescribes) {
   EXPECT_THAT(os.str(), ::testing::HasSubstr("5"));
 }
 
+TEST(ErrorMessageTest, FailureIncludesTrace) {
+  fourward::InjectPacketResponse resp;
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  auto* event = resp.mutable_trace()->add_events();
+  event->mutable_table_lookup()->set_table_name("my_table");
+
+  ::testing::Matcher<const fourward::InjectPacketResponse&> m = Drops();
+  ::testing::StringMatchResultListener listener;
+  EXPECT_FALSE(m.MatchAndExplain(resp, &listener));
+  EXPECT_THAT(listener.str(), ::testing::HasSubstr("my_table"));
+}
+
+TEST(ErrorMessageTest, NoTraceWhenMatches) {
+  fourward::InjectPacketResponse resp;
+  resp.add_possible_outcomes();
+  resp.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
+      "my_table");
+
+  ::testing::Matcher<const fourward::InjectPacketResponse&> m = Drops();
+  ::testing::StringMatchResultListener listener;
+  EXPECT_TRUE(m.MatchAndExplain(resp, &listener));
+  EXPECT_THAT(listener.str(), Not(::testing::HasSubstr("my_table")));
+}
+
 // --- Composition ---
 
 TEST(CompositionTest, ForwardsToWithIngress) {

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -368,6 +368,25 @@ TEST(ErrorMessageTest, FailureIncludesTrace) {
   EXPECT_THAT(listener.str(), ::testing::HasSubstr("my_table"));
 }
 
+TEST(ErrorMessageTest, FailureIncludesTraceOnProcessPacketResult) {
+  fourward::ProcessPacketResult result;
+  result.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  result.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
+      "ingress_table");
+
+  ::testing::Matcher<const fourward::ProcessPacketResult&> m = Drops();
+  ::testing::StringMatchResultListener listener;
+  EXPECT_FALSE(m.MatchAndExplain(result, &listener));
+  EXPECT_THAT(listener.str(), ::testing::HasSubstr("ingress_table"));
+}
+
+TEST(ErrorMessageTest, FailureOmitsTraceWhenAbsent) {
+  ::testing::Matcher<const fourward::InjectPacketResponse&> m = Drops();
+  ::testing::StringMatchResultListener listener;
+  EXPECT_FALSE(m.MatchAndExplain(Forward(1), &listener));
+  EXPECT_THAT(listener.str(), Not(::testing::HasSubstr("trace")));
+}
+
 TEST(ErrorMessageTest, NoTraceWhenMatches) {
   fourward::InjectPacketResponse resp;
   resp.add_possible_outcomes();


### PR DESCRIPTION
## Summary

- Adds `Forwards()` as the natural counterpart to `Drops()` — asserts a single deterministic outcome with at least one output packet, regardless of port. Useful when you just need to confirm a packet wasn't dropped.
- Outcome-level matchers now print the full `TraceTree` on failure, giving immediate visibility into how the simulator processed the packet without needing to rerun with extra debugging.
- Extracts an `ExplainMatch` test helper to reduce boilerplate in error-message tests.

## Test plan

- [x] `ForwardsTest` — matches single forward, multicast, rejects drops and non-deterministic results, works on `ProcessPacketResult`
- [x] Trace appears in failure message for both `InjectPacketResponse` and `ProcessPacketResult`
- [x] No trace output when matcher succeeds or when trace is absent
- [x] `bazel test //fourward_cc:dataplane_matchers_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)