### PR TITLE
p4runtime_diff: update design doc and README

### DIFF
--- a/designs/p4runtime_diff.md
+++ b/designs/p4runtime_diff.md
@@ -116,8 +116,10 @@ over them.
 
 ## Future work
 
-- **Corpus growth.** Add scenarios as P4Runtime features land. Strong
-  candidates: role config, idle timeout.
+No active plans. The harness exists and works — add scenarios when a
+new P4Runtime feature lands or a spec ambiguity surfaces, not before.
+Role config and idle timeout are theoretically interesting but not
+worth building scenarios for until 4ward actually implements them.
 
 ## Alternatives considered
 

--- a/e2e_tests/p4runtime_diff/README.md
+++ b/e2e_tests/p4runtime_diff/README.md
@@ -25,8 +25,10 @@ Top-level targets:
   `piserver` / `pifeproto`. No Apache Thrift in the runtime.
 - `:libbmpi` — bmv2's Thrift-free PI integration adapter
   (sources from `@behavioral_model//:libbmpi_srcs`).
-- `:basic_table_fourward` / `:basic_table_bmv2_json` — the test
-  fixture P4 program compiled for both backends.
+- `:basic_table_fourward` / `:basic_table_bmv2_json` — `basic_table.p4`
+  compiled for both backends (scenarios 1-7).
+- `:action_selector_fourward` / `:action_selector_bmv2_json` —
+  `action_selector_3.p4` compiled for both backends (scenarios 8-10).
 
 Test targets:
 
@@ -34,9 +36,7 @@ Test targets:
   helpers ([`ResponseDiff.kt`](ResponseDiff.kt)). Always runnable.
 - `:P4RuntimeDiffSmokeTest` — spawns both servers, exercises
   `Capabilities` RPC. Skipped via `Assume` if the binary isn't built.
-- `:P4RuntimeDiffScenariosTest` — the five spec scenarios from the
-  design doc. Skipped via `Assume` if the fixtures aren't built.
-
-The Kotlin runners `Bmv2P4RuntimeRunner` and `FourwardP4RuntimeRunner`
-expose a uniform `P4RuntimeBlockingStub` over both implementations so
-test code is symmetric.
+- `:P4RuntimeDiffScenariosTest` — table entry scenarios (encoding,
+  error semantics, wildcard reads, default actions).
+- `:P4RuntimeDiffActionProfileTest` — action profile scenarios
+  (member CRUD, groups, table entries referencing groups).


### PR DESCRIPTION
## Summary

- **Design doc:** replace aspirational future-work list with honest "no active plans — add scenarios when features land."
- **README:** reflect the 10-scenario corpus — list both fixtures (basic_table, action_selector_3) and all 4 test targets including the new `P4RuntimeDiffActionProfileTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)