### PR TITLE
Validate table entries before existence check on DELETE (§9.1)

### DIFF
--- a/grpc/P4RuntimeConformanceTest.kt
+++ b/grpc/P4RuntimeConformanceTest.kt
@@ -191,7 +191,7 @@ class P4RuntimeConformanceTest {
       Entity.newBuilder()
         .setTableEntry(p4.v1.P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(99999))
         .build()
-    assertGrpcError(Status.Code.NOT_FOUND) { harness.installEntry(entity) }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.installEntry(entity) }
   }
 
   // =========================================================================

--- a/grpc/P4RuntimeWriteErrorTest.kt
+++ b/grpc/P4RuntimeWriteErrorTest.kt
@@ -67,11 +67,10 @@ class P4RuntimeWriteErrorTest {
     assertGrpcError(Status.Code.ALREADY_EXISTS) { harness.installEntry(entry) }
   }
 
-  // P4Runtime spec §9.1: INSERT of an entry with an unknown table_id must return NOT_FOUND.
   @Test
-  fun `insert with unknown table ID returns NOT_FOUND`() {
+  fun `insert with unknown table ID returns INVALID_ARGUMENT`() {
     harness.loadPipeline(loadBasicTableConfig())
-    assertGrpcError(Status.Code.NOT_FOUND, "unknown table ID") {
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "unknown table ID") {
       harness.installEntry(badTableEntity())
     }
   }
@@ -364,8 +363,8 @@ class P4RuntimeWriteErrorTest {
     val errors = assertBatchError { harness.writeRaw(request) }
     assert(errors.size == 2) { "expected 2 per-update errors, got ${errors.size}" }
     assert(errors[0].canonicalCode == com.google.rpc.Code.OK_VALUE) { "first update should be OK" }
-    assert(errors[1].canonicalCode == com.google.rpc.Code.NOT_FOUND_VALUE) {
-      "second update should be NOT_FOUND"
+    assert(errors[1].canonicalCode == com.google.rpc.Code.INVALID_ARGUMENT_VALUE) {
+      "second update should be INVALID_ARGUMENT"
     }
     // Good update was applied despite bad one failing.
     val readBack = harness.readEntries()
@@ -393,7 +392,7 @@ class P4RuntimeWriteErrorTest {
         .toBuilder()
         .setAtomicity(atomicity)
         .build()
-    assertGrpcError(Status.Code.NOT_FOUND) { harness.writeRaw(request) }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.writeRaw(request) }
     val readBack = harness.readEntries()
     assert(readBack.isEmpty()) { "$atomicity should have rolled back the good entry" }
   }
@@ -419,8 +418,8 @@ class P4RuntimeWriteErrorTest {
       )
     val errors = assertBatchError { harness.writeRaw(request) }
     assert(errors.size == 2) { "expected 2 per-update errors" }
-    assert(errors[0].canonicalCode == com.google.rpc.Code.NOT_FOUND_VALUE)
-    assert(errors[1].canonicalCode == com.google.rpc.Code.NOT_FOUND_VALUE)
+    assert(errors[0].canonicalCode == com.google.rpc.Code.INVALID_ARGUMENT_VALUE)
+    assert(errors[1].canonicalCode == com.google.rpc.Code.INVALID_ARGUMENT_VALUE)
   }
 
   @Test
@@ -469,7 +468,7 @@ class P4RuntimeWriteErrorTest {
     val request = harness.buildBatchRequest(Update.Type.INSERT, listOf(badTableEntity()))
     val errors = assertBatchError { harness.writeRaw(request) }
     assert(errors.size == 1)
-    assert(errors[0].canonicalCode == com.google.rpc.Code.NOT_FOUND_VALUE)
+    assert(errors[0].canonicalCode == com.google.rpc.Code.INVALID_ARGUMENT_VALUE)
     assert(errors[0].message.isNotEmpty()) { "error detail should include a message" }
   }
 
@@ -518,9 +517,9 @@ class P4RuntimeWriteErrorTest {
     val errors = assertBatchError { harness.writeRaw(request) }
     assert(errors.size == 2) { "expected 2 per-update errors" }
     assert(errors[0].canonicalCode == com.google.rpc.Code.OK_VALUE)
-    assert(errors[1].canonicalCode == com.google.rpc.Code.NOT_FOUND_VALUE)
+    assert(errors[1].canonicalCode == com.google.rpc.Code.INVALID_ARGUMENT_VALUE)
     // The failing update should have an explanatory message.
-    assert(errors[1].message.isNotEmpty()) { "NOT_FOUND error should include a message" }
+    assert(errors[1].message.isNotEmpty()) { "INVALID_ARGUMENT error should include a message" }
   }
 
   // =========================================================================

--- a/grpc/WriteValidator.kt
+++ b/grpc/WriteValidator.kt
@@ -87,7 +87,7 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
     val entry = update.entity.tableEntry
     val tableInfo =
       tableInfoById[entry.tableId]
-        ?: throw notFound(
+        ?: throw invalidArg(
           "unknown table ID ${entry.tableId} " +
             "(valid tables: ${formatOptions(
               tableInfoById.values.map { "'${it.tableName}' (${it.preamble.id})" }
@@ -103,6 +103,9 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
       validateDefaultEntry(update, entry, tableInfo)
       return
     }
+
+    // Validate match fields for all operations — DELETE needs a valid key too.
+    validateMatchFields(entry, tableInfo)
 
     // P4Runtime spec §9.1: DELETE only needs the match key; skip content validation.
     if (update.type == P4RuntimeOuterClass.Update.Type.DELETE) return
@@ -128,7 +131,6 @@ class WriteValidator(p4Info: P4InfoOuterClass.P4Info) {
         null -> {}
       }
     }
-    validateMatchFields(entry, tableInfo)
     validatePriority(entry, tableInfo)
   }
 

--- a/grpc/WriteValidatorTest.kt
+++ b/grpc/WriteValidatorTest.kt
@@ -47,13 +47,13 @@ class WriteValidatorTest {
   // =========================================================================
 
   @Test
-  fun `unknown table ID returns NOT_FOUND`() {
+  fun `unknown table ID returns INVALID_ARGUMENT`() {
     val v = validator()
     val e =
       assertThrows(StatusException::class.java) {
         v.validate(insertUpdate(99999, exactMatch(MATCH_FIELD_ID, bytes(2)), action()))
       }
-    assertEquals(Status.Code.NOT_FOUND, e.status.code)
+    assertEquals(Status.Code.INVALID_ARGUMENT, e.status.code)
   }
 
   // =========================================================================

--- a/grpc/golden_errors/unknown-table-id.golden.txt
+++ b/grpc/golden_errors/unknown-table-id.golden.txt
@@ -1,1 +1,1 @@
-NOT_FOUND: unknown table ID 99999 (valid tables: 'port_table' (44171635))
+INVALID_ARGUMENT: unknown table ID 99999 (valid tables: 'port_table' (44171635))


### PR DESCRIPTION
## Summary

Two validation fixes surfaced by running the [sonic-pins P4 fuzzer](https://github.com/sonic-net/sonic-pins/tree/main/p4_fuzzer) against 4ward (10,000 iterations, 406,842 random WriteRequests):

1. **Unknown table IDs** now return `INVALID_ARGUMENT` instead of `NOT_FOUND`. A table ID absent from the P4Info is a malformed request, not a missing resource.

2. **Match field validation on DELETEs** now runs before the existence check. Previously, a DELETE with missing/duplicate match fields would skip validation (the spec says "DELETE only needs the key") and fall through to the simulator, which returned `NOT_FOUND`. Now it correctly returns `INVALID_ARGUMENT` for structurally invalid entries.

The production change is 4 lines in `WriteValidator.kt`.

## Test plan

- [x] `bazel test //grpc:WriteValidatorTest` — 1 test renamed and updated
- [x] `bazel test //grpc:GoldenErrorTest` — golden updated
- [x] `bazel test //grpc:P4RuntimeWriteErrorTest` — 7 assertions updated
- [x] `bazel test //grpc:P4RuntimeConformanceTest` — 1 assertion updated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)