### PR TITLE
simulator: multi-replica clone sessions

### DIFF
--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -89,6 +89,7 @@ events {
     session_id: 100
     session_found: true
     dataplane_egress_port: 3
+    replica_count: 1
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -89,6 +89,7 @@ events {
     session_id: 100
     session_found: true
     dataplane_egress_port: 1
+    replica_count: 1
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -100,6 +100,7 @@ events {
     session_id: 100
     session_found: true
     dataplane_egress_port: 1
+    replica_count: 1
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -141,6 +141,7 @@ fork_outcome {
           session_id: 100
           session_found: true
           dataplane_egress_port: 1
+          replica_count: 1
         }
       }
       fork_outcome {
@@ -320,6 +321,7 @@ fork_outcome {
           session_id: 100
           session_found: true
           dataplane_egress_port: 1
+          replica_count: 1
         }
       }
       fork_outcome {

--- a/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
@@ -113,6 +113,7 @@ events {
     session_id: 100
     session_found: true
     dataplane_egress_port: 2
+    replica_count: 1
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -89,6 +89,7 @@ events {
     session_id: 100
     session_found: true
     dataplane_egress_port: 3
+    replica_count: 1
   }
 }
 fork_outcome {

--- a/e2e_tests/trace_tree/e2e_clone.golden.txtpb
+++ b/e2e_tests/trace_tree/e2e_clone.golden.txtpb
@@ -193,6 +193,7 @@ events {
     session_id: 100
     session_found: true
     dataplane_egress_port: 5
+    replica_count: 1
   }
 }
 fork_outcome {

--- a/grpc/TraceEnricher.kt
+++ b/grpc/TraceEnricher.kt
@@ -91,6 +91,7 @@ object TraceEnricher {
     if (event.hasCloneSessionLookup() && pt != null) {
       val csl = event.cloneSessionLookup
       if (!csl.sessionFound) return null
+      // Enriches the first replica's port only; per-replica details are in fork branch labels.
       val p4rtPort = pt.dataplaneToP4rt(csl.dataplaneEgressPort) ?: return null
       return event
         .toBuilder()

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -360,26 +360,22 @@ class V1ModelArchitecture(
         },
       )
     val cloneCtx = truncatePayload(ctx, fork.truncateBytes)
-    val clone =
-      runBranch(
+    return assembleCloneFork(
+      fork.eventsBeforeFork,
+      original,
+      fork.replicas,
+      buildCloneBranches(
         cloneCtx,
+        fork.replicas,
         fork.bytesConsumed,
         fork.postParserEnv,
-        configure = { s ->
-          s.standardMetadata.setBitField("instance_type", CLONE_I2E_INSTANCE_TYPE)
-          s.standardMetadata.setBitField("egress_port", fork.clonePort)
-          s.standardMetadata.setBitField("egress_rid", fork.egressRid.toLong())
-          s.standardMetadata.setBitField("packet_length", cloneCtx.payload.size.toLong())
-          applyPreservedMetadata(cloneCtx, s.env, fork.preservedMetadata)
-        },
-        pipelineTail = { c, s -> runEgressAndDeparser(c, s) },
-      )
-    val branches =
-      listOf(
-        ForkBranch.newBuilder().setLabel("original").setSubtree(original).build(),
-        ForkBranch.newBuilder().setLabel("clone").setSubtree(clone).build(),
-      )
-    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.CLONE, branches))
+        snapshotPendingOps = null,
+        CLONE_I2E_INSTANCE_TYPE,
+        fork.preservedMetadata,
+      ) { c, s ->
+        runEgressAndDeparser(c, s)
+      },
+    )
   }
 
   /**
@@ -404,34 +400,85 @@ class V1ModelArchitecture(
         },
       )
     val cloneCtx = truncatePayload(ctx, fork.truncateBytes)
-    val clone =
-      runBranch(
+    return assembleCloneFork(
+      fork.eventsBeforeFork,
+      original,
+      fork.replicas,
+      buildCloneBranches(
         cloneCtx,
+        fork.replicas,
         fork.bytesConsumed,
         fork.forkPointEnv,
         fork.forkPointPendingOps,
+        CLONE_E2E_INSTANCE_TYPE,
+        fork.preservedMetadata,
+      ) { _, s ->
+        resetEgressSpec(s)
+        runControlStages(s, s.egressControls, dataplanePort = readEgressPort(s))
+        if (egressSpecIsDropPort(s))
+          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        else runDeparser(s)
+      },
+    )
+  }
+
+  /** Builds one clone branch per replica, setting instance_type/egress_port/egress_rid. */
+  @Suppress("LongParameterList")
+  private fun buildCloneBranches(
+    ctx: PipelineContext,
+    replicas: List<Replica>,
+    bytesConsumed: Int,
+    snapshotEnv: Environment,
+    snapshotPendingOps: V1ModelPendingOps?,
+    instanceType: Long,
+    preservedMetadata: Map<String, Value>?,
+    pipelineTail: (PipelineContext, PipelineState) -> TraceTree,
+  ): List<TraceTree> {
+    val buildBranch = { replica: Replica ->
+      runBranch(
+        ctx,
+        bytesConsumed,
+        snapshotEnv,
+        snapshotPendingOps,
         configure = { s ->
+          s.pendingOps.cloneSessionId = null
           s.pendingOps.egressCloneSessionId = null
-          s.standardMetadata.setBitField("instance_type", CLONE_E2E_INSTANCE_TYPE)
-          s.standardMetadata.setBitField("egress_port", fork.clonePort)
-          s.standardMetadata.setBitField("egress_rid", fork.egressRid.toLong())
-          s.standardMetadata.setBitField("packet_length", cloneCtx.payload.size.toLong())
-          applyPreservedMetadata(cloneCtx, s.env, fork.preservedMetadata)
+          s.standardMetadata.setBitField("instance_type", instanceType)
+          s.standardMetadata.setBitField("egress_port", replica.port.toLong())
+          s.standardMetadata.setBitField("egress_rid", replica.rid.toLong())
+          s.standardMetadata.setBitField("packet_length", ctx.payload.size.toLong())
+          applyPreservedMetadata(ctx, s.env, preservedMetadata)
         },
-        pipelineTail = { _, s ->
-          resetEgressSpec(s)
-          runControlStages(s, s.egressControls, dataplanePort = readEgressPort(s))
-          if (egressSpecIsDropPort(s))
-            buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
-          else runDeparser(s)
-        },
+        pipelineTail = pipelineTail,
       )
+    }
+    return if (INTRA_PACKET_PARALLELISM_ENABLED) {
+      replicas.parallelStream().map(buildBranch).toList()
+    } else {
+      replicas.map(buildBranch)
+    }
+  }
+
+  /** Assembles the "original" branch + clone branches into a CLONE fork result. */
+  private fun assembleCloneFork(
+    eventsBeforeFork: List<TraceEvent>,
+    original: TraceTree,
+    replicas: List<Replica>,
+    clones: List<TraceTree>,
+  ): PipelineResult {
     val branches =
-      listOf(
-        ForkBranch.newBuilder().setLabel("original").setSubtree(original).build(),
-        ForkBranch.newBuilder().setLabel("clone").setSubtree(clone).build(),
-      )
-    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.CLONE, branches))
+      buildList(replicas.size + 1) {
+        add(ForkBranch.newBuilder().setLabel("original").setSubtree(original).build())
+        replicas.zip(clones).mapTo(this) { (replica, trace) ->
+          ForkBranch.newBuilder()
+            .setLabel(
+              if (replicas.size == 1) "clone" else "clone_${replica.rid}_port_${replica.port}"
+            )
+            .setSubtree(trace)
+            .build()
+        }
+      }
+    return PipelineResult(buildForkTree(eventsBeforeFork, ForkReason.CLONE, branches))
   }
 
   /** Resubmit: restarts the pipeline with preserved metadata. */
@@ -757,8 +804,7 @@ class V1ModelArchitecture(
       resolveCloneSession(ctx, s, pendingClone)?.let { session ->
         throw CloneFork(
           pendingClone,
-          session.replica.port.toLong(),
-          session.replica.rid,
+          session.replicas,
           s.packetCtx.getEvents(),
           snapshotPreservedMetadata(s, s.pendingOps.cloneFieldListId),
           s.env.deepCopy(),
@@ -805,8 +851,7 @@ class V1ModelArchitecture(
       resolveCloneSession(ctx, s, pendingE2EClone)?.let { session ->
         throw EgressCloneFork(
           pendingE2EClone,
-          session.replica.port.toLong(),
-          session.replica.rid,
+          session.replicas,
           s.packetCtx.getEvents(),
           snapshotPreservedMetadata(s, s.pendingOps.egressCloneFieldListId),
           s.env.deepCopy(),
@@ -859,13 +904,12 @@ class V1ModelArchitecture(
   private fun egressSpecIsDropPort(s: PipelineState): Boolean =
     (s.standardMetadata.fields["egress_spec"] as? BitVal)?.bits?.value?.toLong() == s.dropPort
 
-  /** Resolved clone session: first replica and optional packet truncation length. */
-  private data class CloneSessionResult(val replica: Replica, val truncateBytes: Int)
+  /** Resolved clone session: all replicas and optional packet truncation length. */
+  private data class CloneSessionResult(val replicas: List<Replica>, val truncateBytes: Int)
 
   /**
-   * Resolves a pending clone session: emits a [CloneSessionLookupEvent] and returns the first
-   * replica with truncation info, or emits a miss event and returns null if the session doesn't
-   * exist.
+   * Resolves a pending clone session: emits a [CloneSessionLookupEvent] and returns all replicas
+   * with truncation info, or emits a miss event and returns null if the session doesn't exist.
    */
   private fun resolveCloneSession(
     ctx: PipelineContext,
@@ -874,21 +918,23 @@ class V1ModelArchitecture(
   ): CloneSessionResult? {
     val session = ctx.tableStore.getCloneSession(sessionId)
     if (session != null) {
-      val firstReplica = session.replicasList.first()
-      val egressPort = replicaPort(firstReplica)
+      val replicas = session.replicasList.map { Replica(it.instance, replicaPort(it)) }
+      val first = replicas.first()
       s.packetCtx.addTraceEvent(
-        cloneSessionLookupEvent(sessionId, egressPort, firstReplica.instance)
+        cloneSessionLookupEvent(sessionId, first.port, first.rid, replicas.size)
       )
-      return CloneSessionResult(
-        Replica(firstReplica.instance, egressPort),
-        session.packetLengthBytes,
-      )
+      return CloneSessionResult(replicas, session.packetLengthBytes)
     }
     s.packetCtx.addTraceEvent(cloneSessionMissEvent(sessionId))
     return null
   }
 
-  private fun cloneSessionLookupEvent(sessionId: Int, egressPort: Int, egressRid: Int): TraceEvent =
+  private fun cloneSessionLookupEvent(
+    sessionId: Int,
+    egressPort: Int,
+    egressRid: Int,
+    replicaCount: Int,
+  ): TraceEvent =
     TraceEvent.newBuilder()
       .setCloneSessionLookup(
         CloneSessionLookupEvent.newBuilder()
@@ -896,6 +942,7 @@ class V1ModelArchitecture(
           .setSessionFound(true)
           .setDataplaneEgressPort(egressPort)
           .setEgressRid(egressRid)
+          .setReplicaCount(replicaCount)
       )
       .build()
 
@@ -1269,13 +1316,12 @@ internal class V1ModelSelectorFork(
 ) : ForkException(fork.eventsBeforeFork)
 
 /**
- * Fork at the ingress→egress boundary when an I2E clone was requested — "original" and "clone".
- * Carries fork-point state so both branches can continue via fork-point resume.
+ * Fork at the ingress→egress boundary when an I2E clone was requested — "original" plus one clone
+ * branch per replica. Carries fork-point state so all branches can continue via fork-point resume.
  */
 internal class CloneFork(
   val sessionId: Int,
-  val clonePort: Long,
-  val egressRid: Int,
+  val replicas: List<Replica>,
   eventsBeforeFork: List<TraceEvent>,
   val preservedMetadata: Map<String, Value>? = null,
   /** Deep copy of the post-ingress environment (for the "original" branch). */
@@ -1284,20 +1330,19 @@ internal class CloneFork(
   val bytesConsumed: Int,
   /** Pending operations at the fork point. */
   val forkPointPendingOps: V1ModelPendingOps,
-  /** Post-parser env (for the "clone" branch — BMv2: clone gets pre-ingress state). */
+  /** Post-parser env (for clone branches — BMv2: clone gets pre-ingress state). */
   val postParserEnv: Environment,
   /** Clone session packet_length_bytes: 0 = no truncation, >0 = truncate to this many bytes. */
   val truncateBytes: Int = 0,
 ) : ForkException(eventsBeforeFork)
 
 /**
- * Fork after egress controls when an E2E clone was requested — "original" and "clone". Carries
- * fork-point state so both branches can continue via fork-point resume.
+ * Fork after egress controls when an E2E clone was requested — "original" plus one clone branch per
+ * replica. Carries fork-point state so all branches can continue via fork-point resume.
  */
 internal class EgressCloneFork(
   val sessionId: Int,
-  val clonePort: Long,
-  val egressRid: Int,
+  val replicas: List<Replica>,
   eventsBeforeFork: List<TraceEvent>,
   val preservedMetadata: Map<String, Value>? = null,
   /** Deep copy of the post-egress environment (for both branches). */

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -244,6 +244,22 @@ class V1ModelArchitectureTest {
     usePortBytes: Boolean = false,
     packetLengthBytes: Int = 0,
   ) {
+    writeCloneSession(
+      store,
+      sessionId,
+      listOf(egressPort to instance),
+      usePortBytes,
+      packetLengthBytes,
+    )
+  }
+
+  private fun writeCloneSession(
+    store: TableStore,
+    sessionId: Int,
+    replicas: List<Pair<Int, Int>>,
+    usePortBytes: Boolean = false,
+    packetLengthBytes: Int = 0,
+  ) {
     store.write(
       P4RuntimeOuterClass.Update.newBuilder()
         .setType(P4RuntimeOuterClass.Update.Type.INSERT)
@@ -254,7 +270,11 @@ class V1ModelArchitectureTest {
                 .setCloneSessionEntry(
                   P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
                     .setSessionId(sessionId)
-                    .addReplicas(buildReplica(egressPort, instance, usePortBytes = usePortBytes))
+                    .addAllReplicas(
+                      replicas.map { (port, instance) ->
+                        buildReplica(port, instance, usePortBytes)
+                      }
+                    )
                     .setPacketLengthBytes(packetLengthBytes)
                 )
             )
@@ -688,6 +708,135 @@ class V1ModelArchitectureTest {
   }
 
   @Test
+  fun `I2E clone with multi-replica session produces one clone per replica`() {
+    val config =
+      v1modelConfig(
+        externCall("clone", enumArg("I2E"), intArg(1, 32)),
+        assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, replicas = listOf(7 to 10, 8 to 20))
+
+    val result =
+      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+
+    assertTrue(result.trace.hasForkOutcome())
+    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    val branches = result.trace.forkOutcome.branchesList
+    assertEquals(3, branches.size)
+    assertEquals("original", branches[0].label)
+    assertEquals("clone_10_port_7", branches[1].label)
+    assertEquals("clone_20_port_8", branches[2].label)
+
+    val outputs = result.possibleOutcomes.single()
+    assertEquals(3, outputs.size)
+    assertEquals(2, outputs[0].dataplaneEgressPort)
+    assertEquals(7, outputs[1].dataplaneEgressPort)
+    assertEquals(8, outputs[2].dataplaneEgressPort)
+  }
+
+  @Test
+  fun `E2E clone with multi-replica session produces one clone per replica`() {
+    val config =
+      v1modelConfig(
+        ingressStmts =
+          listOf(assignField("sm", "egress_spec", 3, V1ModelArchitecture.DEFAULT_PORT_BITS)),
+        egressStmts =
+          listOf(
+            ifFieldEquals(
+              "sm",
+              "instance_type",
+              0,
+              32,
+              externCall("clone", enumArg("E2E"), intArg(1, 32)),
+            )
+          ),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, replicas = listOf(5 to 1, 6 to 2))
+
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+
+    assertTrue(result.trace.hasForkOutcome())
+    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    val branches = result.trace.forkOutcome.branchesList
+    assertEquals(3, branches.size)
+    assertEquals("original", branches[0].label)
+
+    val outputs = result.possibleOutcomes.single()
+    assertEquals(3, outputs.size)
+    assertEquals(3, outputs[0].dataplaneEgressPort)
+    assertEquals(5, outputs[1].dataplaneEgressPort)
+    assertEquals(6, outputs[2].dataplaneEgressPort)
+  }
+
+  @Test
+  fun `multi-replica clone sets correct egress_rid per replica`() {
+    val config =
+      v1modelConfig(
+        ingressStmts =
+          listOf(
+            externCall("clone", enumArg("I2E"), intArg(1, 32)),
+            assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+          ),
+        egressStmts =
+          listOf(
+            ifFieldEquals(
+              "sm",
+              "instance_type",
+              1,
+              32,
+              ifFieldEquals("sm", "egress_rid", 0, 16, markToDrop),
+            )
+          ),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, replicas = listOf(7 to 0, 8 to 10))
+
+    val result =
+      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(2, outputs.size)
+    assertEquals(2, outputs[0].dataplaneEgressPort)
+    assertEquals(8, outputs[1].dataplaneEgressPort)
+  }
+
+  @Test
+  fun `multi-replica clone preserves metadata on all clone branches`() {
+    val config =
+      v1modelConfig(
+        ingressStmts =
+          listOf(
+            assignField("meta", "preserved", 0xABCD, 16),
+            externCall("clone_preserving_field_list", enumArg("I2E"), intArg(1, 32), intArg(1, 8)),
+            assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+          ),
+        egressStmts =
+          listOf(
+            ifFieldEquals(
+              "sm",
+              "instance_type",
+              1,
+              32,
+              ifFieldEquals("meta", "preserved", 0, 16, externCall("mark_to_drop", nameRef("sm"))),
+            )
+          ),
+        metaTypeDecl = metaTypeWithFieldList,
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, replicas = listOf(7 to 1, 8 to 2))
+
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(3, outputs.size)
+    assertEquals(2, outputs[0].dataplaneEgressPort)
+    assertEquals(7, outputs[1].dataplaneEgressPort)
+    assertEquals(8, outputs[2].dataplaneEgressPort)
+  }
+
+  @Test
   fun `clone session trace event includes egress_rid`() {
     val config =
       v1modelConfig(
@@ -705,6 +854,27 @@ class V1ModelArchitectureTest {
     assertEquals(1, cloneEvent.sessionId)
     assertEquals(7, cloneEvent.dataplaneEgressPort)
     assertEquals(42, cloneEvent.egressRid)
+    assertEquals(1, cloneEvent.replicaCount)
+  }
+
+  @Test
+  fun `clone session trace event reports replica_count for multi-replica sessions`() {
+    val config =
+      v1modelConfig(
+        externCall("clone", enumArg("I2E"), intArg(1, 32)),
+        assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val tableStore = TableStore()
+    writeCloneSession(tableStore, sessionId = 1, replicas = listOf(7 to 10, 8 to 20))
+
+    val result =
+      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+    val cloneEvent = result.trace.eventsList.first { it.hasCloneSessionLookup() }.cloneSessionLookup
+
+    assertTrue(cloneEvent.sessionFound)
+    assertEquals(2, cloneEvent.replicaCount)
+    assertEquals(7, cloneEvent.dataplaneEgressPort)
+    assertEquals(10, cloneEvent.egressRid)
   }
 
   @Test

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -210,12 +210,15 @@ message CloneSessionLookupEvent {
   uint32 session_id = 1;
   optional bool session_found =
       2;  // false = session not configured, clone silently dropped
-  uint32 dataplane_egress_port =
-      3;  // clone destination; only meaningful when session_found
+  // First replica's destination port; only meaningful when session_found.
+  uint32 dataplane_egress_port = 3;
   // P4Runtime port ID. Populated by enrichment layers, never by the simulator.
   bytes p4rt_egress_port = 4;
-  // Replica instance from the clone session entry, mapped to egress_rid.
+  // First replica's instance, mapped to egress_rid.
   uint32 egress_rid = 5;
+  // Total number of replicas in the clone session. Multi-replica sessions
+  // (e.g., mirror-and-punt) produce one clone branch per replica.
+  uint32 replica_count = 6;
 }
 
 // Fired when a packet arrives at the pipeline — the very first event in any


### PR DESCRIPTION
## Summary

Clone sessions with multiple replicas (e.g., mirror-and-punt) now produce
one clone branch per replica, matching BMv2's simple_switch behavior.
Previously only the first replica was processed; the rest were silently
dropped.

- **`resolveCloneSession`** returns all replicas instead of just the first.
- **`CloneFork` / `EgressCloneFork`** carry `replicas: List<Replica>`.
- **`buildCloneBranches`** — new shared helper used by both I2E and E2E
  clone handlers. Unconditionally clears pending clone session IDs (a
  clone-branch invariant), and supports `parallelStream()` like multicast.
- **`assembleCloneFork`** — assembles "original" + per-replica clone
  branches. Single-replica sessions keep the plain `clone` label;
  multi-replica sessions use `clone_<rid>_port_<port>`.
- **`CloneSessionLookupEvent`** gains `replica_count` so trace consumers
  can see multi-replica sessions without inspecting branch labels.

Fixes #671.

## Test plan

- [x] `I2E clone with multi-replica session produces one clone per replica`
- [x] `E2E clone with multi-replica session produces one clone per replica`
- [x] `multi-replica clone sets correct egress_rid per replica`
- [x] `multi-replica clone preserves metadata on all clone branches`
- [x] `clone session trace event reports replica_count for multi-replica sessions`
- [x] All 78 non-heavy tests pass (including golden trace trees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)