### PR TITLE
fourward_cc: add PacketsByDataplanePort and PacketsByP4RuntimePort

### DIFF
--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -62,6 +62,7 @@ cc_library(
         ":dataplane_client",
         "//grpc:dataplane_cc_proto",
         "//simulator:simulator_cc_proto",
+        "@abseil-cpp//absl/container:btree",
         "@googletest//:gtest",
     ],
 )

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -421,8 +421,9 @@ template <typename T>
 absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>>
 PacketsByDataplanePort(const T& result) {
   absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>> groups;
-  for (const auto& pkt : internal::DeterministicPackets(result)) {
-    groups[pkt.dataplane_egress_port()].push_back(pkt);
+  auto packets = internal::DeterministicPackets(result);
+  for (auto& pkt : packets) {
+    groups[pkt.dataplane_egress_port()].push_back(std::move(pkt));
   }
   return groups;
 }
@@ -431,8 +432,9 @@ template <typename T>
 absl::btree_map<std::string, std::vector<fourward::OutputPacket>>
 PacketsByP4RuntimePort(const T& result) {
   absl::btree_map<std::string, std::vector<fourward::OutputPacket>> groups;
-  for (const auto& pkt : internal::DeterministicPackets(result)) {
-    groups[pkt.p4rt_egress_port()].push_back(pkt);
+  auto packets = internal::DeterministicPackets(result);
+  for (auto& pkt : packets) {
+    groups[pkt.p4rt_egress_port()].push_back(std::move(pkt));
   }
   return groups;
 }

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -136,6 +136,16 @@ inline void PrintPortKey(std::ostream* os, const PortKey& key) {
   }
 }
 
+template <typename T>
+PacketList DeterministicPackets(const T& result) {
+  auto outcomes = ExtractOutcomes(result);
+  if (outcomes.size() != 1) {
+    ADD_FAILURE() << "expected 1 outcome, got " << outcomes.size();
+    return {};
+  }
+  return std::move(outcomes[0]);
+}
+
 }  // namespace internal
 
 // ---------------------------------------------------------------------------
@@ -400,34 +410,18 @@ inline auto OnPorts(
 }
 
 // ---------------------------------------------------------------------------
-// DeterministicPackets — extract packets from a single deterministic outcome
-//
-// Fails the test if the result has != 1 possible outcome.
-// ---------------------------------------------------------------------------
-
-template <typename T>
-std::vector<fourward::OutputPacket> DeterministicPackets(const T& result) {
-  auto outcomes = internal::ExtractOutcomes(result);
-  if (outcomes.size() != 1) {
-    ADD_FAILURE() << "DeterministicPackets: expected 1 outcome, got "
-                  << outcomes.size();
-    return {};
-  }
-  return std::move(outcomes[0]);
-}
-
-// ---------------------------------------------------------------------------
 // PacketsByDataplanePort / PacketsByP4RuntimePort — extract packets grouped
 // by port
 //
-// Convenience wrappers around DeterministicPackets that group by egress port.
+// Returns a map from port to packets for the single deterministic outcome.
+// Fails the test if the result has != 1 possible outcome.
 // ---------------------------------------------------------------------------
 
 template <typename T>
 absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>>
 PacketsByDataplanePort(const T& result) {
   absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>> groups;
-  for (const auto& pkt : DeterministicPackets(result)) {
+  for (const auto& pkt : internal::DeterministicPackets(result)) {
     groups[pkt.dataplane_egress_port()].push_back(pkt);
   }
   return groups;
@@ -437,7 +431,7 @@ template <typename T>
 absl::btree_map<std::string, std::vector<fourward::OutputPacket>>
 PacketsByP4RuntimePort(const T& result) {
   absl::btree_map<std::string, std::vector<fourward::OutputPacket>> groups;
-  for (const auto& pkt : DeterministicPackets(result)) {
+  for (const auto& pkt : internal::DeterministicPackets(result)) {
     groups[pkt.p4rt_egress_port()].push_back(pkt);
   }
   return groups;

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -362,7 +362,8 @@ class OnPortsMatcher {
   template <typename Container>
   bool MatchAndExplain(const Container& packets,
                        ::testing::MatchResultListener* listener) const {
-    absl::btree_map<internal::PortKey, internal::PacketList, internal::PortKeyLess>
+    absl::btree_map<internal::PortKey, internal::PacketList,
+                    internal::PortKeyLess>
         groups;
     // Port type is inferred from the first entry — all entries must use the
     // same type (DataplanePort or P4RuntimePort).

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -8,7 +8,6 @@
 #define FOURWARD_CC_DATAPLANE_MATCHERS_H_
 
 #include <cstdint>
-#include <map>
 #include <ostream>
 #include <string>
 #include <string_view>
@@ -16,6 +15,7 @@
 #include <variant>
 #include <vector>
 
+#include "absl/container/btree_map.h"
 #include "fourward_cc/dataplane_client.h"
 #include "gmock/gmock.h"
 #include "grpc/dataplane.pb.h"
@@ -352,7 +352,7 @@ class OnPortsMatcher {
   template <typename Container>
   bool MatchAndExplain(const Container& packets,
                        ::testing::MatchResultListener* listener) const {
-    std::map<internal::PortKey, internal::PacketList, internal::PortKeyLess>
+    absl::btree_map<internal::PortKey, internal::PacketList, internal::PortKeyLess>
         groups;
     // Port type is inferred from the first entry — all entries must use the
     // same type (DataplanePort or P4RuntimePort).
@@ -400,21 +400,21 @@ inline auto OnPorts(
 }
 
 // ---------------------------------------------------------------------------
-// PacketsByPort / PacketsByP4RuntimePort — extract packets grouped by port
+// PacketsByDataplanePort / PacketsByP4RuntimePort — extract packets grouped by port
 //
 // Returns a map from port to packets for the single deterministic outcome.
 // Fails the test if the result has != 1 possible outcome.
 // ---------------------------------------------------------------------------
 
 template <typename T>
-std::map<uint32_t, internal::PacketList> PacketsByPort(const T& result) {
+absl::btree_map<uint32_t, internal::PacketList> PacketsByDataplanePort(const T& result) {
   auto outcomes = internal::ExtractOutcomes(result);
   if (outcomes.size() != 1) {
-    ADD_FAILURE() << "PacketsByPort: expected 1 outcome, got "
+    ADD_FAILURE() << "PacketsByDataplanePort: expected 1 outcome, got "
                   << outcomes.size();
     return {};
   }
-  std::map<uint32_t, internal::PacketList> groups;
+  absl::btree_map<uint32_t, internal::PacketList> groups;
   for (const auto& pkt : outcomes[0]) {
     groups[pkt.dataplane_egress_port()].push_back(pkt);
   }
@@ -422,7 +422,7 @@ std::map<uint32_t, internal::PacketList> PacketsByPort(const T& result) {
 }
 
 template <typename T>
-std::map<std::string, internal::PacketList> PacketsByP4RuntimePort(
+absl::btree_map<std::string, internal::PacketList> PacketsByP4RuntimePort(
     const T& result) {
   auto outcomes = internal::ExtractOutcomes(result);
   if (outcomes.size() != 1) {
@@ -430,7 +430,7 @@ std::map<std::string, internal::PacketList> PacketsByP4RuntimePort(
                   << outcomes.size();
     return {};
   }
-  std::map<std::string, internal::PacketList> groups;
+  absl::btree_map<std::string, internal::PacketList> groups;
   for (const auto& pkt : outcomes[0]) {
     groups[pkt.p4rt_egress_port()].push_back(pkt);
   }

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -399,6 +399,44 @@ inline auto OnPorts(
       OnPortsMatcher({expected.begin(), expected.end()})));
 }
 
+// ---------------------------------------------------------------------------
+// PacketsByPort / PacketsByP4RuntimePort — extract packets grouped by port
+//
+// Returns a map from port to packets for the single deterministic outcome.
+// Fails the test if the result has != 1 possible outcome.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+std::map<uint32_t, internal::PacketList> PacketsByPort(const T& result) {
+  auto outcomes = internal::ExtractOutcomes(result);
+  if (outcomes.size() != 1) {
+    ADD_FAILURE() << "PacketsByPort: expected 1 outcome, got "
+                  << outcomes.size();
+    return {};
+  }
+  std::map<uint32_t, internal::PacketList> groups;
+  for (const auto& pkt : outcomes[0]) {
+    groups[pkt.dataplane_egress_port()].push_back(pkt);
+  }
+  return groups;
+}
+
+template <typename T>
+std::map<std::string, internal::PacketList> PacketsByP4RuntimePort(
+    const T& result) {
+  auto outcomes = internal::ExtractOutcomes(result);
+  if (outcomes.size() != 1) {
+    ADD_FAILURE() << "PacketsByP4RuntimePort: expected 1 outcome, got "
+                  << outcomes.size();
+    return {};
+  }
+  std::map<std::string, internal::PacketList> groups;
+  for (const auto& pkt : outcomes[0]) {
+    groups[pkt.p4rt_egress_port()].push_back(pkt);
+  }
+  return groups;
+}
+
 }  // namespace fourward
 
 #endif  // FOURWARD_CC_DATAPLANE_MATCHERS_H_

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -400,38 +400,44 @@ inline auto OnPorts(
 }
 
 // ---------------------------------------------------------------------------
-// PacketsByDataplanePort / PacketsByP4RuntimePort — extract packets grouped by port
+// DeterministicPackets — extract packets from a single deterministic outcome
 //
-// Returns a map from port to packets for the single deterministic outcome.
 // Fails the test if the result has != 1 possible outcome.
 // ---------------------------------------------------------------------------
 
 template <typename T>
-absl::btree_map<uint32_t, internal::PacketList> PacketsByDataplanePort(const T& result) {
+std::vector<fourward::OutputPacket> DeterministicPackets(const T& result) {
   auto outcomes = internal::ExtractOutcomes(result);
   if (outcomes.size() != 1) {
-    ADD_FAILURE() << "PacketsByDataplanePort: expected 1 outcome, got "
+    ADD_FAILURE() << "DeterministicPackets: expected 1 outcome, got "
                   << outcomes.size();
     return {};
   }
-  absl::btree_map<uint32_t, internal::PacketList> groups;
-  for (const auto& pkt : outcomes[0]) {
+  return std::move(outcomes[0]);
+}
+
+// ---------------------------------------------------------------------------
+// PacketsByDataplanePort / PacketsByP4RuntimePort — extract packets grouped
+// by port
+//
+// Convenience wrappers around DeterministicPackets that group by egress port.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>>
+PacketsByDataplanePort(const T& result) {
+  absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>> groups;
+  for (const auto& pkt : DeterministicPackets(result)) {
     groups[pkt.dataplane_egress_port()].push_back(pkt);
   }
   return groups;
 }
 
 template <typename T>
-absl::btree_map<std::string, internal::PacketList> PacketsByP4RuntimePort(
-    const T& result) {
-  auto outcomes = internal::ExtractOutcomes(result);
-  if (outcomes.size() != 1) {
-    ADD_FAILURE() << "PacketsByP4RuntimePort: expected 1 outcome, got "
-                  << outcomes.size();
-    return {};
-  }
-  absl::btree_map<std::string, internal::PacketList> groups;
-  for (const auto& pkt : outcomes[0]) {
+absl::btree_map<std::string, std::vector<fourward::OutputPacket>>
+PacketsByP4RuntimePort(const T& result) {
+  absl::btree_map<std::string, std::vector<fourward::OutputPacket>> groups;
+  for (const auto& pkt : DeterministicPackets(result)) {
     groups[pkt.p4rt_egress_port()].push_back(pkt);
   }
   return groups;

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -414,7 +414,8 @@ inline auto OnPorts(
 // by port
 //
 // Returns a map from port to packets for the single deterministic outcome.
-// Fails the test if the result has != 1 possible outcome.
+// Fails the test if the result has != 1 possible outcome. Uses btree_map
+// for deterministic iteration order in test failure messages.
 // ---------------------------------------------------------------------------
 
 template <typename T>

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -16,12 +16,9 @@ namespace {
 
 using ::testing::AllOf;
 using ::testing::Contains;
-using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 using ::testing::Not;
-using ::testing::Pair;
 using ::testing::SizeIs;
-using ::testing::UnorderedElementsAre;
 
 // --- Test helpers ---
 
@@ -403,23 +400,6 @@ TEST(ErrorMessageTest, NoTraceWhenMatches) {
 
 TEST(CompositionTest, ForwardsToWithIngress) {
   EXPECT_THAT(MakeResult(5, 1), AllOf(ForwardsTo(1), HasIngress(5)));
-}
-
-// --- DeterministicPackets ---
-
-TEST(DeterministicPacketsTest, ExtractsPackets) {
-  auto packets = DeterministicPackets(Multicast(1, 2));
-  EXPECT_THAT(packets, UnorderedElementsAre(OnPort(1), OnPort(2)));
-}
-
-TEST(DeterministicPacketsTest, Drop) {
-  auto packets = DeterministicPackets(Drop());
-  EXPECT_THAT(packets, IsEmpty());
-}
-
-TEST(DeterministicPacketsTest, WorksOnProcessPacketResult) {
-  auto packets = DeterministicPackets(MakeResult(0, 3));
-  EXPECT_THAT(packets, ElementsAre(OnPort(3)));
 }
 
 // --- PacketsByDataplanePort ---

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -472,5 +472,22 @@ TEST(PacketsByP4RuntimePortTest, MissingPortReturnsEmpty) {
   EXPECT_THAT(by_port["Eth99"], IsEmpty());
 }
 
+TEST(PacketsByP4RuntimePortTest, PreservesPayloads) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* pkt = ps->add_packets();
+  pkt->set_p4rt_egress_port("Eth0");
+  pkt->set_payload("hello");
+
+  auto by_port = PacketsByP4RuntimePort(resp);
+  ASSERT_THAT(by_port["Eth0"], SizeIs(1));
+  EXPECT_EQ(by_port["Eth0"][0].payload(), "hello");
+}
+
+TEST(PacketsByP4RuntimePortTest, DropReturnsEmptyMap) {
+  auto by_port = PacketsByP4RuntimePort(Drop());
+  EXPECT_THAT(by_port, IsEmpty());
+}
+
 }  // namespace
 }  // namespace fourward

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -405,9 +405,9 @@ TEST(CompositionTest, ForwardsToWithIngress) {
   EXPECT_THAT(MakeResult(5, 1), AllOf(ForwardsTo(1), HasIngress(5)));
 }
 
-// --- PacketsByPort ---
+// --- PacketsByDataplanePort ---
 
-TEST(PacketsByPortTest, GroupsByDataplanePort) {
+TEST(PacketsByDataplanePortTest, GroupsByDataplanePort) {
   fourward::InjectPacketResponse resp;
   auto* ps = resp.add_possible_outcomes();
   auto* p1a = ps->add_packets();
@@ -418,36 +418,36 @@ TEST(PacketsByPortTest, GroupsByDataplanePort) {
   p1b->set_payload("b");
   ps->add_packets()->set_dataplane_egress_port(2);
 
-  auto by_port = PacketsByPort(resp);
+  auto by_port = PacketsByDataplanePort(resp);
   EXPECT_THAT(by_port, SizeIs(2));
   EXPECT_THAT(by_port[1], SizeIs(2));
   EXPECT_THAT(by_port[2], SizeIs(1));
 }
 
-TEST(PacketsByPortTest, MissingPortReturnsEmpty) {
-  auto by_port = PacketsByPort(Forward(1));
+TEST(PacketsByDataplanePortTest, MissingPortReturnsEmpty) {
+  auto by_port = PacketsByDataplanePort(Forward(1));
   EXPECT_THAT(by_port[99], IsEmpty());
 }
 
-TEST(PacketsByPortTest, WorksOnProcessPacketResult) {
-  auto by_port = PacketsByPort(MakeResult(0, 3));
+TEST(PacketsByDataplanePortTest, WorksOnProcessPacketResult) {
+  auto by_port = PacketsByDataplanePort(MakeResult(0, 3));
   EXPECT_THAT(by_port[3], SizeIs(1));
 }
 
-TEST(PacketsByPortTest, PreservesPayloads) {
+TEST(PacketsByDataplanePortTest, PreservesPayloads) {
   fourward::InjectPacketResponse resp;
   auto* ps = resp.add_possible_outcomes();
   auto* pkt = ps->add_packets();
   pkt->set_dataplane_egress_port(1);
   pkt->set_payload("hello");
 
-  auto by_port = PacketsByPort(resp);
+  auto by_port = PacketsByDataplanePort(resp);
   ASSERT_THAT(by_port[1], SizeIs(1));
   EXPECT_EQ(by_port[1][0].payload(), "hello");
 }
 
-TEST(PacketsByPortTest, DropReturnsEmptyMap) {
-  auto by_port = PacketsByPort(Drop());
+TEST(PacketsByDataplanePortTest, DropReturnsEmptyMap) {
+  auto by_port = PacketsByDataplanePort(Drop());
   EXPECT_THAT(by_port, IsEmpty());
 }
 

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -405,6 +405,23 @@ TEST(CompositionTest, ForwardsToWithIngress) {
   EXPECT_THAT(MakeResult(5, 1), AllOf(ForwardsTo(1), HasIngress(5)));
 }
 
+// --- DeterministicPackets ---
+
+TEST(DeterministicPacketsTest, ExtractsPackets) {
+  auto packets = DeterministicPackets(Multicast(1, 2));
+  EXPECT_THAT(packets, UnorderedElementsAre(OnPort(1), OnPort(2)));
+}
+
+TEST(DeterministicPacketsTest, Drop) {
+  auto packets = DeterministicPackets(Drop());
+  EXPECT_THAT(packets, IsEmpty());
+}
+
+TEST(DeterministicPacketsTest, WorksOnProcessPacketResult) {
+  auto packets = DeterministicPackets(MakeResult(0, 3));
+  EXPECT_THAT(packets, ElementsAre(OnPort(3)));
+}
+
 // --- PacketsByDataplanePort ---
 
 TEST(PacketsByDataplanePortTest, GroupsByDataplanePort) {

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -16,9 +16,12 @@ namespace {
 
 using ::testing::AllOf;
 using ::testing::Contains;
+using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 using ::testing::Not;
+using ::testing::Pair;
 using ::testing::SizeIs;
+using ::testing::UnorderedElementsAre;
 
 // --- Test helpers ---
 
@@ -400,6 +403,76 @@ TEST(ErrorMessageTest, NoTraceWhenMatches) {
 
 TEST(CompositionTest, ForwardsToWithIngress) {
   EXPECT_THAT(MakeResult(5, 1), AllOf(ForwardsTo(1), HasIngress(5)));
+}
+
+// --- PacketsByPort ---
+
+TEST(PacketsByPortTest, GroupsByDataplanePort) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* p1a = ps->add_packets();
+  p1a->set_dataplane_egress_port(1);
+  p1a->set_payload("a");
+  auto* p1b = ps->add_packets();
+  p1b->set_dataplane_egress_port(1);
+  p1b->set_payload("b");
+  ps->add_packets()->set_dataplane_egress_port(2);
+
+  auto by_port = PacketsByPort(resp);
+  EXPECT_THAT(by_port, SizeIs(2));
+  EXPECT_THAT(by_port[1], SizeIs(2));
+  EXPECT_THAT(by_port[2], SizeIs(1));
+}
+
+TEST(PacketsByPortTest, MissingPortReturnsEmpty) {
+  auto by_port = PacketsByPort(Forward(1));
+  EXPECT_THAT(by_port[99], IsEmpty());
+}
+
+TEST(PacketsByPortTest, WorksOnProcessPacketResult) {
+  auto by_port = PacketsByPort(MakeResult(0, 3));
+  EXPECT_THAT(by_port[3], SizeIs(1));
+}
+
+TEST(PacketsByPortTest, PreservesPayloads) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* pkt = ps->add_packets();
+  pkt->set_dataplane_egress_port(1);
+  pkt->set_payload("hello");
+
+  auto by_port = PacketsByPort(resp);
+  ASSERT_THAT(by_port[1], SizeIs(1));
+  EXPECT_EQ(by_port[1][0].payload(), "hello");
+}
+
+TEST(PacketsByPortTest, DropReturnsEmptyMap) {
+  auto by_port = PacketsByPort(Drop());
+  EXPECT_THAT(by_port, IsEmpty());
+}
+
+// --- PacketsByP4RuntimePort ---
+
+TEST(PacketsByP4RuntimePortTest, GroupsByP4RuntimePort) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_p4rt_egress_port("Eth0");
+  ps->add_packets()->set_p4rt_egress_port("Eth0");
+  ps->add_packets()->set_p4rt_egress_port("Eth1");
+
+  auto by_port = PacketsByP4RuntimePort(resp);
+  EXPECT_THAT(by_port, SizeIs(2));
+  EXPECT_THAT(by_port["Eth0"], SizeIs(2));
+  EXPECT_THAT(by_port["Eth1"], SizeIs(1));
+}
+
+TEST(PacketsByP4RuntimePortTest, MissingPortReturnsEmpty) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_p4rt_egress_port("Eth0");
+
+  auto by_port = PacketsByP4RuntimePort(resp);
+  EXPECT_THAT(by_port["Eth99"], IsEmpty());
 }
 
 }  // namespace

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -26,7 +26,7 @@ Shorthands   ForwardsTo  Forwards  Drops
 Outcomes     OutcomeIs  OutcomesAre  EachOutcome  AnyOutcome  Outcome
 Packets      OnPort  HasPayload  OnPorts  Packets
 Input        HasIngress
-Extraction   PacketsByDataplanePort  PacketsByP4RuntimePort
+Extraction   DeterministicPackets  PacketsByDataplanePort  PacketsByP4RuntimePort
 ```
 
 ## The basics
@@ -191,11 +191,24 @@ EXPECT_THAT(response, OutcomeIs(OnPorts({
 })));
 ```
 
-## Extracting packets by port
+## Extracting packets
 
 When you need packets in variables for follow-up work — parsing headers,
-computing deltas, feeding into helpers — `PacketsByDataplanePort` groups the
-single deterministic outcome into a map you can index directly:
+computing deltas, feeding into helpers — use the extraction functions.
+
+`DeterministicPackets` returns the flat packet list from a single
+deterministic outcome:
+
+```cpp
+using ::fourward::DeterministicPackets;
+
+auto packets = DeterministicPackets(response);
+EXPECT_THAT(packets, SizeIs(3));
+auto parsed = ParseHeader(packets[0].payload());
+```
+
+`PacketsByDataplanePort` and `PacketsByP4RuntimePort` go one step
+further and group by egress port:
 
 ```cpp
 using ::fourward::PacketsByDataplanePort;
@@ -206,12 +219,7 @@ auto& port2 = by_port[2];
 
 EXPECT_THAT(port1, SizeIs(2));
 EXPECT_THAT(port2, ElementsAre(HasPayload(expected_bytes)));
-
-// Or do non-matcher work:
-auto parsed = ParseHeader(port1[0].payload());
 ```
-
-For P4Runtime ports, use `PacketsByP4RuntimePort`:
 
 ```cpp
 using ::fourward::PacketsByP4RuntimePort;
@@ -221,8 +229,9 @@ auto& eth0 = by_port["Ethernet0"];
 auto& eth1 = by_port["Ethernet1"];
 ```
 
-Both functions fail the test if the response has more than one possible
-outcome. Indexing a port that received no packets returns an empty vector.
+All three functions fail the test if the response has more than one
+possible outcome. Indexing a port that received no packets returns an
+empty vector.
 
 ## Ingress port
 

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -31,7 +31,7 @@ Extraction   PacketsByDataplanePort  PacketsByP4RuntimePort
 
 ## The basics
 
-Most tests only need the shorthands. They work on both
+Many tests only need the shorthands. They work on both
 `InjectPacketResponse` (from `InjectPacket`) and `ProcessPacketResult`
 (from `ResultStream::Next`):
 
@@ -103,60 +103,6 @@ with `Eq`, `StartsWith`, `ResultOf`, and anything else gmock offers.
 EXPECT_THAT(dataplane.InjectPacket({...}), IsOkAndHolds(Forwards()));
 ```
 
-## Handling multiple outcomes
-
-P4 programs with action selectors can produce multiple possible outcomes
-— each representing one "possible world."
-
-**`OutcomesAre`** pins the exact set of outcomes (order-independent).
-Each argument is a packet matcher for a single-packet outcome; use
-`Outcome(...)` to spell out a multi-packet outcome:
-
-```cpp
-using ::fourward::OutcomesAre;
-using ::fourward::Outcome;
-
-// Action selector: forwards to port 1 or port 2.
-EXPECT_THAT(response, OutcomesAre(OnPort(1), OnPort(2)));
-
-// One outcome multicasts, the other drops:
-EXPECT_THAT(response, OutcomesAre(
-    Outcome(OnPort(1), OnPort(2)),
-    Outcome()));
-```
-
-**`EachOutcome`** and **`AnyOutcome`** quantify when you don't need to
-pin the exact set:
-
-```cpp
-using ::fourward::EachOutcome;
-using ::fourward::AnyOutcome;
-
-// No matter what the selector picks, the packet reaches port 1:
-EXPECT_THAT(response, EachOutcome(OnPort(1)));
-
-// At least one branch drops:
-EXPECT_THAT(response, AnyOutcome(Packets(IsEmpty())));
-```
-
-## Container-level matching with Packets(...)
-
-When you need to match properties of the packet *list* rather than
-individual packets — size, port grouping, etc. — wrap the matcher in
-`Packets(...)`:
-
-```cpp
-using ::fourward::Packets;
-
-// Exactly 7 output packets:
-EXPECT_THAT(response, OutcomeIs(Packets(SizeIs(7))));
-
-// At least one output packet on port 1:
-EXPECT_THAT(response, OutcomeIs(Packets(Contains(OnPort(1)))));
-```
-
-`Packets(...)` works inside `OutcomeIs`, `EachOutcome`, and `AnyOutcome`.
-
 ## Grouping by port
 
 `OnPorts` groups packets by egress port and applies per-group matchers —
@@ -226,6 +172,60 @@ Both functions fail the test if the response has more than one possible
 outcome. Indexing a port that received no packets returns an empty
 vector.
 
+## Handling multiple outcomes
+
+P4 programs with action selectors can produce multiple possible outcomes
+— each representing one "possible world."
+
+**`OutcomesAre`** pins the exact set of outcomes (order-independent).
+Each argument is a packet matcher for a single-packet outcome; use
+`Outcome(...)` to spell out a multi-packet outcome:
+
+```cpp
+using ::fourward::OutcomesAre;
+using ::fourward::Outcome;
+
+// Action selector: forwards to port 1 or port 2.
+EXPECT_THAT(response, OutcomesAre(OnPort(1), OnPort(2)));
+
+// One outcome multicasts, the other drops:
+EXPECT_THAT(response, OutcomesAre(
+    Outcome(OnPort(1), OnPort(2)),
+    Outcome()));
+```
+
+**`EachOutcome`** and **`AnyOutcome`** quantify when you don't need to
+pin the exact set:
+
+```cpp
+using ::fourward::EachOutcome;
+using ::fourward::AnyOutcome;
+
+// No matter what the selector picks, the packet reaches port 1:
+EXPECT_THAT(response, EachOutcome(OnPort(1)));
+
+// At least one branch drops:
+EXPECT_THAT(response, AnyOutcome(Packets(IsEmpty())));
+```
+
+## Container-level matching with Packets(...)
+
+When you need to match properties of the packet *list* rather than
+individual packets — size, port grouping, etc. — wrap the matcher in
+`Packets(...)`:
+
+```cpp
+using ::fourward::Packets;
+
+// Exactly 7 output packets:
+EXPECT_THAT(response, OutcomeIs(Packets(SizeIs(7))));
+
+// At least one output packet on port 1:
+EXPECT_THAT(response, OutcomeIs(Packets(Contains(OnPort(1)))));
+```
+
+`Packets(...)` works inside `OutcomeIs`, `EachOutcome`, and `AnyOutcome`.
+
 ## Ingress port
 
 `HasIngress` works on `ProcessPacketResult` (which carries the input
@@ -276,30 +276,6 @@ EXPECT_THAT(response, OutcomeIs(OnPort(1), HasParsedPayload(
 4ward doesn't depend on packetlib — `HasPayload` just hands its matcher
 whatever `ResultOf` returns, so any `bytes → T` parser works the same
 way.
-
-## Trace on failure
-
-When an outcome-level matcher fails (`ForwardsTo`, `Forwards`, `Drops`,
-`OutcomeIs`, `OutcomesAre`, `EachOutcome`, `AnyOutcome`), the full
-simulator trace is automatically appended to the failure message — if the
-response carries one. This gives you immediate visibility into how the
-packet was processed without rerunning the test:
-
-```
-Expected: drop the packet
-  Actual: (has 1 possible outcomes),
-full trace:
-events {
-  table_lookup {
-    table_name: "ingress.acl"
-    hit: true
-    ...
-  }
-}
-...
-```
-
-No opt-in needed — the trace shows up whenever the response has one.
 
 ## Bazel dependency
 

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -26,7 +26,7 @@ Shorthands   ForwardsTo  Forwards  Drops
 Outcomes     OutcomeIs  OutcomesAre  EachOutcome  AnyOutcome  Outcome
 Packets      OnPort  HasPayload  OnPorts  Packets
 Input        HasIngress
-Extraction   PacketsByPort  PacketsByP4RuntimePort
+Extraction   PacketsByDataplanePort  PacketsByP4RuntimePort
 ```
 
 ## The basics
@@ -194,13 +194,13 @@ EXPECT_THAT(response, OutcomeIs(OnPorts({
 ## Extracting packets by port
 
 When you need packets in variables for follow-up work — parsing headers,
-computing deltas, feeding into helpers — `PacketsByPort` groups the
-single deterministic outcome into a `std::map` you can index directly:
+computing deltas, feeding into helpers — `PacketsByDataplanePort` groups the
+single deterministic outcome into a map you can index directly:
 
 ```cpp
-using ::fourward::PacketsByPort;
+using ::fourward::PacketsByDataplanePort;
 
-auto by_port = PacketsByPort(response);
+auto by_port = PacketsByDataplanePort(response);
 auto& port1 = by_port[1];
 auto& port2 = by_port[2];
 

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -81,14 +81,17 @@ using ::fourward::OutcomeIs;
 using ::fourward::OnPort;
 using ::fourward::HasPayload;
 
+// Single packet on port 1:
+EXPECT_THAT(response, OutcomeIs(OnPort(1)));
+
+// Multicast — two output packets:
+EXPECT_THAT(response, OutcomeIs(OnPort(1), OnPort(2)));
+
 // Port and payload:
 EXPECT_THAT(response, OutcomeIs(OnPort(1, expected_bytes)));
 
 // With a payload matcher:
-EXPECT_THAT(response, OutcomeIs(OnPort(1, HasPayload(StartsWith("hello")))));
-
-// Multicast — two output packets:
-EXPECT_THAT(response, OutcomeIs(OnPort(1), OnPort(2)));
+EXPECT_THAT(response, OutcomeIs(OnPort(1, HasPayload(EndsWith("hello")))));
 ```
 
 `HasPayload` takes any `Matcher<const std::string&>`, so it plays nicely
@@ -110,8 +113,7 @@ use it when a single `EXPECT_THAT` covers everything you need. When you
 need packets in variables for more involved follow-up, see
 [Extracting packets by port](#extracting-packets-by-port) below.
 
-`OnPorts` doesn't need a `Packets(...)` wrapper — use it directly
-inside `OutcomeIs`:
+Use `OnPorts` directly inside `OutcomeIs`:
 
 ```cpp
 using ::fourward::OnPorts;
@@ -146,26 +148,37 @@ EXPECT_THAT(response, OutcomeIs(OnPorts({
 `PacketsByDataplanePort` and `PacketsByP4RuntimePort` are the
 variable-extraction counterpart to [`OnPorts`](#grouping-by-port) —
 same grouping, but the result lands in a map you can index directly
-for follow-up work (parsing headers, computing deltas, feeding into
-helpers):
+or match exhaustively with gmock's container matchers:
 
 ```cpp
 using ::fourward::PacketsByDataplanePort;
 
 auto by_port = PacketsByDataplanePort(response);
-auto& port1 = by_port[1];
-auto& port2 = by_port[2];
 
-EXPECT_THAT(port1, SizeIs(2));
-EXPECT_THAT(port2, ElementsAre(HasPayload(expected_bytes)));
+// Index into individual ports:
+EXPECT_THAT(by_port[1], SizeIs(2));
+EXPECT_THAT(by_port[2], ElementsAre(HasPayload(expected_bytes)));
+
+// Or match the whole map — exhaustive, no stray ports:
+EXPECT_THAT(by_port, UnorderedElementsAreArray({
+    Pair(1, UnorderedElementsAreArray({
+        HasPayload(packet_a),
+        HasPayload(packet_b),
+    })),
+    Pair(2, UnorderedElementsAreArray({
+        HasPayload(packet_c),
+    })),
+}));
 ```
 
 ```cpp
 using ::fourward::PacketsByP4RuntimePort;
 
 auto by_port = PacketsByP4RuntimePort(response);
-auto& eth0 = by_port["Ethernet0"];
-auto& eth1 = by_port["Ethernet1"];
+EXPECT_THAT(by_port, UnorderedElementsAreArray({
+    Pair("Ethernet0", SizeIs(1)),
+    Pair("Ethernet1", SizeIs(1)),
+}));
 ```
 
 Both functions fail the test if the response has more than one possible

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -26,6 +26,7 @@ Shorthands   ForwardsTo  Forwards  Drops
 Outcomes     OutcomeIs  OutcomesAre  EachOutcome  AnyOutcome  Outcome
 Packets      OnPort  HasPayload  OnPorts  Packets
 Input        HasIngress
+Extraction   PacketsByPort  PacketsByP4RuntimePort
 ```
 
 ## The basics
@@ -189,6 +190,39 @@ EXPECT_THAT(response, OutcomeIs(OnPorts({
     {P4RuntimePort{"Ethernet1"}, SizeIs(1)},
 })));
 ```
+
+## Extracting packets by port
+
+When you need packets in variables for follow-up work — parsing headers,
+computing deltas, feeding into helpers — `PacketsByPort` groups the
+single deterministic outcome into a `std::map` you can index directly:
+
+```cpp
+using ::fourward::PacketsByPort;
+
+auto by_port = PacketsByPort(response);
+auto& port1 = by_port[1];
+auto& port2 = by_port[2];
+
+EXPECT_THAT(port1, SizeIs(2));
+EXPECT_THAT(port2, ElementsAre(HasPayload(expected_bytes)));
+
+// Or do non-matcher work:
+auto parsed = ParseHeader(port1[0].payload());
+```
+
+For P4Runtime ports, use `PacketsByP4RuntimePort`:
+
+```cpp
+using ::fourward::PacketsByP4RuntimePort;
+
+auto by_port = PacketsByP4RuntimePort(response);
+auto& eth0 = by_port["Ethernet0"];
+auto& eth1 = by_port["Ethernet1"];
+```
+
+Both functions fail the test if the response has more than one possible
+outcome. Indexing a port that received no packets returns an empty vector.
 
 ## Ingress port
 

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -174,8 +174,7 @@ EXPECT_THAT(by_port, UnorderedElementsAreArray({
 ```cpp
 using ::fourward::PacketsByP4RuntimePort;
 
-auto by_port = PacketsByP4RuntimePort(response);
-EXPECT_THAT(by_port, UnorderedElementsAreArray({
+EXPECT_THAT(PacketsByP4RuntimePort(response), UnorderedElementsAreArray({
     Pair("Ethernet0", SizeIs(1)),
     Pair("Ethernet1", SizeIs(1)),
 }));
@@ -289,6 +288,30 @@ EXPECT_THAT(response, OutcomeIs(OnPort(1), HasParsedPayload(
 4ward doesn't depend on packetlib — `HasPayload` just hands its matcher
 whatever `ResultOf` returns, so any `bytes → T` parser works the same
 way.
+
+## Trace on failure
+
+When an outcome-level matcher fails (`ForwardsTo`, `Forwards`, `Drops`,
+`OutcomeIs`, `OutcomesAre`, `EachOutcome`, `AnyOutcome`), the full
+simulator trace is automatically appended to the failure message — if the
+response carries one. This gives you immediate visibility into how the
+packet was processed without rerunning the test:
+
+```
+Expected: drop the packet
+  Actual: (has 1 possible outcomes),
+full trace:
+events {
+  table_lookup {
+    table_name: "ingress.acl"
+    hit: true
+    ...
+  }
+}
+...
+```
+
+No opt-in needed — the trace shows up whenever the response has one.
 
 ## Bazel dependency
 

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -159,9 +159,13 @@ EXPECT_THAT(response, OutcomeIs(Packets(Contains(OnPort(1)))));
 
 ## Grouping by port
 
-`OnPorts` groups packets by egress port and applies per-group matchers.
-It doesn't need a `Packets(...)` wrapper — use it directly inside
-`OutcomeIs`:
+`OnPorts` groups packets by egress port and applies per-group matchers —
+use it when a single `EXPECT_THAT` covers everything you need. When you
+need packets in variables for more involved follow-up, see
+[Extracting packets by port](#extracting-packets-by-port) below.
+
+`OnPorts` doesn't need a `Packets(...)` wrapper — use it directly
+inside `OutcomeIs`:
 
 ```cpp
 using ::fourward::OnPorts;
@@ -193,10 +197,11 @@ EXPECT_THAT(response, OutcomeIs(OnPorts({
 
 ## Extracting packets by port
 
-When you need packets in variables for follow-up work — parsing headers,
-computing deltas, feeding into helpers — `PacketsByDataplanePort` and
-`PacketsByP4RuntimePort` group the single deterministic outcome into a
-map you can index directly:
+`PacketsByDataplanePort` and `PacketsByP4RuntimePort` are the
+variable-extraction counterpart to [`OnPorts`](#grouping-by-port) —
+same grouping, but the result lands in a map you can index directly
+for follow-up work (parsing headers, computing deltas, feeding into
+helpers):
 
 ```cpp
 using ::fourward::PacketsByDataplanePort;
@@ -217,9 +222,9 @@ auto& eth0 = by_port["Ethernet0"];
 auto& eth1 = by_port["Ethernet1"];
 ```
 
-All three functions fail the test if the response has more than one
-possible outcome. Indexing a port that received no packets returns an
-empty vector.
+Both functions fail the test if the response has more than one possible
+outcome. Indexing a port that received no packets returns an empty
+vector.
 
 ## Ingress port
 

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -26,7 +26,7 @@ Shorthands   ForwardsTo  Forwards  Drops
 Outcomes     OutcomeIs  OutcomesAre  EachOutcome  AnyOutcome  Outcome
 Packets      OnPort  HasPayload  OnPorts  Packets
 Input        HasIngress
-Extraction   DeterministicPackets  PacketsByDataplanePort  PacketsByP4RuntimePort
+Extraction   PacketsByDataplanePort  PacketsByP4RuntimePort
 ```
 
 ## The basics
@@ -191,24 +191,12 @@ EXPECT_THAT(response, OutcomeIs(OnPorts({
 })));
 ```
 
-## Extracting packets
+## Extracting packets by port
 
 When you need packets in variables for follow-up work — parsing headers,
-computing deltas, feeding into helpers — use the extraction functions.
-
-`DeterministicPackets` returns the flat packet list from a single
-deterministic outcome:
-
-```cpp
-using ::fourward::DeterministicPackets;
-
-auto packets = DeterministicPackets(response);
-EXPECT_THAT(packets, SizeIs(3));
-auto parsed = ParseHeader(packets[0].payload());
-```
-
-`PacketsByDataplanePort` and `PacketsByP4RuntimePort` go one step
-further and group by egress port:
+computing deltas, feeding into helpers — `PacketsByDataplanePort` and
+`PacketsByP4RuntimePort` group the single deterministic outcome into a
+map you can index directly:
 
 ```cpp
 using ::fourward::PacketsByDataplanePort;


### PR DESCRIPTION
Fixes #654.

## Summary

Adds `PacketsByDataplanePort` and `PacketsByP4RuntimePort` — extraction
functions that group a deterministic outcome's packets into an
`absl::btree_map` keyed by egress port. Useful when you need packets in
variables for multi-step follow-up assertions, rather than one-shotting
everything in a single `OnPorts` matcher expression.

```cpp
auto by_port = PacketsByDataplanePort(response);
EXPECT_THAT(by_port[1], SizeIs(2));
EXPECT_THAT(by_port[2], ElementsAre(HasPayload(expected)));
```

Composes with gmock's container matchers for exhaustive port matching:

```cpp
EXPECT_THAT(by_port, UnorderedElementsAreArray({
    Pair(1, UnorderedElementsAreArray({
        HasPayload(packet_a),
        HasPayload(packet_b),
    })),
    Pair(2, UnorderedElementsAreArray({
        HasPayload(packet_c),
    })),
}));
```

Also:
- Migrates all `std::map` usage in `dataplane_matchers.h` to `absl::btree_map`
- Reorganizes the matchers docs to put port grouping/extraction earlier
- Various doc improvements (unicast-first examples, `EndsWith` for realistic payload matching, cross-references between `OnPorts` and `PacketsBy*`)

## Test plan

- [x] Unit tests for both functions: grouping, missing port, drop, payload preservation, ProcessPacketResult support
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)