### PR TITLE
fourward_cc: constrain matcher templates with PacketResult concept

### DIFF
--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -7,6 +7,7 @@
 #ifndef FOURWARD_CC_DATAPLANE_MATCHERS_H_
 #define FOURWARD_CC_DATAPLANE_MATCHERS_H_
 
+#include <concepts>
 #include <cstdint>
 #include <ostream>
 #include <string>
@@ -26,7 +27,14 @@ namespace internal {
 
 using PacketList = std::vector<fourward::OutputPacket>;
 
+// Satisfied by InjectPacketResponse and ProcessPacketResult.
 template <typename T>
+concept HasPossibleOutcomes = requires(const T& r) {
+  { r.possible_outcomes() };
+};
+
+template <typename T>
+  requires(HasPossibleOutcomes<T>)
 std::vector<PacketList> ExtractOutcomes(const T& result) {
   std::vector<PacketList> outcomes;
   for (const auto& ps : result.possible_outcomes()) {
@@ -72,6 +80,7 @@ class OutcomesMatcherBase {
       : inner_(std::move(inner)), description_(std::move(description)) {}
 
   template <typename T>
+    requires(HasPossibleOutcomes<T>)
   bool MatchAndExplain(const T& result,
                        ::testing::MatchResultListener* listener) const {
     auto outcomes = ExtractOutcomes(result);
@@ -137,6 +146,7 @@ inline void PrintPortKey(std::ostream* os, const PortKey& key) {
 }
 
 template <typename T>
+  requires(HasPossibleOutcomes<T>)
 PacketList DeterministicPackets(const T& result) {
   auto outcomes = ExtractOutcomes(result);
   if (outcomes.size() != 1) {
@@ -420,6 +430,7 @@ inline auto OnPorts(
 // ---------------------------------------------------------------------------
 
 template <typename T>
+  requires(internal::HasPossibleOutcomes<T>)
 absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>>
 PacketsByDataplanePort(const T& result) {
   absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>> groups;
@@ -431,6 +442,7 @@ PacketsByDataplanePort(const T& result) {
 }
 
 template <typename T>
+  requires(internal::HasPossibleOutcomes<T>)
 absl::btree_map<std::string, std::vector<fourward::OutputPacket>>
 PacketsByP4RuntimePort(const T& result) {
   absl::btree_map<std::string, std::vector<fourward::OutputPacket>> groups;


### PR DESCRIPTION
## Summary

Adds an internal `PacketResult` concept that checks for
`possible_outcomes()`, and constrains all matcher templates that operate
on response types. Passing the wrong type now produces a clear
"constraints not satisfied" error at the call site instead of a cryptic
failure deep in `ExtractOutcomes`.

Constrained templates:
- `ExtractOutcomes`
- `OutcomesMatcherBase::MatchAndExplain`
- `DeterministicPackets`
- `PacketsByDataplanePort`
- `PacketsByP4RuntimePort`

`HasIngressMatcher::MatchAndExplain` is left unconstrained — it accesses
`input_packet()` which only `ProcessPacketResult` has, but gmock's
polymorphic matcher machinery needs the template to remain open.

## Test plan

- [x] `dataplane_matchers_test` passes
- [x] Downstream tests (`dataplane_client_e2e_test`, `fourward_server_test`) pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)