### PR TITLE
fix compileInlineP4 in hermetic sandboxes; extract ensureCcOnPath

### DIFF
--- a/bazel/Runfiles.kt
+++ b/bazel/Runfiles.kt
@@ -1,6 +1,8 @@
 package fourward.bazel
 
 import com.google.devtools.build.runfiles.Runfiles
+import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
 
 private val runfiles: Runfiles = Runfiles.preload().unmapped()
@@ -30,6 +32,27 @@ fun resolveRunfileProperty(key: String): Path {
         "-D$key=\$(rlocationpath <label>) in jvm_flags."
     }
   return resolveRlocation(rlocation, "$key ($rlocation)")
+}
+
+/**
+ * Prepends a BUILD-provided `cc` shim to [pb]'s PATH if no system `cc` is found. p4c shells out to
+ * `cc` for preprocessing, which doesn't exist in hermetic sandboxes (blaze/google3).
+ *
+ * Requires the caller's BUILD target to include `cc_shim` in `data` and pass its path via
+ * `-D<shimPropertyKey>=$(rlocationpath ...)` in `jvm_flags`.
+ */
+fun ensureCcOnPath(pb: ProcessBuilder, shimPropertyKey: String = "cc_shim") {
+  if (!hasSystemCc) {
+    val shimDir = resolveRunfileProperty(shimPropertyKey).parent
+    val env = pb.environment()
+    env["PATH"] = "$shimDir${File.pathSeparator}${env["PATH"] ?: ""}"
+  }
+}
+
+private val hasSystemCc: Boolean by lazy {
+  System.getenv("PATH")?.split(File.pathSeparator).orEmpty().any { dir ->
+    Files.isExecutable(Path.of(dir, "cc"))
+  }
 }
 
 private fun resolveRlocation(rlocation: String, what: String): Path =

--- a/e2e_tests/BUILD.bazel
+++ b/e2e_tests/BUILD.bazel
@@ -1,10 +1,16 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//bazel:cc_shim.bzl", "cc_shim")
 
 package(
     default_applicable_licenses = ["//:license"],
     default_testonly = True,
     licenses = ["notice"],
+)
+
+cc_shim(
+    name = "cc_shim",
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(

--- a/e2e_tests/InlineP4Compiler.kt
+++ b/e2e_tests/InlineP4Compiler.kt
@@ -2,7 +2,9 @@ package fourward.e2e
 
 import com.google.protobuf.TextFormat
 import fourward.PipelineConfig
+import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Compiles a P4 source string at test time using p4c-4ward. Useful for tests that need a custom P4
@@ -21,8 +23,13 @@ import java.nio.file.Files
  *
  * Requires the test's BUILD target to include:
  * ```
- * data = ["//p4c_backend:p4c-4ward", "@p4c//p4include"],
+ * data = [
+ *     "//e2e_tests:cc_shim",
+ *     "//p4c_backend:p4c-4ward",
+ *     "@p4c//p4include",
+ * ],
  * jvm_flags = [
+ *     "-Dcc_shim=$(rlocationpath //e2e_tests:cc_shim)",
  *     "-Dp4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
  *     "-Dp4include=$(rlocationpath @p4c//p4include:core.p4)",
  * ],
@@ -38,7 +45,7 @@ fun compileInlineP4(source: String): PipelineConfig {
     val outFile = tmpDir.resolve("pipeline.txtpb")
     Files.writeString(srcFile, source)
 
-    val process =
+    val pb =
       ProcessBuilder(
           p4cBinary.toString(),
           srcFile.toString(),
@@ -48,7 +55,15 @@ fun compileInlineP4(source: String): PipelineConfig {
           p4includeDir.toString(),
         )
         .redirectErrorStream(true)
-        .start()
+    // p4c shells out to `cc` for preprocessing. Hermetic sandboxes
+    // (blaze/google3) don't have `cc` on PATH, so fall back to a
+    // BUILD-provided shim that execs the CC toolchain compiler.
+    if (!hasSystemCc()) {
+      val shimDir = fourward.bazel.resolveRunfileProperty("cc_shim").parent
+      val env = pb.environment()
+      env["PATH"] = "$shimDir${File.pathSeparator}${env["PATH"] ?: ""}"
+    }
+    val process = pb.start()
 
     val output = process.inputStream.bufferedReader().readText()
     val exitCode = process.waitFor()
@@ -61,3 +76,8 @@ fun compileInlineP4(source: String): PipelineConfig {
     tmpDir.toFile().deleteRecursively()
   }
 }
+
+private fun hasSystemCc(): Boolean =
+  System.getenv("PATH")?.split(File.pathSeparator).orEmpty().any { dir ->
+    Files.isExecutable(Path.of(dir, "cc"))
+  }

--- a/e2e_tests/InlineP4Compiler.kt
+++ b/e2e_tests/InlineP4Compiler.kt
@@ -2,9 +2,7 @@ package fourward.e2e
 
 import com.google.protobuf.TextFormat
 import fourward.PipelineConfig
-import java.io.File
 import java.nio.file.Files
-import java.nio.file.Path
 
 /**
  * Compiles a P4 source string at test time using p4c-4ward. Useful for tests that need a custom P4
@@ -55,14 +53,7 @@ fun compileInlineP4(source: String): PipelineConfig {
           p4includeDir.toString(),
         )
         .redirectErrorStream(true)
-    // p4c shells out to `cc` for preprocessing. Hermetic sandboxes
-    // (blaze/google3) don't have `cc` on PATH, so fall back to a
-    // BUILD-provided shim that execs the CC toolchain compiler.
-    if (!hasSystemCc()) {
-      val shimDir = fourward.bazel.resolveRunfileProperty("cc_shim").parent
-      val env = pb.environment()
-      env["PATH"] = "$shimDir${File.pathSeparator}${env["PATH"] ?: ""}"
-    }
+    fourward.bazel.ensureCcOnPath(pb)
     val process = pb.start()
 
     val output = process.inputStream.bufferedReader().readText()
@@ -76,8 +67,3 @@ fun compileInlineP4(source: String): PipelineConfig {
     tmpDir.toFile().deleteRecursively()
   }
 }
-
-private fun hasSystemCc(): Boolean =
-  System.getenv("PATH")?.split(File.pathSeparator).orEmpty().any { dir ->
-    Files.isExecutable(Path.of(dir, "cc"))
-  }

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -219,11 +219,13 @@ kt_jvm_test(
         "FourwardTestHarness.kt",
     ],
     data = [
+        "//e2e_tests:cc_shim",
         "//p4c_backend:p4c-4ward",
         "@p4c//p4include",
         "@p4c//p4include:core.p4",
     ],
     jvm_flags = [
+        "-Dcc_shim=$(rlocationpath //e2e_tests:cc_shim)",
         "-Dp4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
         "-Dp4include=$(rlocationpath @p4c//p4include:core.p4)",
     ],

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -333,16 +333,7 @@ class WebServer(
     cmd += source.toString()
 
     val pb = ProcessBuilder(cmd).redirectErrorStream(true)
-    // p4c shells out to `cc` for preprocessing. Hermetic sandboxes
-    // (blaze/google3) don't have `cc` on PATH, so fall back to a
-    // BUILD-provided shim that execs the CC toolchain compiler. Where
-    // system `cc` exists (Linux CI, macOS CLT), prefer it — the shim's
-    // transitive runfiles are toolchain-specific and can be finicky.
-    if (!hasSystemCc()) {
-      val shimDir = resolveRunfileProperty("fourward.cc_shim").parent
-      val env = pb.environment()
-      env["PATH"] = "$shimDir${File.pathSeparator}${env["PATH"] ?: ""}"
-    }
+    fourward.bazel.ensureCcOnPath(pb, shimPropertyKey = "fourward.cc_shim")
     val process = pb.start()
     val processOutput = process.inputStream.bufferedReader().readText()
     val exitCode = process.waitFor()
@@ -351,18 +342,13 @@ class WebServer(
 
   private fun findP4c(): Path? {
     repoRoot.resolve("p4c_backend/p4c-4ward").let { if (Files.isExecutable(it)) return it }
-    val pathDirs = System.getenv("PATH")?.split(":") ?: emptyList()
+    val pathDirs = System.getenv("PATH")?.split(File.pathSeparator) ?: emptyList()
     for (dir in pathDirs) {
       val candidate = Path.of(dir, "p4c-4ward")
       if (Files.isExecutable(candidate)) return candidate
     }
     return null
   }
-
-  private fun hasSystemCc(): Boolean =
-    System.getenv("PATH")?.split(":").orEmpty().any { dir ->
-      Files.isExecutable(Path.of(dir, "cc"))
-    }
 
   // ---------------------------------------------------------------------------
   // Helpers


### PR DESCRIPTION
Fixes #666.

## Summary

p4c shells out to `cc` for preprocessing, which doesn't exist on PATH
in hermetic sandboxes like google3. Adds a shared `ensureCcOnPath`
helper to `bazel/Runfiles.kt` that both `InlineP4Compiler.kt` and
`WebServer.kt` now use.

- **`ensureCcOnPath(pb)`** — prepends a BUILD-provided cc_shim to a
  ProcessBuilder's PATH when no system `cc` is found
- Caches the system-cc check (`lazy val`) so it runs once per JVM
- Fixes a latent bug in `WebServer.kt` that hardcoded `":"` instead of
  `File.pathSeparator`

## Test plan

- [x] `BitLevelSerializationTest` passes
- [x] `WebServerTest` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)