### PR TITLE
Always use cc_shim for p4c preprocessing (fixes #666)

### DIFF
--- a/bazel/Runfiles.kt
+++ b/bazel/Runfiles.kt
@@ -34,9 +34,10 @@ fun resolveRunfileProperty(key: String): Path {
 }
 
 /**
- * Prepends a BUILD-provided `cc` shim to [pb]'s PATH. p4c shells out to `cc` for preprocessing; the
- * shim wraps the Bazel CC toolchain compiler so this works in hermetic sandboxes (blaze/google3)
- * where no system `cc` exists.
+ * Appends a BUILD-provided `cc` shim to [pb]'s PATH as a fallback. p4c shells out to `cc` for
+ * preprocessing; the shim wraps the Bazel CC toolchain compiler so this works in hermetic sandboxes
+ * (blaze/google3) where no system `cc` exists. Where a system `cc` does exist (macOS, Linux CI), it
+ * takes priority.
  *
  * WORKAROUND for https://github.com/p4lang/p4c/issues/5618: p4c hardcodes the preprocessor binary
  * (`cc` or `cpp`); once p4c supports `--cc <path>`, pass the compiler path directly and remove the
@@ -48,7 +49,7 @@ fun resolveRunfileProperty(key: String): Path {
 fun ensureCcOnPath(pb: ProcessBuilder, shimPropertyKey: String = "cc_shim") {
   val shimDir = resolveRunfileProperty(shimPropertyKey).parent
   val env = pb.environment()
-  env["PATH"] = "$shimDir${File.pathSeparator}${env["PATH"] ?: ""}"
+  env["PATH"] = "${env["PATH"] ?: ""}${File.pathSeparator}$shimDir"
 }
 
 private fun resolveRlocation(rlocation: String, what: String): Path =

--- a/bazel/Runfiles.kt
+++ b/bazel/Runfiles.kt
@@ -2,7 +2,6 @@ package fourward.bazel
 
 import com.google.devtools.build.runfiles.Runfiles
 import java.io.File
-import java.nio.file.Files
 import java.nio.file.Path
 
 private val runfiles: Runfiles = Runfiles.preload().unmapped()
@@ -35,24 +34,21 @@ fun resolveRunfileProperty(key: String): Path {
 }
 
 /**
- * Prepends a BUILD-provided `cc` shim to [pb]'s PATH if no system `cc` is found. p4c shells out to
- * `cc` for preprocessing, which doesn't exist in hermetic sandboxes (blaze/google3).
+ * Prepends a BUILD-provided `cc` shim to [pb]'s PATH. p4c shells out to `cc` for preprocessing; the
+ * shim wraps the Bazel CC toolchain compiler so this works in hermetic sandboxes (blaze/google3)
+ * where no system `cc` exists.
+ *
+ * WORKAROUND for https://github.com/p4lang/p4c/issues/5618: p4c hardcodes the preprocessor binary
+ * (`cc` or `cpp`); once p4c supports `--cc <path>`, pass the compiler path directly and remove the
+ * shim from PATH.
  *
  * Requires the caller's BUILD target to include `cc_shim` in `data` and pass its path via
  * `-D<shimPropertyKey>=$(rlocationpath ...)` in `jvm_flags`.
  */
 fun ensureCcOnPath(pb: ProcessBuilder, shimPropertyKey: String = "cc_shim") {
-  if (!hasSystemCc) {
-    val shimDir = resolveRunfileProperty(shimPropertyKey).parent
-    val env = pb.environment()
-    env["PATH"] = "$shimDir${File.pathSeparator}${env["PATH"] ?: ""}"
-  }
-}
-
-private val hasSystemCc: Boolean by lazy {
-  System.getenv("PATH")?.split(File.pathSeparator).orEmpty().any { dir ->
-    Files.isExecutable(Path.of(dir, "cc"))
-  }
+  val shimDir = resolveRunfileProperty(shimPropertyKey).parent
+  val env = pb.environment()
+  env["PATH"] = "$shimDir${File.pathSeparator}${env["PATH"] ?: ""}"
 }
 
 private fun resolveRlocation(rlocation: String, what: String): Path =

--- a/bazel/fourward_pipeline.bzl
+++ b/bazel/fourward_pipeline.bzl
@@ -84,10 +84,10 @@ def _fourward_pipeline_impl(ctx):
         transitive = [ctx.attr._p4include[DefaultInfo].files],
     )
 
-    # p4c shells out to `cc` for preprocessing. Provide it via the CC
-    # toolchain rather than relying on PATH — remote execution sandboxes
-    # (e.g. google3/blaze) don't have a system `cc`.
-    # Pattern from @p4c//bazel:p4_library.bzl.
+    # WORKAROUND for https://github.com/p4lang/p4c/issues/5618: p4c hardcodes
+    # `popen("cc -E …")` for preprocessing with no flag to override the binary.
+    # Define a shell function so the toolchain compiler answers to `cc`.
+    # Once p4c supports `--cc <path>`, pass compiler_executable directly.
     cc_toolchain = find_cc_toolchain(ctx)
     p4c = ctx.executable._p4c_4ward
     ctx.actions.run_shell(

--- a/e2e_tests/p4testgen.bzl
+++ b/e2e_tests/p4testgen.bzl
@@ -44,9 +44,10 @@ def _p4testgen_stfs_impl(ctx):
         "--out-dir " + out_dir.path,
     ])
 
-    # p4c hard-codes `popen("cc -E …")` for P4 preprocessing. Define a
-    # shell function that redirects `cc` to the Bazel CC toolchain compiler
-    # (same approach as p4lang/p4c's own p4_library rule).
+    # WORKAROUND for https://github.com/p4lang/p4c/issues/5618: p4c hardcodes
+    # `popen("cc -E …")` for preprocessing with no flag to override the binary.
+    # Define a shell function so the toolchain compiler answers to `cc`.
+    # Once p4c supports `--cc <path>`, pass compiler_executable directly.
     ctx.actions.run_shell(
         command = """
             function cc () {{ "{cc}" "$@"; }}


### PR DESCRIPTION
p4c hardcodes `cc` as the preprocessor binary — no flag to override it
(filed [p4lang/p4c#5618](https://github.com/p4lang/p4c/issues/5618)).
The previous fix (#667) tried to detect whether a system `cc` exists
and only fall back to a Bazel-provided shim when it doesn't. This
heuristic breaks in google3: `Files.isExecutable()` finds a `cc` that
the subprocess can't actually use.

## Summary

- **Append the cc_shim to PATH as a fallback** instead of conditionally
  prepending it. Where a system `cc` exists (macOS, Linux CI), it takes
  priority. In hermetic sandboxes without a system `cc` (google3), the
  shim is found as the only `cc`. This avoids both the broken heuristic
  _and_ a macOS issue where the shim's embedded `cc_wrapper.sh` path
  doesn't resolve in the test's runfiles tree.
- **Add `WORKAROUND` comments** referencing p4lang/p4c#5618 at all three
  sites that work around the hardcoded preprocessor: `ensureCcOnPath`,
  `fourward_pipeline.bzl`, and `p4testgen.bzl`.

## Test plan

- [x] `BitLevelSerializationTest` passes
- [x] `RunfilesTest` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)