### PR TITLE
simulator: bit-level parser, deparser, and PacketIn stripping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ you want before you write the code. If you can't write a clear test, you
 don't understand the problem yet. A failing test is the starting point for
 every change, not an afterthought.
 
+**Write DAMP tests, not DRY tests.** Each test should be readable
+top-to-bottom without chasing helpers. Prefer duplicating setup over
+extracting it into a shared function — when a test fails, you want the
+full context right there. Three similar test bodies are better than one
+parameterized helper that obscures the scenario.
+
 ## Walking skeleton first
 
 Build a minimal end-to-end slice through the entire system before filling in

--- a/e2e_tests/sai_p4/fixed/metadata.p4
+++ b/e2e_tests/sai_p4/fixed/metadata.p4
@@ -101,18 +101,10 @@ header packet_in_header_t {
   // The initial intended egress port decided for the packet by the pipeline.
   @id(PACKET_IN_TARGET_EGRESS_PORT_ID)
   port_id_t target_egress_port;
-  // Padding field to align the header to 8-bit multiple, as required by BMv2.
-  // Carries no information.
-  //
-  // Contrary to the corresponding field in the `packet_out` header, we include
-  // this field only on BMv2, as clients will generally ignore this field anyhow
-  // and thus not observe this minor API deviation.
-  // TODO: Handle packet-in uniformly for all platforms.
-#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
+  // Padding field to align the header to an 8-bit multiple.
   @id(PACKET_IN_UNUSED_PAD_ID)
   @padding
   bit<6> unused_pad;
-#endif
 }
 
 @controller_header("packet_out")
@@ -140,13 +132,9 @@ header packet_out_header_t {
 
 // LINT.IfChange
 struct headers_t {
-// TODO: Clean up once we have better solution to handle packet-in
-// across platforms.
-#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
   // Never extracted during parsing, but serialized during deparsing for packets
   // punted to the controller.
   packet_in_header_t packet_in_header;
-#endif
 
   // PacketOut header; extracted only for packets received from the controller.
   packet_out_header_t packet_out_header;

--- a/e2e_tests/sai_p4/fixed/metadata.p4
+++ b/e2e_tests/sai_p4/fixed/metadata.p4
@@ -101,10 +101,12 @@ header packet_in_header_t {
   // The initial intended egress port decided for the packet by the pipeline.
   @id(PACKET_IN_TARGET_EGRESS_PORT_ID)
   port_id_t target_egress_port;
-  // Padding field to align the header to an 8-bit multiple.
+  // Padding field to align the header to an 8-bit multiple, as required by BMv2.
+#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
   @id(PACKET_IN_UNUSED_PAD_ID)
   @padding
   bit<6> unused_pad;
+#endif
 }
 
 @controller_header("packet_out")

--- a/e2e_tests/sai_p4/fixed/packet_io.p4
+++ b/e2e_tests/sai_p4/fixed/packet_io.p4
@@ -7,8 +7,6 @@
 #include "ids.h"
 #include "bmv2_intrinsics.h"
 
-// TODO: Clean up once we have better solution to handle packet-in
-// across platforms.
 control packet_in_encap(inout headers_t headers,
                         inout local_metadata_t local_metadata,
                         inout standard_metadata_t standard_metadata) {
@@ -25,7 +23,6 @@ control packet_in_encap(inout headers_t headers,
       // CPU-bound packets do not traverse the egress pipeline.
       local_metadata.bypass_egress = true;
 
-#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
       if (IS_PACKET_IN_COPY(standard_metadata)) {
         headers.packet_out_header.setInvalid();
         headers.packet_in_header = {
@@ -39,8 +36,7 @@ control packet_in_encap(inout headers_t headers,
         // local switch CPU.
         // From a modeling perspective, this is like dropping the packet.
         mark_to_drop(standard_metadata);
-      }    
-#endif
+      }
     }
   }
 }  // control populate_packet_in_header

--- a/e2e_tests/sai_p4/fixed/packet_io.p4
+++ b/e2e_tests/sai_p4/fixed/packet_io.p4
@@ -28,8 +28,10 @@ control packet_in_encap(inout headers_t headers,
         headers.packet_in_header = {
           ingress_port = (port_id_t) local_metadata.packet_in_ingress_port,
           target_egress_port =
-            (port_id_t) local_metadata.packet_in_target_egress_port,
-          unused_pad = 0
+            (port_id_t) local_metadata.packet_in_target_egress_port
+#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
+          , unused_pad = 0
+#endif
         };
       } else {
         // CPU-bound packets that are not packet-ins get terminated by the

--- a/e2e_tests/sai_p4/fixed/parser.p4
+++ b/e2e_tests/sai_p4/fixed/parser.p4
@@ -212,11 +212,7 @@ control packet_deparser(packet_out packet, in headers_t headers) {
     // We always expect the packet_out_header to be invalid at the end of the
     // pipeline, so this line has no effect on the output packet.
     packet.emit(headers.packet_out_header);
-// TODO: Clean up once we have better solution to handle packet-in
-// across platforms.
-#if defined(PLATFORM_BMV2) || defined(PLATFORM_P4SYMBOLIC)
     packet.emit(headers.packet_in_header);
-#endif
     packet.emit(headers.mirror_encap_ethernet);
     packet.emit(headers.mirror_encap_vlan);
     packet.emit(headers.mirror_encap_ipv6);

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -1,6 +1,7 @@
 package fourward.grpc
 
 import fourward.e2e.compileInlineP4
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -69,6 +70,128 @@ class InlineP4CompilerTest {
       val response = it.injectPacket(ingressPort = 0, payload = packet)
       val outputs = response.possibleOutcomesList.flatMap { it.packetsList }
       assertTrue("expected output on port 1", outputs.any { it.dataplaneEgressPort == 1 })
+    }
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `non-byte-aligned header emitted by deparser adds padding byte to output`() {
+    // A 6-bit header is not byte-aligned. The deparser pads it to 1 byte, so the
+    // output payload is 1 byte larger than the original packet.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header extra_t { bit<6> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { extra_t extra; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          sm.egress_spec = 1;
+          h.extra.setValid();
+          h.extra.value = 0x3F;
+        }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.extra); pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+      val packet = ByteArray(14) { 0xAB.toByte() }
+      val response = it.injectPacket(ingressPort = 0, payload = packet)
+      val output = response.possibleOutcomesList.single().packetsList.single()
+      val payload = output.payload.toByteArray()
+      // The 6-bit header is padded to 1 byte by the deparser, so the output is
+      // 15 bytes (1 header byte + 14 original) instead of the original 14.
+      assertEquals(
+        "deparser should pad 6-bit header to 1 byte, making output 15 bytes",
+        15,
+        payload.size,
+      )
+    }
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `non-byte-aligned header packs as continuous bit stream`() {
+    // A 6-bit tag header (value 0x3F = 0b111111) followed by a 14-byte ethernet header
+    // (dst = 0xAA repeated). Total: 6 + 112 = 118 bits = 15 bytes.
+    //
+    // Continuous bit stream (MSB-first):
+    //   byte 0 = tag[5:0] ++ eth_dst[47:46] = 111111_10 = 0xFE
+    //   byte 1 = eth_dst[45:38] = 10101010 = 0xAA
+    //   ... subsequent bytes bit-shifted by 2, with 2 trailing zero bits at the end.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header tag_t { bit<6> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { tag_t tag; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          sm.egress_spec = 1;
+          h.tag.setValid();
+          h.tag.value = 0x3F;
+        }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.tag); pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+      val packet =
+        byteArrayOf(
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0x08,
+          0x00,
+        )
+      val response = it.injectPacket(ingressPort = 0, payload = packet)
+      val output = response.possibleOutcomesList.single().packetsList.single()
+      val payload = output.payload.toByteArray()
+
+      assertEquals("output should be 15 bytes", 15, payload.size)
+
+      // Continuous bit stream: tag 0b111111 ++ ethernet dst 0xAA = 0b10101010...
+      // byte 0: 111111_10 = 0xFE
+      assertEquals("byte 0: tag bits + first 2 ethernet bits", 0xFE, payload[0].toInt() and 0xFF)
     }
   }
 }

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -114,13 +114,8 @@ class InlineP4CompilerTest {
       val response = it.injectPacket(ingressPort = 0, payload = packet)
       val output = response.possibleOutcomesList.single().packetsList.single()
       val payload = output.payload.toByteArray()
-      // The 6-bit header is padded to 1 byte by the deparser, so the output is
-      // 15 bytes (1 header byte + 14 original) instead of the original 14.
-      assertEquals(
-        "deparser should pad 6-bit header to 1 byte, making output 15 bytes",
-        15,
-        payload.size,
-      )
+      // 6 header bits + 112 ethernet bits = 118 bits → ceil(118/8) = 15 bytes.
+      assertEquals("output should be 15 bytes", 15, payload.size)
     }
   }
 
@@ -192,6 +187,153 @@ class InlineP4CompilerTest {
       // Continuous bit stream: tag 0b111111 ++ ethernet dst 0xAA = 0b10101010...
       // byte 0: 111111_10 = 0xFE
       assertEquals("byte 0: tag bits + first 2 ethernet bits", 0xFE, payload[0].toInt() and 0xFF)
+    }
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `byte-level stripping of non-byte-aligned header corrupts payload`() {
+    // Simulate what P4RuntimeService.buildPacketInResponses does: strip
+    // ceil(headerBits/8) bytes from the front of the deparsed payload.
+    //
+    // With a 6-bit controller header, the deparsed bit stream is:
+    //   bits: HHHHHH EEEEEEEE EEEEEEEE ... (6 header + 112 ethernet = 118 bits)
+    //   bytes: [HHHHHHEE] [EEEEEEEE] ... [EEEEEE00]  (15 bytes, 2 trailing pad bits)
+    //
+    // ByteString.substring(1) removes the first byte (8 bits), but only 6 were
+    // header — 2 bits of the ethernet frame are lost, and all remaining bytes are
+    // shifted by 2 relative to the original.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header tag_t { bit<6> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { tag_t tag; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          sm.egress_spec = 1;
+          h.tag.setValid();
+          h.tag.value = 0x3F;
+        }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.tag); pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+      // Use ethertype 0x0806 (ARP) so the last byte (0x06) makes corruption visible.
+      val packet =
+        byteArrayOf(
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0x08,
+          0x06,
+        )
+      val response = it.injectPacket(ingressPort = 0, payload = packet)
+      val output = response.possibleOutcomesList.single().packetsList.single()
+      val deparsed = output.payload
+
+      // Byte-level strip: remove ceil(6/8) = 1 byte.
+      val stripped = deparsed.substring(1)
+
+      // The stripped payload is 14 bytes — same size as the original.
+      assertEquals(14, stripped.size())
+      // But the last byte is corrupted. The original ends with 0x06 = 0b00000110.
+      // In the continuous bit stream, these 8 bits are shifted left by 2. The last
+      // deparsed byte contains the final 6 ethernet bits (000110) + 2 pad zeros
+      // = 0b00011000 = 0x18. After byte-level stripping, this becomes the last
+      // byte of the "recovered" payload — wrong.
+      val strippedBytes = stripped.toByteArray()
+      assertEquals(
+        "last byte should be corrupted: original 0x06 becomes 0x18 due to 2-bit shift",
+        0x18,
+        strippedBytes[13].toInt() and 0xFF,
+      )
+    }
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `parser extracts non-byte-aligned headers correctly`() {
+    // Parse a 4-bit tag followed by a 12-bit length field (= 16 bits total, byte-aligned
+    // as a pair but each sub-byte). Then parse ethernet.
+    // Ingress writes the parsed len value into ethernet etype for observability.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header tag_t { bit<4> value; }
+      header len_t { bit<12> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { tag_t tag; len_t len; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start {
+          pkt.extract(hdr.tag);
+          pkt.extract(hdr.len);
+          pkt.extract(hdr.eth);
+          transition accept;
+        }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          sm.egress_spec = 1;
+          h.eth.etype = (bit<16>) h.len.value;
+        }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+      // First 2 bytes: tag=0xA (4 bits) ++ length=0xBC3 (12 bits) = 0xABC3
+      // Bytes 2-15: ethernet header (14 bytes, all zeros)
+      val packet = byteArrayOf(0xAB.toByte(), 0xC3.toByte()) + ByteArray(14) { 0x00 }
+      val response = it.injectPacket(ingressPort = 0, payload = packet)
+      val output = response.possibleOutcomesList.single().packetsList.single()
+      val payload = output.payload.toByteArray()
+
+      // With correct bit-level parsing, the parser would consume exactly 16 bits
+      // (4 + 12) for tag+len, leaving 14 bytes for ethernet → 14-byte output.
+      // With the current byte-level parser, extracting the 4-bit tag consumes a
+      // full byte, so tag+len consume 3 bytes, leaving only 13 for ethernet.
+      assertEquals("output should be 14 bytes with correct bit-level parsing", 14, payload.size)
+
+      val etype = ((payload[12].toInt() and 0xFF) shl 8) or (payload[13].toInt() and 0xFF)
+      assertEquals("len should parse as 0xBC3 (written into etype)", 0x0BC3, etype)
     }
   }
 }

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -1,5 +1,6 @@
 package fourward.grpc
 
+import fourward.PipelineConfig
 import fourward.e2e.compileInlineP4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -9,63 +10,16 @@ class InlineP4CompilerTest {
 
   @Test
   fun `compiles minimal passthrough program`() {
-    val config =
-      compileInlineP4(
-        """
-      #include <core.p4>
-      #include <v1model.p4>
-
-      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
-      struct headers_t { ethernet_t eth; }
-      struct meta_t {}
-
-      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
-        state start { pkt.extract(hdr.eth); transition accept; }
-      }
-      control VC(inout headers_t h, inout meta_t m) { apply {} }
-      control CC(inout headers_t h, inout meta_t m) { apply {} }
-      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
-        apply { sm.egress_spec = 1; }
-      }
-      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
-      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
-      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
-      """
-      )
-
+    val config = compilePassthrough()
     assertTrue(config.hasP4Info())
     assertTrue(config.hasDevice())
   }
 
   @Test
   fun `compiled program runs in simulator`() {
-    val config =
-      compileInlineP4(
-        """
-      #include <core.p4>
-      #include <v1model.p4>
-
-      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
-      struct headers_t { ethernet_t eth; }
-      struct meta_t {}
-
-      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
-        state start { pkt.extract(hdr.eth); transition accept; }
-      }
-      control VC(inout headers_t h, inout meta_t m) { apply {} }
-      control CC(inout headers_t h, inout meta_t m) { apply {} }
-      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
-        apply { sm.egress_spec = 1; }
-      }
-      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
-      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
-      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
-      """
-      )
-
     val harness = FourwardTestHarness()
     harness.use {
-      it.loadPipeline(config)
+      it.loadPipeline(compilePassthrough())
       val packet = ByteArray(14) { 0xFF.toByte() }
       val response = it.injectPacket(ingressPort = 0, payload = packet)
       val outputs = response.possibleOutcomesList.flatMap { it.packetsList }
@@ -76,91 +30,25 @@ class InlineP4CompilerTest {
   @Test
   @Suppress("MagicNumber")
   fun `non-byte-aligned header in continuous bit stream increases output size`() {
-    // A 6-bit header is not byte-aligned. The deparser pads it to 1 byte, so the
-    // output payload is 1 byte larger than the original packet.
-    val config =
-      compileInlineP4(
-        """
-      #include <core.p4>
-      #include <v1model.p4>
-
-      header extra_t { bit<6> value; }
-      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
-      struct headers_t { extra_t extra; ethernet_t eth; }
-      struct meta_t {}
-
-      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
-        state start { pkt.extract(hdr.eth); transition accept; }
-      }
-      control VC(inout headers_t h, inout meta_t m) { apply {} }
-      control CC(inout headers_t h, inout meta_t m) { apply {} }
-      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
-        apply {
-          sm.egress_spec = 1;
-          h.extra.setValid();
-          h.extra.value = 0x3F;
-        }
-      }
-      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
-      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.extra); pkt.emit(h.eth); } }
-      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
-      """
-      )
-
     val harness = FourwardTestHarness()
     harness.use {
-      it.loadPipeline(config)
+      it.loadPipeline(compileSixBitTag())
       val packet = ByteArray(14) { 0xAB.toByte() }
       val response = it.injectPacket(ingressPort = 0, payload = packet)
       val output = response.possibleOutcomesList.single().packetsList.single()
-      val payload = output.payload.toByteArray()
       // 6 header bits + 112 ethernet bits = 118 bits → ceil(118/8) = 15 bytes.
-      assertEquals("output should be 15 bytes", 15, payload.size)
+      assertEquals("output should be 15 bytes", 15, output.payload.size())
     }
   }
 
   @Test
   @Suppress("MagicNumber")
   fun `non-byte-aligned header packs as continuous bit stream`() {
-    // A 6-bit tag header (value 0x3F = 0b111111) followed by a 14-byte ethernet header
-    // (dst = 0xAA repeated). Total: 6 + 112 = 118 bits = 15 bytes.
-    //
-    // Continuous bit stream (MSB-first):
-    //   byte 0 = tag[5:0] ++ eth_dst[47:46] = 111111_10 = 0xFE
-    //   byte 1 = eth_dst[45:38] = 10101010 = 0xAA
-    //   ... subsequent bytes bit-shifted by 2, with 2 trailing zero bits at the end.
-    val config =
-      compileInlineP4(
-        """
-      #include <core.p4>
-      #include <v1model.p4>
-
-      header tag_t { bit<6> value; }
-      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
-      struct headers_t { tag_t tag; ethernet_t eth; }
-      struct meta_t {}
-
-      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
-        state start { pkt.extract(hdr.eth); transition accept; }
-      }
-      control VC(inout headers_t h, inout meta_t m) { apply {} }
-      control CC(inout headers_t h, inout meta_t m) { apply {} }
-      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
-        apply {
-          sm.egress_spec = 1;
-          h.tag.setValid();
-          h.tag.value = 0x3F;
-        }
-      }
-      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
-      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.tag); pkt.emit(h.eth); } }
-      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
-      """
-      )
-
+    // A 6-bit tag (0x3F = 0b111111) followed by ethernet dst 0xAA (0b10101010).
+    // Continuous bit stream byte 0: 111111_10 = 0xFE.
     val harness = FourwardTestHarness()
     harness.use {
-      it.loadPipeline(config)
+      it.loadPipeline(compileSixBitTag())
       val packet =
         byteArrayOf(
           0xAA.toByte(),
@@ -179,13 +67,10 @@ class InlineP4CompilerTest {
           0x00,
         )
       val response = it.injectPacket(ingressPort = 0, payload = packet)
-      val output = response.possibleOutcomesList.single().packetsList.single()
-      val payload = output.payload.toByteArray()
+      val payload =
+        response.possibleOutcomesList.single().packetsList.single().payload.toByteArray()
 
       assertEquals("output should be 15 bytes", 15, payload.size)
-
-      // Continuous bit stream: tag 0b111111 ++ ethernet dst 0xAA = 0b10101010...
-      // byte 0: 111111_10 = 0xFE
       assertEquals("byte 0: tag bits + first 2 ethernet bits", 0xFE, payload[0].toInt() and 0xFF)
     }
   }
@@ -193,49 +78,12 @@ class InlineP4CompilerTest {
   @Test
   @Suppress("MagicNumber")
   fun `byte-level stripping of non-byte-aligned header corrupts payload`() {
-    // Simulate what P4RuntimeService.buildPacketInResponses does: strip
-    // ceil(headerBits/8) bytes from the front of the deparsed payload.
-    //
-    // With a 6-bit controller header, the deparsed bit stream is:
-    //   bits: HHHHHH EEEEEEEE EEEEEEEE ... (6 header + 112 ethernet = 118 bits)
-    //   bytes: [HHHHHHEE] [EEEEEEEE] ... [EEEEEE00]  (15 bytes, 2 trailing pad bits)
-    //
-    // ByteString.substring(1) removes the first byte (8 bits), but only 6 were
-    // header — 2 bits of the ethernet frame are lost, and all remaining bytes are
-    // shifted by 2 relative to the original.
-    val config =
-      compileInlineP4(
-        """
-      #include <core.p4>
-      #include <v1model.p4>
-
-      header tag_t { bit<6> value; }
-      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
-      struct headers_t { tag_t tag; ethernet_t eth; }
-      struct meta_t {}
-
-      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
-        state start { pkt.extract(hdr.eth); transition accept; }
-      }
-      control VC(inout headers_t h, inout meta_t m) { apply {} }
-      control CC(inout headers_t h, inout meta_t m) { apply {} }
-      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
-        apply {
-          sm.egress_spec = 1;
-          h.tag.setValid();
-          h.tag.value = 0x3F;
-        }
-      }
-      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
-      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.tag); pkt.emit(h.eth); } }
-      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
-      """
-      )
-
+    // With a 6-bit header, ByteString.substring(1) strips 8 bits instead of 6,
+    // losing 2 payload bits and shifting all subsequent bytes.
     val harness = FourwardTestHarness()
     harness.use {
-      it.loadPipeline(config)
-      // Use ethertype 0x0806 (ARP) so the last byte (0x06) makes corruption visible.
+      it.loadPipeline(compileSixBitTag())
+      // Ethertype 0x0806 so the last byte (0x06) makes corruption visible.
       val packet =
         byteArrayOf(
           0xAA.toByte(),
@@ -254,24 +102,15 @@ class InlineP4CompilerTest {
           0x06,
         )
       val response = it.injectPacket(ingressPort = 0, payload = packet)
-      val output = response.possibleOutcomesList.single().packetsList.single()
-      val deparsed = output.payload
+      val deparsed = response.possibleOutcomesList.single().packetsList.single().payload
 
-      // Byte-level strip: remove ceil(6/8) = 1 byte.
       val stripped = deparsed.substring(1)
-
-      // The stripped payload is 14 bytes — same size as the original.
       assertEquals(14, stripped.size())
-      // But the last byte is corrupted. The original ends with 0x06 = 0b00000110.
-      // In the continuous bit stream, these 8 bits are shifted left by 2. The last
-      // deparsed byte contains the final 6 ethernet bits (000110) + 2 pad zeros
-      // = 0b00011000 = 0x18. After byte-level stripping, this becomes the last
-      // byte of the "recovered" payload — wrong.
-      val strippedBytes = stripped.toByteArray()
+      // Original last byte 0x06 = 0b00000110 becomes 0b00011000 = 0x18 after 2-bit shift.
       assertEquals(
-        "last byte should be corrupted: original 0x06 becomes 0x18 due to 2-bit shift",
+        "last byte corrupted: 0x06 becomes 0x18 due to 2-bit shift",
         0x18,
-        strippedBytes[13].toInt() and 0xFF,
+        stripped.toByteArray()[13].toInt() and 0xFF,
       )
     }
   }
@@ -279,9 +118,8 @@ class InlineP4CompilerTest {
   @Test
   @Suppress("MagicNumber")
   fun `parser extracts non-byte-aligned headers correctly`() {
-    // Parse a 4-bit tag followed by a 12-bit length field (= 16 bits total, byte-aligned
-    // as a pair but each sub-byte). Then parse ethernet.
-    // Ingress writes the parsed len value into ethernet etype for observability.
+    // Parse a 4-bit tag followed by a 12-bit length (16 bits total, byte-aligned as a pair
+    // but each sub-byte). Ingress writes the parsed len into ethernet etype for observability.
     val config =
       compileInlineP4(
         """
@@ -319,21 +157,70 @@ class InlineP4CompilerTest {
     val harness = FourwardTestHarness()
     harness.use {
       it.loadPipeline(config)
-      // First 2 bytes: tag=0xA (4 bits) ++ length=0xBC3 (12 bits) = 0xABC3
-      // Bytes 2-15: ethernet header (14 bytes, all zeros)
+      // tag=0xA (4 bits) ++ length=0xBC3 (12 bits) = 0xABC3, then 14 zero bytes for ethernet.
       val packet = byteArrayOf(0xAB.toByte(), 0xC3.toByte()) + ByteArray(14) { 0x00 }
       val response = it.injectPacket(ingressPort = 0, payload = packet)
-      val output = response.possibleOutcomesList.single().packetsList.single()
-      val payload = output.payload.toByteArray()
+      val payload =
+        response.possibleOutcomesList.single().packetsList.single().payload.toByteArray()
 
-      // With correct bit-level parsing, the parser would consume exactly 16 bits
-      // (4 + 12) for tag+len, leaving 14 bytes for ethernet → 14-byte output.
-      // With the current byte-level parser, extracting the 4-bit tag consumes a
-      // full byte, so tag+len consume 3 bytes, leaving only 13 for ethernet.
       assertEquals("output should be 14 bytes with correct bit-level parsing", 14, payload.size)
-
       val etype = ((payload[12].toInt() and 0xFF) shl 8) or (payload[13].toInt() and 0xFF)
       assertEquals("len should parse as 0xBC3 (written into etype)", 0x0BC3, etype)
     }
+  }
+
+  companion object {
+    private fun compilePassthrough(): PipelineConfig =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 1; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    private fun compileSixBitTag(): PipelineConfig =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header tag_t { bit<6> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { tag_t tag; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          sm.egress_spec = 1;
+          h.tag.setValid();
+          h.tag.value = 0x3F;
+        }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.tag); pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
   }
 }

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -336,4 +336,66 @@ class InlineP4CompilerTest {
       assertEquals("len should parse as 0xBC3 (written into etype)", 0x0BC3, etype)
     }
   }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `unparsed remainder after sub-byte extract is preserved`() {
+    // Parse a 4-bit tag from byte 0, leave the remaining 12 bits + bytes 1..13 unparsed.
+    // The deparser emits nothing — the output should be the unparsed remainder, which
+    // starts at bit 4 of the input. On a real target the output is a continuous bit
+    // stream: the 4 remaining bits of byte 0 followed by bytes 1..13, totaling
+    // 4 + 13*8 = 108 bits = 14 bytes (with 4 trailing pad bits).
+    //
+    // If drainRemainingInput() rounds up to the next byte boundary, it skips the
+    // remaining 4 bits of byte 0 and returns only bytes 1..13 = 13 bytes.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header tag_t { bit<4> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { tag_t tag; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start {
+          pkt.extract(hdr.tag);
+          transition accept;
+        }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 1; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply {} }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+      // Byte 0 = 0xAB = 0b10101011. Tag extracts top 4 bits (0xA).
+      // Remaining: 0b1011 ++ bytes 1..13.
+      val packet = byteArrayOf(0xAB.toByte()) + ByteArray(13) { 0xFF.toByte() }
+      val response = it.injectPacket(ingressPort = 0, payload = packet)
+      val output = response.possibleOutcomesList.single().packetsList.single()
+      val payload = output.payload.toByteArray()
+
+      // The deparser emits 0 bits. The output should be the unparsed remainder:
+      // 4 bits from byte 0 (0b1011) + 13 bytes (0xFF each) = 108 bits = 14 bytes
+      // (with 4 trailing pad bits). The first byte should be 0b1011_1111 = 0xBF
+      // (4 remaining bits from byte 0 + first 4 bits of byte 1 = 0xFF).
+      assertEquals("output should preserve all unparsed bits (14 bytes)", 14, payload.size)
+      assertEquals(
+        "first byte should be 0xBF (remaining 4 bits of byte 0 + start of byte 1)",
+        0xBF,
+        payload[0].toInt() and 0xFF,
+      )
+    }
+  }
 }

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -1,6 +1,5 @@
 package fourward.grpc
 
-import fourward.PipelineConfig
 import fourward.e2e.compileInlineP4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -10,16 +9,63 @@ class InlineP4CompilerTest {
 
   @Test
   fun `compiles minimal passthrough program`() {
-    val config = compilePassthrough()
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 1; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
     assertTrue(config.hasP4Info())
     assertTrue(config.hasDevice())
   }
 
   @Test
   fun `compiled program runs in simulator`() {
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 1; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
     val harness = FourwardTestHarness()
     harness.use {
-      it.loadPipeline(compilePassthrough())
+      it.loadPipeline(config)
       val packet = ByteArray(14) { 0xFF.toByte() }
       val response = it.injectPacket(ingressPort = 0, payload = packet)
       val outputs = response.possibleOutcomesList.flatMap { it.packetsList }
@@ -30,25 +76,91 @@ class InlineP4CompilerTest {
   @Test
   @Suppress("MagicNumber")
   fun `non-byte-aligned header in continuous bit stream increases output size`() {
+    // A 6-bit header is not byte-aligned. The deparser pads it to 1 byte, so the
+    // output payload is 1 byte larger than the original packet.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header extra_t { bit<6> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { extra_t extra; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          sm.egress_spec = 1;
+          h.extra.setValid();
+          h.extra.value = 0x3F;
+        }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.extra); pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
     val harness = FourwardTestHarness()
     harness.use {
-      it.loadPipeline(compileSixBitTag())
+      it.loadPipeline(config)
       val packet = ByteArray(14) { 0xAB.toByte() }
       val response = it.injectPacket(ingressPort = 0, payload = packet)
       val output = response.possibleOutcomesList.single().packetsList.single()
+      val payload = output.payload.toByteArray()
       // 6 header bits + 112 ethernet bits = 118 bits → ceil(118/8) = 15 bytes.
-      assertEquals("output should be 15 bytes", 15, output.payload.size())
+      assertEquals("output should be 15 bytes", 15, payload.size)
     }
   }
 
   @Test
   @Suppress("MagicNumber")
   fun `non-byte-aligned header packs as continuous bit stream`() {
-    // A 6-bit tag (0x3F = 0b111111) followed by ethernet dst 0xAA (0b10101010).
-    // Continuous bit stream byte 0: 111111_10 = 0xFE.
+    // A 6-bit tag header (value 0x3F = 0b111111) followed by a 14-byte ethernet header
+    // (dst = 0xAA repeated). Total: 6 + 112 = 118 bits = 15 bytes.
+    //
+    // Continuous bit stream (MSB-first):
+    //   byte 0 = tag[5:0] ++ eth_dst[47:46] = 111111_10 = 0xFE
+    //   byte 1 = eth_dst[45:38] = 10101010 = 0xAA
+    //   ... subsequent bytes bit-shifted by 2, with 2 trailing zero bits at the end.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header tag_t { bit<6> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { tag_t tag; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          sm.egress_spec = 1;
+          h.tag.setValid();
+          h.tag.value = 0x3F;
+        }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.tag); pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
     val harness = FourwardTestHarness()
     harness.use {
-      it.loadPipeline(compileSixBitTag())
+      it.loadPipeline(config)
       val packet =
         byteArrayOf(
           0xAA.toByte(),
@@ -67,10 +179,13 @@ class InlineP4CompilerTest {
           0x00,
         )
       val response = it.injectPacket(ingressPort = 0, payload = packet)
-      val payload =
-        response.possibleOutcomesList.single().packetsList.single().payload.toByteArray()
+      val output = response.possibleOutcomesList.single().packetsList.single()
+      val payload = output.payload.toByteArray()
 
       assertEquals("output should be 15 bytes", 15, payload.size)
+
+      // Continuous bit stream: tag 0b111111 ++ ethernet dst 0xAA = 0b10101010...
+      // byte 0: 111111_10 = 0xFE
       assertEquals("byte 0: tag bits + first 2 ethernet bits", 0xFE, payload[0].toInt() and 0xFF)
     }
   }
@@ -78,12 +193,49 @@ class InlineP4CompilerTest {
   @Test
   @Suppress("MagicNumber")
   fun `byte-level stripping of non-byte-aligned header corrupts payload`() {
-    // With a 6-bit header, ByteString.substring(1) strips 8 bits instead of 6,
-    // losing 2 payload bits and shifting all subsequent bytes.
+    // Simulate what P4RuntimeService.buildPacketInResponses does: strip
+    // ceil(headerBits/8) bytes from the front of the deparsed payload.
+    //
+    // With a 6-bit controller header, the deparsed bit stream is:
+    //   bits: HHHHHH EEEEEEEE EEEEEEEE ... (6 header + 112 ethernet = 118 bits)
+    //   bytes: [HHHHHHEE] [EEEEEEEE] ... [EEEEEE00]  (15 bytes, 2 trailing pad bits)
+    //
+    // ByteString.substring(1) removes the first byte (8 bits), but only 6 were
+    // header — 2 bits of the ethernet frame are lost, and all remaining bytes are
+    // shifted by 2 relative to the original.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      header tag_t { bit<6> value; }
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { tag_t tag; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          sm.egress_spec = 1;
+          h.tag.setValid();
+          h.tag.value = 0x3F;
+        }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.tag); pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
     val harness = FourwardTestHarness()
     harness.use {
-      it.loadPipeline(compileSixBitTag())
-      // Ethertype 0x0806 so the last byte (0x06) makes corruption visible.
+      it.loadPipeline(config)
+      // Use ethertype 0x0806 (ARP) so the last byte (0x06) makes corruption visible.
       val packet =
         byteArrayOf(
           0xAA.toByte(),
@@ -102,15 +254,24 @@ class InlineP4CompilerTest {
           0x06,
         )
       val response = it.injectPacket(ingressPort = 0, payload = packet)
-      val deparsed = response.possibleOutcomesList.single().packetsList.single().payload
+      val output = response.possibleOutcomesList.single().packetsList.single()
+      val deparsed = output.payload
 
+      // Byte-level strip: remove ceil(6/8) = 1 byte.
       val stripped = deparsed.substring(1)
+
+      // The stripped payload is 14 bytes — same size as the original.
       assertEquals(14, stripped.size())
-      // Original last byte 0x06 = 0b00000110 becomes 0b00011000 = 0x18 after 2-bit shift.
+      // But the last byte is corrupted. The original ends with 0x06 = 0b00000110.
+      // In the continuous bit stream, these 8 bits are shifted left by 2. The last
+      // deparsed byte contains the final 6 ethernet bits (000110) + 2 pad zeros
+      // = 0b00011000 = 0x18. After byte-level stripping, this becomes the last
+      // byte of the "recovered" payload — wrong.
+      val strippedBytes = stripped.toByteArray()
       assertEquals(
-        "last byte corrupted: 0x06 becomes 0x18 due to 2-bit shift",
+        "last byte should be corrupted: original 0x06 becomes 0x18 due to 2-bit shift",
         0x18,
-        stripped.toByteArray()[13].toInt() and 0xFF,
+        strippedBytes[13].toInt() and 0xFF,
       )
     }
   }
@@ -118,8 +279,9 @@ class InlineP4CompilerTest {
   @Test
   @Suppress("MagicNumber")
   fun `parser extracts non-byte-aligned headers correctly`() {
-    // Parse a 4-bit tag followed by a 12-bit length (16 bits total, byte-aligned as a pair
-    // but each sub-byte). Ingress writes the parsed len into ethernet etype for observability.
+    // Parse a 4-bit tag followed by a 12-bit length field (= 16 bits total, byte-aligned
+    // as a pair but each sub-byte). Then parse ethernet.
+    // Ingress writes the parsed len value into ethernet etype for observability.
     val config =
       compileInlineP4(
         """
@@ -157,70 +319,21 @@ class InlineP4CompilerTest {
     val harness = FourwardTestHarness()
     harness.use {
       it.loadPipeline(config)
-      // tag=0xA (4 bits) ++ length=0xBC3 (12 bits) = 0xABC3, then 14 zero bytes for ethernet.
+      // First 2 bytes: tag=0xA (4 bits) ++ length=0xBC3 (12 bits) = 0xABC3
+      // Bytes 2-15: ethernet header (14 bytes, all zeros)
       val packet = byteArrayOf(0xAB.toByte(), 0xC3.toByte()) + ByteArray(14) { 0x00 }
       val response = it.injectPacket(ingressPort = 0, payload = packet)
-      val payload =
-        response.possibleOutcomesList.single().packetsList.single().payload.toByteArray()
+      val output = response.possibleOutcomesList.single().packetsList.single()
+      val payload = output.payload.toByteArray()
 
+      // With correct bit-level parsing, the parser would consume exactly 16 bits
+      // (4 + 12) for tag+len, leaving 14 bytes for ethernet → 14-byte output.
+      // With the current byte-level parser, extracting the 4-bit tag consumes a
+      // full byte, so tag+len consume 3 bytes, leaving only 13 for ethernet.
       assertEquals("output should be 14 bytes with correct bit-level parsing", 14, payload.size)
+
       val etype = ((payload[12].toInt() and 0xFF) shl 8) or (payload[13].toInt() and 0xFF)
       assertEquals("len should parse as 0xBC3 (written into etype)", 0x0BC3, etype)
     }
-  }
-
-  companion object {
-    private fun compilePassthrough(): PipelineConfig =
-      compileInlineP4(
-        """
-      #include <core.p4>
-      #include <v1model.p4>
-
-      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
-      struct headers_t { ethernet_t eth; }
-      struct meta_t {}
-
-      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
-        state start { pkt.extract(hdr.eth); transition accept; }
-      }
-      control VC(inout headers_t h, inout meta_t m) { apply {} }
-      control CC(inout headers_t h, inout meta_t m) { apply {} }
-      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
-        apply { sm.egress_spec = 1; }
-      }
-      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
-      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
-      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
-      """
-      )
-
-    private fun compileSixBitTag(): PipelineConfig =
-      compileInlineP4(
-        """
-      #include <core.p4>
-      #include <v1model.p4>
-
-      header tag_t { bit<6> value; }
-      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
-      struct headers_t { tag_t tag; ethernet_t eth; }
-      struct meta_t {}
-
-      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
-        state start { pkt.extract(hdr.eth); transition accept; }
-      }
-      control VC(inout headers_t h, inout meta_t m) { apply {} }
-      control CC(inout headers_t h, inout meta_t m) { apply {} }
-      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
-        apply {
-          sm.egress_spec = 1;
-          h.tag.setValid();
-          h.tag.value = 0x3F;
-        }
-      }
-      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
-      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.tag); pkt.emit(h.eth); } }
-      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
-      """
-      )
   }
 }

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -75,7 +75,7 @@ class InlineP4CompilerTest {
 
   @Test
   @Suppress("MagicNumber")
-  fun `non-byte-aligned header emitted by deparser adds padding byte to output`() {
+  fun `non-byte-aligned header in continuous bit stream increases output size`() {
     // A 6-bit header is not byte-aligned. The deparser pads it to 1 byte, so the
     // output payload is 1 byte larger than the original packet.
     val config =

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -707,8 +707,10 @@ class P4RuntimeService(
       .filter { it.dataplaneEgressPort == cpuPort }
       .map { outputPacket ->
         val metadata = codec.buildPacketInMetadata(ingressPort, outputPacket.dataplaneEgressPort)
-        val rawPacketIn =
-          PacketIn.newBuilder().setPayload(outputPacket.payload).addAllMetadata(metadata).build()
+        // The deparser emits the @controller_header("packet_in") as part of the
+        // payload. Strip it — metadata is constructed from the simulation context.
+        val payload = outputPacket.payload.substring(codec.packetInHeaderBytes)
+        val rawPacketIn = PacketIn.newBuilder().setPayload(payload).addAllMetadata(metadata).build()
         StreamMessageResponse.newBuilder()
           .setPacket(translator?.translatePacketIn(rawPacketIn) ?: rawPacketIn)
           .build()

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -709,7 +709,7 @@ class P4RuntimeService(
         val metadata = codec.buildPacketInMetadata(ingressPort, outputPacket.dataplaneEgressPort)
         // The deparser emits the @controller_header("packet_in") as part of the
         // payload. Strip it — metadata is constructed from the simulation context.
-        val payload = outputPacket.payload.substring(codec.packetInHeaderBytes)
+        val payload = codec.stripPacketInHeader(outputPacket.payload)
         val rawPacketIn = PacketIn.newBuilder().setPayload(payload).addAllMetadata(metadata).build()
         StreamMessageResponse.newBuilder()
           .setPacket(translator?.translatePacketIn(rawPacketIn) ?: rawPacketIn)

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -179,24 +179,7 @@ private constructor(
           )
         } ?: emptyList()
 
-      // The deparser emits the full header type (including @padding fields). Byte
-      // alignment is required so that stripping the header preserves the remaining
-      // payload byte-for-byte. Validate using the behavioral config widths, which
-      // include @padding fields that p4info metadata may omit.
-      requireByteAligned("packet_out_header_t", packetOutType)
-      requireByteAligned("packet_in_header_t", packetInType)
-
       return PacketHeaderCodec(packetOutFields, packetInFields, cpuPort)
-    }
-
-    @Suppress("MagicNumber")
-    private fun requireByteAligned(headerName: String, fieldWidths: Map<String, Int>?) {
-      if (fieldWidths == null) return
-      val totalBits = fieldWidths.values.sum()
-      require(totalBits % 8 == 0) {
-        "@controller_header $headerName is $totalBits bits, which is not byte-aligned. " +
-          "Add a @padding field to round to a multiple of 8."
-      }
     }
 
     private const val DEFAULT_PORT_BITS = 9

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -72,7 +72,10 @@ private constructor(
   /** Total bytes of the serialized packet_out header. */
   val packetOutHeaderBytes: Int = (packetOutFields.sumOf { it.bitWidth } + 7) / 8
 
-  /** Total bits of the serialized packet_in header. */
+  /**
+   * Total bits of the serialized packet_in header, derived from p4info field widths. Correctness
+   * depends on p4info matching the behavioral config's `packet_in_header_t` type definition.
+   */
   val packetInHeaderBits: Int = packetInFields.sumOf { it.bitWidth }
 
   /** Total bytes of the serialized packet_in header (stripped from deparsed payload on punt). */
@@ -93,8 +96,9 @@ private constructor(
     // Bit-level strip: remove exactly packetInHeaderBits from the front of the
     // continuous bit stream and repack the remaining bits into bytes.
     val bytes = payload.toByteArray()
-    // The original payload was N whole bytes. The deparsed stream is
-    // ceil((headerBits + N*8) / 8) bytes. Recover N by integer division.
+    // Assumes the original payload was N whole bytes. The deparsed stream is
+    // ceil((headerBits + N*8) / 8) bytes. We recover N via integer division,
+    // which truncates any sub-byte remainder — only whole payload bytes survive.
     val payloadBits = (bytes.size * 8 - packetInHeaderBits) / 8 * 8
     if (payloadBits <= 0) return ByteString.EMPTY
     val outBytes = payloadBits / 8

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -6,6 +6,7 @@
 
 package fourward.grpc
 
+import com.google.protobuf.ByteString
 import fourward.BehavioralConfig
 import fourward.Type
 import p4.config.v1.P4InfoOuterClass.P4Info
@@ -71,8 +72,46 @@ private constructor(
   /** Total bytes of the serialized packet_out header. */
   val packetOutHeaderBytes: Int = (packetOutFields.sumOf { it.bitWidth } + 7) / 8
 
+  /** Total bits of the serialized packet_in header. */
+  val packetInHeaderBits: Int = packetInFields.sumOf { it.bitWidth }
+
   /** Total bytes of the serialized packet_in header (stripped from deparsed payload on punt). */
-  val packetInHeaderBytes: Int = (packetInFields.sumOf { it.bitWidth } + 7) / 8
+  val packetInHeaderBytes: Int = (packetInHeaderBits + 7) / 8
+
+  /**
+   * Strips the `@controller_header("packet_in")` from the front of a deparsed payload.
+   *
+   * The deparser emits the controller header as a continuous bit stream before the remaining packet
+   * headers. This method removes exactly [packetInHeaderBits] bits from the front and returns the
+   * remaining payload, byte-aligned with trailing zero padding.
+   */
+  @Suppress("MagicNumber")
+  fun stripPacketInHeader(payload: ByteString): ByteString {
+    if (packetInHeaderBits == 0) return payload
+    // Fast path: byte-aligned header, no bit-shifting needed.
+    if (packetInHeaderBits % 8 == 0) return payload.substring(packetInHeaderBytes)
+    // Bit-level strip: remove exactly packetInHeaderBits from the front of the
+    // continuous bit stream and repack the remaining bits into bytes.
+    val bytes = payload.toByteArray()
+    // The original payload was N whole bytes. The deparsed stream is
+    // ceil((headerBits + N*8) / 8) bytes. Recover N by integer division.
+    val payloadBits = (bytes.size * 8 - packetInHeaderBits) / 8 * 8
+    if (payloadBits <= 0) return ByteString.EMPTY
+    val outBytes = payloadBits / 8
+    val result = ByteArray(outBytes)
+    val skipBits = packetInHeaderBits
+    for (i in 0 until outBytes) {
+      val bitPos = skipBits + i * 8
+      val byteIdx = bitPos / 8
+      val bitOff = bitPos % 8
+      var value = (bytes[byteIdx].toInt() and 0xFF) shl bitOff
+      if (bitOff > 0 && byteIdx + 1 < bytes.size) {
+        value = value or ((bytes[byteIdx + 1].toInt() and 0xFF) ushr (8 - bitOff))
+      }
+      result[i] = (value and 0xFF).toByte()
+    }
+    return ByteString.copyFrom(result)
+  }
 
   /** Packs PacketOut metadata into a bit-packed binary header. */
   fun serializePacketOut(metadata: List<PacketMetadata>): ByteArray {

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -71,6 +71,9 @@ private constructor(
   /** Total bytes of the serialized packet_out header. */
   val packetOutHeaderBytes: Int = (packetOutFields.sumOf { it.bitWidth } + 7) / 8
 
+  /** Total bytes of the serialized packet_in header (stripped from deparsed payload on punt). */
+  val packetInHeaderBytes: Int = (packetInFields.sumOf { it.bitWidth } + 7) / 8
+
   /** Packs PacketOut metadata into a bit-packed binary header. */
   fun serializePacketOut(metadata: List<PacketMetadata>): ByteArray {
     val metadataById = metadata.associateBy { it.metadataId }
@@ -80,8 +83,9 @@ private constructor(
   /**
    * Builds PacketIn metadata from ingress and egress port values.
    *
-   * On non-BMv2 platforms, the P4 program does not prepend a packet_in header to CPU-bound packets.
-   * Instead, the service constructs metadata from the simulation context.
+   * Metadata is constructed from the simulation context rather than parsed from the deparsed
+   * payload. The caller is responsible for stripping the `@controller_header("packet_in")` bytes
+   * from the payload (see [packetInHeaderBytes]).
    */
   fun buildPacketInMetadata(ingressPort: Int, egressPort: Int): List<PacketMetadata> =
     packetInFields.map { field ->
@@ -175,7 +179,24 @@ private constructor(
           )
         } ?: emptyList()
 
+      // The deparser emits the full header type (including @padding fields). Byte
+      // alignment is required so that stripping the header preserves the remaining
+      // payload byte-for-byte. Validate using the behavioral config widths, which
+      // include @padding fields that p4info metadata may omit.
+      requireByteAligned("packet_out_header_t", packetOutType)
+      requireByteAligned("packet_in_header_t", packetInType)
+
       return PacketHeaderCodec(packetOutFields, packetInFields, cpuPort)
+    }
+
+    @Suppress("MagicNumber")
+    private fun requireByteAligned(headerName: String, fieldWidths: Map<String, Int>?) {
+      if (fieldWidths == null) return
+      val totalBits = fieldWidths.values.sum()
+      require(totalBits % 8 == 0) {
+        "@controller_header $headerName is $totalBits bits, which is not byte-aligned. " +
+          "Add a @padding field to round to a multiple of 8."
+      }
     }
 
     private const val DEFAULT_PORT_BITS = 9

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -157,6 +157,83 @@ class PacketHeaderCodecTest {
   }
 
   // =========================================================================
+  // stripPacketInHeader
+  // =========================================================================
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `stripPacketInHeader removes byte-aligned header correctly`() {
+    val (p4info, behavioral) = buildSaiLikeConfig()
+    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    // 24-bit header (3 bytes) + 4-byte payload = 7 bytes total.
+    val deparsed =
+      com.google.protobuf.ByteString.copyFrom(
+        byteArrayOf(0x00, 0x00, 0x00, 0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+      )
+    val stripped = codec.stripPacketInHeader(deparsed)
+    assertArrayEquals(
+      byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte()),
+      stripped.toByteArray(),
+    )
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `stripPacketInHeader handles non-byte-aligned header`() {
+    // 10-bit packet_in header (two 5-bit fields). The deparsed bit stream has
+    // the 10 header bits followed by the payload bits, packed continuously.
+    //
+    // Header: 10 bits of zeros. Payload: 0xDE 0xAD = 16 bits.
+    // Bit stream: 0000000000_11011110_10101101 + 6 pad zeros = 32 bits = 4 bytes.
+    // = 00000000 00110111 10101011 01000000
+    // = 0x00     0x37     0xAB     0x40
+    //
+    // After stripping 10 header bits, we should recover: 0xDE 0xAD (16 bits → 2 bytes).
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(2, "field_a", 5))
+            .addMetadata(metaWithBitwidth(3, "field_b", 5))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_in_header_t")
+            .setHeader(
+              HeaderDecl.newBuilder()
+                .addFields(bitField("field_a", 5))
+                .addFields(bitField("field_b", 5))
+            )
+        )
+        .build()
+    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    assertEquals(10, codec.packetInHeaderBits)
+
+    val deparsed =
+      com.google.protobuf.ByteString.copyFrom(byteArrayOf(0x00, 0x37, 0xAB.toByte(), 0x40))
+    val stripped = codec.stripPacketInHeader(deparsed)
+    assertArrayEquals(
+      "should recover original 0xDEAD after stripping 10-bit header",
+      byteArrayOf(0xDE.toByte(), 0xAD.toByte()),
+      stripped.toByteArray(),
+    )
+  }
+
+  // =========================================================================
   // Helpers
   // =========================================================================
 

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -245,46 +245,6 @@ class PacketHeaderCodecTest {
       .build()
 
   // =========================================================================
-  // Byte-alignment validation
-  // =========================================================================
-
-  @Test(expected = IllegalArgumentException::class)
-  @Suppress("MagicNumber")
-  fun `create rejects non-byte-aligned packet_in header`() {
-    val p4info =
-      P4Info.newBuilder()
-        .addControllerPacketMetadata(
-          ControllerPacketMetadata.newBuilder()
-            .setPreamble(Preamble.newBuilder().setName("packet_out"))
-            .addMetadata(meta(1, "egress_port"))
-        )
-        .addControllerPacketMetadata(
-          ControllerPacketMetadata.newBuilder()
-            .setPreamble(Preamble.newBuilder().setName("packet_in"))
-            .addMetadata(meta(2, "ingress_port"))
-        )
-        .build()
-    val behavioral =
-      BehavioralConfig.newBuilder()
-        .addTypes(
-          TypeDecl.newBuilder()
-            .setName("packet_out_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
-        )
-        .addTypes(
-          TypeDecl.newBuilder()
-            .setName("packet_in_header_t")
-            .setHeader(
-              HeaderDecl.newBuilder()
-                .addFields(bitField("ingress_port", 9))
-                .addFields(bitField("target_egress_port", 9))
-            )
-        )
-        .build()
-    PacketHeaderCodec.create(p4info, behavioral)
-  }
-
-  // =========================================================================
   // CPU port override
   // =========================================================================
 

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -47,6 +47,8 @@ class PacketHeaderCodecTest {
     val codec = PacketHeaderCodec.create(p4info, behavioral)
     assertNotNull(codec)
     assertEquals(2, codec!!.packetOutHeaderBytes)
+    // packet_in: 9-bit ingress_port + 9-bit target_egress_port = 18 bits = 3 bytes
+    assertEquals(3, codec.packetInHeaderBytes)
     // CPU port = 2^9 - 2 = 510
     assertEquals(510, codec.cpuPort)
   }
@@ -137,7 +139,7 @@ class PacketHeaderCodecTest {
     val codec = PacketHeaderCodec.create(p4info, behavioral)!!
 
     val metadata = codec.buildPacketInMetadata(ingressPort = 510, egressPort = 1)
-    assertEquals(2, metadata.size)
+    assertEquals(3, metadata.size)
 
     // First field = ingress_port (metadata_id=3 in our test config)
     assertEquals(3, metadata[0].metadataId)
@@ -148,6 +150,10 @@ class PacketHeaderCodecTest {
     assertEquals(4, metadata[1].metadataId)
     val egressBytes = metadata[1].value.toByteArray()
     assertEquals(1, bytesToInt(egressBytes))
+
+    // Third field = unused_pad (metadata_id=5) — always 0
+    assertEquals(5, metadata[2].metadataId)
+    assertEquals(0, bytesToInt(metadata[2].value.toByteArray()))
   }
 
   // =========================================================================
@@ -168,8 +174,8 @@ class PacketHeaderCodecTest {
 
   /**
    * Builds a SAI-like p4info + behavioral config:
-   * - packet_out: egress_port (9-bit, id=1), submit_to_ingress (1-bit, id=2)
-   * - packet_in: ingress_port (9-bit, id=3), target_egress_port (9-bit, id=4)
+   * - packet_out: egress_port (9-bit, id=1), submit_to_ingress (1-bit, id=2), unused_pad (6-bit)
+   * - packet_in: ingress_port (9-bit, id=3), target_egress_port (9-bit, id=4), unused_pad (6-bit)
    * - Behavioral config with header types for field width resolution.
    */
   @Suppress("MagicNumber")
@@ -187,6 +193,7 @@ class PacketHeaderCodecTest {
             .setPreamble(Preamble.newBuilder().setName("packet_in"))
             .addMetadata(meta(3, "ingress_port"))
             .addMetadata(meta(4, "target_egress_port"))
+            .addMetadata(metaWithBitwidth(5, "unused_pad", 6))
         )
         .build()
 
@@ -209,6 +216,7 @@ class PacketHeaderCodecTest {
               HeaderDecl.newBuilder()
                 .addFields(bitField("ingress_port", 9))
                 .addFields(bitField("target_egress_port", 9))
+                .addFields(bitField("unused_pad", 6))
             )
         )
         .build()
@@ -219,11 +227,62 @@ class PacketHeaderCodecTest {
   private fun meta(id: Int, name: String): ControllerPacketMetadata.Metadata =
     ControllerPacketMetadata.Metadata.newBuilder().setId(id).setName(name).build()
 
+  private fun metaWithBitwidth(
+    id: Int,
+    name: String,
+    bitwidth: Int,
+  ): ControllerPacketMetadata.Metadata =
+    ControllerPacketMetadata.Metadata.newBuilder()
+      .setId(id)
+      .setName(name)
+      .setBitwidth(bitwidth)
+      .build()
+
   private fun bitField(name: String, width: Int): FieldDecl =
     FieldDecl.newBuilder()
       .setName(name)
       .setType(Type.newBuilder().setBit(BitType.newBuilder().setWidth(width)))
       .build()
+
+  // =========================================================================
+  // Byte-alignment validation
+  // =========================================================================
+
+  @Test(expected = IllegalArgumentException::class)
+  @Suppress("MagicNumber")
+  fun `create rejects non-byte-aligned packet_in header`() {
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(meta(1, "egress_port"))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(meta(2, "ingress_port"))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_in_header_t")
+            .setHeader(
+              HeaderDecl.newBuilder()
+                .addFields(bitField("ingress_port", 9))
+                .addFields(bitField("target_egress_port", 9))
+            )
+        )
+        .build()
+    PacketHeaderCodec.create(p4info, behavioral)
+  }
 
   // =========================================================================
   // CPU port override

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -139,7 +139,7 @@ class PacketHeaderCodecTest {
     val codec = PacketHeaderCodec.create(p4info, behavioral)!!
 
     val metadata = codec.buildPacketInMetadata(ingressPort = 510, egressPort = 1)
-    assertEquals(3, metadata.size)
+    assertEquals(2, metadata.size)
 
     // First field = ingress_port (metadata_id=3 in our test config)
     assertEquals(3, metadata[0].metadataId)
@@ -150,10 +150,6 @@ class PacketHeaderCodecTest {
     assertEquals(4, metadata[1].metadataId)
     val egressBytes = metadata[1].value.toByteArray()
     assertEquals(1, bytesToInt(egressBytes))
-
-    // Third field = unused_pad (metadata_id=5) — always 0
-    assertEquals(5, metadata[2].metadataId)
-    assertEquals(0, bytesToInt(metadata[2].value.toByteArray()))
   }
 
   // =========================================================================
@@ -163,12 +159,43 @@ class PacketHeaderCodecTest {
   @Test
   @Suppress("MagicNumber")
   fun `stripPacketInHeader removes byte-aligned header correctly`() {
-    val (p4info, behavioral) = buildSaiLikeConfig()
+    // 16-bit packet_in header (two 8-bit fields) — byte-aligned, exercises the fast path.
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(2, "ingress_port", 8))
+            .addMetadata(metaWithBitwidth(3, "egress_port", 8))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_in_header_t")
+            .setHeader(
+              HeaderDecl.newBuilder()
+                .addFields(bitField("ingress_port", 8))
+                .addFields(bitField("egress_port", 8))
+            )
+        )
+        .build()
     val codec = PacketHeaderCodec.create(p4info, behavioral)!!
-    // 24-bit header (3 bytes) + 4-byte payload = 7 bytes total.
+    // 16-bit header (2 bytes) + 4-byte payload = 6 bytes total.
     val deparsed =
       com.google.protobuf.ByteString.copyFrom(
-        byteArrayOf(0x00, 0x00, 0x00, 0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+        byteArrayOf(0x00, 0x00, 0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
       )
     val stripped = codec.stripPacketInHeader(deparsed)
     assertArrayEquals(
@@ -252,7 +279,7 @@ class PacketHeaderCodecTest {
   /**
    * Builds a SAI-like p4info + behavioral config:
    * - packet_out: egress_port (9-bit, id=1), submit_to_ingress (1-bit, id=2), unused_pad (6-bit)
-   * - packet_in: ingress_port (9-bit, id=3), target_egress_port (9-bit, id=4), unused_pad (6-bit)
+   * - packet_in: ingress_port (9-bit, id=3), target_egress_port (9-bit, id=4)
    * - Behavioral config with header types for field width resolution.
    */
   @Suppress("MagicNumber")
@@ -270,7 +297,6 @@ class PacketHeaderCodecTest {
             .setPreamble(Preamble.newBuilder().setName("packet_in"))
             .addMetadata(meta(3, "ingress_port"))
             .addMetadata(meta(4, "target_egress_port"))
-            .addMetadata(metaWithBitwidth(5, "unused_pad", 6))
         )
         .build()
 
@@ -293,7 +319,6 @@ class PacketHeaderCodecTest {
               HeaderDecl.newBuilder()
                 .addFields(bitField("ingress_port", 9))
                 .addFields(bitField("target_egress_port", 9))
-                .addFields(bitField("unused_pad", 6))
             )
         )
         .build()

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -545,6 +545,39 @@ class SaiP4E2ETest {
 
   @Test
   @Suppress("MagicNumber")
+  fun `ACL trap PacketIn payload does not include controller header bytes`() {
+    installRoutingChain()
+    installAclEntry(findAction("acl_trap"))
+    installCopyToCpuCloneSession()
+
+    val originalPacket = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
+    harness.openStream().use { session ->
+      session.arbitrate()
+      val packetOut = buildCpuPacketOut(submitToIngress = true)
+      val response = session.sendPacketOut(packetOut)
+      assertNotNull("ACL trap should produce PacketIn", response)
+
+      val packetIn = response!!.packet
+      val payload = packetIn.payload.toByteArray()
+      // The deparser emits a @controller_header("packet_in") before the Ethernet frame.
+      // The P4Runtime server must strip it — the payload should be the original packet.
+      assertEquals(
+        "PacketIn payload should match original packet size (no controller header)",
+        originalPacket.size,
+        payload.size,
+      )
+      // The I2E clone uses post-parser (pre-ingress) headers, so the Ethernet and IP
+      // fields are unmodified. The IPv4 checksum may differ because v1model's
+      // ComputeChecksum stage recomputes it.
+      assertBytesEqual("dst_mac", UNICAST_MAC, payload, 0)
+      assertBytesEqual("src_mac", SRC_MAC, payload, MAC_LEN)
+      assertBytesEqual("src_ip", SRC_IP, payload, SRC_IP_OFFSET)
+      assertBytesEqual("dst_ip", DST_IP, payload, DST_IP_OFFSET)
+    }
+  }
+
+  @Test
+  @Suppress("MagicNumber")
   fun `ACL copy produces both outputs but only CPU clone becomes PacketIn`() {
     installRoutingChain()
     // ACL: copy packets to CPU without dropping (forward normally + clone to CPU).

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -102,7 +102,11 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
 
   fun extractBytes(count: Int): ByteArray = buffer.read(count)
 
+  fun extractBits(bitCount: Int): BigInteger = buffer.readBits(bitCount)
+
   fun peekBytes(count: Int): ByteArray = buffer.peek(count)
+
+  fun peekBits(bitCount: Int): BigInteger = buffer.peekBits(bitCount)
 
   fun advanceBits(bits: Int) = buffer.advanceBits(bits)
 
@@ -192,48 +196,100 @@ class PacketTooShortException(message: String) : ParserErrorException("PacketToo
 /** Thrown by the interpreter when a parser error occurs (P4 spec §12.8). */
 open class ParserErrorException(val errorName: String, message: String) : Exception(message)
 
-/** A simple byte-level cursor over a packet buffer, used by the parser. */
-private class ParserCursor(private val data: ByteArray, initialOffset: Int = 0) {
-  private var offset: Int = initialOffset
+/**
+ * Bit-level cursor over a packet buffer, used by the parser.
+ *
+ * Tracks a bit offset so that sub-byte header extracts (e.g., a 4-bit tag followed by a 12-bit
+ * length) consume exactly the right number of bits without over-reading.
+ */
+@Suppress("MagicNumber")
+private class ParserCursor(private val data: ByteArray, initialByteOffset: Int = 0) {
+  private var bitOffset: Int = initialByteOffset * 8
 
-  /** Number of bytes consumed from the start of the buffer. */
+  /** Number of whole bytes consumed from the start of the buffer. */
   val bytesConsumed: Int
-    get() = offset
+    get() = (bitOffset + 7) / 8
 
-  fun remaining(): Int = data.size - offset
+  private fun remainingBits(): Int = data.size * 8 - bitOffset
 
-  fun readAll(): ByteArray = data.copyOfRange(offset, data.size).also { offset = data.size }
+  /** Returns all bytes from the current byte-aligned position to the end. */
+  fun readAll(): ByteArray {
+    val byteStart = (bitOffset + 7) / 8
+    bitOffset = data.size * 8
+    return data.copyOfRange(byteStart, data.size)
+  }
 
-  /** Returns all remaining bytes without advancing the cursor. */
-  fun peekAll(): ByteArray = data.copyOfRange(offset, data.size)
+  /** Returns all bytes from the current byte-aligned position without advancing. */
+  fun peekAll(): ByteArray {
+    val byteStart = (bitOffset + 7) / 8
+    return data.copyOfRange(byteStart, data.size)
+  }
 
+  /** Reads [count] bytes from the current position (must be byte-aligned). */
   fun read(count: Int): ByteArray {
-    if (count > remaining()) {
+    val bitsNeeded = count * 8
+    if (bitsNeeded > remainingBits()) {
       throw PacketTooShortException(
-        "attempted to extract $count bytes but only ${remaining()} remain in packet"
+        "attempted to extract $count bytes but only ${remainingBits() / 8} remain in packet"
       )
     }
-    return data.copyOfRange(offset, offset + count).also { offset += count }
+    val byteStart = bitOffset / 8
+    bitOffset += bitsNeeded
+    return data.copyOfRange(byteStart, byteStart + count)
   }
 
-  /** Peeks at the next [count] bytes without advancing the cursor (P4 spec §12.8.2). */
+  /** Reads [bitCount] bits from the current position as a BigInteger, MSB-first. */
+  fun readBits(bitCount: Int): BigInteger {
+    if (bitCount > remainingBits()) {
+      throw PacketTooShortException(
+        "attempted to extract $bitCount bits but only ${remainingBits()} remain in packet"
+      )
+    }
+    val result = peekBitsInternal(bitCount)
+    bitOffset += bitCount
+    return result
+  }
+
+  /** Peeks at [count] bytes without advancing (must be byte-aligned). */
   fun peek(count: Int): ByteArray {
-    if (count > remaining()) {
+    val bitsNeeded = count * 8
+    if (bitsNeeded > remainingBits()) {
       throw PacketTooShortException(
-        "lookahead: need $count bytes but only ${remaining()} remain in packet"
+        "lookahead: need $count bytes but only ${remainingBits() / 8} remain in packet"
       )
     }
-    return data.copyOfRange(offset, offset + count)
+    val byteStart = bitOffset / 8
+    return data.copyOfRange(byteStart, byteStart + count)
   }
 
-  /** Advances the cursor by [bits] bits, which must be a multiple of 8 (P4 spec §12.8.3). */
-  fun advanceBits(bits: Int) {
-    val bytes = bits / 8
-    if (bytes > remaining()) {
+  /** Peeks at [bitCount] bits without advancing, MSB-first. */
+  fun peekBits(bitCount: Int): BigInteger {
+    if (bitCount > remainingBits()) {
       throw PacketTooShortException(
-        "advance: need $bytes bytes but only ${remaining()} remain in packet"
+        "lookahead: need $bitCount bits but only ${remainingBits()} remain in packet"
       )
     }
-    offset += bytes
+    return peekBitsInternal(bitCount)
+  }
+
+  /** Advances the cursor by [bits] bits. */
+  fun advanceBits(bits: Int) {
+    if (bits > remainingBits()) {
+      throw PacketTooShortException(
+        "advance: need $bits bits but only ${remainingBits()} remain in packet"
+      )
+    }
+    bitOffset += bits
+  }
+
+  private fun peekBitsInternal(bitCount: Int): BigInteger {
+    if (bitCount == 0) return BigInteger.ZERO
+    val startByte = bitOffset / 8
+    val endByte = (bitOffset + bitCount - 1) / 8
+    val raw = BigInteger(1, data.copyOfRange(startByte, endByte + 1))
+    val trailingBits = (endByte + 1) * 8 - (bitOffset + bitCount)
+    val shifted = raw.shiftRight(trailingBits)
+    val mask = BigInteger.ONE.shiftLeft(bitCount).subtract(BigInteger.ONE)
+    return shifted.and(mask)
   }
 }

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -2,6 +2,7 @@ package fourward.simulator
 
 import fourward.TraceEvent
 import java.io.ByteArrayOutputStream
+import java.math.BigInteger
 
 /**
  * Variable scope stack for a single packet traversal.
@@ -96,8 +97,8 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
   val bytesConsumed: Int
     get() = buffer.bytesConsumed
 
-  /** Output packet bytes, written by deparser emit(). */
-  private val outputBuffer = ByteArrayOutputStream()
+  /** Bit-level output buffer, written by deparser emit(). */
+  private val outputBits = BitAccumulator()
 
   fun extractBytes(count: Int): ByteArray = buffer.read(count)
 
@@ -105,11 +106,12 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
 
   fun advanceBits(bits: Int) = buffer.advanceBits(bits)
 
-  fun emitBytes(bytes: ByteArray) {
-    outputBuffer.write(bytes)
+  fun emitBits(value: BigInteger, width: Int) {
+    outputBits.append(value, width)
   }
 
-  fun outputPayload(): ByteArray = outputBuffer.toByteArray()
+  /** Returns the accumulated output bits as bytes (zero-padded to byte boundary). */
+  fun outputPayload(): ByteArray = outputBits.toByteArray()
 
   /** Returns all bytes not yet consumed by the parser (the un-parsed packet body). */
   fun drainRemainingInput(): ByteArray = buffer.readAll()
@@ -128,6 +130,55 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
   }
 
   fun getEvents(): List<TraceEvent> = traceEvents.toList()
+}
+
+/**
+ * Accumulates bits from deparser emit() calls into a continuous bit stream, producing a
+ * byte-aligned output with trailing zero padding — matching real P4 target behavior.
+ */
+@Suppress("MagicNumber")
+class BitAccumulator {
+  private val bytes = ByteArrayOutputStream()
+  private var pendingBits = 0L
+  private var pendingCount = 0
+
+  fun append(value: BigInteger, width: Int) {
+    var remaining = width
+    var bits = value
+    while (remaining > 0) {
+      val space = 8 - pendingCount
+      if (remaining >= space) {
+        val shift = remaining - space
+        val top =
+          if (shift < 64) (bits shr shift).toLong() and ((1L shl space) - 1)
+          else bits.shiftRight(shift).toLong() and ((1L shl space) - 1)
+        pendingBits = (pendingBits shl space) or top
+        bytes.write(pendingBits.toInt() and 0xFF)
+        pendingBits = 0
+        pendingCount = 0
+        remaining -= space
+        if (remaining > 0 && remaining < 64) {
+          bits = bits.and(BigInteger.ONE.shiftLeft(remaining).subtract(BigInteger.ONE))
+        }
+      } else {
+        val top =
+          if (remaining < 64) bits.toLong() and ((1L shl remaining) - 1)
+          else bits.and(BigInteger.ONE.shiftLeft(remaining).subtract(BigInteger.ONE)).toLong()
+        pendingBits = (pendingBits shl remaining) or top
+        pendingCount += remaining
+        remaining = 0
+      }
+    }
+  }
+
+  fun toByteArray(): ByteArray {
+    if (pendingCount > 0) {
+      bytes.write((pendingBits shl (8 - pendingCount)).toInt() and 0xFF)
+      pendingBits = 0
+      pendingCount = 0
+    }
+    return bytes.toByteArray()
+  }
 }
 
 /**

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -150,24 +150,21 @@ class BitAccumulator {
     var remaining = width
     var bits = value
     while (remaining > 0) {
+      // space is always 1..8, so the shifts below are always < 64.
       val space = 8 - pendingCount
       if (remaining >= space) {
         val shift = remaining - space
-        val top =
-          if (shift < 64) (bits shr shift).toLong() and ((1L shl space) - 1)
-          else bits.shiftRight(shift).toLong() and ((1L shl space) - 1)
+        val top = bits.shiftRight(shift).toLong() and ((1L shl space) - 1)
         pendingBits = (pendingBits shl space) or top
         bytes.write(pendingBits.toInt() and 0xFF)
         pendingBits = 0
         pendingCount = 0
         remaining -= space
-        if (remaining > 0 && remaining < 64) {
+        if (remaining > 0) {
           bits = bits.and(BigInteger.ONE.shiftLeft(remaining).subtract(BigInteger.ONE))
         }
       } else {
-        val top =
-          if (remaining < 64) bits.toLong() and ((1L shl remaining) - 1)
-          else bits.and(BigInteger.ONE.shiftLeft(remaining).subtract(BigInteger.ONE)).toLong()
+        val top = bits.toLong() and ((1L shl remaining) - 1)
         pendingBits = (pendingBits shl remaining) or top
         pendingCount += remaining
         remaining = 0
@@ -176,12 +173,12 @@ class BitAccumulator {
   }
 
   fun toByteArray(): ByteArray {
-    if (pendingCount > 0) {
-      bytes.write((pendingBits shl (8 - pendingCount)).toInt() and 0xFF)
-      pendingBits = 0
-      pendingCount = 0
-    }
-    return bytes.toByteArray()
+    val result = bytes.toByteArray()
+    if (pendingCount == 0) return result
+    // Append the pending partial byte without mutating accumulator state.
+    val padded = result.copyOf(result.size + 1)
+    padded[result.size] = ((pendingBits shl (8 - pendingCount)).toInt() and 0xFF).toByte()
+    return padded
   }
 }
 
@@ -227,6 +224,7 @@ private class ParserCursor(private val data: ByteArray, initialByteOffset: Int =
 
   /** Reads [count] bytes from the current position (must be byte-aligned). */
   fun read(count: Int): ByteArray {
+    require(bitOffset % 8 == 0) { "read() requires byte-aligned cursor, but bitOffset=$bitOffset" }
     val bitsNeeded = count * 8
     if (bitsNeeded > remainingBits()) {
       throw PacketTooShortException(
@@ -284,6 +282,11 @@ private class ParserCursor(private val data: ByteArray, initialByteOffset: Int =
 
   private fun peekBitsInternal(bitCount: Int): BigInteger {
     if (bitCount == 0) return BigInteger.ZERO
+    // Fast path: byte-aligned reads skip the shift/mask entirely.
+    if (bitOffset % 8 == 0 && bitCount % 8 == 0) {
+      val startByte = bitOffset / 8
+      return BigInteger(1, data.copyOfRange(startByte, startByte + bitCount / 8))
+    }
     val startByte = bitOffset / 8
     val endByte = (bitOffset + bitCount - 1) / 8
     val raw = BigInteger(1, data.copyOfRange(startByte, endByte + 1))

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -117,6 +117,18 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
   /** Returns the accumulated output bits as bytes (zero-padded to byte boundary). */
   fun outputPayload(): ByteArray = outputBits.toByteArray()
 
+  /**
+   * Returns the deparser output concatenated with the unparsed remainder as a continuous bit
+   * stream. This is the complete output packet — deparser-emitted headers followed by whatever the
+   * parser didn't consume, with trailing zero padding to byte boundary.
+   */
+  fun deparsedPayload(): ByteArray {
+    if (!buffer.hasRemaining()) return outputBits.toByteArray()
+    val combined = outputBits.copy()
+    buffer.appendRemainingTo(combined)
+    return combined.toByteArray()
+  }
+
   /** Returns all bytes not yet consumed by the parser (the un-parsed packet body). */
   fun drainRemainingInput(): ByteArray = buffer.readAll()
 
@@ -172,6 +184,31 @@ class BitAccumulator {
     }
   }
 
+  /** Appends raw bytes from [data] starting at bit offset [bitOff] for [bitCount] bits. */
+  fun appendRawBytes(data: ByteArray, bitOff: Int, bitCount: Int) {
+    var pos = bitOff
+    var remaining = bitCount
+    while (remaining > 0) {
+      val byteIdx = pos / 8
+      val bitInByte = pos % 8
+      val available = 8 - bitInByte
+      val take = minOf(available, remaining)
+      val shift = available - take
+      val bits = ((data[byteIdx].toInt() and 0xFF) ushr shift) and ((1 shl take) - 1)
+      append(BigInteger.valueOf(bits.toLong()), take)
+      pos += take
+      remaining -= take
+    }
+  }
+
+  fun copy(): BitAccumulator {
+    val clone = BitAccumulator()
+    clone.bytes.write(bytes.toByteArray())
+    clone.pendingBits = pendingBits
+    clone.pendingCount = pendingCount
+    return clone
+  }
+
   fun toByteArray(): ByteArray {
     val result = bytes.toByteArray()
     if (pendingCount == 0) return result
@@ -206,6 +243,12 @@ private class ParserCursor(private val data: ByteArray, initialByteOffset: Int =
   /** Number of whole bytes consumed from the start of the buffer. */
   val bytesConsumed: Int
     get() = (bitOffset + 7) / 8
+
+  fun hasRemaining(): Boolean = bitOffset < data.size * 8
+
+  fun appendRemainingTo(acc: BitAccumulator) {
+    acc.appendRawBytes(data, bitOffset, data.size * 8 - bitOffset)
+  }
 
   private fun remainingBits(): Int = data.size * 8 - bitOffset
 

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -209,7 +209,7 @@ private class ParserCursor(private val data: ByteArray, initialByteOffset: Int =
 
   private fun remainingBits(): Int = data.size * 8 - bitOffset
 
-  /** Returns all bytes from the current byte-aligned position to the end. */
+  /** Returns all bytes from the next byte boundary to the end (sub-byte remainder is discarded). */
   fun readAll(): ByteArray {
     val byteStart = (bitOffset + 7) / 8
     bitOffset = data.size * 8

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -115,24 +115,31 @@ class EnvironmentTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  fun `outputPayload is empty before any emitBytes call`() {
+  fun `outputPayload is empty before any emitBits call`() {
     val pktCtx = PacketContext(byteArrayOf())
     assertArrayEquals(byteArrayOf(), pktCtx.outputPayload())
   }
 
   @Test
-  fun `emitBytes appends bytes to the output buffer`() {
+  @Suppress("MagicNumber")
+  fun `emitBits appends bits to the output buffer`() {
     val pktCtx = PacketContext(byteArrayOf())
-    pktCtx.emitBytes(byteArrayOf(0x08, 0x00))
+    // 16 bits = 0x0800
+    pktCtx.emitBits(java.math.BigInteger.valueOf(0x0800), 16)
     assertArrayEquals(byteArrayOf(0x08, 0x00), pktCtx.outputPayload())
   }
 
   @Test
-  fun `multiple emitBytes calls concatenate in order`() {
+  @Suppress("MagicNumber")
+  fun `multiple emitBits calls form continuous bit stream`() {
     val pktCtx = PacketContext(byteArrayOf())
-    pktCtx.emitBytes(byteArrayOf(0x01, 0x02))
-    pktCtx.emitBytes(byteArrayOf(0x03, 0x04))
-    assertArrayEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04), pktCtx.outputPayload())
+    // 6 bits: 0b111111 = 0x3F, then 10 bits: 0b1010101010 = 0x2AA
+    // Continuous: 111111_1010101010 = 16 bits = 0xFAAA? Let's compute:
+    // 111111_10_10101010 = 0xFAAA? No:
+    // 111111 10 10101010 = byte 0: 11111110 = 0xFE, byte 1: 10101010 = 0xAA
+    pktCtx.emitBits(java.math.BigInteger.valueOf(0x3F), 6)
+    pktCtx.emitBits(java.math.BigInteger.valueOf(0x2AA), 10)
+    assertArrayEquals(byteArrayOf(0xFE.toByte(), 0xAA.toByte()), pktCtx.outputPayload())
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -16,6 +16,7 @@ package fourward.simulator
 
 import fourward.MarkToDropEvent
 import fourward.TraceEvent
+import java.math.BigInteger
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
@@ -125,7 +126,7 @@ class EnvironmentTest {
   fun `emitBits appends bits to the output buffer`() {
     val pktCtx = PacketContext(byteArrayOf())
     // 16 bits = 0x0800
-    pktCtx.emitBits(java.math.BigInteger.valueOf(0x0800), 16)
+    pktCtx.emitBits(BigInteger.valueOf(0x0800), 16)
     assertArrayEquals(byteArrayOf(0x08, 0x00), pktCtx.outputPayload())
   }
 
@@ -137,8 +138,8 @@ class EnvironmentTest {
     // Continuous: 111111_1010101010 = 16 bits = 0xFAAA? Let's compute:
     // 111111_10_10101010 = 0xFAAA? No:
     // 111111 10 10101010 = byte 0: 11111110 = 0xFE, byte 1: 10101010 = 0xAA
-    pktCtx.emitBits(java.math.BigInteger.valueOf(0x3F), 6)
-    pktCtx.emitBits(java.math.BigInteger.valueOf(0x2AA), 10)
+    pktCtx.emitBits(BigInteger.valueOf(0x3F), 6)
+    pktCtx.emitBits(BigInteger.valueOf(0x2AA), 10)
     assertArrayEquals(byteArrayOf(0xFE.toByte(), 0xAA.toByte()), pktCtx.outputPayload())
   }
 
@@ -171,5 +172,84 @@ class EnvironmentTest {
     val second = pktCtx.getEvents()
     assertEquals(first, second)
     assertNotSame(first, second)
+  }
+
+  // ---------------------------------------------------------------------------
+  // BitAccumulator
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `BitAccumulator empty toByteArray returns empty`() {
+    val acc = BitAccumulator()
+    assertArrayEquals(byteArrayOf(), acc.toByteArray())
+  }
+
+  @Test
+  fun `BitAccumulator width-0 append is a no-op`() {
+    val acc = BitAccumulator()
+    acc.append(BigInteger.valueOf(0xFF), 0)
+    assertArrayEquals(byteArrayOf(), acc.toByteArray())
+  }
+
+  @Test
+  fun `BitAccumulator single-bit append`() {
+    val acc = BitAccumulator()
+    acc.append(BigInteger.ONE, 1)
+    // 1 bit = 0b1 → padded to 0b10000000 = 0x80
+    assertArrayEquals(byteArrayOf(0x80.toByte()), acc.toByteArray())
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `BitAccumulator wide value greater than 64 bits`() {
+    val acc = BitAccumulator()
+    // 72-bit value: 0xFF repeated 9 times.
+    val wide = BigInteger.ONE.shiftLeft(72).subtract(BigInteger.ONE)
+    acc.append(wide, 72)
+    val expected = ByteArray(9) { 0xFF.toByte() }
+    assertArrayEquals(expected, acc.toByteArray())
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `BitAccumulator toByteArray is idempotent`() {
+    val acc = BitAccumulator()
+    acc.append(BigInteger.valueOf(0x3F), 6)
+    val first = acc.toByteArray()
+    val second = acc.toByteArray()
+    assertArrayEquals(first, second)
+  }
+
+  // ---------------------------------------------------------------------------
+  // ParserCursor — bit-level reads
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `extractBits extracts sub-byte value`() {
+    // Byte 0xA5 = 0b10100101. Extract top 4 bits = 0b1010 = 10.
+    val pktCtx = PacketContext(byteArrayOf(0xA5.toByte()))
+    assertEquals(BigInteger.valueOf(0xA), pktCtx.extractBits(4))
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `peekBits does not advance cursor`() {
+    val pktCtx = PacketContext(byteArrayOf(0xA5.toByte()))
+    val first = pktCtx.peekBits(4)
+    val second = pktCtx.peekBits(4)
+    assertEquals(first, second)
+    // extractBits should still read the same value.
+    assertEquals(BigInteger.valueOf(0xA), pktCtx.extractBits(4))
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `extractBits across byte boundaries`() {
+    // Bytes: 0xA5 0xC3 = 0b10100101_11000011
+    // Skip 4 bits (0b1010), then extract 8 bits: 0b01011100 = 0x5C
+    val pktCtx = PacketContext(byteArrayOf(0xA5.toByte(), 0xC3.toByte()))
+    pktCtx.extractBits(4) // skip first 4 bits
+    assertEquals(BigInteger.valueOf(0x5C), pktCtx.extractBits(8))
   }
 }

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -134,10 +134,7 @@ class EnvironmentTest {
   @Suppress("MagicNumber")
   fun `multiple emitBits calls form continuous bit stream`() {
     val pktCtx = PacketContext(byteArrayOf())
-    // 6 bits: 0b111111 = 0x3F, then 10 bits: 0b1010101010 = 0x2AA
-    // Continuous: 111111_1010101010 = 16 bits = 0xFAAA? Let's compute:
-    // 111111_10_10101010 = 0xFAAA? No:
-    // 111111 10 10101010 = byte 0: 11111110 = 0xFE, byte 1: 10101010 = 0xAA
+    // 6 bits (0b111111) ++ 10 bits (0b1010101010) → 0b11111110_10101010 = 0xFE 0xAA
     pktCtx.emitBits(BigInteger.valueOf(0x3F), 6)
     pktCtx.emitBits(BigInteger.valueOf(0x2AA), 10)
     assertArrayEquals(byteArrayOf(0xFE.toByte(), 0xAA.toByte()), pktCtx.outputPayload())

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -1255,7 +1255,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
 
       val widths = headerDecl.fieldsList.map { fieldWireWidth(it.type, varbitBits) }
       val totalBits = widths.sum()
-      val allBits = BigInteger(1, packet.extractBytes((totalBits + 7) / 8))
+      val allBits = packet.extractBits(totalBits)
       val newFields = unpackFields(headerDecl.fieldsList, widths, allBits, totalBits)
       if (!unionHandled) invalidateUnionSiblings(call.argsList[0], header, env)
       header.setValid(newFields)
@@ -1264,13 +1264,9 @@ class Interpreter internal constructor(config: BehavioralConfig) {
 
     /** P4 spec §12.8.2: peek at packet bits and construct a value of type T without consuming. */
     private fun execLookahead(returnType: Type): Value {
-      // Primitive bit<N> lookahead: peek N bits and return a BitVal.
       if (returnType.hasBit()) {
         val width = returnType.bit.width
-        val raw = BigInteger(1, packet.peekBytes((width + 7) / 8))
-        // Mask to exactly N bits (peekBytes may return extra high bits from byte alignment).
-        val mask = BigInteger.ONE.shiftLeft(width).subtract(BigInteger.ONE)
-        return BitVal(BitVector(raw.and(mask), width))
+        return BitVal(BitVector(packet.peekBits(width), width))
       }
 
       val typeName = returnType.named
@@ -1286,7 +1282,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         }
       val widths = fields.map { fieldWireWidth(it.type) }
       val totalBits = widths.sum()
-      val allBits = BigInteger(1, packet.peekBytes((totalBits + 7) / 8))
+      val allBits = packet.peekBits(totalBits)
       val newFields = unpackFields(fields, widths, allBits, totalBits)
       return if (typeDecl.hasHeader()) {
         HeaderVal(typeName, newFields, valid = true)

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -1454,14 +1454,13 @@ class Interpreter internal constructor(config: BehavioralConfig) {
         bitOffset += width
       }
       if (totalBits > 0) {
-        val bytes = BitVector(packedBits, totalBits).toByteArray()
-        packet.emitBytes(bytes)
+        packet.emitBits(packedBits, totalBits)
         packetCtx?.addTraceEvent(
           TraceEvent.newBuilder()
             .setDeparserEmit(
               DeparserEmitEvent.newBuilder()
                 .setHeaderType(header.typeName)
-                .setByteLength(bytes.size)
+                .setByteLength((totalBits + 7) / 8)
             )
             .build()
         )

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -198,7 +198,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     // the deparsed packet (post-modification), matching DPDK SoftNIC behavior.
     bindStageParams(env, pipeline.mainDeparser.blockName, pipeline.blockParams, values)
     runControlStage(interpreter, ctx, env, pipeline.mainDeparser)
-    val deparsedBytes = ctx.outputPayload() + ctx.drainRemainingInput()
+    val deparsedBytes = ctx.deparsedPayload()
 
     val mirrorBranches = buildMirrorBranches(pipeline, deparsedBytes, forwardingState)
 

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -269,7 +269,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       )
     }
 
-    val deparsedBytes = ctx.outputPayload() + ctx.drainRemainingInput()
+    val deparsedBytes = ctx.deparsedPayload()
     return IngressResult(ctx.getEvents(), output, deparsedBytes, dropped = false)
   }
 
@@ -457,7 +457,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     bindStageParams(egressEnv, p.egressDeparser.blockName, p.blockParams, egressValues)
     runControlStage(egressInterpreter, egressCtx, egressEnv, p.egressDeparser)
 
-    val outputBytes = egressCtx.outputPayload() + egressCtx.drainRemainingInput()
+    val outputBytes = egressCtx.deparsedPayload()
     return EgressCoreResult(egressCtx.getEvents(), dropped, outputBytes, egressOutput)
   }
 

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -667,7 +667,7 @@ class V1ModelArchitecture(
       }
     }
 
-    val outputBytes = s.packetCtx.outputPayload() + s.packetCtx.drainRemainingInput()
+    val outputBytes = s.packetCtx.deparsedPayload()
 
     if (s.pendingOps.recirculate) {
       throw RecirculateFork(


### PR DESCRIPTION
Closes #642, #646, #647, #648, #650.

## Summary

Five related fixes making the entire packet pipeline — parser, deparser, output assembly, and PacketIn stripping — operate at bit granularity instead of byte granularity.

**PacketIn payload stripping (#642):** the P4 deparser emits the `@controller_header("packet_in")` as part of the deparsed payload. The P4Runtime server now strips it before delivering PacketIn to the controller. Also aligns the open-source SAI P4 with internal behavior — the `packet_in_header` is now emitted on all platforms.

**Deparser bit-stream (#646):** the deparser was byte-padding each header independently, inserting spurious zero bits between non-byte-aligned headers. Replaced with a `BitAccumulator` that packs bits continuously across `emit()` calls.

**Parser bit-level extraction (#647):** the parser consumed `ceil(totalBits/8)` bytes per header, over-reading for non-byte-aligned headers. Replaced with a bit-level `ParserCursor` that reads exactly N bits per extract.

**Bit-level PacketIn stripping (#648):** `ByteString.substring()` strips whole bytes, corrupting the payload when the controller header is not byte-aligned. Extracted into `PacketHeaderCodec.stripPacketInHeader()` with a bit-level implementation.

**Bit-level output assembly (#650):** `outputPayload() + drainRemainingInput()` dropped sub-byte bits left by a non-byte-aligned parser extract. Replaced with `deparsedPayload()` which feeds remaining input bits into the `BitAccumulator` as a continuous stream.

## Test plan

- [x] `PacketHeaderCodecTest`: `packetInHeaderBytes`, byte-aligned strip, non-byte-aligned strip
- [x] `SaiP4E2ETest`: PacketIn payload matches original frame after stripping
- [x] `EnvironmentTest`: BitAccumulator (empty, width-0, single-bit, wide, idempotency), ParserCursor (sub-byte, peek, cross-byte)
- [x] `InlineP4CompilerTest`: non-byte-aligned deparser output, continuous bit stream, byte-level stripping corruption, parser sub-byte extraction, unparsed sub-byte remainder preservation
- [x] Full test suite passes (78/78)

🤖 Generated with [Claude Code](https://claude.com/claude-code)