### PR TITLE
BCR: use prebuilt protoc to avoid ~5 min build-from-source

### DIFF
--- a/bcr_test_module/.bazelrc
+++ b/bcr_test_module/.bazelrc
@@ -9,10 +9,13 @@ common --noenable_workspace
 build --cxxopt=-std=c++20
 build --host_cxxopt=-std=c++20
 
-# Match the root .bazelrc's compiler selection so C++ action hashes
-# align with the main build — enabling BuildBuddy remote cache hits.
+# Match the root .bazelrc so action hashes align with the main build,
+# enabling BuildBuddy remote cache hits.
 build --action_env=CC=clang
 build --action_env=CXX=clang++
+
+# TODO: remove once we upgrade to protobuf 34+ (prebuilt becomes the default).
+build --@protobuf//bazel/toolchains:prefer_prebuilt_protoc=true
 
 # Hermetic JDK so local builds don't depend on whatever system Java
 # happens to be installed (same rationale as the root `.bazelrc`).

--- a/bcr_test_module/MODULE.bazel
+++ b/bcr_test_module/MODULE.bazel
@@ -17,6 +17,12 @@ local_path_override(
 # skip this — those targets resolve entirely through @fourward_maven.
 bazel_dep(name = "rules_jvm_external", version = "6.10")
 
+# WORKAROUND: direct dep so --@protobuf//bazel/toolchains:prefer_prebuilt_protoc
+# resolves from .bazelrc, avoiding a ~5 min protoc-from-source build. Remove
+# once we upgrade to protobuf 34+ where prebuilt is the default (blocked on
+# gRPC compatibility — no released gRPC supports protobuf 34 yet).
+bazel_dep(name = "protobuf", version = "33.5")
+
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     known_contributing_modules = [


### PR DESCRIPTION
## Why

PR #640 aligned the BCR `.bazelrc` with the root for C++ compiler flags,
enabling remote cache hits. But protoc was still building from source
(~5 min) because `--@protobuf//bazel/toolchains:prefer_prebuilt_protoc`
couldn't resolve without `protobuf` as a direct `bazel_dep`.

## Fix

Add `protobuf` as a direct dep in `bcr_test_module/MODULE.bazel` so the
prebuilt-protoc flag resolves. Marked as a WORKAROUND with a TODO to
remove once protobuf 34+ is available (where prebuilt is the default).

Blocked on gRPC: no released gRPC version supports protobuf 34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)