### PR TITLE
p4runtime: bit-level PacketOut packing and trailing-zeros assertion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,11 @@ obvious approach, works around a non-obvious constraint, or implements a
 subtle spec requirement. Include spec references (section numbers, GitHub
 issues) where helpful. Do not add comments that merely restate the code.
 
+**Encode invariants as assertions, not comments.** A `require()`,
+`check()`, or exhaustive `when` that fails at runtime is worth more than
+a comment that hopes the next reader will notice. Comments describe
+intent; assertions enforce it.
+
 **Never use deprecated APIs.** When a library marks a function deprecated,
 find and use the successor immediately — don't suppress the warning. A
 deprecated call that works today is a broken call on the next upgrade.

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -213,10 +213,10 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
-    name = "InlineP4CompilerTest",
+    name = "BitLevelSerializationTest",
     srcs = [
+        "BitLevelSerializationTest.kt",
         "FourwardTestHarness.kt",
-        "InlineP4CompilerTest.kt",
     ],
     data = [
         "//p4c_backend:p4c-4ward",
@@ -227,7 +227,7 @@ kt_jvm_test(
         "-Dp4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
         "-Dp4include=$(rlocationpath @p4c//p4include:core.p4)",
     ],
-    test_class = "fourward.grpc.InlineP4CompilerTest",
+    test_class = "fourward.grpc.BitLevelSerializationTest",
     deps = [
         ":dataplane_java_proto",
         ":dataplane_kt_grpc",

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -692,6 +692,7 @@ kt_jvm_test(
     test_class = "fourward.grpc.PacketHeaderCodecTest",
     deps = [
         ":grpc",
+        "//simulator",
         "//simulator:ir_java_proto",
         "//simulator:p4info_java_proto",
         "//simulator:p4runtime_java_proto",

--- a/grpc/BitLevelSerializationTest.kt
+++ b/grpc/BitLevelSerializationTest.kt
@@ -2,6 +2,7 @@ package fourward.grpc
 
 import fourward.e2e.compileInlineP4
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -482,6 +483,112 @@ class BitLevelSerializationTest {
           "(first byte: expected != 0xAA, got 0x${"%02X".format(outputBytes[0])})",
         outputBytes[0] != 0xAA.toByte(),
       )
+    }
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `PacketOut with non-byte-aligned header preserves payload through P4Runtime`() {
+    // A 5-bit @controller_header("packet_out") + 5-bit @controller_header("packet_in").
+    // The program always forwards to CPU port (510), so the PacketOut produces a
+    // PacketIn response whose payload we can check for corruption.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      @controller_header("packet_out")
+      header packet_out_t { bit<5> tag; }
+
+      @controller_header("packet_in")
+      header packet_in_t { bit<5> tag; }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { packet_out_t pkt_out; packet_in_t pkt_in; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start {
+          pkt.extract(hdr.pkt_out);
+          pkt.extract(hdr.eth);
+          transition accept;
+        }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 510; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          h.pkt_out.setInvalid();
+          h.pkt_in.setValid();
+          h.pkt_in.tag = 0;
+        }
+      }
+      control D(packet_out pkt, in headers_t h) {
+        apply {
+          pkt.emit(h.pkt_out);
+          pkt.emit(h.pkt_in);
+          pkt.emit(h.eth);
+        }
+      }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+
+      it.openStream().use { session ->
+        session.arbitrate()
+
+        val packetOut =
+          p4.v1.P4RuntimeOuterClass.PacketOut.newBuilder()
+            .setPayload(
+              com.google.protobuf.ByteString.copyFrom(
+                byteArrayOf(
+                  0xAA.toByte(),
+                  0xAA.toByte(),
+                  0xAA.toByte(),
+                  0xAA.toByte(),
+                  0xAA.toByte(),
+                  0xAA.toByte(),
+                  0xBB.toByte(),
+                  0xBB.toByte(),
+                  0xBB.toByte(),
+                  0xBB.toByte(),
+                  0xBB.toByte(),
+                  0xBB.toByte(),
+                  0x08,
+                  0x06,
+                )
+              )
+            )
+            .addMetadata(
+              p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
+                .setMetadataId(1)
+                .setValue(com.google.protobuf.ByteString.copyFrom(byteArrayOf(0)))
+            )
+            .build()
+
+        val response = session.sendPacketOut(packetOut)
+
+        // If packPacketOut correctly bit-packed the 5-bit header with the payload,
+        // the parser reads the correct ethernet frame. If it used byte-concat,
+        // 3 padding zeros would corrupt the dst_mac.
+        assertNotNull("should get PacketIn response from CPU port", response)
+        assertTrue("response should be PacketIn", response!!.hasPacket())
+        val payload = response.packet.payload.toByteArray()
+
+        assertEquals(
+          "dst_mac first byte should be 0xAA (not corrupted by padding)",
+          0xAA.toByte(),
+          payload[0],
+        )
+      }
     }
   }
 }

--- a/grpc/BitLevelSerializationTest.kt
+++ b/grpc/BitLevelSerializationTest.kt
@@ -5,7 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class InlineP4CompilerTest {
+class BitLevelSerializationTest {
 
   @Test
   fun `compiles minimal passthrough program`() {

--- a/grpc/InlineP4CompilerTest.kt
+++ b/grpc/InlineP4CompilerTest.kt
@@ -398,4 +398,90 @@ class InlineP4CompilerTest {
       )
     }
   }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `non-byte-aligned packet_out header corrupts payload on PacketOut`() {
+    // A 5-bit @controller_header("packet_out") header. serializePacketOut produces
+    // ceil(5/8) = 1 byte (5 data bits + 3 padding zeros). This byte is prepended to
+    // the payload via byte concatenation: [header_byte] [payload_byte_0] ...
+    //
+    // The parser extracts 5 bits for the header, then tries to extract ethernet
+    // starting at bit 5. But bits 5-7 are padding zeros from the byte-aligned
+    // serialization — they're not part of the original payload. The parser reads
+    // garbage, and the output packet is corrupted.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      @controller_header("packet_out")
+      header packet_out_t { bit<5> port; }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { packet_out_t pkt_out; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start {
+          pkt.extract(hdr.pkt_out);
+          pkt.extract(hdr.eth);
+          transition accept;
+        }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = (bit<9>) h.pkt_out.port; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+
+      // Manually construct what the P4Runtime server does: serialize the 5-bit
+      // header and prepend it to the payload.
+      val headerByte = byteArrayOf(0x08) // port=1 → 00001 left-aligned = 00001_000 = 0x08
+      val ethernetPayload =
+        byteArrayOf(
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xAA.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0xBB.toByte(),
+          0x08,
+          0x06,
+        )
+      val packet = headerByte + ethernetPayload
+
+      // The simulator receives this as a byte array. The parser extracts 5 bits
+      // for the header (port=1), then 112 bits for ethernet starting at bit 5.
+      // But bits 5-7 are padding zeros, not ethernet data.
+      val response = it.simulatePacket(ingressPort = 0, payload = packet)
+      val output = response.single().packetsList.single()
+      val outputBytes = output.payload.toByteArray()
+
+      // If the parser correctly handled the 5-bit header, the ethernet dst_mac
+      // would be 0xAA repeated. But because of the 3 padding bits, the parser
+      // reads 000_10101010... instead of 10101010..., corrupting the MAC.
+      assertTrue(
+        "ethernet dst_mac should be corrupted by 3 padding bits between header and payload " +
+          "(first byte: expected != 0xAA, got 0x${"%02X".format(outputBytes[0])})",
+        outputBytes[0] != 0xAA.toByte(),
+      )
+    }
+  }
 }

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -676,8 +676,8 @@ class P4RuntimeService(
     // port with the header prepended.
     val (ingressPort, payload) =
       if (codec != null) {
-        val header = codec.serializePacketOut(packetOut.metadataList)
-        codec.cpuPort to (header + packetOut.payload.toByteArray())
+        codec.cpuPort to
+          codec.packPacketOut(packetOut.metadataList, packetOut.payload.toByteArray())
       } else {
         extractIngressPort(packetOut.metadataList) to packetOut.payload.toByteArray()
       }

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -71,8 +71,10 @@ private constructor(
 ) {
   data class FieldDef(val id: Int, val name: String, val bitWidth: Int)
 
+  private val packetOutHeaderBits: Int = packetOutFields.sumOf { it.bitWidth }
+
   /** Total bytes of the serialized packet_out header. */
-  val packetOutHeaderBytes: Int = (packetOutFields.sumOf { it.bitWidth } + 7) / 8
+  val packetOutHeaderBytes: Int = (packetOutHeaderBits + 7) / 8
 
   /**
    * Total bits of the serialized packet_in header, derived from p4info field widths. Correctness
@@ -132,10 +134,9 @@ private constructor(
    */
   @Suppress("MagicNumber")
   fun packPacketOut(metadata: List<PacketMetadata>, payload: ByteArray): ByteArray {
-    val headerBits = packetOutFields.sumOf { it.bitWidth }
     // When the header is byte-aligned, serializePacketOut produces exact-width bytes
     // and byte-concatenation with the payload introduces no padding gap.
-    if (headerBits % 8 == 0) return serializePacketOut(metadata) + payload
+    if (packetOutHeaderBits % 8 == 0) return serializePacketOut(metadata) + payload
     val metadataById = metadata.associateBy { it.metadataId }
     val acc = BitAccumulator()
     for (field in packetOutFields) {

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -96,11 +96,25 @@ private constructor(
     // Bit-level strip: remove exactly packetInHeaderBits from the front of the
     // continuous bit stream and repack the remaining bits into bytes.
     val bytes = payload.toByteArray()
-    // Assumes the original payload was N whole bytes. The deparsed stream is
-    // ceil((headerBits + N*8) / 8) bytes. We recover N via integer division,
-    // which truncates any sub-byte remainder — only whole payload bytes survive.
-    val payloadBits = (bytes.size * 8 - packetInHeaderBits) / 8 * 8
+    // The deparsed byte array contains: headerBits + payloadBits + trailingPadBits,
+    // where trailingPadBits < 8 are zeros added by byte-alignment at the end.
+    // The payload (everything after the controller header) is always a whole number
+    // of bytes: it consists of deparser-emitted headers (byte-aligned by the P4
+    // spec for all real targets) followed by the unparsed packet remainder (a suffix
+    // of the original byte-array input). Integer division by 8 recovers the exact
+    // payload byte count, discarding only the trailing pad zeros.
+    val totalBits = bytes.size * 8
+    val payloadBits = (totalBits - packetInHeaderBits) / 8 * 8
     if (payloadBits <= 0) return ByteString.EMPTY
+    val discardedBits = totalBits - packetInHeaderBits - payloadBits
+    if (discardedBits > 0) {
+      val trailingMask = (1 shl discardedBits) - 1
+      check(bytes.last().toInt() and trailingMask == 0) {
+        "expected $discardedBits trailing zero-pad bits, but last byte is 0x${
+          "%02X".format(bytes.last())
+        } — payload after @controller_header may not be byte-aligned"
+      }
+    }
     val outBytes = payloadBits / 8
     val result = ByteArray(outBytes)
     val skipBits = packetInHeaderBits

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -138,6 +138,46 @@ private constructor(
   }
 
   /**
+   * Packs the PacketOut header and payload into a continuous bit stream. The header fields are
+   * packed at bit granularity followed immediately by the payload bits — no inter-field padding.
+   * This avoids the corruption that byte-concatenation causes for non-byte-aligned headers.
+   */
+  @Suppress("MagicNumber")
+  fun packPacketOut(metadata: List<PacketMetadata>, payload: ByteArray): ByteArray {
+    val headerBits = packetOutFields.sumOf { it.bitWidth }
+    if (headerBits % 8 == 0) return serializePacketOut(metadata) + payload
+    val metadataById = metadata.associateBy { it.metadataId }
+    val totalBits = headerBits + payload.size * 8
+    val outBytes = (totalBits + 7) / 8
+    val result = ByteArray(outBytes)
+    // Pack header fields into bit positions 0..headerBits-1.
+    var bitPos = 0
+    for (field in packetOutFields) {
+      val raw = metadataById[field.id]?.value?.toByteArray() ?: ByteArray(0)
+      var v = 0L
+      for (b in raw) v = (v shl 8) or (b.toLong() and 0xFF)
+      if (field.bitWidth < Long.SIZE_BITS) v = v and ((1L shl field.bitWidth) - 1)
+      for (bit in field.bitWidth - 1 downTo 0) {
+        if (v and (1L shl bit) != 0L) {
+          result[bitPos / 8] = (result[bitPos / 8].toInt() or (0x80 ushr (bitPos % 8))).toByte()
+        }
+        bitPos++
+      }
+    }
+    // Pack payload bytes immediately after the header bits.
+    for (b in payload) {
+      val byteIdx = bitPos / 8
+      val bitOff = bitPos % 8
+      result[byteIdx] = (result[byteIdx].toInt() or ((b.toInt() and 0xFF) ushr bitOff)).toByte()
+      if (bitOff > 0 && byteIdx + 1 < outBytes) {
+        result[byteIdx + 1] = ((b.toInt() and 0xFF) shl (8 - bitOff)).toByte()
+      }
+      bitPos += 8
+    }
+    return result
+  }
+
+  /**
    * Builds PacketIn metadata from ingress and egress port values.
    *
    * Metadata is constructed from the simulation context rather than parsed from the deparsed

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -9,6 +9,8 @@ package fourward.grpc
 import com.google.protobuf.ByteString
 import fourward.BehavioralConfig
 import fourward.Type
+import fourward.simulator.BitAccumulator
+import java.math.BigInteger
 import p4.config.v1.P4InfoOuterClass.P4Info
 import p4.v1.P4RuntimeOuterClass.PacketMetadata
 
@@ -91,10 +93,7 @@ private constructor(
   @Suppress("MagicNumber")
   fun stripPacketInHeader(payload: ByteString): ByteString {
     if (packetInHeaderBits == 0) return payload
-    // Fast path: byte-aligned header, no bit-shifting needed.
     if (packetInHeaderBits % 8 == 0) return payload.substring(packetInHeaderBytes)
-    // Bit-level strip: remove exactly packetInHeaderBits from the front of the
-    // continuous bit stream and repack the remaining bits into bytes.
     val bytes = payload.toByteArray()
     // The deparsed byte array contains: headerBits + payloadBits + trailingPadBits,
     // where trailingPadBits < 8 are zeros added by byte-alignment at the end.
@@ -115,20 +114,9 @@ private constructor(
         } — payload after @controller_header may not be byte-aligned"
       }
     }
-    val outBytes = payloadBits / 8
-    val result = ByteArray(outBytes)
-    val skipBits = packetInHeaderBits
-    for (i in 0 until outBytes) {
-      val bitPos = skipBits + i * 8
-      val byteIdx = bitPos / 8
-      val bitOff = bitPos % 8
-      var value = (bytes[byteIdx].toInt() and 0xFF) shl bitOff
-      if (bitOff > 0 && byteIdx + 1 < bytes.size) {
-        value = value or ((bytes[byteIdx + 1].toInt() and 0xFF) ushr (8 - bitOff))
-      }
-      result[i] = (value and 0xFF).toByte()
-    }
-    return ByteString.copyFrom(result)
+    val acc = BitAccumulator()
+    acc.appendRawBytes(bytes, packetInHeaderBits, payloadBits)
+    return ByteString.copyFrom(acc.toByteArray())
   }
 
   /** Packs PacketOut metadata into a bit-packed binary header. */
@@ -147,34 +135,16 @@ private constructor(
     val headerBits = packetOutFields.sumOf { it.bitWidth }
     if (headerBits % 8 == 0) return serializePacketOut(metadata) + payload
     val metadataById = metadata.associateBy { it.metadataId }
-    val totalBits = headerBits + payload.size * 8
-    val outBytes = (totalBits + 7) / 8
-    val result = ByteArray(outBytes)
-    // Pack header fields into bit positions 0..headerBits-1.
-    var bitPos = 0
+    val acc = BitAccumulator()
     for (field in packetOutFields) {
       val raw = metadataById[field.id]?.value?.toByteArray() ?: ByteArray(0)
       var v = 0L
       for (b in raw) v = (v shl 8) or (b.toLong() and 0xFF)
       if (field.bitWidth < Long.SIZE_BITS) v = v and ((1L shl field.bitWidth) - 1)
-      for (bit in field.bitWidth - 1 downTo 0) {
-        if (v and (1L shl bit) != 0L) {
-          result[bitPos / 8] = (result[bitPos / 8].toInt() or (0x80 ushr (bitPos % 8))).toByte()
-        }
-        bitPos++
-      }
+      acc.append(BigInteger.valueOf(v), field.bitWidth)
     }
-    // Pack payload bytes immediately after the header bits.
-    for (b in payload) {
-      val byteIdx = bitPos / 8
-      val bitOff = bitPos % 8
-      result[byteIdx] = (result[byteIdx].toInt() or ((b.toInt() and 0xFF) ushr bitOff)).toByte()
-      if (bitOff > 0 && byteIdx + 1 < outBytes) {
-        result[byteIdx + 1] = ((b.toInt() and 0xFF) shl (8 - bitOff)).toByte()
-      }
-      bitPos += 8
-    }
-    return result
+    acc.appendRawBytes(payload, 0, payload.size * 8)
+    return acc.toByteArray()
   }
 
   /**

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -133,6 +133,8 @@ private constructor(
   @Suppress("MagicNumber")
   fun packPacketOut(metadata: List<PacketMetadata>, payload: ByteArray): ByteArray {
     val headerBits = packetOutFields.sumOf { it.bitWidth }
+    // When the header is byte-aligned, serializePacketOut produces exact-width bytes
+    // and byte-concatenation with the payload introduces no padding gap.
     if (headerBits % 8 == 0) return serializePacketOut(metadata) + payload
     val metadataById = metadata.associateBy { it.metadataId }
     val acc = BitAccumulator()

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -12,6 +12,8 @@ import fourward.FieldDecl
 import fourward.HeaderDecl
 import fourward.Type
 import fourward.TypeDecl
+import fourward.simulator.BitAccumulator
+import java.math.BigInteger
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -405,6 +407,70 @@ class PacketHeaderCodecTest {
       "6 payload bits (0x3F) left-aligned with 2 trailing zeros = 0xFC",
       0xFC,
       stripped.toByteArray()[0].toInt() and 0xFF,
+    )
+  }
+
+  // =========================================================================
+  // Round-trip: pack → simulate → strip = identity
+  // =========================================================================
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `stripPacketInHeader round-trips non-byte-aligned header with BitAccumulator`() {
+    // 10-bit packet_in header (two 5-bit fields) + 32-bit payload (0xDEADBEEF).
+    // Total = 42 bits → ceil(42/8) = 6 bytes.
+    //
+    // We use BitAccumulator to pack the deparsed output exactly as the simulator
+    // would: 10 header bits (zeros) followed by 32 payload bits. Stripping the
+    // header should recover the original payload bytes.
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(2, "field_a", 5))
+            .addMetadata(metaWithBitwidth(3, "field_b", 5))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_in_header_t")
+            .setHeader(
+              HeaderDecl.newBuilder()
+                .addFields(bitField("field_a", 5))
+                .addFields(bitField("field_b", 5))
+            )
+        )
+        .build()
+    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    assertEquals(10, codec.packetInHeaderBits)
+
+    // Simulate deparser output: 10 zero header bits + 0xDEADBEEF payload.
+    val acc = BitAccumulator()
+    acc.append(BigInteger.ZERO, 5) // field_a = 0
+    acc.append(BigInteger.ZERO, 5) // field_b = 0
+    acc.append(BigInteger.valueOf(0xDEADBEEFL), 32) // payload
+    val deparsed = com.google.protobuf.ByteString.copyFrom(acc.toByteArray())
+    assertEquals(6, deparsed.size()) // 42 bits → 6 bytes
+
+    val stripped = codec.stripPacketInHeader(deparsed)
+    val originalPayload = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+    assertArrayEquals(
+      "pack + strip should recover the original payload",
+      originalPayload,
+      stripped.toByteArray(),
     )
   }
 

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -260,6 +260,59 @@ class PacketHeaderCodecTest {
     )
   }
 
+  @Test
+  @Suppress("MagicNumber")
+  fun `stripPacketInHeader with non-byte-aligned payload rounds to whole bytes`() {
+    // 6-bit packet_in header + 6-bit tag payload = 12 bits = 2 bytes (4 pad bits).
+    // After stripping 6 header bits, the payload is 6 bits — but bytes can only
+    // represent whole bytes. The result is 1 byte: the 6 payload bits left-aligned
+    // with 2 trailing zeros.
+    //
+    // This matches what a real target would produce (ceil(6/8) = 1 byte), but
+    // the receiver can't distinguish a 6-bit payload from an 8-bit payload.
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(2, "field_a", 6))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_in_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("field_a", 6)))
+        )
+        .build()
+    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+
+    // Deparsed: 6 header bits (zeros) + 6 payload bits (0x3F = 0b111111) + 4 pad zeros
+    // = 000000_11 1111_0000 = 0x03 0xF0
+    val deparsed = com.google.protobuf.ByteString.copyFrom(byteArrayOf(0x03, 0xF0.toByte()))
+    val stripped = codec.stripPacketInHeader(deparsed)
+
+    // Integer division: (16 - 6) / 8 * 8 = 8 bits = 1 byte.
+    // The 6 payload bits (111111) are shifted to the front: 0b11111100 = 0xFC.
+    assertEquals("stripped payload should be 1 byte", 1, stripped.size())
+    assertEquals(
+      "6 payload bits (0x3F) left-aligned with 2 trailing zeros = 0xFC",
+      0xFC,
+      stripped.toByteArray()[0].toInt() and 0xFF,
+    )
+  }
+
   // =========================================================================
   // Helpers
   // =========================================================================

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -54,6 +54,101 @@ class PacketHeaderCodecTest {
   }
 
   // =========================================================================
+  // packPacketOut
+  // =========================================================================
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `packPacketOut bit-packs non-byte-aligned header with payload`() {
+    // 5-bit packet_out header (port=1 = 0b00001) + 2-byte payload (0xAA 0xBB).
+    // Continuous bit stream: 00001_10101010_10111011_000
+    // = 00001101 01010101 11011000
+    // = 0x0D     0x55     0xD8
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "port", 5))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(2, "ingress_port", 8))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("port", 5)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_in_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("ingress_port", 8)))
+        )
+        .build()
+    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+
+    val metadata = listOf(buildMetadata(id = 1, value = byteArrayOf(1))) // port=1
+    val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
+    val packed = codec.packPacketOut(metadata, payload)
+
+    assertEquals(3, packed.size)
+    assertArrayEquals(byteArrayOf(0x0D, 0x55, 0xD8.toByte()), packed)
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `packPacketOut byte-aligned header matches serializePacketOut + concat`() {
+    // 16-bit packet_out header (two 8-bit fields) — byte-aligned.
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+            .addMetadata(metaWithBitwidth(2, "submit_to_ingress", 8))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(3, "ingress_port", 8))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(
+              HeaderDecl.newBuilder()
+                .addFields(bitField("egress_port", 8))
+                .addFields(bitField("submit_to_ingress", 8))
+            )
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_in_header_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("ingress_port", 8)))
+        )
+        .build()
+    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+
+    val metadata =
+      listOf(
+        buildMetadata(id = 1, value = byteArrayOf(1)),
+        buildMetadata(id = 2, value = byteArrayOf(0)),
+      )
+    val payload = byteArrayOf(0xDE.toByte(), 0xAD.toByte())
+    val packed = codec.packPacketOut(metadata, payload)
+
+    assertArrayEquals(codec.serializePacketOut(metadata) + payload, packed)
+  }
+
+  // =========================================================================
   // serializePacketOut
   // =========================================================================
 

--- a/simulator/BitAccumulator.kt
+++ b/simulator/BitAccumulator.kt
@@ -57,9 +57,29 @@ class BitAccumulator {
       val take = minOf(available, remaining)
       val shift = available - take
       val bits = ((data[byteIdx].toInt() and 0xFF) ushr shift) and ((1 shl take) - 1)
-      append(BigInteger.valueOf(bits.toLong()), take)
+      appendSmall(bits.toLong(), take)
       pos += take
       remaining -= take
+    }
+  }
+
+  /** Appends a value that fits in a Long, avoiding BigInteger allocation. */
+  private fun appendSmall(value: Long, width: Int) {
+    val space = 8 - pendingCount
+    if (width < space) {
+      pendingBits = (pendingBits shl width) or (value and ((1L shl width) - 1))
+      pendingCount += width
+    } else {
+      val top = (value ushr (width - space)) and ((1L shl space) - 1)
+      pendingBits = (pendingBits shl space) or top
+      bytes.write(pendingBits.toInt() and 0xFF)
+      pendingBits = 0
+      pendingCount = 0
+      val leftover = width - space
+      if (leftover > 0) {
+        pendingBits = value and ((1L shl leftover) - 1)
+        pendingCount = leftover
+      }
     }
   }
 

--- a/simulator/BitAccumulator.kt
+++ b/simulator/BitAccumulator.kt
@@ -4,8 +4,12 @@ import java.io.ByteArrayOutputStream
 import java.math.BigInteger
 
 /**
- * Accumulates bits into a continuous bit stream, producing a byte-aligned output with trailing zero
- * padding — matching real P4 target behavior.
+ * Accumulates bits into a continuous MSB-first bit stream, producing a byte-aligned output with
+ * trailing zero padding — matching real P4 target behavior.
+ *
+ * Bits are packed from the most significant bit of each byte toward the least significant. For
+ * example, appending 6 bits `0b111111` followed by 10 bits `0b1010101010` produces the bytes
+ * `[0xFE, 0xAA]` (= `0b11111110 10101010`).
  *
  * Used by the deparser (emit), the output assembly (deparsedPayload), and the P4Runtime codec
  * (PacketOut packing, PacketIn stripping).

--- a/simulator/BitAccumulator.kt
+++ b/simulator/BitAccumulator.kt
@@ -63,8 +63,8 @@ class BitAccumulator {
     }
   }
 
-  /** Appends a value that fits in a Long, avoiding BigInteger allocation. */
   private fun appendSmall(value: Long, width: Int) {
+    require(width in 0..8)
     val space = 8 - pendingCount
     if (width < space) {
       pendingBits = (pendingBits shl width) or (value and ((1L shl width) - 1))

--- a/simulator/BitAccumulator.kt
+++ b/simulator/BitAccumulator.kt
@@ -63,6 +63,9 @@ class BitAccumulator {
     }
   }
 
+  val isByteAligned: Boolean
+    get() = pendingCount == 0
+
   fun copy(): BitAccumulator {
     val clone = BitAccumulator()
     clone.bytes.write(bytes.toByteArray())

--- a/simulator/BitAccumulator.kt
+++ b/simulator/BitAccumulator.kt
@@ -1,0 +1,77 @@
+package fourward.simulator
+
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+
+/**
+ * Accumulates bits into a continuous bit stream, producing a byte-aligned output with trailing zero
+ * padding — matching real P4 target behavior.
+ *
+ * Used by the deparser (emit), the output assembly (deparsedPayload), and the P4Runtime codec
+ * (PacketOut packing, PacketIn stripping).
+ */
+@Suppress("MagicNumber")
+class BitAccumulator {
+  private val bytes = ByteArrayOutputStream()
+  private var pendingBits = 0L
+  private var pendingCount = 0
+
+  fun append(value: BigInteger, width: Int) {
+    var remaining = width
+    var bits = value
+    while (remaining > 0) {
+      // space is always 1..8, so the shifts below are always < 64.
+      val space = 8 - pendingCount
+      if (remaining >= space) {
+        val shift = remaining - space
+        val top = bits.shiftRight(shift).toLong() and ((1L shl space) - 1)
+        pendingBits = (pendingBits shl space) or top
+        bytes.write(pendingBits.toInt() and 0xFF)
+        pendingBits = 0
+        pendingCount = 0
+        remaining -= space
+        if (remaining > 0) {
+          bits = bits.and(BigInteger.ONE.shiftLeft(remaining).subtract(BigInteger.ONE))
+        }
+      } else {
+        val top = bits.toLong() and ((1L shl remaining) - 1)
+        pendingBits = (pendingBits shl remaining) or top
+        pendingCount += remaining
+        remaining = 0
+      }
+    }
+  }
+
+  /** Appends raw bytes from [data] starting at bit offset [bitOff] for [bitCount] bits. */
+  fun appendRawBytes(data: ByteArray, bitOff: Int, bitCount: Int) {
+    var pos = bitOff
+    var remaining = bitCount
+    while (remaining > 0) {
+      val byteIdx = pos / 8
+      val bitInByte = pos % 8
+      val available = 8 - bitInByte
+      val take = minOf(available, remaining)
+      val shift = available - take
+      val bits = ((data[byteIdx].toInt() and 0xFF) ushr shift) and ((1 shl take) - 1)
+      append(BigInteger.valueOf(bits.toLong()), take)
+      pos += take
+      remaining -= take
+    }
+  }
+
+  fun copy(): BitAccumulator {
+    val clone = BitAccumulator()
+    clone.bytes.write(bytes.toByteArray())
+    clone.pendingBits = pendingBits
+    clone.pendingCount = pendingCount
+    return clone
+  }
+
+  fun toByteArray(): ByteArray {
+    val result = bytes.toByteArray()
+    if (pendingCount == 0) return result
+    val padded = result.copyOf(result.size + 1)
+    padded[result.size] = ((pendingBits shl (8 - pendingCount)).toInt() and 0xFF).toByte()
+    return padded
+  }
+}

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -229,7 +229,7 @@ private class ParserCursor(private val data: ByteArray, initialByteOffset: Int =
 
   /** Peeks at [count] bytes without advancing (must be byte-aligned). */
   fun peek(count: Int): ByteArray {
-    require(bitOffset % 8 == 0) { "peek() requires byte-aligned cursor, but bitOffset=$bitOffset" }
+    require(isByteAligned) { "peek() requires byte-aligned cursor, but bitOffset=$bitOffset" }
     val bitsNeeded = count * 8
     if (bitsNeeded > remainingBits()) {
       throw PacketTooShortException(

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -123,6 +123,11 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
    */
   fun deparsedPayload(): ByteArray {
     if (!buffer.hasRemaining()) return outputBits.toByteArray()
+    // When both sides are byte-aligned, plain byte concatenation is correct and
+    // avoids copying the BitAccumulator.
+    if (outputBits.isByteAligned && buffer.isByteAligned) {
+      return outputBits.toByteArray() + buffer.readAll()
+    }
     val combined = outputBits.copy()
     buffer.appendRemainingTo(combined)
     return combined.toByteArray()
@@ -173,6 +178,9 @@ private class ParserCursor(private val data: ByteArray, initialByteOffset: Int =
     get() = (bitOffset + 7) / 8
 
   fun hasRemaining(): Boolean = bitOffset < data.size * 8
+
+  val isByteAligned: Boolean
+    get() = bitOffset % 8 == 0
 
   fun appendRemainingTo(acc: BitAccumulator) {
     acc.appendRawBytes(data, bitOffset, data.size * 8 - bitOffset)

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -221,6 +221,7 @@ private class ParserCursor(private val data: ByteArray, initialByteOffset: Int =
 
   /** Peeks at [count] bytes without advancing (must be byte-aligned). */
   fun peek(count: Int): ByteArray {
+    require(bitOffset % 8 == 0) { "peek() requires byte-aligned cursor, but bitOffset=$bitOffset" }
     val bitsNeeded = count * 8
     if (bitsNeeded > remainingBits()) {
       throw PacketTooShortException(
@@ -253,11 +254,12 @@ private class ParserCursor(private val data: ByteArray, initialByteOffset: Int =
 
   private fun peekBitsInternal(bitCount: Int): BigInteger {
     if (bitCount == 0) return BigInteger.ZERO
-    // Fast path: byte-aligned reads skip the shift/mask entirely.
     if (bitOffset % 8 == 0 && bitCount % 8 == 0) {
       val startByte = bitOffset / 8
       return BigInteger(1, data.copyOfRange(startByte, startByte + bitCount / 8))
     }
+    // Read the minimal span of bytes that covers [bitOffset, bitOffset+bitCount),
+    // then right-shift to discard trailing bits and mask to the desired width.
     val startByte = bitOffset / 8
     val endByte = (bitOffset + bitCount - 1) / 8
     val raw = BigInteger(1, data.copyOfRange(startByte, endByte + 1))

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -1,7 +1,6 @@
 package fourward.simulator
 
 import fourward.TraceEvent
-import java.io.ByteArrayOutputStream
 import java.math.BigInteger
 
 /**
@@ -146,77 +145,6 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
   }
 
   fun getEvents(): List<TraceEvent> = traceEvents.toList()
-}
-
-/**
- * Accumulates bits from deparser emit() calls into a continuous bit stream, producing a
- * byte-aligned output with trailing zero padding — matching real P4 target behavior.
- */
-@Suppress("MagicNumber")
-class BitAccumulator {
-  private val bytes = ByteArrayOutputStream()
-  private var pendingBits = 0L
-  private var pendingCount = 0
-
-  fun append(value: BigInteger, width: Int) {
-    var remaining = width
-    var bits = value
-    while (remaining > 0) {
-      // space is always 1..8, so the shifts below are always < 64.
-      val space = 8 - pendingCount
-      if (remaining >= space) {
-        val shift = remaining - space
-        val top = bits.shiftRight(shift).toLong() and ((1L shl space) - 1)
-        pendingBits = (pendingBits shl space) or top
-        bytes.write(pendingBits.toInt() and 0xFF)
-        pendingBits = 0
-        pendingCount = 0
-        remaining -= space
-        if (remaining > 0) {
-          bits = bits.and(BigInteger.ONE.shiftLeft(remaining).subtract(BigInteger.ONE))
-        }
-      } else {
-        val top = bits.toLong() and ((1L shl remaining) - 1)
-        pendingBits = (pendingBits shl remaining) or top
-        pendingCount += remaining
-        remaining = 0
-      }
-    }
-  }
-
-  /** Appends raw bytes from [data] starting at bit offset [bitOff] for [bitCount] bits. */
-  fun appendRawBytes(data: ByteArray, bitOff: Int, bitCount: Int) {
-    var pos = bitOff
-    var remaining = bitCount
-    while (remaining > 0) {
-      val byteIdx = pos / 8
-      val bitInByte = pos % 8
-      val available = 8 - bitInByte
-      val take = minOf(available, remaining)
-      val shift = available - take
-      val bits = ((data[byteIdx].toInt() and 0xFF) ushr shift) and ((1 shl take) - 1)
-      append(BigInteger.valueOf(bits.toLong()), take)
-      pos += take
-      remaining -= take
-    }
-  }
-
-  fun copy(): BitAccumulator {
-    val clone = BitAccumulator()
-    clone.bytes.write(bytes.toByteArray())
-    clone.pendingBits = pendingBits
-    clone.pendingCount = pendingCount
-    return clone
-  }
-
-  fun toByteArray(): ByteArray {
-    val result = bytes.toByteArray()
-    if (pendingCount == 0) return result
-    // Append the pending partial byte without mutating accumulator state.
-    val padded = result.copyOf(result.size + 1)
-    padded[result.size] = ((pendingBits shl (8 - pendingCount)).toInt() and 0xFF).toByte()
-    return padded
-  }
 }
 
 /**

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -249,4 +249,49 @@ class EnvironmentTest {
     pktCtx.extractBits(4) // skip first 4 bits
     assertEquals(BigInteger.valueOf(0x5C), pktCtx.extractBits(8))
   }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `extractBits spanning 3 bytes`() {
+    // Bytes: [0xA5, 0xC3, 0x7F] = 0b10100101_11000011_01111111
+    // Skip 4 bits → remaining: 0b0101_11000011_01111111
+    // Extract 16 bits: 0b0101110000110111 = 0x5C37
+    val pktCtx = PacketContext(byteArrayOf(0xA5.toByte(), 0xC3.toByte(), 0x7F.toByte()))
+    pktCtx.extractBits(4) // skip first 4 bits
+    assertEquals(BigInteger.valueOf(0x5C37), pktCtx.extractBits(16))
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `extractBits exactly 1 bit at a byte boundary`() {
+    // Byte: [0x80] = 0b10000000. Extract 1 bit → should be 1.
+    val pktCtx = PacketContext(byteArrayOf(0x80.toByte()))
+    assertEquals(BigInteger.ONE, pktCtx.extractBits(1))
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `extractBits of full byte at non-aligned position`() {
+    // Bytes: [0xFF, 0x00] = 0b11111111_00000000
+    // Skip 1 bit → remaining: 0b1111111_00000000
+    // Extract 8 bits: 0b11111110 = 0xFE
+    val pktCtx = PacketContext(byteArrayOf(0xFF.toByte(), 0x00))
+    pktCtx.extractBits(1) // skip first bit
+    assertEquals(BigInteger.valueOf(0xFE), pktCtx.extractBits(8))
+  }
+
+  // ---------------------------------------------------------------------------
+  // BitAccumulator — adversarial inputs
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `BitAccumulator masks value wider than declared width`() {
+    // append(0xFF, 4): the value 0xFF has 8 significant bits, but only 4 bits
+    // are declared. BitAccumulator masks to the lower 4 bits (0xF) internally.
+    // Output: 0xF in top 4 bits → 0xF0.
+    val acc = BitAccumulator()
+    acc.append(BigInteger.valueOf(0xFF), 4)
+    assertArrayEquals(byteArrayOf(0xF0.toByte()), acc.toByteArray())
+  }
 }


### PR DESCRIPTION
Closes #651.

## Summary

Three changes building on #645's bit-level pipeline:

**PacketOut bit-level packing:** `serializePacketOut()` + byte-concatenation inserts padding zeros between the header and payload for non-byte-aligned `@controller_header("packet_out")` types. The bit-level parser reads these zeros as payload data, corrupting the packet. New `packPacketOut()` method uses `BitAccumulator` to pack header fields followed immediately by payload bits — no inter-field padding.

**Trailing-zeros assertion:** `stripPacketInHeader`'s integer-division trick assumes the discarded trailing bits are zeros. Added a `check()` that fails loudly if violated, with documentation of why the invariant holds.

**Extract BitAccumulator:** Moved from `Environment.kt` to its own file so both `simulator` and `grpc` packages can use it. Rewrote `packPacketOut` and `stripPacketInHeader` to use `BitAccumulator` instead of hand-rolled bit-shifting. Renamed `InlineP4CompilerTest` → `BitLevelSerializationTest`.

## Test plan

- [x] `PacketHeaderCodecTest`: `packPacketOut` bit-packing (5-bit header), byte-aligned fast path, non-byte-aligned strip, trailing-zeros edge case
- [x] `BitLevelSerializationTest`: e2e PacketOut corruption demo (5-bit header)
- [x] `EnvironmentTest`: BitAccumulator tests still pass after extraction
- [x] Full test suite passes (78/78)

🤖 Generated with [Claude Code](https://claude.com/claude-code)