### PR TITLE
p4c: resolve enum members in @field_list annotations

### DIFF
--- a/grpc/BitLevelSerializationTest.kt
+++ b/grpc/BitLevelSerializationTest.kt
@@ -591,4 +591,65 @@ class BitLevelSerializationTest {
       }
     }
   }
+
+  @Test
+  fun `field_list_ids emitted for enum-valued field_list annotations`() {
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      enum bit<8> PreservedFieldList { CLONE_COPY = 1 }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { ethernet_t eth; }
+      struct meta_t {
+        @field_list(PreservedFieldList.CLONE_COPY)
+        bit<16> preserved;
+        bit<16> not_preserved;
+      }
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 1; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply { pkt.emit(h.eth); } }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val metaStruct =
+      checkNotNull(
+        config.device.behavioral.typesList
+          .find { it.hasStruct() && it.struct.fieldsList.any { f -> f.name == "preserved" } }
+          ?.struct
+      ) {
+        "meta_t struct should be in IR types"
+      }
+
+    val preserved =
+      checkNotNull(metaStruct.fieldsList.find { it.name == "preserved" }) {
+        "meta_t should contain field 'preserved'"
+      }
+    assertEquals(
+      "preserved field should have field_list_ids",
+      listOf(1),
+      preserved.fieldListIdsList,
+    )
+
+    val notPreserved =
+      checkNotNull(metaStruct.fieldsList.find { it.name == "not_preserved" }) {
+        "meta_t should contain field 'not_preserved'"
+      }
+    assertTrue(
+      "not_preserved field should have no field_list_ids",
+      notPreserved.fieldListIdsList.isEmpty(),
+    )
+  }
 }

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -910,31 +910,18 @@ class SaiP4E2ETest {
     )
 
     // 4. Clone session → replica on MIRROR_PORT with instance=MIRRORING (2).
-    harness.installEntry(
-      Entity.newBuilder()
-        .setPacketReplicationEngineEntry(
-          P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
-            .setCloneSessionEntry(
-              P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
-                .setSessionId(MIRROR_CLONE_SESSION_ID)
-                .addReplicas(
-                  P4RuntimeOuterClass.Replica.newBuilder()
-                    .setPort(ByteString.copyFromUtf8(MIRROR_PORT.toString()))
-                    .setInstance(REPLICA_INSTANCE_MIRRORING)
-                )
-            )
-        )
-        .build()
-    )
+    installCloneSession(MIRROR_CLONE_SESSION_ID, MIRROR_PORT.toString(), REPLICA_INSTANCE_MIRRORING)
 
     // Inject an IPv4 packet and check the mirrored output.
     val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
     val result = harness.injectPacket(ingressPort = 0, payload = packet)
     val outputs = result.possibleOutcomesList.single().packetsList
-    val mirroredPacket = outputs.find { it.dataplaneEgressPort == MIRROR_PORT }
-    assertNotNull("expected a mirrored packet on port $MIRROR_PORT", mirroredPacket)
+    val mirroredPacket =
+      checkNotNull(outputs.find { it.dataplaneEgressPort == MIRROR_PORT }) {
+        "expected a mirrored packet on port $MIRROR_PORT"
+      }
 
-    val mirroredBytes = mirroredPacket!!.payload.toByteArray()
+    val mirroredBytes = mirroredPacket.payload.toByteArray()
     // The mirrored packet should be: Ethernet(14) + VLAN(4) + IPv6(40) + UDP(8) + IPFIX(16) +
     // PSAMP(28) + original_packet. Encap overhead = 110 bytes.
     val encapOverhead = 14 + 4 + 40 + 8 + 16 + 28
@@ -948,8 +935,8 @@ class SaiP4E2ETest {
     assertBytesEqual("encap dst_mac", mirrorEncapDstMac, mirroredBytes, 0)
     assertBytesEqual("encap src_mac", mirrorEncapSrcMac, mirroredBytes, 6)
     // EtherType = 0x8100 (802.1Q VLAN).
-    assertEquals("encap ethertype", 0x81.toByte(), mirroredBytes[12])
-    assertEquals("encap ethertype", 0x00.toByte(), mirroredBytes[13])
+    assertEquals("encap ethertype high", 0x81.toByte(), mirroredBytes[12])
+    assertEquals("encap ethertype low", 0x00.toByte(), mirroredBytes[13])
 
     // VLAN ethertype = 0x86DD (IPv6) at offset 16.
     assertEquals("vlan ethertype high", 0x86.toByte(), mirroredBytes[16])
@@ -963,8 +950,8 @@ class SaiP4E2ETest {
     // only the Ethernet header and IP src/dst addresses.
     assertBytesEqual("original dst_mac", UNICAST_MAC, mirroredBytes, encapOverhead)
     assertBytesEqual("original src_mac", SRC_MAC, mirroredBytes, encapOverhead + MAC_LEN)
-    assertEquals("original ethertype", 0x08.toByte(), mirroredBytes[encapOverhead + 12])
-    assertEquals("original ethertype", 0x00.toByte(), mirroredBytes[encapOverhead + 13])
+    assertEquals("original ethertype high", 0x08.toByte(), mirroredBytes[encapOverhead + 12])
+    assertEquals("original ethertype low", 0x00.toByte(), mirroredBytes[encapOverhead + 13])
     assertBytesEqual("original src_ip", SRC_IP, mirroredBytes, encapOverhead + SRC_IP_OFFSET)
     assertBytesEqual("original dst_ip", DST_IP, mirroredBytes, encapOverhead + DST_IP_OFFSET)
   }
@@ -1861,14 +1848,14 @@ class SaiP4E2ETest {
    * metadata and `p4rt_egress_port` in InjectPacket responses.
    */
   @Suppress("MagicNumber", "SameParameterValue")
-  private fun installCloneSession(sessionId: Int, p4rtPort: String) {
+  private fun installCloneSession(sessionId: Int, p4rtPort: String, instance: Int = 1) {
     val entry =
       P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
         .setSessionId(sessionId)
         .addReplicas(
           P4RuntimeOuterClass.Replica.newBuilder()
             .setPort(ByteString.copyFromUtf8(p4rtPort))
-            .setInstance(1)
+            .setInstance(instance)
         )
         .build()
     harness.installEntry(

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -39,7 +39,16 @@ class SaiP4E2ETest {
     // On a real switch, these come from platform config; in tests, we pin them so auto-allocation
     // (for table entry ports like "Ethernet0") doesn't conflict with ports that must map to
     // specific dataplane values (CPU port 510, multicast replica ports 0/1).
-    config = withPortMappings(config, mapOf("0" to 0, "1" to 1, CPU_PORT.toString() to CPU_PORT))
+    config =
+      withPortMappings(
+        config,
+        mapOf(
+          "0" to 0,
+          "1" to 1,
+          MIRROR_PORT.toString() to MIRROR_PORT,
+          CPU_PORT.toString() to CPU_PORT,
+        ),
+      )
     harness.loadPipeline(config)
   }
 
@@ -818,6 +827,146 @@ class SaiP4E2ETest {
       }
     assertTrue("nhop-a should be in members", "nhop-a" in memberNexthops)
     assertTrue("nhop-b should be in members", "nhop-b" in memberNexthops)
+  }
+
+  // =========================================================================
+  // Mirroring with VLAN + IPFIX encapsulation
+  // =========================================================================
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `mirrored packet has VLAN and IPFIX encapsulation headers prepended`() {
+    // 1. Mirror session: mirror-1 → encap with VLAN + IPv6 + UDP + IPFIX + PSAMP.
+    //    Must be installed before the ACL entry due to @refers_to constraint.
+    val mirrorSessionTable = findTable("mirror_session_table")
+    val mirrorAction = findAction("mirror_with_vlan_tag_and_ipfix_encapsulation")
+    val mirrorEncapSrcMac = byteArrayOf(0x00, 0x08, 0x08, 0x08, 0x08, 0x08)
+    val mirrorEncapDstMac = byteArrayOf(0x01, 0x09, 0x09, 0x09, 0x09, 0x09)
+    harness.installEntry(
+      buildEntry(
+        mirrorSessionTable,
+        mirrorAction,
+        matches = listOf(exactMatch(mirrorSessionTable, "mirror_session_id", "mirror-1")),
+        params =
+          listOf(
+            stringParam(mirrorAction, "monitor_port", MIRROR_PORT.toString()),
+            stringParam(mirrorAction, "monitor_failover_port", MIRROR_PORT.toString()),
+            bytesParam(mirrorAction, "mirror_encap_src_mac", mirrorEncapSrcMac),
+            bytesParam(mirrorAction, "mirror_encap_dst_mac", mirrorEncapDstMac),
+            bytesParam(mirrorAction, "mirror_encap_vlan_id", byteArrayOf(0x01, 0x23)),
+            bytesParam(
+              mirrorAction,
+              "mirror_encap_src_ip",
+              ByteArray(16) { if (it == 15) 1 else 0 },
+            ),
+            bytesParam(
+              mirrorAction,
+              "mirror_encap_dst_ip",
+              ByteArray(16) { if (it == 15) 2 else 0 },
+            ),
+            bytesParam(mirrorAction, "mirror_encap_udp_src_port", byteArrayOf(0x12, 0x34)),
+            bytesParam(mirrorAction, "mirror_encap_udp_dst_port", byteArrayOf(0x12, 0x83.toByte())),
+          ),
+      )
+    )
+
+    // 2. ACL: mark IPv4 packets for mirroring with mirror_session_id="mirror-1".
+    val mirrorAclTable = findTable("acl_ingress_mirror_and_redirect_table")
+    val aclMirror = findAction("acl_mirror")
+    harness.installEntry(
+      buildEntry(
+        mirrorAclTable,
+        aclMirror,
+        matches = listOf(optionalMatch(mirrorAclTable, "is_ipv4", byteArrayOf(1))),
+        params = listOf(stringParam(aclMirror, "mirror_session_id", "mirror-1")),
+        priority = 1,
+      )
+    )
+
+    // 3. Ingress clone table: marked_to_mirror=true, mirror_egress_port=MIRROR_PORT
+    //    → clone_preserving_field_list with session MIRROR_CLONE_SESSION_ID.
+    val cloneTable = findTable("ingress_clone_table")
+    val ingressClone = findAction("ingress_clone")
+    harness.installEntry(
+      buildEntry(
+        cloneTable,
+        ingressClone,
+        matches =
+          listOf(
+            exactMatch(cloneTable, "marked_to_copy", byteArrayOf(0)),
+            exactMatch(cloneTable, "marked_to_mirror", byteArrayOf(1)),
+            optionalMatch(cloneTable, "mirror_egress_port", MIRROR_PORT.toString()),
+          ),
+        params =
+          listOf(
+            bytesParam(
+              ingressClone,
+              "clone_session",
+              FourwardTestHarness.longToBytes(MIRROR_CLONE_SESSION_ID.toLong(), 4),
+            )
+          ),
+        priority = 1,
+      )
+    )
+
+    // 4. Clone session → replica on MIRROR_PORT with instance=MIRRORING (2).
+    harness.installEntry(
+      Entity.newBuilder()
+        .setPacketReplicationEngineEntry(
+          P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+            .setCloneSessionEntry(
+              P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
+                .setSessionId(MIRROR_CLONE_SESSION_ID)
+                .addReplicas(
+                  P4RuntimeOuterClass.Replica.newBuilder()
+                    .setPort(ByteString.copyFromUtf8(MIRROR_PORT.toString()))
+                    .setInstance(REPLICA_INSTANCE_MIRRORING)
+                )
+            )
+        )
+        .build()
+    )
+
+    // Inject an IPv4 packet and check the mirrored output.
+    val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
+    val result = harness.injectPacket(ingressPort = 0, payload = packet)
+    val outputs = result.possibleOutcomesList.single().packetsList
+    val mirroredPacket = outputs.find { it.dataplaneEgressPort == MIRROR_PORT }
+    assertNotNull("expected a mirrored packet on port $MIRROR_PORT", mirroredPacket)
+
+    val mirroredBytes = mirroredPacket!!.payload.toByteArray()
+    // The mirrored packet should be: Ethernet(14) + VLAN(4) + IPv6(40) + UDP(8) + IPFIX(16) +
+    // PSAMP(28) + original_packet. Encap overhead = 110 bytes.
+    val encapOverhead = 14 + 4 + 40 + 8 + 16 + 28
+    assertEquals(
+      "mirrored packet should be original + encap overhead",
+      packet.size + encapOverhead,
+      mirroredBytes.size,
+    )
+
+    // Verify encap Ethernet dst/src MAC.
+    assertBytesEqual("encap dst_mac", mirrorEncapDstMac, mirroredBytes, 0)
+    assertBytesEqual("encap src_mac", mirrorEncapSrcMac, mirroredBytes, 6)
+    // EtherType = 0x8100 (802.1Q VLAN).
+    assertEquals("encap ethertype", 0x81.toByte(), mirroredBytes[12])
+    assertEquals("encap ethertype", 0x00.toByte(), mirroredBytes[13])
+
+    // VLAN ethertype = 0x86DD (IPv6) at offset 16.
+    assertEquals("vlan ethertype high", 0x86.toByte(), mirroredBytes[16])
+    assertEquals("vlan ethertype low", 0xDD.toByte(), mirroredBytes[17])
+
+    // IPv6 version nibble at offset 18.
+    assertEquals("ipv6 version", 0x60.toByte(), (mirroredBytes[18].toInt() and 0xF0).toByte())
+
+    // Original packet's Ethernet header starts at offset encapOverhead.
+    // The IPv4 checksum may differ (recomputed by v1model's ComputeChecksum), so compare
+    // only the Ethernet header and IP src/dst addresses.
+    assertBytesEqual("original dst_mac", UNICAST_MAC, mirroredBytes, encapOverhead)
+    assertBytesEqual("original src_mac", SRC_MAC, mirroredBytes, encapOverhead + MAC_LEN)
+    assertEquals("original ethertype", 0x08.toByte(), mirroredBytes[encapOverhead + 12])
+    assertEquals("original ethertype", 0x00.toByte(), mirroredBytes[encapOverhead + 13])
+    assertBytesEqual("original src_ip", SRC_IP, mirroredBytes, encapOverhead + SRC_IP_OFFSET)
+    assertBytesEqual("original dst_ip", DST_IP, mirroredBytes, encapOverhead + DST_IP_OFFSET)
   }
 
   // =========================================================================
@@ -1840,6 +1989,10 @@ class SaiP4E2ETest {
     // CPU port = 2^9 - 2 = 510 for 9-bit ports (SAI P4 ids.h: SAI_P4_CPU_PORT).
     private const val CPU_PORT = 510
     private const val COPY_TO_CPU_SESSION_ID = 255
+    private const val MIRROR_PORT = 5
+    private const val MIRROR_CLONE_SESSION_ID = 100
+    // ids.h: SAI_P4_REPLICA_INSTANCE_MIRRORING
+    private const val REPLICA_INSTANCE_MIRRORING = 2
 
     /**
      * Adds explicit port_id_t translation entries to the pipeline config (hybrid mode: explicit

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -561,6 +561,13 @@ void FourWardBackend::emitTypeDecls(const IR::P4Program* program) {
             for (const auto* arg : ann->getExpr()) {
               if (const auto* c = arg->to<IR::Constant>()) {
                 fd->add_field_list_ids(c->asInt());
+              } else if (const auto* ei =
+                             P4::EnumInstance::resolve(arg, &typeMap_)) {
+                if (const auto* sei = ei->to<P4::SerEnumInstance>()) {
+                  if (const auto* val = sei->value->to<IR::Constant>()) {
+                    fd->add_field_list_ids(val->asInt());
+                  }
+                }
               }
             }
           }

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -563,10 +563,13 @@ void FourWardBackend::emitTypeDecls(const IR::P4Program* program) {
                 fd->add_field_list_ids(c->asInt());
               } else if (const auto* ei =
                              P4::EnumInstance::resolve(arg, &typeMap_)) {
-                if (const auto* sei = ei->to<P4::SerEnumInstance>()) {
-                  if (const auto* val = sei->value->to<IR::Constant>()) {
-                    fd->add_field_list_ids(val->asInt());
-                  }
+                const auto* sei = ei->to<P4::SerEnumInstance>();
+                BUG_CHECK(sei != nullptr,
+                          "@field_list argument resolved to non-serializable "
+                          "enum %1%",
+                          arg);
+                if (const auto* val = sei->value->to<IR::Constant>()) {
+                  fd->add_field_list_ids(val->asInt());
                 }
               }
             }


### PR DESCRIPTION
## Summary

Mirrored packets were missing their encapsulation headers because the p4c
backend never emitted `field_list_ids` into the IR — the metadata
preservation mechanism for `clone_preserving_field_list` was silently
broken for any P4 program that uses enum members in `@field_list`
annotations (which is all of SAI P4).

The root cause: p4c's midend does not constant-fold enum member references
inside annotation bodies. `@field_list(PreservedFieldList.MIRROR_AND_PACKET_IN_COPY)`
stays as an `IR::Member` node, but the backend only handled `IR::Constant`.
The fix uses `EnumInstance::resolve` to extract the underlying integer
value from serializable enum members.

- **p4c_backend/backend.cpp** — handle `IR::Member` (enum references) in
  `@field_list` annotation arguments via `EnumInstance::resolve`.
- **grpc/SaiP4E2ETest.kt** — end-to-end test: installs mirror session +
  ACL + ingress clone table + clone session, injects a packet, and
  verifies the mirrored output has the full Ethernet + VLAN + IPv6 + UDP +
  IPFIX + PSAMP encapsulation with correct field values.
- **grpc/BitLevelSerializationTest.kt** — backend unit test: compiles a P4
  program with `@field_list(SomeEnum.MEMBER)` and asserts `field_list_ids`
  appears in the compiled IR.

Fixes #657.

## Test plan

- [x] New backend unit test: `field_list_ids emitted for enum-valued field_list annotations`
- [x] New E2E test: `mirrored packet has VLAN and IPFIX encapsulation headers prepended`
- [x] All 78 non-heavy tests pass
- [x] Verified `field_list_ids: 1` appears 10 times in compiled SAI middleblock IR (was 0 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)