### PR TITLE
dataplane: implement Reproducer for InjectPacket traces

### DIFF
--- a/designs/reproduce_trace.md
+++ b/designs/reproduce_trace.md
@@ -1,6 +1,6 @@
 # Reproduce Trace Design
 
-**Status: proposed.**
+**Status: implemented.**
 
 ## Goal
 
@@ -89,7 +89,6 @@ events:
 | Trace event | Entity extracted |
 |---|---|
 | `TableLookupEvent` with `hit = true` | `matched_entry` → `Entity.table_entry` |
-| `TableLookupEvent` with `hit = false` and runtime default action | Default action entry → `Entity.table_entry` |
 | `CloneSessionLookupEvent` with `session_found = true` | Clone session from table store → `Entity.clone_session_entry` |
 | `Fork` with reason `MULTICAST` | Multicast group from table store → `Entity.multicast_group_entry` |
 | Action profile references in matched entries | Members/groups from table store → `Entity.action_profile_member` / `Entity.action_profile_group` |

--- a/designs/reproduce_trace.md
+++ b/designs/reproduce_trace.md
@@ -45,9 +45,7 @@ service Dataplane {
 message Reproducer {
   PipelineConfig pipeline_config = 1;
   repeated p4.v1.Entity entities = 2;
-  InputPacket input_packet = 3;
-  TraceTree trace = 4;
-  repeated PacketSet possible_outcomes = 5;
+  ProcessPacketResult result = 3;
 }
 ```
 

--- a/designs/reproduce_trace.md
+++ b/designs/reproduce_trace.md
@@ -57,16 +57,13 @@ message InjectPacketResponse {
   Reproducer reproducer = 3;
 }
 
-// Everything needed to reproduce a trace, minus the input packet and
-// trace itself (which are already in the enclosing response).
+// Self-contained reproduction case for a packet trace.
 message Reproducer {
-  // The compiled P4 program (IR + p4info).
   PipelineConfig pipeline_config = 1;
-
-  // P4Runtime entities needed to reproduce the trace: matched table
-  // entries, clone sessions, multicast groups, action profile
-  // members/groups.
   repeated p4.v1.Entity entities = 2;
+  InputPacket input_packet = 3;
+  TraceTree trace = 4;
+  repeated PacketSet possible_outcomes = 5;
 }
 ```
 
@@ -77,9 +74,10 @@ extra step, and a TOCTOU risk if state changed between calls. The flag
 lets the user get the reproducer in the same call where the bug was
 observed.
 
-`Reproducer` doesn't duplicate the input packet or trace — those
-are already in `InjectPacketResponse`. Together, the response fields
-form a complete, self-contained reproduction case.
+The `Reproducer` is fully self-contained: pipeline config, entities,
+input packet, trace, and possible outcomes. Serialize it to a file
+and hand it to someone — they have everything needed to reproduce
+the trace and see what happened.
 
 ### Entity extraction
 
@@ -89,6 +87,7 @@ events:
 | Trace event | Entity extracted |
 |---|---|
 | `TableLookupEvent` with `hit = true` | `matched_entry` → `Entity.table_entry` |
+| `TableLookupEvent` with `hit = false` and modified default action | Default action from table store → `Entity.table_entry` (with `is_default_action`) |
 | `CloneSessionLookupEvent` with `session_found = true` | Clone session from table store → `Entity.clone_session_entry` |
 | `Fork` with reason `MULTICAST` | Multicast group from table store → `Entity.multicast_group_entry` |
 | Action profile references in matched entries | Members/groups from table store → `Entity.action_profile_member` / `Entity.action_profile_group` |

--- a/designs/reproduce_trace.md
+++ b/designs/reproduce_trace.md
@@ -33,31 +33,15 @@ test stays as a guard.
 
 ### Proto
 
-An opt-in flag on `InjectPacketRequest` and a new `Reproducer`
-message, both in `grpc/dataplane.proto`:
+A new `ReproduceTrace` RPC on the `Dataplane` service, defined in
+`grpc/dataplane.proto`:
 
 ```proto
-message InjectPacketRequest {
-  oneof ingress_port {
-    uint32 dataplane_ingress_port = 1;
-    bytes p4rt_ingress_port = 2;
-  }
-  bytes payload = 3;
-
-  // When true, the response includes a Reproducer with the
-  // pipeline config and entities needed to reproduce this trace.
-  bool include_reproducer = 4;
+service Dataplane {
+  // ...existing RPCs...
+  rpc ReproduceTrace(InjectPacketRequest) returns (Reproducer);
 }
 
-message InjectPacketResponse {
-  TraceTree trace = 1;
-  repeated PacketSet possible_outcomes = 2;
-
-  // Populated when include_reproducer is set on the request.
-  Reproducer reproducer = 3;
-}
-
-// Self-contained reproduction case for a packet trace.
 message Reproducer {
   PipelineConfig pipeline_config = 1;
   repeated p4.v1.Entity entities = 2;
@@ -67,17 +51,10 @@ message Reproducer {
 }
 ```
 
-Why a flag on `InjectPacket` rather than a separate RPC: the user
-discovers the bug *during* an `InjectPacket` call. A separate
-`ReproduceTrace` RPC would require re-injecting the same packet — an
-extra step, and a TOCTOU risk if state changed between calls. The flag
-lets the user get the reproducer in the same call where the bug was
-observed.
-
-The `Reproducer` is fully self-contained: pipeline config, entities,
-input packet, trace, and possible outcomes. Serialize it to a file
-and hand it to someone — they have everything needed to reproduce
-the trace and see what happened.
+The RPC reuses `InjectPacketRequest` — same input as `InjectPacket` —
+and returns a self-contained `Reproducer`. Serialize it to a file and
+hand it to someone — they have everything needed to reproduce the
+trace and see what happened.
 
 ### Entity extraction
 
@@ -118,10 +95,10 @@ tradeoff: the reproducer is a recording, not a diagnosis.
 
 | Component | Change |
 |---|---|
-| `grpc/dataplane.proto` | Add `include_reproducer` flag, `Reproducer` message, and `reproducer` field on `InjectPacketResponse` |
-| `grpc/DataplaneService.kt` | When flag is set: extract entities from trace, bundle with pipeline config |
-| `simulator/` (new file) | Entity extraction logic: walk trace tree, collect referenced entities from `ForwardingSnapshot` |
-| `fourward_cc/dataplane_client.h` | Add `include_reproducer` to `InjectPacketArgs` |
+| `grpc/dataplane.proto` | Add `ReproduceTrace` RPC and `Reproducer` message |
+| `grpc/DataplaneService.kt` | Implement `reproduceTrace`: inject packet, extract entities, bundle with pipeline config |
+| `simulator/ReproducerExtractor.kt` | Entity extraction: walk trace tree, collect referenced entities from `TableStore` |
+| `fourward_cc/dataplane_client.h` | Add `ReproduceTrace` method to `DataplaneClient` |
 
 ### Future work
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -93,6 +93,10 @@ guilt — just write it down so someone can find it later.
   time-dependent features that have no meaningful semantics in a reference
   simulator: there are no real packet rates to trigger digests, and no
   wall-clock time to expire idle entries. These are explicitly out of scope.
+- **Reproducer includes all multicast groups.** The `Reproducer` entity
+  extraction cannot determine which specific multicast group triggered a
+  MULTICAST fork (the `Fork` proto doesn't carry the group ID), so it
+  includes all multicast groups from the forwarding snapshot.
 
 ## Simulator
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -97,6 +97,11 @@ guilt — just write it down so someone can find it later.
   extraction cannot determine which specific multicast group triggered a
   MULTICAST fork (the `Fork` proto doesn't carry the group ID), so it
   includes all multicast groups from the forwarding snapshot.
+- **Reproducer does not capture register state.** Programs that read
+  registers and branch on the result will produce a different trace when
+  replayed from a reproducer (registers start at zero). Counter and
+  meter state is not affected: counters don't influence forwarding,
+  and meters always return GREEN in the simulator.
 
 ## Simulator
 

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -66,6 +66,7 @@ fourward_pipeline(
     visibility = [
         "//cli:__pkg__",
         "//e2e_tests/network:__pkg__",
+        "//grpc:__pkg__",
     ],
 )
 

--- a/fourward_cc/dataplane_client.cc
+++ b/fourward_cc/dataplane_client.cc
@@ -60,7 +60,6 @@ fourward::InjectPacketRequest ToProto(
              },
              args.ingress_port);
   req.set_payload(args.payload);
-  if (args.include_reproducer) req.set_include_reproducer(true);
   return req;
 }
 
@@ -88,6 +87,18 @@ DataplaneClient::InjectPacket(const InjectPacketArgs& args,
   fourward::InjectPacketRequest req = ToProto(args);
   fourward::InjectPacketResponse resp;
   grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
+  if (!status.ok()) return ToAbsl(status);
+  return resp;
+}
+
+absl::StatusOr<fourward::Reproducer>
+DataplaneClient::ReproduceTrace(const InjectPacketArgs& args,
+                                std::optional<absl::Duration> deadline) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(deadline)));
+  fourward::InjectPacketRequest req = ToProto(args);
+  fourward::Reproducer resp;
+  grpc::Status status = stub_->ReproduceTrace(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
   return resp;
 }

--- a/fourward_cc/dataplane_client.cc
+++ b/fourward_cc/dataplane_client.cc
@@ -60,6 +60,7 @@ fourward::InjectPacketRequest ToProto(
              },
              args.ingress_port);
   req.set_payload(args.payload);
+  if (args.include_reproducer) req.set_include_reproducer(true);
   return req;
 }
 

--- a/fourward_cc/dataplane_client.h
+++ b/fourward_cc/dataplane_client.h
@@ -57,6 +57,7 @@ struct P4RuntimePort {
 struct InjectPacketArgs {
   std::variant<DataplanePort, P4RuntimePort> ingress_port;
   std::string payload;
+  bool include_reproducer = false;
 };
 
 // RAII handle for an open SubscribeResults stream. Destructor cancels and

--- a/fourward_cc/dataplane_client.h
+++ b/fourward_cc/dataplane_client.h
@@ -57,7 +57,6 @@ struct P4RuntimePort {
 struct InjectPacketArgs {
   std::variant<DataplanePort, P4RuntimePort> ingress_port;
   std::string payload;
-  bool include_reproducer = false;
 };
 
 // RAII handle for an open SubscribeResults stream. Destructor cancels and
@@ -110,6 +109,12 @@ class DataplaneClient {
   // Results are delivered via SubscribeResults, not in the response.
   absl::Status InjectPackets(
       absl::Span<const InjectPacketArgs> args,
+      std::optional<absl::Duration> deadline = std::nullopt);
+
+  // Inject a packet and return a self-contained Reproducer for the
+  // resulting trace.
+  absl::StatusOr<fourward::Reproducer> ReproduceTrace(
+      const InjectPacketArgs& args,
       std::optional<absl::Duration> deadline = std::nullopt);
 
   // Blocks until the server confirms the subscription is active. The

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -666,6 +666,7 @@ kt_jvm_test(
     data = [
         "//e2e_tests/basic_table",
         "//e2e_tests/passthrough",
+        "//e2e_tests/trace_tree:multicast",
     ],
     test_class = "fourward.grpc.DataplaneServiceTest",
     deps = [

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -22,6 +22,7 @@ proto_library(
     srcs = ["dataplane.proto"],
     visibility = ["//visibility:public"],
     deps = [
+        "//simulator:ir_proto",
         "//simulator:simulator_proto",
         "@p4runtime//proto/p4/config/v1:p4info_proto",
         "@p4runtime//proto/p4/v1:p4runtime_proto",

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -70,6 +70,7 @@ class DataplaneService(
       .addAllEntities(
         extractReproducerEntities(
           enrichedResult.rawTrace,
+          enrichedResult.forwardingSnapshot,
           pipeline.tableStore,
           pipeline.config.device.staticEntries.updatesList,
         )
@@ -82,6 +83,7 @@ class DataplaneService(
     val ingressPort: Int,
     val payload: ByteArray,
     val rawTrace: TraceTree,
+    val forwardingSnapshot: TableStore.ForwardingSnapshot,
     val trace: TraceTree,
     val possibleOutcomes: List<PacketSet>,
   ) {
@@ -114,6 +116,7 @@ class DataplaneService(
           ingressPort = ingressPort,
           payload = payload,
           rawTrace = result.trace,
+          forwardingSnapshot = result.forwardingSnapshot,
           trace = enrichTrace(result.trace, translator),
           possibleOutcomes =
             result.possibleOutcomes.map { world ->

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -35,21 +35,23 @@ import kotlinx.coroutines.launch
  * service is responsible for gRPC protocol: request/response translation, port resolution, trace
  * enrichment, and hook stream management.
  *
- * @param typeTranslator provides the current [TypeTranslator] from the loaded pipeline, or null if
- *   no pipeline is loaded or the pipeline has no type translation.
- * @param reproducerData provides the pipeline config and forwarding snapshot for building
- *   reproducers. Returns null if no pipeline is loaded.
+ * @param pipelineSnapshot provides the currently loaded pipeline state, or null if no pipeline is
+ *   loaded.
  */
 class DataplaneService(
   private val broker: PacketBroker,
-  private val typeTranslator: () -> TypeTranslator? = { null },
-  private val reproducerData: () -> ReproducerData? = { null },
+  private val pipelineSnapshot: () -> PipelineSnapshot? = { null },
 ) : DataplaneGrpcKt.DataplaneCoroutineImplBase() {
 
-  data class ReproducerData(val config: PipelineConfig, val snapshot: TableStore.ForwardingSnapshot)
+  data class PipelineSnapshot(
+    val config: PipelineConfig,
+    val tableStore: TableStore,
+    val typeTranslator: TypeTranslator?,
+  )
 
   override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse {
-    val translator = typeTranslator()
+    val pipeline = pipelineSnapshot()
+    val translator = pipeline?.typeTranslator
     val ingressPort = resolveIngressPort(request, translator)
     val payload = request.payload.toByteArray()
     // Translate anything thrown past this point into INTERNAL with a
@@ -67,20 +69,18 @@ class DataplaneService(
         InjectPacketResponse.newBuilder()
           .addAllPossibleOutcomes(possibleOutcomes)
           .setTrace(enrichedTrace)
-      if (request.includeReproducer) {
-        reproducerData()?.let { data ->
-          response.setReproducer(
-            Reproducer.newBuilder()
-              .setPipelineConfig(data.config)
-              .addAllEntities(
-                extractReproducerEntities(
-                  result.trace,
-                  data.snapshot,
-                  data.config.device.staticEntries.updatesList,
-                )
+      if (request.includeReproducer && pipeline != null) {
+        response.setReproducer(
+          Reproducer.newBuilder()
+            .setPipelineConfig(pipeline.config)
+            .addAllEntities(
+              extractReproducerEntities(
+                result.trace,
+                pipeline.tableStore,
+                pipeline.config.device.staticEntries.updatesList,
               )
-          )
-        }
+            )
+        )
       }
       return response.build()
     } catch (e: StatusException) {
@@ -95,7 +95,7 @@ class DataplaneService(
   }
 
   override suspend fun injectPackets(requests: Flow<InjectPacketRequest>): InjectPacketsResponse {
-    val translator = typeTranslator()
+    val translator = pipelineSnapshot()?.typeTranslator
     broker.withHookOnce { processPacket ->
       val futures = mutableListOf<java.util.concurrent.ForkJoinTask<*>>()
       kotlinx.coroutines.runBlocking {
@@ -123,7 +123,7 @@ class DataplaneService(
       val handle =
         broker.subscribe { subResult ->
           try {
-            val translator = typeTranslator()
+            val translator = pipelineSnapshot()?.typeTranslator
             val pt = translator?.portTranslator
             val result =
               ProcessPacketResultProto.newBuilder()

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -80,6 +80,13 @@ class DataplaneService(
                 pipeline.config.device.staticEntries.updatesList,
               )
             )
+            .setInputPacket(
+              InputPacket.newBuilder()
+                .setDataplaneIngressPort(ingressPort)
+                .setPayload(ByteString.copyFrom(payload))
+            )
+            .setTrace(enrichedTrace)
+            .addAllPossibleOutcomes(possibleOutcomes)
         )
       }
       return response.build()

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -65,6 +65,9 @@ class DataplaneService(
         .asException()
     }
     val (enrichedResult, pipeline) = processAndEnrich(request, "ReproduceTrace")
+    // pipeline is non-null: the pre-check above rejects the no-pipeline case, and pipeline
+    // unload between the check and here requires a concurrent SetForwardingPipelineConfig
+    // that replaces the pipeline (not unloads it — there's no "unload" API).
     return Reproducer.newBuilder()
       .setPipelineConfig(pipeline!!.config)
       .addAllEntities(
@@ -107,6 +110,8 @@ class DataplaneService(
     val translator = pipeline?.typeTranslator
     val ingressPort = resolveIngressPort(request, translator)
     val payload = request.payload.toByteArray()
+    // Translate anything thrown past this point into INTERNAL with a
+    // description, so the client never sees a bare UNKNOWN. See #499.
     @Suppress("TooGenericExceptionCaught")
     try {
       val result = broker.processPacket(ingressPort, payload)
@@ -125,7 +130,7 @@ class DataplaneService(
         )
       return enrichedResult to pipeline
     } catch (e: StatusException) {
-      throw e
+      throw e // already has a proper status; don't rewrap.
     } catch (e: IllegalArgumentException) {
       val detail = listOfNotNull("$rpcName failed", e.message).joinToString(": ")
       throw Status.INVALID_ARGUMENT.withDescription(detail).withCause(e).asException()

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -50,77 +50,84 @@ class DataplaneService(
   )
 
   override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse {
-    val translator = pipelineSnapshot()?.typeTranslator
-    val ingressPort = resolveIngressPort(request, translator)
-    val payload = request.payload.toByteArray()
-    // Translate anything thrown past this point into INTERNAL with a
-    // description, so the client never sees a bare UNKNOWN. See #499.
-    @Suppress("TooGenericExceptionCaught")
-    try {
-      val result = broker.processPacket(ingressPort, payload)
-      val pt = translator?.portTranslator
-      val possibleOutcomes =
-        result.possibleOutcomes.map { world ->
-          PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
-        }
-      return InjectPacketResponse.newBuilder()
-        .addAllPossibleOutcomes(possibleOutcomes)
-        .setTrace(enrichTrace(result.trace, translator))
-        .build()
-    } catch (e: StatusException) {
-      throw e // already has a proper status; don't rewrap.
-    } catch (e: IllegalArgumentException) {
-      val detail = listOfNotNull("InjectPacket failed", e.message).joinToString(": ")
-      throw Status.INVALID_ARGUMENT.withDescription(detail).withCause(e).asException()
-    } catch (e: Exception) {
-      val detail = listOfNotNull("InjectPacket failed", e.message).joinToString(": ")
-      throw Status.INTERNAL.withDescription(detail).withCause(e).asException()
-    }
+    val (enrichedResult, _) = processAndEnrich(request, "InjectPacket")
+    return InjectPacketResponse.newBuilder()
+      .addAllPossibleOutcomes(enrichedResult.possibleOutcomes)
+      .setTrace(enrichedResult.trace)
+      .build()
   }
 
   override suspend fun reproduceTrace(request: InjectPacketRequest): Reproducer {
-    val pipeline =
-      pipelineSnapshot()
-        ?: throw Status.FAILED_PRECONDITION.withDescription(
-            "No pipeline loaded — call SetForwardingPipelineConfig first"
-          )
-          .asException()
-    val translator = pipeline.typeTranslator
-    val ingressPort = resolveIngressPort(request, translator)
-    val payload = request.payload.toByteArray()
-    @Suppress("TooGenericExceptionCaught")
-    try {
-      val result = broker.processPacket(ingressPort, payload)
-      val pt = translator?.portTranslator
-      val enrichedTrace = enrichTrace(result.trace, translator)
-      val possibleOutcomes =
-        result.possibleOutcomes.map { world ->
-          PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
-        }
-      return Reproducer.newBuilder()
-        .setPipelineConfig(pipeline.config)
-        .addAllEntities(
-          extractReproducerEntities(
-            result.trace,
-            pipeline.tableStore,
-            pipeline.config.device.staticEntries.updatesList,
-          )
+    if (pipelineSnapshot() == null) {
+      throw Status.FAILED_PRECONDITION.withDescription(
+          "No pipeline loaded — call SetForwardingPipelineConfig first"
         )
+        .asException()
+    }
+    val (enrichedResult, pipeline) = processAndEnrich(request, "ReproduceTrace")
+    return Reproducer.newBuilder()
+      .setPipelineConfig(pipeline!!.config)
+      .addAllEntities(
+        extractReproducerEntities(
+          enrichedResult.rawTrace,
+          pipeline.tableStore,
+          pipeline.config.device.staticEntries.updatesList,
+        )
+      )
+      .setResult(enrichedResult.toProcessPacketResult())
+      .build()
+  }
+
+  private class EnrichedResult(
+    val ingressPort: Int,
+    val payload: ByteArray,
+    val rawTrace: TraceTree,
+    val trace: TraceTree,
+    val possibleOutcomes: List<PacketSet>,
+  ) {
+    fun toProcessPacketResult(): ProcessPacketResultProto =
+      ProcessPacketResultProto.newBuilder()
         .setInputPacket(
           InputPacket.newBuilder()
             .setDataplaneIngressPort(ingressPort)
             .setPayload(ByteString.copyFrom(payload))
         )
-        .setTrace(enrichedTrace)
+        .setTrace(trace)
         .addAllPossibleOutcomes(possibleOutcomes)
         .build()
+  }
+
+  private fun processAndEnrich(
+    request: InjectPacketRequest,
+    rpcName: String,
+  ): Pair<EnrichedResult, PipelineSnapshot?> {
+    val pipeline = pipelineSnapshot()
+    val translator = pipeline?.typeTranslator
+    val ingressPort = resolveIngressPort(request, translator)
+    val payload = request.payload.toByteArray()
+    @Suppress("TooGenericExceptionCaught")
+    try {
+      val result = broker.processPacket(ingressPort, payload)
+      val pt = translator?.portTranslator
+      val enrichedResult =
+        EnrichedResult(
+          ingressPort = ingressPort,
+          payload = payload,
+          rawTrace = result.trace,
+          trace = enrichTrace(result.trace, translator),
+          possibleOutcomes =
+            result.possibleOutcomes.map { world ->
+              PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
+            },
+        )
+      return enrichedResult to pipeline
     } catch (e: StatusException) {
       throw e
     } catch (e: IllegalArgumentException) {
-      val detail = listOfNotNull("ReproduceTrace failed", e.message).joinToString(": ")
+      val detail = listOfNotNull("$rpcName failed", e.message).joinToString(": ")
       throw Status.INVALID_ARGUMENT.withDescription(detail).withCause(e).asException()
     } catch (e: Exception) {
-      val detail = listOfNotNull("ReproduceTrace failed", e.message).joinToString(": ")
+      val detail = listOfNotNull("$rpcName failed", e.message).joinToString(": ")
       throw Status.INTERNAL.withDescription(detail).withCause(e).asException()
     }
   }

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -50,12 +50,44 @@ class DataplaneService(
   )
 
   override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse {
-    val pipeline = pipelineSnapshot()
-    val translator = pipeline?.typeTranslator
+    val translator = pipelineSnapshot()?.typeTranslator
     val ingressPort = resolveIngressPort(request, translator)
     val payload = request.payload.toByteArray()
     // Translate anything thrown past this point into INTERNAL with a
     // description, so the client never sees a bare UNKNOWN. See #499.
+    @Suppress("TooGenericExceptionCaught")
+    try {
+      val result = broker.processPacket(ingressPort, payload)
+      val pt = translator?.portTranslator
+      val possibleOutcomes =
+        result.possibleOutcomes.map { world ->
+          PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
+        }
+      return InjectPacketResponse.newBuilder()
+        .addAllPossibleOutcomes(possibleOutcomes)
+        .setTrace(enrichTrace(result.trace, translator))
+        .build()
+    } catch (e: StatusException) {
+      throw e // already has a proper status; don't rewrap.
+    } catch (e: IllegalArgumentException) {
+      val detail = listOfNotNull("InjectPacket failed", e.message).joinToString(": ")
+      throw Status.INVALID_ARGUMENT.withDescription(detail).withCause(e).asException()
+    } catch (e: Exception) {
+      val detail = listOfNotNull("InjectPacket failed", e.message).joinToString(": ")
+      throw Status.INTERNAL.withDescription(detail).withCause(e).asException()
+    }
+  }
+
+  override suspend fun reproduceTrace(request: InjectPacketRequest): Reproducer {
+    val pipeline =
+      pipelineSnapshot()
+        ?: throw Status.FAILED_PRECONDITION.withDescription(
+            "No pipeline loaded — call SetForwardingPipelineConfig first"
+          )
+          .asException()
+    val translator = pipeline.typeTranslator
+    val ingressPort = resolveIngressPort(request, translator)
+    val payload = request.payload.toByteArray()
     @Suppress("TooGenericExceptionCaught")
     try {
       val result = broker.processPacket(ingressPort, payload)
@@ -65,38 +97,30 @@ class DataplaneService(
         result.possibleOutcomes.map { world ->
           PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
         }
-      val response =
-        InjectPacketResponse.newBuilder()
-          .addAllPossibleOutcomes(possibleOutcomes)
-          .setTrace(enrichedTrace)
-      if (request.includeReproducer && pipeline != null) {
-        response.setReproducer(
-          Reproducer.newBuilder()
-            .setPipelineConfig(pipeline.config)
-            .addAllEntities(
-              extractReproducerEntities(
-                result.trace,
-                pipeline.tableStore,
-                pipeline.config.device.staticEntries.updatesList,
-              )
-            )
-            .setInputPacket(
-              InputPacket.newBuilder()
-                .setDataplaneIngressPort(ingressPort)
-                .setPayload(ByteString.copyFrom(payload))
-            )
-            .setTrace(enrichedTrace)
-            .addAllPossibleOutcomes(possibleOutcomes)
+      return Reproducer.newBuilder()
+        .setPipelineConfig(pipeline.config)
+        .addAllEntities(
+          extractReproducerEntities(
+            result.trace,
+            pipeline.tableStore,
+            pipeline.config.device.staticEntries.updatesList,
+          )
         )
-      }
-      return response.build()
+        .setInputPacket(
+          InputPacket.newBuilder()
+            .setDataplaneIngressPort(ingressPort)
+            .setPayload(ByteString.copyFrom(payload))
+        )
+        .setTrace(enrichedTrace)
+        .addAllPossibleOutcomes(possibleOutcomes)
+        .build()
     } catch (e: StatusException) {
-      throw e // already has a proper status; don't rewrap.
+      throw e
     } catch (e: IllegalArgumentException) {
-      val detail = listOfNotNull("InjectPacket failed", e.message).joinToString(": ")
+      val detail = listOfNotNull("ReproduceTrace failed", e.message).joinToString(": ")
       throw Status.INVALID_ARGUMENT.withDescription(detail).withCause(e).asException()
     } catch (e: Exception) {
-      val detail = listOfNotNull("InjectPacket failed", e.message).joinToString(": ")
+      val detail = listOfNotNull("ReproduceTrace failed", e.message).joinToString(": ")
       throw Status.INTERNAL.withDescription(detail).withCause(e).asException()
     }
   }

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -8,13 +8,17 @@ import fourward.InjectPacketsResponse
 import fourward.InputPacket
 import fourward.OutputPacket
 import fourward.PacketSet
+import fourward.PipelineConfig
 import fourward.PrePacketHookInvocation
 import fourward.PrePacketHookResponse
 import fourward.ProcessPacketResult as ProcessPacketResultProto
+import fourward.Reproducer
 import fourward.SubscribeResultsRequest
 import fourward.SubscribeResultsResponse
 import fourward.SubscriptionActive
 import fourward.TraceTree
+import fourward.simulator.TableStore
+import fourward.simulator.extractReproducerEntities
 import io.grpc.Status
 import io.grpc.StatusException
 import kotlinx.coroutines.channels.Channel
@@ -33,11 +37,16 @@ import kotlinx.coroutines.launch
  *
  * @param typeTranslator provides the current [TypeTranslator] from the loaded pipeline, or null if
  *   no pipeline is loaded or the pipeline has no type translation.
+ * @param reproducerData provides the pipeline config and forwarding snapshot for building
+ *   reproducers. Returns null if no pipeline is loaded.
  */
 class DataplaneService(
   private val broker: PacketBroker,
   private val typeTranslator: () -> TypeTranslator? = { null },
+  private val reproducerData: () -> ReproducerData? = { null },
 ) : DataplaneGrpcKt.DataplaneCoroutineImplBase() {
+
+  data class ReproducerData(val config: PipelineConfig, val snapshot: TableStore.ForwardingSnapshot)
 
   override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse {
     val translator = typeTranslator()
@@ -49,14 +58,31 @@ class DataplaneService(
     try {
       val result = broker.processPacket(ingressPort, payload)
       val pt = translator?.portTranslator
+      val enrichedTrace = enrichTrace(result.trace, translator)
       val possibleOutcomes =
         result.possibleOutcomes.map { world ->
           PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
         }
-      return InjectPacketResponse.newBuilder()
-        .addAllPossibleOutcomes(possibleOutcomes)
-        .setTrace(enrichTrace(result.trace, translator))
-        .build()
+      val response =
+        InjectPacketResponse.newBuilder()
+          .addAllPossibleOutcomes(possibleOutcomes)
+          .setTrace(enrichedTrace)
+      if (request.includeReproducer) {
+        reproducerData()?.let { data ->
+          response.setReproducer(
+            Reproducer.newBuilder()
+              .setPipelineConfig(data.config)
+              .addAllEntities(
+                extractReproducerEntities(
+                  result.trace,
+                  data.snapshot,
+                  data.config.device.staticEntries.updatesList,
+                )
+              )
+          )
+        }
+      }
+      return response.build()
     } catch (e: StatusException) {
       throw e // already has a proper status; don't rewrap.
     } catch (e: IllegalArgumentException) {

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -119,16 +119,22 @@ class DataplaneServiceTest {
   }
 
   @Test
-  fun `InjectPacket with include_reproducer returns pipeline config`() {
+  fun `reproducer is self-contained`() {
     val config = loadPassthroughConfig()
     harness.loadPipeline(config)
-    val response = harness.injectPacketWithReproducer(ingressPort = 0, payload = byteArrayOf(0x01))
+    val payload = byteArrayOf(0x01)
+    val response = harness.injectPacketWithReproducer(ingressPort = 0, payload = payload)
 
     assertTrue("reproducer should be present", response.hasReproducer())
+    val reproducer = response.reproducer
+    assertEquals("pipeline config", config, reproducer.pipelineConfig)
+    assertEquals("ingress port", 0, reproducer.inputPacket.dataplaneIngressPort)
+    assertEquals("payload", ByteString.copyFrom(payload), reproducer.inputPacket.payload)
+    assertTrue("trace", reproducer.hasTrace())
     assertEquals(
-      "reproducer should contain the pipeline config",
-      config,
-      response.reproducer.pipelineConfig,
+      "possible outcomes match response",
+      response.possibleOutcomesList,
+      reproducer.possibleOutcomesList,
     )
   }
 

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -108,6 +108,61 @@ class DataplaneServiceTest {
   }
 
   // =========================================================================
+  // Reproducer
+  // =========================================================================
+
+  @Test
+  fun `InjectPacket without include_reproducer omits reproducer`() {
+    harness.loadPipeline(loadPassthroughConfig())
+    val response = harness.injectPacket(ingressPort = 0, payload = byteArrayOf(0x01))
+    assertTrue("reproducer should not be present", !response.hasReproducer())
+  }
+
+  @Test
+  fun `InjectPacket with include_reproducer returns pipeline config`() {
+    val config = loadPassthroughConfig()
+    harness.loadPipeline(config)
+    val response = harness.injectPacketWithReproducer(ingressPort = 0, payload = byteArrayOf(0x01))
+
+    assertTrue("reproducer should be present", response.hasReproducer())
+    assertEquals(
+      "reproducer should contain the pipeline config",
+      config,
+      response.reproducer.pipelineConfig,
+    )
+  }
+
+  @Test
+  fun `reproducer contains matched table entry`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(entry)
+
+    val payload = buildEthernetFrame(etherType = 0x0800)
+    val response = harness.injectPacketWithReproducer(ingressPort = 0, payload = payload)
+
+    assertTrue("reproducer should be present", response.hasReproducer())
+    val tableEntities = response.reproducer.entitiesList.filter { it.hasTableEntry() }
+    assertTrue("reproducer should contain the matched entry", tableEntities.isNotEmpty())
+  }
+
+  @Test
+  fun `reproducer excludes entries on table miss`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    // No table entries installed — default action is drop.
+    val payload = buildEthernetFrame(etherType = 0x0800)
+    val response = harness.injectPacketWithReproducer(ingressPort = 0, payload = payload)
+
+    assertTrue("reproducer should be present", response.hasReproducer())
+    assertTrue(
+      "reproducer should have no entities on miss",
+      response.reproducer.entitiesList.isEmpty(),
+    )
+  }
+
+  // =========================================================================
   // SubscribeResults
   // =========================================================================
 

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -119,10 +119,11 @@ class DataplaneServiceTest {
     val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
 
     assertEquals("pipeline config", config, reproducer.pipelineConfig)
-    assertEquals("ingress port", 0, reproducer.inputPacket.dataplaneIngressPort)
-    assertEquals("payload", ByteString.copyFrom(payload), reproducer.inputPacket.payload)
-    assertTrue("trace", reproducer.hasTrace())
-    assertTrue("possible outcomes", reproducer.possibleOutcomesCount > 0)
+    assertTrue("result", reproducer.hasResult())
+    assertEquals("ingress port", 0, reproducer.result.inputPacket.dataplaneIngressPort)
+    assertEquals("payload", ByteString.copyFrom(payload), reproducer.result.inputPacket.payload)
+    assertTrue("trace", reproducer.result.hasTrace())
+    assertTrue("possible outcomes", reproducer.result.possibleOutcomesCount > 0)
   }
 
   @Test

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -10,6 +10,7 @@ import fourward.SubscribeResultsResponse
 import fourward.grpc.FourwardTestHarness.Companion.assertGrpcError
 import fourward.grpc.FourwardTestHarness.Companion.buildEthernetFrame
 import fourward.grpc.FourwardTestHarness.Companion.buildExactEntry
+import fourward.grpc.FourwardTestHarness.Companion.buildMulticastGroup
 import fourward.grpc.FourwardTestHarness.Companion.loadConfig
 import io.grpc.Status
 import kotlinx.coroutines.CompletableDeferred
@@ -155,6 +156,60 @@ class DataplaneServiceTest {
     assertGrpcError(Status.Code.FAILED_PRECONDITION) {
       harness.reproduceTrace(ingressPort = 0, payload = byteArrayOf(0x01))
     }
+  }
+
+  @Test
+  fun `ReproduceTrace round-trip produces same trace as InjectPacket`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(entry)
+
+    val payload = buildEthernetFrame(etherType = 0x0800)
+    val injectResponse = harness.injectPacket(ingressPort = 0, payload = payload)
+    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+
+    assertEquals("trace should match InjectPacket", injectResponse.trace, reproducer.result.trace)
+    assertEquals(
+      "possible outcomes should match InjectPacket",
+      injectResponse.possibleOutcomesList,
+      reproducer.result.possibleOutcomesList,
+    )
+  }
+
+  @Test
+  fun `ReproduceTrace includes multicast group entities`() {
+    val config = loadConfig("e2e_tests/trace_tree/multicast.txtpb")
+    harness.loadPipeline(config)
+    harness.installEntry(buildMulticastGroup(groupId = 1, ports = listOf(1, 2, 3)))
+
+    val payload = buildEthernetFrame(etherType = 0x0800)
+    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+
+    val preEntities = reproducer.entitiesList.filter { it.hasPacketReplicationEngineEntry() }
+    assertTrue("reproducer should contain multicast group", preEntities.isNotEmpty())
+    assertEquals(
+      1,
+      preEntities.first().packetReplicationEngineEntry.multicastGroupEntry.multicastGroupId,
+    )
+  }
+
+  @Test
+  fun `ReproduceTrace includes modified default action`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val table = config.p4Info.tablesList.first()
+    val noAction = config.p4Info.actionsList.find { it.preamble.name == "NoAction" }!!
+    harness.modifyEntry(
+      FourwardTestHarness.buildDefaultActionEntity(table.preamble.id, noAction.preamble.id)
+    )
+
+    val payload = buildEthernetFrame(etherType = 0x0800)
+    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+
+    val defaultEntities =
+      reproducer.entitiesList.filter { it.hasTableEntry() && it.tableEntry.isDefaultAction }
+    assertTrue("reproducer should contain modified default", defaultEntities.isNotEmpty())
   }
 
   // =========================================================================

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -108,64 +108,52 @@ class DataplaneServiceTest {
   }
 
   // =========================================================================
-  // Reproducer
+  // ReproduceTrace
   // =========================================================================
 
   @Test
-  fun `InjectPacket without include_reproducer omits reproducer`() {
-    harness.loadPipeline(loadPassthroughConfig())
-    val response = harness.injectPacket(ingressPort = 0, payload = byteArrayOf(0x01))
-    assertTrue("reproducer should not be present", !response.hasReproducer())
-  }
-
-  @Test
-  fun `reproducer is self-contained`() {
+  fun `ReproduceTrace is self-contained`() {
     val config = loadPassthroughConfig()
     harness.loadPipeline(config)
     val payload = byteArrayOf(0x01)
-    val response = harness.injectPacketWithReproducer(ingressPort = 0, payload = payload)
+    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
 
-    assertTrue("reproducer should be present", response.hasReproducer())
-    val reproducer = response.reproducer
     assertEquals("pipeline config", config, reproducer.pipelineConfig)
     assertEquals("ingress port", 0, reproducer.inputPacket.dataplaneIngressPort)
     assertEquals("payload", ByteString.copyFrom(payload), reproducer.inputPacket.payload)
     assertTrue("trace", reproducer.hasTrace())
-    assertEquals(
-      "possible outcomes match response",
-      response.possibleOutcomesList,
-      reproducer.possibleOutcomesList,
-    )
+    assertTrue("possible outcomes", reproducer.possibleOutcomesCount > 0)
   }
 
   @Test
-  fun `reproducer contains matched table entry`() {
+  fun `ReproduceTrace contains matched table entry`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
     harness.installEntry(entry)
 
     val payload = buildEthernetFrame(etherType = 0x0800)
-    val response = harness.injectPacketWithReproducer(ingressPort = 0, payload = payload)
+    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
 
-    assertTrue("reproducer should be present", response.hasReproducer())
-    val tableEntities = response.reproducer.entitiesList.filter { it.hasTableEntry() }
+    val tableEntities = reproducer.entitiesList.filter { it.hasTableEntry() }
     assertTrue("reproducer should contain the matched entry", tableEntities.isNotEmpty())
   }
 
   @Test
-  fun `reproducer excludes entries on table miss`() {
+  fun `ReproduceTrace excludes entries on table miss`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
-    // No table entries installed — default action is drop.
     val payload = buildEthernetFrame(etherType = 0x0800)
-    val response = harness.injectPacketWithReproducer(ingressPort = 0, payload = payload)
+    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
 
-    assertTrue("reproducer should be present", response.hasReproducer())
-    assertTrue(
-      "reproducer should have no entities on miss",
-      response.reproducer.entitiesList.isEmpty(),
-    )
+    assertTrue("reproducer should have no entities on miss", reproducer.entitiesList.isEmpty())
+  }
+
+  @Test
+  fun `ReproduceTrace fails without loaded pipeline`() {
+    assertGrpcError(Status.Code.FAILED_PRECONDITION) {
+      harness.reproduceTrace(ingressPort = 0, payload = byteArrayOf(0x01))
+    }
   }
 
   // =========================================================================

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -38,7 +38,17 @@ class FourwardServer(
       disableP4ConstraintsChecking = disableP4ConstraintsChecking,
     )
   private val dataplaneService =
-    DataplaneService(broker, typeTranslator = { service.typeTranslator })
+    DataplaneService(
+      broker,
+      typeTranslator = { service.typeTranslator },
+      reproducerData = {
+        try {
+          DataplaneService.ReproducerData(simulator.pipelineConfig, simulator.forwardingSnapshot)
+        } catch (_: IllegalStateException) {
+          null
+        }
+      },
+    )
 
   init {
     // Wire P4RuntimeService lambdas into the broker for hook support.

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -38,17 +38,11 @@ class FourwardServer(
       disableP4ConstraintsChecking = disableP4ConstraintsChecking,
     )
   private val dataplaneService =
-    DataplaneService(
-      broker,
-      typeTranslator = { service.typeTranslator },
-      reproducerData = {
-        try {
-          DataplaneService.ReproducerData(simulator.pipelineConfig, simulator.forwardingSnapshot)
-        } catch (_: IllegalStateException) {
-          null
-        }
-      },
-    )
+    DataplaneService(broker) {
+      val config = simulator.pipelineConfig ?: return@DataplaneService null
+      val tableStore = simulator.tableStore ?: return@DataplaneService null
+      DataplaneService.PipelineSnapshot(config, tableStore, service.typeTranslator)
+    }
 
   init {
     // Wire P4RuntimeService lambdas into the broker for hook support.

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -76,17 +76,11 @@ class FourwardTestHarness(
       disableP4ConstraintsChecking = disableP4ConstraintsChecking,
     )
   private val dataplaneService =
-    DataplaneService(
-      broker,
-      typeTranslator = { service.typeTranslator },
-      reproducerData = {
-        try {
-          DataplaneService.ReproducerData(simulator.pipelineConfig, simulator.forwardingSnapshot)
-        } catch (_: IllegalStateException) {
-          null
-        }
-      },
-    )
+    DataplaneService(broker) {
+      val config = simulator.pipelineConfig ?: return@DataplaneService null
+      val tableStore = simulator.tableStore ?: return@DataplaneService null
+      DataplaneService.PipelineSnapshot(config, tableStore, service.typeTranslator)
+    }
 
   init {
     broker.readAllEntities = { service.readAllEntities() }

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -169,17 +169,15 @@ class FourwardTestHarness(
     )
   }
 
-  /** Injects a packet with the reproducer flag set. Returns outputs + trace + reproducer. */
-  fun injectPacketWithReproducer(ingressPort: Int, payload: ByteArray): InjectPacketResponse =
-    runBlocking {
-      dataplaneStub.injectPacket(
-        InjectPacketRequest.newBuilder()
-          .setDataplaneIngressPort(ingressPort)
-          .setPayload(ByteString.copyFrom(payload))
-          .setIncludeReproducer(true)
-          .build()
-      )
-    }
+  /** Injects a packet and returns a self-contained Reproducer for the trace. */
+  fun reproduceTrace(ingressPort: Int, payload: ByteArray): fourward.Reproducer = runBlocking {
+    dataplaneStub.reproduceTrace(
+      InjectPacketRequest.newBuilder()
+        .setDataplaneIngressPort(ingressPort)
+        .setPayload(ByteString.copyFrom(payload))
+        .build()
+    )
+  }
 
   /** Injects a packet using a P4Runtime port ID. Returns outputs + trace. */
   fun injectPacketP4rt(p4rtPort: ByteString, payload: ByteArray): InjectPacketResponse =

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -774,5 +774,25 @@ class FourwardTestHarness(
             )
         )
         .build()
+
+    /** Builds a multicast group Entity with replicas on the given ports. */
+    fun buildMulticastGroup(groupId: Int, ports: List<Int>): Entity =
+      Entity.newBuilder()
+        .setPacketReplicationEngineEntry(
+          P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+            .setMulticastGroupEntry(
+              P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
+                .setMulticastGroupId(groupId)
+                .addAllReplicas(
+                  ports.mapIndexed { idx, port ->
+                    P4RuntimeOuterClass.Replica.newBuilder()
+                      .setPort(ByteString.copyFrom(longToBytes(port.toLong(), 2)))
+                      .setInstance(idx)
+                      .build()
+                  }
+                )
+            )
+        )
+        .build()
   }
 }

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -76,7 +76,17 @@ class FourwardTestHarness(
       disableP4ConstraintsChecking = disableP4ConstraintsChecking,
     )
   private val dataplaneService =
-    DataplaneService(broker, typeTranslator = { service.typeTranslator })
+    DataplaneService(
+      broker,
+      typeTranslator = { service.typeTranslator },
+      reproducerData = {
+        try {
+          DataplaneService.ReproducerData(simulator.pipelineConfig, simulator.forwardingSnapshot)
+        } catch (_: IllegalStateException) {
+          null
+        }
+      },
+    )
 
   init {
     broker.readAllEntities = { service.readAllEntities() }
@@ -164,6 +174,18 @@ class FourwardTestHarness(
         .build()
     )
   }
+
+  /** Injects a packet with the reproducer flag set. Returns outputs + trace + reproducer. */
+  fun injectPacketWithReproducer(ingressPort: Int, payload: ByteArray): InjectPacketResponse =
+    runBlocking {
+      dataplaneStub.injectPacket(
+        InjectPacketRequest.newBuilder()
+          .setDataplaneIngressPort(ingressPort)
+          .setPayload(ByteString.copyFrom(payload))
+          .setIncludeReproducer(true)
+          .build()
+      )
+    }
 
   /** Injects a packet using a P4Runtime port ID. Returns outputs + trace. */
   fun injectPacketP4rt(p4rtPort: ByteString, payload: ByteArray): InjectPacketResponse =

--- a/grpc/PacketBrokerTest.kt
+++ b/grpc/PacketBrokerTest.kt
@@ -22,7 +22,11 @@ class PacketBrokerTest {
       .build()
 
   private fun result(vararg outputs: OutputPacket) =
-    ProcessPacketResult(TraceTree.getDefaultInstance(), listOf(outputs.toList()))
+    ProcessPacketResult(
+      TraceTree.getDefaultInstance(),
+      listOf(outputs.toList()),
+      fourward.simulator.TableStore().snapshot,
+    )
 
   private fun fakeProcessor(
     vararg results: Pair<Int, ProcessPacketResult>

--- a/grpc/dataplane.proto
+++ b/grpc/dataplane.proto
@@ -102,12 +102,9 @@ message Reproducer {
   // Excludes const entries (already in pipeline_config.device.static_entries).
   repeated p4.v1.Entity entities = 2;
 
-  // The input packet that produced the trace.
-  InputPacket input_packet = 3;
-
-  // The trace being reproduced, including all possible outcomes.
-  TraceTree trace = 4;
-  repeated PacketSet possible_outcomes = 5;
+  // The packet result being reproduced: input packet, trace, and possible
+  // outcomes.
+  ProcessPacketResult result = 3;
 }
 
 // Result bundle for SubscribeResults: input + outputs + trace.

--- a/grpc/dataplane.proto
+++ b/grpc/dataplane.proto
@@ -92,10 +92,9 @@ message InjectPacketResponse {
   Reproducer reproducer = 3;
 }
 
-// Everything needed to reproduce a trace, minus the input packet and
-// trace itself (already in the enclosing response). Load the pipeline,
-// install the entities via P4Runtime Write, and inject the same packet
-// to get the same trace.
+// Self-contained reproduction case for a packet trace. Load the pipeline,
+// install the entities via P4Runtime Write, inject the packet, and you
+// get the same trace.
 message Reproducer {
   // The compiled P4 program (IR + p4info).
   PipelineConfig pipeline_config = 1;
@@ -104,6 +103,13 @@ message Reproducer {
   // clone sessions, multicast groups, action profile members/groups.
   // Excludes const entries (already in pipeline_config.device.static_entries).
   repeated p4.v1.Entity entities = 2;
+
+  // The input packet that produced the trace.
+  InputPacket input_packet = 3;
+
+  // The trace being reproduced, including all possible outcomes.
+  TraceTree trace = 4;
+  repeated PacketSet possible_outcomes = 5;
 }
 
 // Result bundle for SubscribeResults: input + outputs + trace.

--- a/grpc/dataplane.proto
+++ b/grpc/dataplane.proto
@@ -10,6 +10,7 @@ package fourward;
 
 import "p4/config/v1/p4info.proto";
 import "p4/v1/p4runtime.proto";
+import "simulator/ir.proto";
 import "simulator/simulator.proto";
 
 option java_package = "fourward";
@@ -63,6 +64,10 @@ message InjectPacketRequest {
     bytes p4rt_ingress_port = 2;
   }
   bytes payload = 3;
+
+  // When true, the response includes a Reproducer with the pipeline
+  // config and entities needed to reproduce this trace.
+  bool include_reproducer = 4;
 }
 
 // A set of output packets from one possible real execution.
@@ -81,6 +86,24 @@ message InjectPacketResponse {
   // Programs with alternative forks (action selectors) have one entry per
   // alternative — each representing a "possible world".
   repeated PacketSet possible_outcomes = 2;
+
+  // Populated when include_reproducer is set on the request. Contains the
+  // pipeline config and entities needed to reproduce this trace.
+  Reproducer reproducer = 3;
+}
+
+// Everything needed to reproduce a trace, minus the input packet and
+// trace itself (already in the enclosing response). Load the pipeline,
+// install the entities via P4Runtime Write, and inject the same packet
+// to get the same trace.
+message Reproducer {
+  // The compiled P4 program (IR + p4info).
+  PipelineConfig pipeline_config = 1;
+
+  // P4Runtime entities referenced by the trace: matched table entries,
+  // clone sessions, multicast groups, action profile members/groups.
+  // Excludes const entries (already in pipeline_config.device.static_entries).
+  repeated p4.v1.Entity entities = 2;
 }
 
 // Result bundle for SubscribeResults: input + outputs + trace.

--- a/grpc/dataplane.proto
+++ b/grpc/dataplane.proto
@@ -31,6 +31,12 @@ service Dataplane {
   rpc SubscribeResults(SubscribeResultsRequest)
       returns (stream SubscribeResultsResponse);
 
+  // Inject a packet and return a self-contained Reproducer for the resulting
+  // trace. The Reproducer bundles the pipeline config, relevant entities,
+  // input packet, trace, and possible outcomes — everything needed to replay
+  // the trace in another 4ward instance.
+  rpc ReproduceTrace(InjectPacketRequest) returns (Reproducer);
+
   // Registers a pre-packet hook that fires before every dataplane RPC.
   //
   // Some systems need to update P4 state in response to external
@@ -64,10 +70,6 @@ message InjectPacketRequest {
     bytes p4rt_ingress_port = 2;
   }
   bytes payload = 3;
-
-  // When true, the response includes a Reproducer with the pipeline
-  // config and entities needed to reproduce this trace.
-  bool include_reproducer = 4;
 }
 
 // A set of output packets from one possible real execution.
@@ -86,10 +88,6 @@ message InjectPacketResponse {
   // Programs with alternative forks (action selectors) have one entry per
   // alternative — each representing a "possible world".
   repeated PacketSet possible_outcomes = 2;
-
-  // Populated when include_reproducer is set on the request. Contains the
-  // pipeline config and entities needed to reproduce this trace.
-  Reproducer reproducer = 3;
 }
 
 // Self-contained reproduction case for a packet trace. Load the pipeline,

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -393,6 +393,8 @@ kt_jvm_test(
     associates = [":simulator"],
     test_class = "fourward.simulator.ReproducerExtractorTest",
     deps = [
+        ":ir_java_proto",
+        ":p4info_java_proto",
         ":p4runtime_java_proto",
         ":simulator_java_proto",
         "@fourward_maven//:com_google_protobuf_protobuf_java",

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -386,3 +386,16 @@ kt_jvm_test(
         "@fourward_maven//:junit_junit",
     ],
 )
+
+kt_jvm_test(
+    name = "ReproducerExtractorTest",
+    srcs = ["ReproducerExtractorTest.kt"],
+    associates = [":simulator"],
+    test_class = "fourward.simulator.ReproducerExtractorTest",
+    deps = [
+        ":p4runtime_java_proto",
+        ":simulator_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:junit_junit",
+    ],
+)

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -11,31 +11,34 @@ import p4.v1.P4RuntimeOuterClass.Update
  * Extracts the minimal set of P4Runtime entities needed to reproduce a trace.
  *
  * Walks the [TraceTree] recursively and collects entities referenced by trace events: matched table
- * entries, clone sessions, multicast groups, and action profile members/groups. Static entries
- * (declared with `const entries` in the P4 source) are excluded — they come with the pipeline
- * config.
+ * entries, modified default actions, clone sessions, multicast groups, and action profile
+ * members/groups. Static entries (declared with `const entries` in the P4 source) are excluded —
+ * they come with the pipeline config.
  */
 fun extractReproducerEntities(
   trace: TraceTree,
-  snapshot: TableStore.ForwardingSnapshot,
+  tableStore: TableStore,
   staticEntries: List<Update>,
 ): List<Entity> {
-  val staticTableEntries = staticEntries.mapNotNullTo(mutableSetOf()) { update ->
-    update.entity.takeIf { it.hasTableEntry() }?.tableEntry
-  }
+  val snapshot = tableStore.snapshot
+  val staticTableEntries =
+    staticEntries.mapNotNullTo(mutableSetOf()) { update ->
+      update.entity.takeIf { it.hasTableEntry() }?.tableEntry
+    }
   val entities = linkedSetOf<Entity>()
-  collectEntities(trace, snapshot, staticTableEntries, entities)
+  collectEntities(trace, snapshot, tableStore, staticTableEntries, entities)
   return entities.toList()
 }
 
 private fun collectEntities(
   trace: TraceTree,
   snapshot: TableStore.ForwardingSnapshot,
+  tableStore: TableStore,
   staticEntries: Set<TableEntry>,
   out: MutableSet<Entity>,
 ) {
   for (event in trace.eventsList) {
-    collectFromEvent(event, snapshot, staticEntries, out)
+    collectFromEvent(event, snapshot, tableStore, staticEntries, out)
   }
   when (trace.outcomeCase) {
     TraceTree.OutcomeCase.FORK_OUTCOME -> {
@@ -44,7 +47,7 @@ private fun collectEntities(
         collectMulticastGroups(snapshot, out)
       }
       for (branch in fork.branchesList) {
-        collectEntities(branch.subtree, snapshot, staticEntries, out)
+        collectEntities(branch.subtree, snapshot, tableStore, staticEntries, out)
       }
     }
     TraceTree.OutcomeCase.PACKET_OUTCOME,
@@ -56,6 +59,7 @@ private fun collectEntities(
 private fun collectFromEvent(
   event: TraceEvent,
   snapshot: TableStore.ForwardingSnapshot,
+  tableStore: TableStore,
   staticEntries: Set<TableEntry>,
   out: MutableSet<Entity>,
 ) {
@@ -68,18 +72,21 @@ private fun collectFromEvent(
           out += Entity.newBuilder().setTableEntry(entry).build()
           collectActionProfileEntities(entry, snapshot, out)
         }
+      } else if (!lookup.hit) {
+        tableStore.buildModifiedDefaultActionEntity(lookup.tableName)?.let { out += it }
       }
     }
     TraceEvent.EventCase.CLONE_SESSION_LOOKUP -> {
       val cloneLookup = event.cloneSessionLookup
       if (cloneLookup.sessionFound) {
         snapshot.cloneSessions[cloneLookup.sessionId]?.let { cloneSession ->
-          out += Entity.newBuilder()
-            .setPacketReplicationEngineEntry(
-              p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
-                .setCloneSessionEntry(cloneSession)
-            )
-            .build()
+          out +=
+            Entity.newBuilder()
+              .setPacketReplicationEngineEntry(
+                p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+                  .setCloneSessionEntry(cloneSession)
+              )
+              .build()
         }
       }
     }
@@ -108,12 +115,13 @@ private fun collectMulticastGroups(
   // architecture records it there. For now, include all multicast groups from the
   // snapshot — the typical reproducer involves at most one or two.
   for ((_, group) in snapshot.multicastGroups) {
-    out += Entity.newBuilder()
-      .setPacketReplicationEngineEntry(
-        p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
-          .setMulticastGroupEntry(group)
-      )
-      .build()
+    out +=
+      Entity.newBuilder()
+        .setPacketReplicationEngineEntry(
+          p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+            .setMulticastGroupEntry(group)
+        )
+        .build()
   }
 }
 

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -17,10 +17,10 @@ import p4.v1.P4RuntimeOuterClass.Update
  */
 fun extractReproducerEntities(
   trace: TraceTree,
+  snapshot: TableStore.ForwardingSnapshot,
   tableStore: TableStore,
   staticEntries: List<Update>,
 ): List<Entity> {
-  val snapshot = tableStore.snapshot
   val staticTableEntries =
     staticEntries.mapNotNullTo(mutableSetOf()) { update ->
       update.entity.takeIf { it.hasTableEntry() }?.tableEntry
@@ -73,7 +73,7 @@ private fun collectFromEvent(
           collectActionProfileEntities(entry, snapshot, out)
         }
       } else if (!lookup.hit) {
-        tableStore.buildModifiedDefaultActionEntity(lookup.tableName)?.let { out += it }
+        tableStore.buildModifiedDefaultActionEntity(lookup.tableName, snapshot)?.let { out += it }
       }
     }
     TraceEvent.EventCase.CLONE_SESSION_LOOKUP -> {

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -1,0 +1,156 @@
+package fourward.simulator
+
+import fourward.ForkReason
+import fourward.TraceEvent
+import fourward.TraceTree
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.TableEntry
+import p4.v1.P4RuntimeOuterClass.Update
+
+/**
+ * Extracts the minimal set of P4Runtime entities needed to reproduce a trace.
+ *
+ * Walks the [TraceTree] recursively and collects entities referenced by trace events: matched table
+ * entries, clone sessions, multicast groups, and action profile members/groups. Static entries
+ * (declared with `const entries` in the P4 source) are excluded — they come with the pipeline
+ * config.
+ */
+fun extractReproducerEntities(
+  trace: TraceTree,
+  snapshot: TableStore.ForwardingSnapshot,
+  staticEntries: List<Update>,
+): List<Entity> {
+  val staticTableEntries = staticEntries.mapNotNullTo(mutableSetOf()) { update ->
+    update.entity.takeIf { it.hasTableEntry() }?.tableEntry
+  }
+  val entities = linkedSetOf<Entity>()
+  collectEntities(trace, snapshot, staticTableEntries, entities)
+  return entities.toList()
+}
+
+private fun collectEntities(
+  trace: TraceTree,
+  snapshot: TableStore.ForwardingSnapshot,
+  staticEntries: Set<TableEntry>,
+  out: MutableSet<Entity>,
+) {
+  for (event in trace.eventsList) {
+    collectFromEvent(event, snapshot, staticEntries, out)
+  }
+  when (trace.outcomeCase) {
+    TraceTree.OutcomeCase.FORK_OUTCOME -> {
+      val fork = trace.forkOutcome
+      if (fork.reason == ForkReason.MULTICAST) {
+        collectMulticastGroups(snapshot, out)
+      }
+      for (branch in fork.branchesList) {
+        collectEntities(branch.subtree, snapshot, staticEntries, out)
+      }
+    }
+    TraceTree.OutcomeCase.PACKET_OUTCOME,
+    TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+    null -> {}
+  }
+}
+
+private fun collectFromEvent(
+  event: TraceEvent,
+  snapshot: TableStore.ForwardingSnapshot,
+  staticEntries: Set<TableEntry>,
+  out: MutableSet<Entity>,
+) {
+  when (event.eventCase) {
+    TraceEvent.EventCase.TABLE_LOOKUP -> {
+      val lookup = event.tableLookup
+      if (lookup.hit && lookup.hasMatchedEntry()) {
+        val entry = lookup.matchedEntry
+        if (entry !in staticEntries) {
+          out += Entity.newBuilder().setTableEntry(entry).build()
+          collectActionProfileEntities(entry, snapshot, out)
+        }
+      }
+    }
+    TraceEvent.EventCase.CLONE_SESSION_LOOKUP -> {
+      val cloneLookup = event.cloneSessionLookup
+      if (cloneLookup.sessionFound) {
+        snapshot.cloneSessions[cloneLookup.sessionId]?.let { cloneSession ->
+          out += Entity.newBuilder()
+            .setPacketReplicationEngineEntry(
+              p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+                .setCloneSessionEntry(cloneSession)
+            )
+            .build()
+        }
+      }
+    }
+    TraceEvent.EventCase.PARSER_TRANSITION,
+    TraceEvent.EventCase.ACTION_EXECUTION,
+    TraceEvent.EventCase.BRANCH,
+    TraceEvent.EventCase.EXTERN_CALL,
+    TraceEvent.EventCase.MARK_TO_DROP,
+    TraceEvent.EventCase.CLONE,
+    TraceEvent.EventCase.PACKET_INGRESS,
+    TraceEvent.EventCase.PIPELINE_STAGE,
+    TraceEvent.EventCase.LOG_MESSAGE,
+    TraceEvent.EventCase.ASSERTION,
+    TraceEvent.EventCase.DEPARSER_EMIT,
+    TraceEvent.EventCase.ASSIGNMENT,
+    TraceEvent.EventCase.EVENT_NOT_SET,
+    null -> {}
+  }
+}
+
+private fun collectMulticastGroups(
+  snapshot: TableStore.ForwardingSnapshot,
+  out: MutableSet<Entity>,
+) {
+  // TODO: Extract the specific multicast group ID from the Fork proto once the
+  // architecture records it there. For now, include all multicast groups from the
+  // snapshot — the typical reproducer involves at most one or two.
+  for ((_, group) in snapshot.multicastGroups) {
+    out += Entity.newBuilder()
+      .setPacketReplicationEngineEntry(
+        p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+          .setMulticastGroupEntry(group)
+      )
+      .build()
+  }
+}
+
+/** Collects action profile members and groups referenced by a matched table entry. */
+private fun collectActionProfileEntities(
+  entry: TableEntry,
+  snapshot: TableStore.ForwardingSnapshot,
+  out: MutableSet<Entity>,
+) {
+  if (!entry.hasAction()) return
+  val tableAction = entry.action
+  when (tableAction.typeCase) {
+    p4.v1.P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_MEMBER_ID -> {
+      val memberId = tableAction.actionProfileMemberId
+      for ((profileId, members) in snapshot.profileMembers) {
+        members[memberId]?.let { member ->
+          out += Entity.newBuilder().setActionProfileMember(member).build()
+        }
+      }
+    }
+    p4.v1.P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_GROUP_ID -> {
+      val groupId = tableAction.actionProfileGroupId
+      for ((profileId, groups) in snapshot.profileGroups) {
+        groups[groupId]?.let { group ->
+          out += Entity.newBuilder().setActionProfileGroup(group).build()
+          // Also collect members referenced by the group.
+          for (memberRef in group.membersList) {
+            snapshot.profileMembers[profileId]?.get(memberRef.memberId)?.let { member ->
+              out += Entity.newBuilder().setActionProfileMember(member).build()
+            }
+          }
+        }
+      }
+    }
+    p4.v1.P4RuntimeOuterClass.TableAction.TypeCase.ACTION,
+    p4.v1.P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_ACTION_SET,
+    p4.v1.P4RuntimeOuterClass.TableAction.TypeCase.TYPE_NOT_SET,
+    null -> {}
+  }
+}

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -70,7 +70,7 @@ private fun collectFromEvent(
         val entry = lookup.matchedEntry
         if (entry !in staticEntries) {
           out += Entity.newBuilder().setTableEntry(entry).build()
-          collectActionProfileEntities(entry, snapshot, out)
+          collectActionProfileEntities(entry, snapshot, tableStore, out)
         }
       } else if (!lookup.hit) {
         tableStore.buildModifiedDefaultActionEntity(lookup.tableName, snapshot)?.let { out += it }
@@ -80,13 +80,7 @@ private fun collectFromEvent(
       val cloneLookup = event.cloneSessionLookup
       if (cloneLookup.sessionFound) {
         snapshot.cloneSessions[cloneLookup.sessionId]?.let { cloneSession ->
-          out +=
-            Entity.newBuilder()
-              .setPacketReplicationEngineEntry(
-                p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
-                  .setCloneSessionEntry(cloneSession)
-              )
-              .build()
+          out += buildPreEntity(cloneSession) { setCloneSessionEntry(it) }
         }
       }
     }
@@ -115,13 +109,7 @@ private fun collectMulticastGroups(
   // architecture records it there. For now, include all multicast groups from the
   // snapshot — the typical reproducer involves at most one or two.
   for ((_, group) in snapshot.multicastGroups) {
-    out +=
-      Entity.newBuilder()
-        .setPacketReplicationEngineEntry(
-          p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
-            .setMulticastGroupEntry(group)
-        )
-        .build()
+    out += buildPreEntity(group) { setMulticastGroupEntry(it) }
   }
 }
 
@@ -129,29 +117,24 @@ private fun collectMulticastGroups(
 private fun collectActionProfileEntities(
   entry: TableEntry,
   snapshot: TableStore.ForwardingSnapshot,
+  tableStore: TableStore,
   out: MutableSet<Entity>,
 ) {
   if (!entry.hasAction()) return
+  val profileId = tableStore.actionProfileIdForTable(entry.tableId) ?: return
   val tableAction = entry.action
   when (tableAction.typeCase) {
     p4.v1.P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_MEMBER_ID -> {
-      val memberId = tableAction.actionProfileMemberId
-      for ((profileId, members) in snapshot.profileMembers) {
-        members[memberId]?.let { member ->
-          out += Entity.newBuilder().setActionProfileMember(member).build()
-        }
+      snapshot.profileMembers[profileId]?.get(tableAction.actionProfileMemberId)?.let { member ->
+        out += Entity.newBuilder().setActionProfileMember(member).build()
       }
     }
     p4.v1.P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_GROUP_ID -> {
-      val groupId = tableAction.actionProfileGroupId
-      for ((profileId, groups) in snapshot.profileGroups) {
-        groups[groupId]?.let { group ->
-          out += Entity.newBuilder().setActionProfileGroup(group).build()
-          // Also collect members referenced by the group.
-          for (memberRef in group.membersList) {
-            snapshot.profileMembers[profileId]?.get(memberRef.memberId)?.let { member ->
-              out += Entity.newBuilder().setActionProfileMember(member).build()
-            }
+      snapshot.profileGroups[profileId]?.get(tableAction.actionProfileGroupId)?.let { group ->
+        out += Entity.newBuilder().setActionProfileGroup(group).build()
+        for (memberRef in group.membersList) {
+          snapshot.profileMembers[profileId]?.get(memberRef.memberId)?.let { member ->
+            out += Entity.newBuilder().setActionProfileMember(member).build()
           }
         }
       }

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -398,4 +398,47 @@ class ReproducerExtractorTest {
     val entities = extract(trace, store)
     assertTrue("unmodified default should not be extracted", entities.isEmpty())
   }
+
+  @Test
+  fun `multicast fork extracts multicast groups`() {
+    val group =
+      P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
+        .setMulticastGroupId(1)
+        .addReplicas(
+          P4RuntimeOuterClass.Replica.newBuilder()
+            .setPort(ByteString.copyFrom(byteArrayOf(1)))
+            .setInstance(0)
+        )
+        .addReplicas(
+          P4RuntimeOuterClass.Replica.newBuilder()
+            .setPort(ByteString.copyFrom(byteArrayOf(2)))
+            .setInstance(0)
+        )
+        .build()
+    val store = tableStoreWith { multicastGroups[1] = group }
+
+    val trace =
+      TraceTree.newBuilder()
+        .setForkOutcome(
+          Fork.newBuilder()
+            .setReason(ForkReason.MULTICAST)
+            .addBranches(
+              ForkBranch.newBuilder()
+                .setLabel("replica 0")
+                .setSubtree(TraceTree.newBuilder().setPacketOutcome(dropOutcome()))
+            )
+            .addBranches(
+              ForkBranch.newBuilder()
+                .setLabel("replica 1")
+                .setSubtree(TraceTree.newBuilder().setPacketOutcome(dropOutcome()))
+            )
+        )
+        .build()
+
+    val entities = extract(trace, store)
+
+    assertEquals(1, entities.size)
+    assertTrue(entities[0].hasPacketReplicationEngineEntry())
+    assertEquals(group, entities[0].packetReplicationEngineEntry.multicastGroupEntry)
+  }
 }

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -229,6 +229,33 @@ class ReproducerExtractorTest {
     assertEquals(entry2, entities[1].tableEntry)
   }
 
+  private fun tableStoreWithActionProfile(
+    profileId: Int = 100,
+    tableId: Int = 1,
+    setup: TableStore.ForwardingSnapshot.() -> Unit,
+  ): TableStore {
+    val store = TableStore()
+    val p4info =
+      p4.config.v1.P4InfoOuterClass.P4Info.newBuilder()
+        .addTables(
+          p4.config.v1.P4InfoOuterClass.Table.newBuilder()
+            .setPreamble(
+              p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(tableId).setAlias("t")
+            )
+            .setImplementationId(profileId)
+        )
+        .addActionProfiles(
+          p4.config.v1.P4InfoOuterClass.ActionProfile.newBuilder()
+            .setPreamble(
+              p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(profileId).setAlias("ap")
+            )
+        )
+        .build()
+    store.loadMappings(p4info, fourward.DeviceConfig.getDefaultInstance())
+    store.snapshot.setup()
+    return store
+  }
+
   @Test
   fun `action profile member is extracted from matched entry`() {
     val member =
@@ -238,7 +265,7 @@ class ReproducerExtractorTest {
         .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(10))
         .build()
 
-    val store = tableStoreWith { profileMembers[100] = mutableMapOf(5 to member) }
+    val store = tableStoreWithActionProfile { profileMembers[100] = mutableMapOf(5 to member) }
 
     val entry =
       P4RuntimeOuterClass.TableEntry.newBuilder()
@@ -286,7 +313,7 @@ class ReproducerExtractorTest {
         )
         .build()
 
-    val store = tableStoreWith {
+    val store = tableStoreWithActionProfile {
       profileMembers[100] = mutableMapOf(1 to member1, 2 to member2)
       profileGroups[100] = mutableMapOf(7 to group)
     }

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -1,0 +1,297 @@
+package fourward.simulator
+
+import com.google.protobuf.ByteString
+import fourward.Fork
+import fourward.ForkBranch
+import fourward.ForkReason
+import fourward.PacketOutcome
+import fourward.TableLookupEvent
+import fourward.TraceEvent
+import fourward.TraceTree
+import fourward.CloneSessionLookupEvent
+import fourward.Drop
+import fourward.DropReason
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import p4.v1.P4RuntimeOuterClass
+
+class ReproducerExtractorTest {
+
+  private fun tableEntry(
+    tableId: Int,
+    matchValue: ByteArray,
+    actionId: Int,
+  ): P4RuntimeOuterClass.TableEntry =
+    P4RuntimeOuterClass.TableEntry.newBuilder()
+      .setTableId(tableId)
+      .addMatch(
+        P4RuntimeOuterClass.FieldMatch.newBuilder()
+          .setFieldId(1)
+          .setExact(
+            P4RuntimeOuterClass.FieldMatch.Exact.newBuilder()
+              .setValue(ByteString.copyFrom(matchValue))
+          )
+      )
+      .setAction(
+        P4RuntimeOuterClass.TableAction.newBuilder()
+          .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(actionId))
+      )
+      .build()
+
+  private fun tableLookupHit(entry: P4RuntimeOuterClass.TableEntry): TraceEvent =
+    TraceEvent.newBuilder()
+      .setTableLookup(
+        TableLookupEvent.newBuilder()
+          .setTableName("MyTable")
+          .setHit(true)
+          .setMatchedEntry(entry)
+          .setActionName("forward")
+      )
+      .build()
+
+  private fun tableLookupMiss(tableName: String = "MyTable"): TraceEvent =
+    TraceEvent.newBuilder()
+      .setTableLookup(
+        TableLookupEvent.newBuilder()
+          .setTableName(tableName)
+          .setHit(false)
+          .setActionName("NoAction")
+      )
+      .build()
+
+  private fun cloneSessionLookup(sessionId: Int, found: Boolean): TraceEvent =
+    TraceEvent.newBuilder()
+      .setCloneSessionLookup(
+        CloneSessionLookupEvent.newBuilder()
+          .setSessionId(sessionId)
+          .setSessionFound(found)
+      )
+      .build()
+
+  private fun dropOutcome(): PacketOutcome =
+    PacketOutcome.newBuilder()
+      .setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
+      .build()
+
+  private fun emptySnapshot(): TableStore.ForwardingSnapshot = TableStore.ForwardingSnapshot()
+
+  @Test
+  fun `empty trace produces no entities`() {
+    val trace = TraceTree.newBuilder()
+      .setPacketOutcome(dropOutcome())
+      .build()
+    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    assertTrue(entities.isEmpty())
+  }
+
+  @Test
+  fun `table hit extracts matched entry`() {
+    val entry = tableEntry(tableId = 1, matchValue = byteArrayOf(0x08, 0x00), actionId = 10)
+    val trace = TraceTree.newBuilder()
+      .addEvents(tableLookupHit(entry))
+      .setPacketOutcome(dropOutcome())
+      .build()
+
+    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+
+    assertEquals(1, entities.size)
+    assertTrue(entities[0].hasTableEntry())
+    assertEquals(entry, entities[0].tableEntry)
+  }
+
+  @Test
+  fun `table miss produces no entities`() {
+    val trace = TraceTree.newBuilder()
+      .addEvents(tableLookupMiss())
+      .setPacketOutcome(dropOutcome())
+      .build()
+
+    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    assertTrue(entities.isEmpty())
+  }
+
+  @Test
+  fun `static entries are excluded`() {
+    val entry = tableEntry(tableId = 1, matchValue = byteArrayOf(0x08, 0x00), actionId = 10)
+    val staticUpdate = P4RuntimeOuterClass.Update.newBuilder()
+      .setType(P4RuntimeOuterClass.Update.Type.INSERT)
+      .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry))
+      .build()
+
+    val trace = TraceTree.newBuilder()
+      .addEvents(tableLookupHit(entry))
+      .setPacketOutcome(dropOutcome())
+      .build()
+
+    val entities = extractReproducerEntities(trace, emptySnapshot(), listOf(staticUpdate))
+    assertTrue("static entry should be excluded", entities.isEmpty())
+  }
+
+  @Test
+  fun `duplicate entries are deduplicated`() {
+    val entry = tableEntry(tableId = 1, matchValue = byteArrayOf(0x08, 0x00), actionId = 10)
+    val trace = TraceTree.newBuilder()
+      .addEvents(tableLookupHit(entry))
+      .addEvents(tableLookupHit(entry))
+      .setPacketOutcome(dropOutcome())
+      .build()
+
+    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    assertEquals("duplicate should be deduplicated", 1, entities.size)
+  }
+
+  @Test
+  fun `clone session lookup extracts clone session entry`() {
+    val snapshot = emptySnapshot()
+    val cloneEntry = P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
+      .setSessionId(42)
+      .setClassOfService(0)
+      .setPacketLengthBytes(0)
+      .addReplicas(
+        P4RuntimeOuterClass.Replica.newBuilder()
+          .setPort(ByteString.copyFrom(byteArrayOf(1)))
+          .setInstance(0)
+      )
+      .build()
+    snapshot.cloneSessions[42] = cloneEntry
+
+    val trace = TraceTree.newBuilder()
+      .addEvents(cloneSessionLookup(sessionId = 42, found = true))
+      .setPacketOutcome(dropOutcome())
+      .build()
+
+    val entities = extractReproducerEntities(trace, snapshot, emptyList())
+
+    assertEquals(1, entities.size)
+    assertTrue(entities[0].hasPacketReplicationEngineEntry())
+    assertEquals(cloneEntry, entities[0].packetReplicationEngineEntry.cloneSessionEntry)
+  }
+
+  @Test
+  fun `clone session not found produces no entities`() {
+    val trace = TraceTree.newBuilder()
+      .addEvents(cloneSessionLookup(sessionId = 99, found = false))
+      .setPacketOutcome(dropOutcome())
+      .build()
+
+    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    assertTrue(entities.isEmpty())
+  }
+
+  @Test
+  fun `fork branches are traversed recursively`() {
+    val entry1 = tableEntry(tableId = 1, matchValue = byteArrayOf(0x01), actionId = 10)
+    val entry2 = tableEntry(tableId = 2, matchValue = byteArrayOf(0x02), actionId = 20)
+
+    val trace = TraceTree.newBuilder()
+      .setForkOutcome(
+        Fork.newBuilder()
+          .setReason(ForkReason.CLONE)
+          .addBranches(
+            ForkBranch.newBuilder()
+              .setLabel("original")
+              .setSubtree(
+                TraceTree.newBuilder()
+                  .addEvents(tableLookupHit(entry1))
+                  .setPacketOutcome(dropOutcome())
+              )
+          )
+          .addBranches(
+            ForkBranch.newBuilder()
+              .setLabel("clone")
+              .setSubtree(
+                TraceTree.newBuilder()
+                  .addEvents(tableLookupHit(entry2))
+                  .setPacketOutcome(dropOutcome())
+              )
+          )
+      )
+      .build()
+
+    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+
+    assertEquals(2, entities.size)
+    assertEquals(entry1, entities[0].tableEntry)
+    assertEquals(entry2, entities[1].tableEntry)
+  }
+
+  @Test
+  fun `action profile member is extracted from matched entry`() {
+    val member = P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+      .setActionProfileId(100)
+      .setMemberId(5)
+      .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(10))
+      .build()
+
+    val snapshot = emptySnapshot()
+    snapshot.profileMembers[100] = mutableMapOf(5 to member)
+
+    val entry = P4RuntimeOuterClass.TableEntry.newBuilder()
+      .setTableId(1)
+      .setAction(
+        P4RuntimeOuterClass.TableAction.newBuilder().setActionProfileMemberId(5)
+      )
+      .build()
+
+    val trace = TraceTree.newBuilder()
+      .addEvents(tableLookupHit(entry))
+      .setPacketOutcome(dropOutcome())
+      .build()
+
+    val entities = extractReproducerEntities(trace, snapshot, emptyList())
+
+    assertEquals(2, entities.size)
+    assertTrue(entities[0].hasTableEntry())
+    assertTrue(entities[1].hasActionProfileMember())
+    assertEquals(member, entities[1].actionProfileMember)
+  }
+
+  @Test
+  fun `action profile group and its members are extracted`() {
+    val member1 = P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+      .setActionProfileId(100)
+      .setMemberId(1)
+      .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(10))
+      .build()
+    val member2 = P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+      .setActionProfileId(100)
+      .setMemberId(2)
+      .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(20))
+      .build()
+    val group = P4RuntimeOuterClass.ActionProfileGroup.newBuilder()
+      .setActionProfileId(100)
+      .setGroupId(7)
+      .addMembers(
+        P4RuntimeOuterClass.ActionProfileGroup.Member.newBuilder().setMemberId(1).setWeight(1)
+      )
+      .addMembers(
+        P4RuntimeOuterClass.ActionProfileGroup.Member.newBuilder().setMemberId(2).setWeight(1)
+      )
+      .build()
+
+    val snapshot = emptySnapshot()
+    snapshot.profileMembers[100] = mutableMapOf(1 to member1, 2 to member2)
+    snapshot.profileGroups[100] = mutableMapOf(7 to group)
+
+    val entry = P4RuntimeOuterClass.TableEntry.newBuilder()
+      .setTableId(1)
+      .setAction(
+        P4RuntimeOuterClass.TableAction.newBuilder().setActionProfileGroupId(7)
+      )
+      .build()
+
+    val trace = TraceTree.newBuilder()
+      .addEvents(tableLookupHit(entry))
+      .setPacketOutcome(dropOutcome())
+      .build()
+
+    val entities = extractReproducerEntities(trace, snapshot, emptyList())
+
+    assertEquals(4, entities.size)
+    assertTrue("table entry", entities[0].hasTableEntry())
+    assertTrue("group", entities[1].hasActionProfileGroup())
+    assertTrue("member 1", entities[2].hasActionProfileMember())
+    assertTrue("member 2", entities[3].hasActionProfileMember())
+  }
+}

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -79,10 +79,17 @@ class ReproducerExtractorTest {
     return store
   }
 
+  private fun extract(
+    trace: TraceTree,
+    store: TableStore,
+    staticEntries: List<P4RuntimeOuterClass.Update> = emptyList(),
+  ): List<P4RuntimeOuterClass.Entity> =
+    extractReproducerEntities(trace, store.snapshot, store, staticEntries)
+
   @Test
   fun `empty trace produces no entities`() {
     val trace = TraceTree.newBuilder().setPacketOutcome(dropOutcome()).build()
-    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
+    val entities = extract(trace, emptyTableStore())
     assertTrue(entities.isEmpty())
   }
 
@@ -95,7 +102,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
+    val entities = extract(trace, emptyTableStore())
 
     assertEquals(1, entities.size)
     assertTrue(entities[0].hasTableEntry())
@@ -107,7 +114,7 @@ class ReproducerExtractorTest {
     val trace =
       TraceTree.newBuilder().addEvents(tableLookupMiss()).setPacketOutcome(dropOutcome()).build()
 
-    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
+    val entities = extract(trace, emptyTableStore())
     assertTrue(entities.isEmpty())
   }
 
@@ -126,7 +133,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, emptyTableStore(), listOf(staticUpdate))
+    val entities = extract(trace, emptyTableStore(), listOf(staticUpdate))
     assertTrue("static entry should be excluded", entities.isEmpty())
   }
 
@@ -140,7 +147,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
+    val entities = extract(trace, emptyTableStore())
     assertEquals("duplicate should be deduplicated", 1, entities.size)
   }
 
@@ -165,7 +172,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, store, emptyList())
+    val entities = extract(trace, store)
 
     assertEquals(1, entities.size)
     assertTrue(entities[0].hasPacketReplicationEngineEntry())
@@ -180,7 +187,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
+    val entities = extract(trace, emptyTableStore())
     assertTrue(entities.isEmpty())
   }
 
@@ -215,7 +222,7 @@ class ReproducerExtractorTest {
         )
         .build()
 
-    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
+    val entities = extract(trace, emptyTableStore())
 
     assertEquals(2, entities.size)
     assertEquals(entry1, entities[0].tableEntry)
@@ -245,7 +252,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, store, emptyList())
+    val entities = extract(trace, store)
 
     assertEquals(2, entities.size)
     assertTrue(entities[0].hasTableEntry())
@@ -296,7 +303,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, store, emptyList())
+    val entities = extract(trace, store)
 
     assertEquals(4, entities.size)
     assertTrue("table entry", entities[0].hasTableEntry())
@@ -351,7 +358,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, store, emptyList())
+    val entities = extract(trace, store)
 
     assertEquals(1, entities.size)
     assertTrue(entities[0].hasTableEntry())
@@ -388,7 +395,7 @@ class ReproducerExtractorTest {
         .setPacketOutcome(dropOutcome())
         .build()
 
-    val entities = extractReproducerEntities(trace, store, emptyList())
+    val entities = extract(trace, store)
     assertTrue("unmodified default should not be extracted", entities.isEmpty())
   }
 }

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -1,6 +1,9 @@
 package fourward.simulator
 
 import com.google.protobuf.ByteString
+import fourward.CloneSessionLookupEvent
+import fourward.Drop
+import fourward.DropReason
 import fourward.Fork
 import fourward.ForkBranch
 import fourward.ForkReason
@@ -8,9 +11,6 @@ import fourward.PacketOutcome
 import fourward.TableLookupEvent
 import fourward.TraceEvent
 import fourward.TraceTree
-import fourward.CloneSessionLookupEvent
-import fourward.Drop
-import fourward.DropReason
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -63,37 +63,39 @@ class ReproducerExtractorTest {
   private fun cloneSessionLookup(sessionId: Int, found: Boolean): TraceEvent =
     TraceEvent.newBuilder()
       .setCloneSessionLookup(
-        CloneSessionLookupEvent.newBuilder()
-          .setSessionId(sessionId)
-          .setSessionFound(found)
+        CloneSessionLookupEvent.newBuilder().setSessionId(sessionId).setSessionFound(found)
       )
       .build()
 
   private fun dropOutcome(): PacketOutcome =
-    PacketOutcome.newBuilder()
-      .setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
-      .build()
+    PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP)).build()
 
-  private fun emptySnapshot(): TableStore.ForwardingSnapshot = TableStore.ForwardingSnapshot()
+  private fun emptyTableStore(): TableStore = TableStore()
+
+  /** Creates a TableStore whose published snapshot has the given state pre-populated. */
+  private fun tableStoreWith(setup: TableStore.ForwardingSnapshot.() -> Unit): TableStore {
+    val store = TableStore()
+    store.snapshot.setup()
+    return store
+  }
 
   @Test
   fun `empty trace produces no entities`() {
-    val trace = TraceTree.newBuilder()
-      .setPacketOutcome(dropOutcome())
-      .build()
-    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    val trace = TraceTree.newBuilder().setPacketOutcome(dropOutcome()).build()
+    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
     assertTrue(entities.isEmpty())
   }
 
   @Test
   fun `table hit extracts matched entry`() {
     val entry = tableEntry(tableId = 1, matchValue = byteArrayOf(0x08, 0x00), actionId = 10)
-    val trace = TraceTree.newBuilder()
-      .addEvents(tableLookupHit(entry))
-      .setPacketOutcome(dropOutcome())
-      .build()
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(tableLookupHit(entry))
+        .setPacketOutcome(dropOutcome())
+        .build()
 
-    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
 
     assertEquals(1, entities.size)
     assertTrue(entities[0].hasTableEntry())
@@ -102,66 +104,68 @@ class ReproducerExtractorTest {
 
   @Test
   fun `table miss produces no entities`() {
-    val trace = TraceTree.newBuilder()
-      .addEvents(tableLookupMiss())
-      .setPacketOutcome(dropOutcome())
-      .build()
+    val trace =
+      TraceTree.newBuilder().addEvents(tableLookupMiss()).setPacketOutcome(dropOutcome()).build()
 
-    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
     assertTrue(entities.isEmpty())
   }
 
   @Test
   fun `static entries are excluded`() {
     val entry = tableEntry(tableId = 1, matchValue = byteArrayOf(0x08, 0x00), actionId = 10)
-    val staticUpdate = P4RuntimeOuterClass.Update.newBuilder()
-      .setType(P4RuntimeOuterClass.Update.Type.INSERT)
-      .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry))
-      .build()
+    val staticUpdate =
+      P4RuntimeOuterClass.Update.newBuilder()
+        .setType(P4RuntimeOuterClass.Update.Type.INSERT)
+        .setEntity(P4RuntimeOuterClass.Entity.newBuilder().setTableEntry(entry))
+        .build()
 
-    val trace = TraceTree.newBuilder()
-      .addEvents(tableLookupHit(entry))
-      .setPacketOutcome(dropOutcome())
-      .build()
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(tableLookupHit(entry))
+        .setPacketOutcome(dropOutcome())
+        .build()
 
-    val entities = extractReproducerEntities(trace, emptySnapshot(), listOf(staticUpdate))
+    val entities = extractReproducerEntities(trace, emptyTableStore(), listOf(staticUpdate))
     assertTrue("static entry should be excluded", entities.isEmpty())
   }
 
   @Test
   fun `duplicate entries are deduplicated`() {
     val entry = tableEntry(tableId = 1, matchValue = byteArrayOf(0x08, 0x00), actionId = 10)
-    val trace = TraceTree.newBuilder()
-      .addEvents(tableLookupHit(entry))
-      .addEvents(tableLookupHit(entry))
-      .setPacketOutcome(dropOutcome())
-      .build()
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(tableLookupHit(entry))
+        .addEvents(tableLookupHit(entry))
+        .setPacketOutcome(dropOutcome())
+        .build()
 
-    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
     assertEquals("duplicate should be deduplicated", 1, entities.size)
   }
 
   @Test
   fun `clone session lookup extracts clone session entry`() {
-    val snapshot = emptySnapshot()
-    val cloneEntry = P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
-      .setSessionId(42)
-      .setClassOfService(0)
-      .setPacketLengthBytes(0)
-      .addReplicas(
-        P4RuntimeOuterClass.Replica.newBuilder()
-          .setPort(ByteString.copyFrom(byteArrayOf(1)))
-          .setInstance(0)
-      )
-      .build()
-    snapshot.cloneSessions[42] = cloneEntry
+    val cloneEntry =
+      P4RuntimeOuterClass.CloneSessionEntry.newBuilder()
+        .setSessionId(42)
+        .setClassOfService(0)
+        .setPacketLengthBytes(0)
+        .addReplicas(
+          P4RuntimeOuterClass.Replica.newBuilder()
+            .setPort(ByteString.copyFrom(byteArrayOf(1)))
+            .setInstance(0)
+        )
+        .build()
+    val store = tableStoreWith { cloneSessions[42] = cloneEntry }
 
-    val trace = TraceTree.newBuilder()
-      .addEvents(cloneSessionLookup(sessionId = 42, found = true))
-      .setPacketOutcome(dropOutcome())
-      .build()
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(cloneSessionLookup(sessionId = 42, found = true))
+        .setPacketOutcome(dropOutcome())
+        .build()
 
-    val entities = extractReproducerEntities(trace, snapshot, emptyList())
+    val entities = extractReproducerEntities(trace, store, emptyList())
 
     assertEquals(1, entities.size)
     assertTrue(entities[0].hasPacketReplicationEngineEntry())
@@ -170,12 +174,13 @@ class ReproducerExtractorTest {
 
   @Test
   fun `clone session not found produces no entities`() {
-    val trace = TraceTree.newBuilder()
-      .addEvents(cloneSessionLookup(sessionId = 99, found = false))
-      .setPacketOutcome(dropOutcome())
-      .build()
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(cloneSessionLookup(sessionId = 99, found = false))
+        .setPacketOutcome(dropOutcome())
+        .build()
 
-    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
     assertTrue(entities.isEmpty())
   }
 
@@ -184,32 +189,33 @@ class ReproducerExtractorTest {
     val entry1 = tableEntry(tableId = 1, matchValue = byteArrayOf(0x01), actionId = 10)
     val entry2 = tableEntry(tableId = 2, matchValue = byteArrayOf(0x02), actionId = 20)
 
-    val trace = TraceTree.newBuilder()
-      .setForkOutcome(
-        Fork.newBuilder()
-          .setReason(ForkReason.CLONE)
-          .addBranches(
-            ForkBranch.newBuilder()
-              .setLabel("original")
-              .setSubtree(
-                TraceTree.newBuilder()
-                  .addEvents(tableLookupHit(entry1))
-                  .setPacketOutcome(dropOutcome())
-              )
-          )
-          .addBranches(
-            ForkBranch.newBuilder()
-              .setLabel("clone")
-              .setSubtree(
-                TraceTree.newBuilder()
-                  .addEvents(tableLookupHit(entry2))
-                  .setPacketOutcome(dropOutcome())
-              )
-          )
-      )
-      .build()
+    val trace =
+      TraceTree.newBuilder()
+        .setForkOutcome(
+          Fork.newBuilder()
+            .setReason(ForkReason.CLONE)
+            .addBranches(
+              ForkBranch.newBuilder()
+                .setLabel("original")
+                .setSubtree(
+                  TraceTree.newBuilder()
+                    .addEvents(tableLookupHit(entry1))
+                    .setPacketOutcome(dropOutcome())
+                )
+            )
+            .addBranches(
+              ForkBranch.newBuilder()
+                .setLabel("clone")
+                .setSubtree(
+                  TraceTree.newBuilder()
+                    .addEvents(tableLookupHit(entry2))
+                    .setPacketOutcome(dropOutcome())
+                )
+            )
+        )
+        .build()
 
-    val entities = extractReproducerEntities(trace, emptySnapshot(), emptyList())
+    val entities = extractReproducerEntities(trace, emptyTableStore(), emptyList())
 
     assertEquals(2, entities.size)
     assertEquals(entry1, entities[0].tableEntry)
@@ -218,28 +224,28 @@ class ReproducerExtractorTest {
 
   @Test
   fun `action profile member is extracted from matched entry`() {
-    val member = P4RuntimeOuterClass.ActionProfileMember.newBuilder()
-      .setActionProfileId(100)
-      .setMemberId(5)
-      .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(10))
-      .build()
+    val member =
+      P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+        .setActionProfileId(100)
+        .setMemberId(5)
+        .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(10))
+        .build()
 
-    val snapshot = emptySnapshot()
-    snapshot.profileMembers[100] = mutableMapOf(5 to member)
+    val store = tableStoreWith { profileMembers[100] = mutableMapOf(5 to member) }
 
-    val entry = P4RuntimeOuterClass.TableEntry.newBuilder()
-      .setTableId(1)
-      .setAction(
-        P4RuntimeOuterClass.TableAction.newBuilder().setActionProfileMemberId(5)
-      )
-      .build()
+    val entry =
+      P4RuntimeOuterClass.TableEntry.newBuilder()
+        .setTableId(1)
+        .setAction(P4RuntimeOuterClass.TableAction.newBuilder().setActionProfileMemberId(5))
+        .build()
 
-    val trace = TraceTree.newBuilder()
-      .addEvents(tableLookupHit(entry))
-      .setPacketOutcome(dropOutcome())
-      .build()
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(tableLookupHit(entry))
+        .setPacketOutcome(dropOutcome())
+        .build()
 
-    val entities = extractReproducerEntities(trace, snapshot, emptyList())
+    val entities = extractReproducerEntities(trace, store, emptyList())
 
     assertEquals(2, entities.size)
     assertTrue(entities[0].hasTableEntry())
@@ -249,49 +255,140 @@ class ReproducerExtractorTest {
 
   @Test
   fun `action profile group and its members are extracted`() {
-    val member1 = P4RuntimeOuterClass.ActionProfileMember.newBuilder()
-      .setActionProfileId(100)
-      .setMemberId(1)
-      .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(10))
-      .build()
-    val member2 = P4RuntimeOuterClass.ActionProfileMember.newBuilder()
-      .setActionProfileId(100)
-      .setMemberId(2)
-      .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(20))
-      .build()
-    val group = P4RuntimeOuterClass.ActionProfileGroup.newBuilder()
-      .setActionProfileId(100)
-      .setGroupId(7)
-      .addMembers(
-        P4RuntimeOuterClass.ActionProfileGroup.Member.newBuilder().setMemberId(1).setWeight(1)
-      )
-      .addMembers(
-        P4RuntimeOuterClass.ActionProfileGroup.Member.newBuilder().setMemberId(2).setWeight(1)
-      )
-      .build()
+    val member1 =
+      P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+        .setActionProfileId(100)
+        .setMemberId(1)
+        .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(10))
+        .build()
+    val member2 =
+      P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+        .setActionProfileId(100)
+        .setMemberId(2)
+        .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(20))
+        .build()
+    val group =
+      P4RuntimeOuterClass.ActionProfileGroup.newBuilder()
+        .setActionProfileId(100)
+        .setGroupId(7)
+        .addMembers(
+          P4RuntimeOuterClass.ActionProfileGroup.Member.newBuilder().setMemberId(1).setWeight(1)
+        )
+        .addMembers(
+          P4RuntimeOuterClass.ActionProfileGroup.Member.newBuilder().setMemberId(2).setWeight(1)
+        )
+        .build()
 
-    val snapshot = emptySnapshot()
-    snapshot.profileMembers[100] = mutableMapOf(1 to member1, 2 to member2)
-    snapshot.profileGroups[100] = mutableMapOf(7 to group)
+    val store = tableStoreWith {
+      profileMembers[100] = mutableMapOf(1 to member1, 2 to member2)
+      profileGroups[100] = mutableMapOf(7 to group)
+    }
 
-    val entry = P4RuntimeOuterClass.TableEntry.newBuilder()
-      .setTableId(1)
-      .setAction(
-        P4RuntimeOuterClass.TableAction.newBuilder().setActionProfileGroupId(7)
-      )
-      .build()
+    val entry =
+      P4RuntimeOuterClass.TableEntry.newBuilder()
+        .setTableId(1)
+        .setAction(P4RuntimeOuterClass.TableAction.newBuilder().setActionProfileGroupId(7))
+        .build()
 
-    val trace = TraceTree.newBuilder()
-      .addEvents(tableLookupHit(entry))
-      .setPacketOutcome(dropOutcome())
-      .build()
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(tableLookupHit(entry))
+        .setPacketOutcome(dropOutcome())
+        .build()
 
-    val entities = extractReproducerEntities(trace, snapshot, emptyList())
+    val entities = extractReproducerEntities(trace, store, emptyList())
 
     assertEquals(4, entities.size)
     assertTrue("table entry", entities[0].hasTableEntry())
     assertTrue("group", entities[1].hasActionProfileGroup())
     assertTrue("member 1", entities[2].hasActionProfileMember())
     assertTrue("member 2", entities[3].hasActionProfileMember())
+  }
+
+  @Test
+  fun `modified default action is extracted on table miss`() {
+    val store = TableStore()
+    val p4info =
+      p4.config.v1.P4InfoOuterClass.P4Info.newBuilder()
+        .addTables(
+          p4.config.v1.P4InfoOuterClass.Table.newBuilder()
+            .setPreamble(
+              p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(1).setAlias("MyTable")
+            )
+        )
+        .addActions(
+          p4.config.v1.P4InfoOuterClass.Action.newBuilder()
+            .setPreamble(
+              p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(10).setAlias("my_action")
+            )
+        )
+        .build()
+    store.loadMappings(p4info, fourward.DeviceConfig.getDefaultInstance())
+    store.setDefaultAction("MyTable", "my_action")
+    // Use write() with a MODIFY to mark the default as modified, matching production behavior.
+    store.write(
+      P4RuntimeOuterClass.Update.newBuilder()
+        .setType(P4RuntimeOuterClass.Update.Type.MODIFY)
+        .setEntity(
+          P4RuntimeOuterClass.Entity.newBuilder()
+            .setTableEntry(
+              P4RuntimeOuterClass.TableEntry.newBuilder()
+                .setTableId(1)
+                .setIsDefaultAction(true)
+                .setAction(
+                  P4RuntimeOuterClass.TableAction.newBuilder()
+                    .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(10))
+                )
+            )
+        )
+        .build()
+    )
+    store.publishSnapshot()
+
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(tableLookupMiss("MyTable"))
+        .setPacketOutcome(dropOutcome())
+        .build()
+
+    val entities = extractReproducerEntities(trace, store, emptyList())
+
+    assertEquals(1, entities.size)
+    assertTrue(entities[0].hasTableEntry())
+    assertTrue("should be default action", entities[0].tableEntry.isDefaultAction)
+    assertEquals(1, entities[0].tableEntry.tableId)
+    assertEquals(10, entities[0].tableEntry.action.action.actionId)
+  }
+
+  @Test
+  fun `unmodified default action is not extracted on table miss`() {
+    val store = TableStore()
+    val p4info =
+      p4.config.v1.P4InfoOuterClass.P4Info.newBuilder()
+        .addTables(
+          p4.config.v1.P4InfoOuterClass.Table.newBuilder()
+            .setPreamble(
+              p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(1).setAlias("MyTable")
+            )
+        )
+        .addActions(
+          p4.config.v1.P4InfoOuterClass.Action.newBuilder()
+            .setPreamble(
+              p4.config.v1.P4InfoOuterClass.Preamble.newBuilder().setId(10).setAlias("my_action")
+            )
+        )
+        .build()
+    store.loadMappings(p4info, fourward.DeviceConfig.getDefaultInstance())
+    store.setDefaultAction("MyTable", "my_action")
+    store.publishSnapshot()
+
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(tableLookupMiss("MyTable"))
+        .setPacketOutcome(dropOutcome())
+        .build()
+
+    val entities = extractReproducerEntities(trace, store, emptyList())
+    assertTrue("unmodified default should not be extracted", entities.isEmpty())
   }
 }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -144,13 +144,13 @@ class Simulator : TableDataReader {
   fun writeEntry(update: p4.v1.P4RuntimeOuterClass.Update): WriteResult =
     loaded().tableStore.write(update)
 
-  /** The pipeline config from the currently loaded pipeline. */
-  val pipelineConfig: PipelineConfig
-    get() = loaded().config
+  /** The pipeline config from the currently loaded pipeline, or null if none is loaded. */
+  val pipelineConfig: PipelineConfig?
+    get() = current.get()?.config
 
-  /** The published forwarding snapshot (immutable, lock-free read). */
-  val forwardingSnapshot: TableStore.ForwardingSnapshot
-    get() = loaded().tableStore.snapshot
+  /** The table store from the currently loaded pipeline, or null if none is loaded. */
+  val tableStore: TableStore?
+    get() = current.get()?.tableStore
 
   /** Captures a checkpoint of all mutable state for rollback. */
   fun snapshot(): TableStore.RollbackCheckpoint = loaded().tableStore.snapshot()

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -21,7 +21,11 @@ import java.util.concurrent.atomic.AtomicReference
  * Decouples the simulator from the gRPC wire format ([fourward.InjectPacketResponse]). Each RPC
  * method builds its own wire proto from this data class.
  */
-data class ProcessPacketResult(val trace: TraceTree, val possibleOutcomes: List<List<OutputPacket>>)
+data class ProcessPacketResult(
+  val trace: TraceTree,
+  val possibleOutcomes: List<List<OutputPacket>>,
+  val forwardingSnapshot: TableStore.ForwardingSnapshot,
+)
 
 /**
  * The top-level simulator state machine.
@@ -117,6 +121,9 @@ class Simulator : TableDataReader {
    */
   fun processPacket(ingressPort: Int, payload: ByteArray): ProcessPacketResult {
     val loaded = loaded()
+    // Pin the forwarding snapshot before processing so the reproducer's entity extraction
+    // uses the exact same state the packet saw — no race with concurrent publishSnapshot().
+    val snapshot = loaded.tableStore.snapshot
 
     val result =
       loaded.architecture.processPacket(
@@ -129,7 +136,11 @@ class Simulator : TableDataReader {
     // of truth for packet outcomes. Parallel forks (clone, multicast) combine outputs within
     // each world; alternative forks (action selector) produce separate possible worlds.
     val trace = result.trace
-    return ProcessPacketResult(possibleOutcomes = collectPossibleOutcomes(trace), trace = trace)
+    return ProcessPacketResult(
+      trace = trace,
+      possibleOutcomes = collectPossibleOutcomes(trace),
+      forwardingSnapshot = snapshot,
+    )
   }
 
   /**

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -144,6 +144,14 @@ class Simulator : TableDataReader {
   fun writeEntry(update: p4.v1.P4RuntimeOuterClass.Update): WriteResult =
     loaded().tableStore.write(update)
 
+  /** The pipeline config from the currently loaded pipeline. */
+  val pipelineConfig: PipelineConfig
+    get() = loaded().config
+
+  /** The published forwarding snapshot (immutable, lock-free read). */
+  val forwardingSnapshot: TableStore.ForwardingSnapshot
+    get() = loaded().tableStore.snapshot
+
   /** Captures a checkpoint of all mutable state for rollback. */
   fun snapshot(): TableStore.RollbackCheckpoint = loaded().tableStore.snapshot()
 

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -675,8 +675,14 @@ class TableStore : TableDataReader {
   /**
    * Builds a P4Runtime [Entity] for the modified default action of [displayName] (p4info alias), or
    * null if the default has not been modified or the table doesn't exist.
+   *
+   * Takes an explicit [snapshot] so callers can pin the snapshot that was live during packet
+   * processing, avoiding races with concurrent [publishSnapshot] calls.
    */
-  fun buildModifiedDefaultActionEntity(displayName: String): P4RuntimeOuterClass.Entity? {
+  fun buildModifiedDefaultActionEntity(
+    displayName: String,
+    snapshot: ForwardingSnapshot,
+  ): P4RuntimeOuterClass.Entity? {
     val behavioralName = tableNameByAlias[displayName] ?: displayName
     if (behavioralName !in snapshot.modifiedDefaults) return null
     val default = snapshot.defaultActions[behavioralName] ?: return null

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -341,6 +341,9 @@ class TableStore : TableDataReader {
   var tableAliasByName: Map<String, String> = emptyMap()
     private set
 
+  /** Reverse of [tableAliasByName]: p4info alias → behavioral name. */
+  private var tableNameByAlias: Map<String, String> = emptyMap()
+
   private var registerInfoById: Map<Int, RegisterInfo> = emptyMap()
   private var counterInfoById: Map<Int, IndexedExternInfo> = emptyMap()
   private var meterInfoById: Map<Int, IndexedExternInfo> = emptyMap()
@@ -418,6 +421,7 @@ class TableStore : TableDataReader {
     }
     this.tableNameById = tableById
     this.tableAliasByName = tableByName
+    this.tableNameByAlias = tableByName.entries.associate { (name, alias) -> alias to name }
 
     val actionById = mutableMapOf<Int, String>()
     val actionByName = mutableMapOf<String, String>()
@@ -667,6 +671,33 @@ class TableStore : TableDataReader {
 
   override fun isDefaultModified(tableName: String): Boolean =
     tableName in snapshot.modifiedDefaults
+
+  /**
+   * Builds a P4Runtime [Entity] for the modified default action of [displayName] (p4info alias), or
+   * null if the default has not been modified or the table doesn't exist.
+   */
+  fun buildModifiedDefaultActionEntity(displayName: String): P4RuntimeOuterClass.Entity? {
+    val behavioralName = tableNameByAlias[displayName] ?: displayName
+    if (behavioralName !in snapshot.modifiedDefaults) return null
+    val default = snapshot.defaultActions[behavioralName] ?: return null
+    val tableId = tableIdByName[behavioralName] ?: return null
+    val actionId = actionIdByName[default.name] ?: return null
+    return P4RuntimeOuterClass.Entity.newBuilder()
+      .setTableEntry(
+        P4RuntimeOuterClass.TableEntry.newBuilder()
+          .setTableId(tableId)
+          .setIsDefaultAction(true)
+          .setAction(
+            P4RuntimeOuterClass.TableAction.newBuilder()
+              .setAction(
+                P4RuntimeOuterClass.Action.newBuilder()
+                  .setActionId(actionId)
+                  .addAllParams(default.params)
+              )
+          )
+      )
+      .build()
+  }
 
   override fun getDirectCounterData(entry: TableEntry): P4RuntimeOuterClass.CounterData? {
     val counters = directCounterData[entry] ?: return null

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -705,6 +705,12 @@ class TableStore : TableDataReader {
       .build()
   }
 
+  /** Returns the action profile ID for the table with [tableId], or null if the table has none. */
+  fun actionProfileIdForTable(tableId: Int): Int? {
+    val tableName = tableNameById[tableId] ?: return null
+    return tableActionProfile[tableName]
+  }
+
   override fun getDirectCounterData(entry: TableEntry): P4RuntimeOuterClass.CounterData? {
     val counters = directCounterData[entry] ?: return null
     return P4RuntimeOuterClass.CounterData.newBuilder()
@@ -1348,12 +1354,7 @@ class TableStore : TableDataReader {
   /** Wraps a PRE sub-entry into an `Entity` proto. */
   private fun <T> T.toPreEntity(
     setter: P4RuntimeOuterClass.PacketReplicationEngineEntry.Builder.(T) -> Unit
-  ): P4RuntimeOuterClass.Entity =
-    P4RuntimeOuterClass.Entity.newBuilder()
-      .setPacketReplicationEngineEntry(
-        P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder().also { it.setter(this) }
-      )
-      .build()
+  ): P4RuntimeOuterClass.Entity = buildPreEntity(this, setter)
 
   // -------------------------------------------------------------------------
   // Snapshot / Restore (for ROLLBACK_ON_ERROR / DATAPLANE_ATOMIC)
@@ -1689,3 +1690,14 @@ class TableStore : TableDataReader {
     private val BOOL_FALSE_BITS = BitVector.ofInt(0, 1)
   }
 }
+
+/** Wraps a PRE sub-entry (clone session or multicast group) into an [Entity] proto. */
+internal fun <T> buildPreEntity(
+  entry: T,
+  setter: P4RuntimeOuterClass.PacketReplicationEngineEntry.Builder.(T) -> Unit,
+): P4RuntimeOuterClass.Entity =
+  P4RuntimeOuterClass.Entity.newBuilder()
+    .setPacketReplicationEngineEntry(
+      P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder().also { it.setter(entry) }
+    )
+    .build()

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -41,6 +41,7 @@ kt_jvm_library(
         ":web",
         "//grpc",
         "//simulator",
+        "//simulator:ir_java_proto",
         "//simulator:p4info_java_proto",
         "//simulator:p4runtime_java_proto",
         "@fourward_maven//:io_grpc_grpc_netty",

--- a/web/PlaygroundServer.kt
+++ b/web/PlaygroundServer.kt
@@ -37,7 +37,12 @@ fun main(args: Array<String>) {
       cpuPortConfig = cpuPortConfig,
       dropPortConfig = dropPort,
     )
-  val dataplaneService = DataplaneService(broker, typeTranslator = { service.typeTranslator })
+  val dataplaneService =
+    DataplaneService(broker) {
+      val config = simulator.pipelineConfig ?: return@DataplaneService null
+      val tableStore = simulator.tableStore ?: return@DataplaneService null
+      DataplaneService.PipelineSnapshot(config, tableStore, service.typeTranslator)
+    }
   broker.readAllEntities = { service.readAllEntities() }
   broker.readP4Info = { service.p4Info() }
   broker.applyUpdates = { updates -> service.applyHookUpdates(updates) }


### PR DESCRIPTION
## Summary

A new `ReproduceTrace` RPC on the Dataplane service. Injects a packet and returns a self-contained `Reproducer` proto — everything needed to file a 4ward bug report or build a regression test from a single packet trace.

```proto
service Dataplane {
  rpc ReproduceTrace(InjectPacketRequest) returns (Reproducer);
}

message Reproducer {
  PipelineConfig pipeline_config = 1;
  repeated p4.v1.Entity entities = 2;
  ProcessPacketResult result = 3;
}
```

The `Reproducer` bundles the pipeline config, the minimal set of P4Runtime entities referenced by the trace, and the full `ProcessPacketResult` (input packet, trace, possible outcomes). Serialize it to a file and hand it to someone — they load the pipeline, install the entities, inject the packet, and get the same trace.

### Entity extraction

Walks the trace tree and collects:
- Matched table entries (excluding `const entries` — those come with the pipeline config)
- Modified default actions (installed via P4Runtime, not the compile-time default)
- Clone sessions
- Multicast groups
- Action profile members and groups (resolved via the table's specific profile, not scanned across all profiles)

Entities are deduplicated. The forwarding snapshot is pinned at `processPacket` time to eliminate races with concurrent `publishSnapshot` calls.

### Other changes

- **Unified `PipelineSnapshot` provider** on `DataplaneService` replaces separate `typeTranslator` and `reproducerData` lambdas
- **Nullable accessors** on `Simulator` (`pipelineConfig`, `tableStore`) replace try/catch for "no pipeline loaded"
- **Shared `processAndEnrich` helper** eliminates duplication between `injectPacket` and `reproduceTrace`
- **`buildPreEntity` extracted** from `TableStore` as a reusable package-level function
- **C++ client**: `ReproduceTrace` method on `DataplaneClient`

### Known limitations

- Multicast group extraction includes all groups from the snapshot — the `Fork` proto doesn't carry the group ID (#673)
- Register state is not captured — programs that branch on register values will produce different traces when replayed

### Design doc

#670

## Test plan

- [x] 14 unit tests (`ReproducerExtractorTest`): empty trace, hit/miss, static exclusion, dedup, clone sessions, action profile members/groups (with proper profile resolution), fork recursion, modified/unmodified default actions, multicast fork
- [x] 8 E2E tests (`DataplaneServiceTest`): self-contained reproducer, matched entry, miss → empty, fails without pipeline, round-trip fidelity (trace matches `InjectPacket`), multicast groups, modified default actions
- [x] C++ client builds and all existing tests pass
- [x] Full test suite passes (79/79), format and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)