### PR TITLE
v1model: document gaps + fix clone truncation and timestamps

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -48,7 +48,22 @@ guilt — just write it down so someone can find it later.
   `direct_meter.read()` always return GREEN (0). Rate limiting is not
   simulated — there are no real packet rates in STF tests.
 - **`digest` is a no-op stub.** PSA `Digest.pack()` is accepted but doesn't
-  deliver messages to the control plane. v1model `digest()` is not implemented.
+  deliver messages to the control plane. v1model `digest()` is not
+  implemented and will crash at runtime.
+
+## v1model gaps
+
+- **`truncate()` not implemented.** The v1model extern
+  `truncate(in bit<32> length)` — which caps the output packet to the
+  given number of bytes after the deparser — is not handled. Calling it
+  will crash the simulator.
+- **`random()` not implemented.** The v1model free-function form
+  `random(out bit<32> result, in bit<32> lo, in bit<32> hi)` is not
+  handled and will crash at runtime. (PSA/PNA `Random.read()` works.)
+- **`standard_metadata` queue depth fields are always zero.**
+  `enq_qdepth`, `deq_qdepth`, and `deq_timedelta` are never populated.
+  The simulator has no traffic manager queue model, so these fields stay
+  at their default zero values.
 
 ## P4Runtime server
 

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -359,16 +359,18 @@ class V1ModelArchitecture(
           else runEgressAndDeparser(c, s)
         },
       )
+    val cloneCtx = truncatePayload(ctx, fork.truncateBytes)
     val clone =
       runBranch(
-        ctx,
+        cloneCtx,
         fork.bytesConsumed,
         fork.postParserEnv,
         configure = { s ->
           s.standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
           s.standardMetadata.setBitField("egress_port", fork.clonePort)
           s.standardMetadata.setBitField("egress_rid", fork.egressRid.toLong())
-          applyPreservedMetadata(ctx, s.env, fork.preservedMetadata)
+          s.standardMetadata.setBitField("packet_length", cloneCtx.payload.size.toLong())
+          applyPreservedMetadata(cloneCtx, s.env, fork.preservedMetadata)
         },
         pipelineTail = { c, s -> runEgressAndDeparser(c, s) },
       )
@@ -401,9 +403,10 @@ class V1ModelArchitecture(
           else runDeparser(s)
         },
       )
+    val cloneCtx = truncatePayload(ctx, fork.truncateBytes)
     val clone =
       runBranch(
-        ctx,
+        cloneCtx,
         fork.bytesConsumed,
         fork.forkPointEnv,
         fork.forkPointPendingOps,
@@ -412,7 +415,8 @@ class V1ModelArchitecture(
           s.standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
           s.standardMetadata.setBitField("egress_port", fork.clonePort)
           s.standardMetadata.setBitField("egress_rid", fork.egressRid.toLong())
-          applyPreservedMetadata(ctx, s.env, fork.preservedMetadata)
+          s.standardMetadata.setBitField("packet_length", cloneCtx.payload.size.toLong())
+          applyPreservedMetadata(cloneCtx, s.env, fork.preservedMetadata)
         },
         pipelineTail = { _, s ->
           resetEgressSpec(s)
@@ -510,6 +514,11 @@ class V1ModelArchitecture(
     standardMetadata.setBitField("ingress_port", ctx.ingressPort.toLong())
     standardMetadata.setBitField("packet_length", ctx.payload.size.toLong())
     standardMetadata.fields["parser_error"] = ErrorVal.NO_ERROR
+    setTimestampField(
+      standardMetadata,
+      "ingress_global_timestamp",
+      System.nanoTime() / NANOS_PER_MICRO,
+    )
     if (decisions.instanceTypeOverride != null) {
       standardMetadata.setBitField("instance_type", decisions.instanceTypeOverride)
     }
@@ -631,6 +640,7 @@ class V1ModelArchitecture(
    */
   private fun runEgressAndDeparser(ctx: PipelineContext, s: PipelineState): TraceTree {
     resetEgressSpec(s)
+    setEgressTimestamps(s)
     runControlStages(s, s.egressControls, dataplanePort = readEgressPort(s))
     postEgressBoundary(ctx, s)
 
@@ -744,17 +754,18 @@ class V1ModelArchitecture(
   private fun ingressEgressBoundary(ctx: PipelineContext, s: PipelineState) {
     val pendingClone = s.pendingOps.cloneSessionId
     if (pendingClone != null) {
-      resolveCloneSession(ctx, s, pendingClone)?.let { replica ->
+      resolveCloneSession(ctx, s, pendingClone)?.let { session ->
         throw CloneFork(
           pendingClone,
-          replica.port.toLong(),
-          replica.rid,
+          session.replica.port.toLong(),
+          session.replica.rid,
           s.packetCtx.getEvents(),
           snapshotPreservedMetadata(s, s.pendingOps.cloneFieldListId),
           s.env.deepCopy(),
           s.packetCtx.bytesConsumed,
           s.pendingOps.copy(),
           s.postParserEnv ?: error("no post-parser env for I2E clone"),
+          session.truncateBytes,
         )
       }
     }
@@ -791,16 +802,17 @@ class V1ModelArchitecture(
   private fun postEgressBoundary(ctx: PipelineContext, s: PipelineState) {
     val pendingE2EClone = s.pendingOps.egressCloneSessionId
     if (pendingE2EClone != null) {
-      resolveCloneSession(ctx, s, pendingE2EClone)?.let { replica ->
+      resolveCloneSession(ctx, s, pendingE2EClone)?.let { session ->
         throw EgressCloneFork(
           pendingE2EClone,
-          replica.port.toLong(),
-          replica.rid,
+          session.replica.port.toLong(),
+          session.replica.rid,
           s.packetCtx.getEvents(),
           snapshotPreservedMetadata(s, s.pendingOps.egressCloneFieldListId),
           s.env.deepCopy(),
           s.packetCtx.bytesConsumed,
           s.pendingOps.copy(),
+          session.truncateBytes,
         )
       }
     }
@@ -847,15 +859,19 @@ class V1ModelArchitecture(
   private fun egressSpecIsDropPort(s: PipelineState): Boolean =
     (s.standardMetadata.fields["egress_spec"] as? BitVal)?.bits?.value?.toLong() == s.dropPort
 
+  /** Resolved clone session: first replica and optional packet truncation length. */
+  private data class CloneSessionResult(val replica: Replica, val truncateBytes: Int)
+
   /**
    * Resolves a pending clone session: emits a [CloneSessionLookupEvent] and returns the first
-   * replica, or emits a miss event and returns null if the session doesn't exist.
+   * replica with truncation info, or emits a miss event and returns null if the session doesn't
+   * exist.
    */
   private fun resolveCloneSession(
     ctx: PipelineContext,
     s: PipelineState,
     sessionId: Int,
-  ): Replica? {
+  ): CloneSessionResult? {
     val session = ctx.tableStore.getCloneSession(sessionId)
     if (session != null) {
       val firstReplica = session.replicasList.first()
@@ -863,7 +879,10 @@ class V1ModelArchitecture(
       s.packetCtx.addTraceEvent(
         cloneSessionLookupEvent(sessionId, egressPort, firstReplica.instance)
       )
-      return Replica(firstReplica.instance, egressPort)
+      return CloneSessionResult(
+        Replica(firstReplica.instance, egressPort),
+        session.packetLengthBytes,
+      )
     }
     s.packetCtx.addTraceEvent(cloneSessionMissEvent(sessionId))
     return null
@@ -886,6 +905,35 @@ class V1ModelArchitecture(
         CloneSessionLookupEvent.newBuilder().setSessionId(sessionId).setSessionFound(false)
       )
       .build()
+
+  /**
+   * Populates egress-side timestamp fields if present in standard_metadata.
+   *
+   * BMv2 sets these at the traffic manager (enqueue) and dequeue points. In a zero-queue simulator,
+   * enqueue and dequeue happen at the same instant, so enq_timestamp and egress_global_timestamp
+   * share the same value and deq_timedelta is zero.
+   */
+  private fun setEgressTimestamps(s: PipelineState) {
+    val ts = System.nanoTime() / NANOS_PER_MICRO
+    setTimestampField(s.standardMetadata, "egress_global_timestamp", ts)
+    setTimestampField(s.standardMetadata, "enq_timestamp", ts)
+  }
+
+  /** Sets a timestamp field, truncating the value to fit the field's bit width. */
+  private fun setTimestampField(metadata: StructVal, field: String, microseconds: Long) {
+    val existing = metadata.fields[field] as? BitVal ?: return
+    val width = existing.bits.width
+    val mask = if (width >= Long.SIZE_BITS) -1L else (1L shl width) - 1
+    metadata.setBitField(field, microseconds and mask)
+  }
+
+  /** Returns [ctx] with payload truncated to [maxBytes], or [ctx] unchanged if no truncation. */
+  private fun truncatePayload(ctx: PipelineContext, maxBytes: Int): PipelineContext =
+    if (maxBytes > 0 && maxBytes < ctx.payload.size) {
+      ctx.copy(payload = ctx.payload.copyOf(maxBytes))
+    } else {
+      ctx
+    }
 
   // Trace helpers (buildDropTrace, buildOutputTrace, packetIngressEvent, stageEvent)
   // are shared with PSAArchitecture — see TraceHelpers.kt.
@@ -1152,6 +1200,8 @@ class V1ModelArchitecture(
 
     private const val MAX_PIPELINE_DEPTH = 10
 
+    private const val NANOS_PER_MICRO = 1000
+
     // v1model instance_type values (BMv2 PktInstanceType convention).
     private const val CLONE_I2E_INSTANCE_TYPE = 1L
     private const val CLONE_E2E_INSTANCE_TYPE = 2L
@@ -1236,6 +1286,8 @@ internal class CloneFork(
   val forkPointPendingOps: V1ModelPendingOps,
   /** Post-parser env (for the "clone" branch — BMv2: clone gets pre-ingress state). */
   val postParserEnv: Environment,
+  /** Clone session packet_length_bytes: 0 = no truncation, >0 = truncate to this many bytes. */
+  val truncateBytes: Int = 0,
 ) : ForkException(eventsBeforeFork)
 
 /**
@@ -1254,6 +1306,8 @@ internal class EgressCloneFork(
   val bytesConsumed: Int,
   /** Pending operations at the fork point. */
   val forkPointPendingOps: V1ModelPendingOps,
+  /** Clone session packet_length_bytes: 0 = no truncation, >0 = truncate to this many bytes. */
+  val truncateBytes: Int = 0,
 ) : ForkException(eventsBeforeFork)
 
 /** Fork at the ingress→egress boundary when mcast_grp is set — one branch per replica. */

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -242,6 +242,7 @@ class V1ModelArchitectureTest {
     egressPort: Int,
     instance: Int = 0,
     usePortBytes: Boolean = false,
+    packetLengthBytes: Int = 0,
   ) {
     store.write(
       P4RuntimeOuterClass.Update.newBuilder()
@@ -254,6 +255,7 @@ class V1ModelArchitectureTest {
                   P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
                     .setSessionId(sessionId)
                     .addReplicas(buildReplica(egressPort, instance, usePortBytes = usePortBytes))
+                    .setPacketLengthBytes(packetLengthBytes)
                 )
             )
         )
@@ -780,6 +782,86 @@ class V1ModelArchitectureTest {
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
+  }
+
+  @Test
+  fun `I2E clone with packet_length_bytes truncates cloned packet`() {
+    val config =
+      v1modelConfig(
+        externCall("clone", enumArg("I2E"), intArg(1, 32)),
+        assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, egressPort = 7, packetLengthBytes = 3)
+
+    val payload =
+      byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte())
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+
+    assertTrue(result.trace.hasForkOutcome())
+    val outputs = result.possibleOutcomes.single()
+    assertEquals(2, outputs.size)
+    assertEquals(5, outputs[0].payload.size())
+    assertEquals(3, outputs[1].payload.size())
+    assertEquals(payload.sliceArray(0..2).toList(), outputs[1].payload.toByteArray().toList())
+  }
+
+  @Test
+  fun `E2E clone with packet_length_bytes truncates cloned packet`() {
+    val config =
+      v1modelConfig(
+        ingressStmts =
+          listOf(assignField("sm", "egress_spec", 3, V1ModelArchitecture.DEFAULT_PORT_BITS)),
+        egressStmts = listOf(externCall("clone", enumArg("E2E"), intArg(1, 32))),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, egressPort = 8, packetLengthBytes = 2)
+
+    val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte())
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+
+    assertTrue(result.trace.hasForkOutcome())
+    val outputs = result.possibleOutcomes.single()
+    assertEquals(2, outputs.size)
+    assertEquals(4, outputs[0].payload.size())
+    assertEquals(2, outputs[1].payload.size())
+  }
+
+  @Test
+  fun `clone with packet_length_bytes=0 does not truncate`() {
+    val config =
+      v1modelConfig(
+        externCall("clone", enumArg("I2E"), intArg(1, 32)),
+        assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, egressPort = 7, packetLengthBytes = 0)
+
+    val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte())
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+
+    val outputs = result.possibleOutcomes.single()
+    assertEquals(2, outputs.size)
+    assertEquals(3, outputs[0].payload.size())
+    assertEquals(3, outputs[1].payload.size())
+  }
+
+  @Test
+  fun `clone truncation larger than packet is a no-op`() {
+    val config =
+      v1modelConfig(
+        externCall("clone", enumArg("I2E"), intArg(1, 32)),
+        assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, egressPort = 7, packetLengthBytes = 100)
+
+    val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+
+    val outputs = result.possibleOutcomes.single()
+    assertEquals(2, outputs.size)
+    assertEquals(2, outputs[1].payload.size())
   }
 
   @Test


### PR DESCRIPTION
## Summary

Audited the v1model implementation against the BMv2 simple_switch spec,
documented all gaps, and fixed the two that were silently wrong.

**Documented** (crash at runtime — explicit `error()`):
- `truncate()` extern
- `random()` free-function form
- `digest()` — clarified it crashes, not just "not implemented"

**Fixed** (were silently wrong):
- **Clone session `packet_length_bytes`** — cloned packets are now truncated
  to the configured size at the PRE, with `standard_metadata.packet_length`
  updated on the clone branch. Previously the field was stored but ignored.
- **Timestamp fields** — `ingress_global_timestamp`, `egress_global_timestamp`,
  and `enq_timestamp` are now populated with wall-clock microseconds (truncated
  to field width). Queue depth fields remain at zero (correct for a
  zero-queue simulator).

**Still not simulated** (documented in LIMITATIONS.md):
- Queue depth fields (`enq_qdepth`, `deq_qdepth`, `deq_timedelta`) — no
  traffic manager queue model.

## Test plan
- [x] 4 new unit tests for clone session truncation (I2E, E2E, zero = no-op, larger than packet = no-op)
- [x] All 75 existing tests pass (including full v1model STF corpus and BMv2 differential tests)
- [x] Format and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)