### PR TITLE
enforce coding principles: exhaustive when, assertions over comments

### DIFF
--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -106,6 +106,7 @@ private constructor(
     // payload byte count, discarding only the trailing pad zeros.
     val totalBits = bytes.size * 8
     val payloadBits = (totalBits - packetInHeaderBits) / 8 * 8
+    check(payloadBits % 8 == 0)
     if (payloadBits <= 0) return ByteString.EMPTY
     val discardedBits = totalBits - packetInHeaderBits - payloadBits
     if (discardedBits > 0) {

--- a/simulator/BitAccumulator.kt
+++ b/simulator/BitAccumulator.kt
@@ -24,7 +24,7 @@ class BitAccumulator {
     var remaining = width
     var bits = value
     while (remaining > 0) {
-      // space is always 1..8, so the shifts below are always < 64.
+      check(pendingCount in 0..7)
       val space = 8 - pendingCount
       if (remaining >= space) {
         val shift = remaining - space

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -240,7 +240,12 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when (lit.kindCase) {
             LiteralKind.INTEGER -> "0x${lit.integer.toString(16).uppercase()}"
             LiteralKind.BOOLEAN -> lit.boolean.toString()
-            else -> lit.toString().trim()
+            LiteralKind.BIG_INTEGER,
+            LiteralKind.ERROR_MEMBER,
+            LiteralKind.ENUM_MEMBER,
+            LiteralKind.STRING_LITERAL,
+            LiteralKind.KIND_NOT_SET,
+            null -> lit.toString().trim()
           }
         }
         else -> "?"
@@ -587,7 +592,14 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when (type.kindCase) {
             TypeKind.BIT -> BitVal(BitVector(v, type.bit.width))
             TypeKind.SIGNED_INT -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
-            else -> InfIntVal(v) // compile-time constant integer (P4 spec §8.1)
+            // Compile-time constant integer without explicit width (P4 spec §8.1).
+            TypeKind.VARBIT,
+            TypeKind.BOOLEAN,
+            TypeKind.NAMED,
+            TypeKind.HEADER_STACK,
+            TypeKind.ERROR,
+            TypeKind.KIND_NOT_SET,
+            null -> InfIntVal(v)
           }
         }
         LiteralKind.BIG_INTEGER -> {
@@ -595,7 +607,13 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           when (type.kindCase) {
             TypeKind.SIGNED_INT -> IntVal(SignedBitVector.fromUnsignedBits(v, type.signedInt.width))
             TypeKind.BIT -> BitVal(BitVector(v, type.bit.width))
-            else -> error("big integer literal with unexpected type: $type${sourceContext()}")
+            TypeKind.VARBIT,
+            TypeKind.BOOLEAN,
+            TypeKind.NAMED,
+            TypeKind.HEADER_STACK,
+            TypeKind.ERROR,
+            TypeKind.KIND_NOT_SET,
+            null -> error("big integer literal with unexpected type: $type${sourceContext()}")
           }
         }
         LiteralKind.KIND_NOT_SET,
@@ -1359,7 +1377,13 @@ class Interpreter internal constructor(config: BehavioralConfig) {
       when (type.kindCase) {
         TypeKind.BOOLEAN -> BoolVal(raw != BigInteger.ZERO)
         TypeKind.SIGNED_INT -> IntVal(SignedBitVector.fromUnsignedBits(raw, width))
-        else -> BitVal(BitVector(raw, width))
+        TypeKind.BIT,
+        TypeKind.VARBIT,
+        TypeKind.NAMED,
+        TypeKind.HEADER_STACK,
+        TypeKind.ERROR,
+        TypeKind.KIND_NOT_SET,
+        null -> BitVal(BitVector(raw, width))
       }
 
     private fun execEmit(call: MethodCall, env: Environment): Value {


### PR DESCRIPTION
Codebase audit against AGENTS.md coding principles.

## Exhaustive `when` on proto oneofs

Four `else ->` catch-all branches in `Interpreter.kt` replaced with explicit case listings. Adding a new oneof variant now produces a compiler warning instead of silently falling through:

- `evalLiteral` / `Type.kindCase` for INTEGER literals (was `InfIntVal` fallback)
- `evalLiteral` / `Type.kindCase` for BIG_INTEGER literals (was error fallback)
- `formatExpr` / `LiteralKind` (was `.toString()` fallback)
- `bitsToValue` / `Type.kindCase` (was `BitVal` fallback)

## Assertions over comments

- `BitAccumulator.append`: `check(pendingCount in 0..7)` replaces the comment "space is always 1..8"
- `stripPacketInHeader`: `check(payloadBits % 8 == 0)` enforces the byte-aligned payload invariant

## Follow-up

Filed #660 for the harder TableStore read-path vs write-path enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)