### PR TITLE
cc_shim: resolve compiler path from runfiles root at runtime (fixes #676)

### DIFF
--- a/bazel/cc_shim.bzl
+++ b/bazel/cc_shim.bzl
@@ -26,10 +26,12 @@ def _cc_shim_impl(ctx):
         # compiler_executable is relative to the Bazel execroot, but in the
         # runfiles tree external repos are top-level siblings of _main/ — not
         # under _main/external/. Resolve from the runfiles root at runtime.
-        runfiles_path = cc.removeprefix("external/") if cc.startswith("external/") else "_main/" + cc
+        runfiles_path = cc[len("external/"):] if cc.startswith("external/") else "_main/" + cc
         script = "#!/bin/sh\n" + \
                  'SHIM_DIR="$(cd "$(dirname "$0")" && pwd)"\n' + \
-                 'exec "${{SHIM_DIR%/_main/*}}/{runfiles_path}" "$@"\n'.format(runfiles_path = runfiles_path)
+                 'RUNFILES="${{SHIM_DIR%/_main/*}}"\n'.format() + \
+                 'if [ "$RUNFILES" = "$SHIM_DIR" ]; then echo "cc_shim: cannot find runfiles root from $SHIM_DIR" >&2; exit 1; fi\n' + \
+                 'exec "$RUNFILES/{runfiles_path}" "$@"\n'.format(runfiles_path = runfiles_path)
 
     ctx.actions.write(
         output = shim,

--- a/bazel/cc_shim.bzl
+++ b/bazel/cc_shim.bzl
@@ -17,9 +17,23 @@ def _cc_shim_impl(ctx):
     # Subdir so the output basename can be literally `cc` without colliding
     # with the target name; callers take `.parent` to get a dir for PATH.
     shim = ctx.actions.declare_file(ctx.label.name + "/cc")
+
+    if cc.startswith("/"):
+        # Absolute path (e.g. /usr/lib/llvm-18/bin/clang on Linux).
+        script = '#!/bin/sh\nexec "{cc}" "$@"\n'.format(cc = cc)
+    else:
+        # Relative path (e.g. external/<repo>/cc_wrapper.sh on macOS).
+        # compiler_executable is relative to the Bazel execroot, but in the
+        # runfiles tree external repos are top-level siblings of _main/ — not
+        # under _main/external/. Resolve from the runfiles root at runtime.
+        runfiles_path = cc.removeprefix("external/") if cc.startswith("external/") else "_main/" + cc
+        script = "#!/bin/sh\n" + \
+                 'SHIM_DIR="$(cd "$(dirname "$0")" && pwd)"\n' + \
+                 'exec "${{SHIM_DIR%/_main/*}}/{runfiles_path}" "$@"\n'.format(runfiles_path = runfiles_path)
+
     ctx.actions.write(
         output = shim,
-        content = "#!/bin/sh\nexec \"{}\" \"$@\"\n".format(cc),
+        content = script,
         is_executable = True,
     )
 


### PR DESCRIPTION
On macOS, `compiler_executable` is a relative path
(`external/<repo>/cc_wrapper.sh`) that's valid at the Bazel execroot but
not in the runfiles tree — external repos live as top-level siblings of
`_main/`, not under `_main/external/`. The old shim baked the
execroot-relative path verbatim, so it broke whenever the shim was
actually invoked on macOS.

## Summary

- For **absolute paths** (Linux): behavior unchanged — `exec "/usr/lib/llvm-18/bin/clang" "$@"`.
- For **relative paths** (macOS): the shim now resolves `$(dirname "$0")` at
  runtime, walks up to the runfiles root via `${SHIM_DIR%/_main/*}`, and
  execs the compiler from there.

## Test plan

- [x] `BitLevelSerializationTest` passes (Linux)
- [x] `WebServerTest` passes (Linux)
- [x] `RunfilesTest` passes
- [x] Verified generated shim on Linux uses absolute path (unchanged)
- [ ] CI (macOS is the real test — Linux uses absolute paths so the new codepath isn't exercised there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)