### PR TITLE
simulator: MulticastGroupLookupEvent for precise reproducer extraction

### DIFF
--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -85,6 +85,11 @@ object TraceFormatter {
         val a = event.assignment
         appendLine("${prefix}${a.target} = ${event.resultValue}")
       }
+      TraceEvent.EventCase.MULTICAST_GROUP_LOOKUP -> {
+        val ml = event.multicastGroupLookup
+        val result = if (ml.groupFound) "${ml.replicaCount} replicas" else "not found"
+        appendLine("${prefix}multicast group ${ml.multicastGroupId}: $result")
+      }
       TraceEvent.EventCase.PACKET_INGRESS,
       TraceEvent.EventCase.PIPELINE_STAGE,
       TraceEvent.EventCase.CLONE_SESSION_LOOKUP,

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -93,11 +93,7 @@ guilt — just write it down so someone can find it later.
   time-dependent features that have no meaningful semantics in a reference
   simulator: there are no real packet rates to trigger digests, and no
   wall-clock time to expire idle entries. These are explicitly out of scope.
-- **Reproducer includes all multicast groups.** The `Reproducer` entity
-  extraction cannot determine which specific multicast group triggered a
-  MULTICAST fork (the `Fork` proto doesn't carry the group ID), so it
-  includes all multicast groups from the forwarding snapshot.
-- **Reproducer does not capture register state.** Programs that read
+- **Reproducer does not capture register state (#679).** Programs that read
   registers and branch on the result will produce a different trace when
   replayed from a reproducer (registers start at zero). Counter and
   meter state is not affected: counters don't influence forwarding,

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -97,6 +97,13 @@ fork_outcome {
   branches {
     label: "original"
     subtree {
+      events {
+        multicast_group_lookup {
+          multicast_group_id: 1
+          group_found: true
+          replica_count: 2
+        }
+      }
       fork_outcome {
         reason: MULTICAST
         branches {

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -73,6 +73,13 @@ events {
     dataplane_port: 0
   }
 }
+events {
+  multicast_group_lookup {
+    multicast_group_id: 1
+    group_found: true
+    replica_count: 3
+  }
+}
 fork_outcome {
   reason: MULTICAST
   branches {

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -73,6 +73,13 @@ events {
     dataplane_port: 0
   }
 }
+events {
+  multicast_group_lookup {
+    multicast_group_id: 1
+    group_found: true
+    replica_count: 3
+  }
+}
 fork_outcome {
   reason: MULTICAST
   branches {

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -73,6 +73,13 @@ events {
     dataplane_port: 0
   }
 }
+events {
+  multicast_group_lookup {
+    multicast_group_id: 1
+    group_found: true
+    replica_count: 2
+  }
+}
 fork_outcome {
   reason: MULTICAST
   branches {

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -195,6 +195,24 @@ class DataplaneServiceTest {
   }
 
   @Test
+  fun `ReproduceTrace extracts only the multicast group used by the trace`() {
+    val config = loadConfig("e2e_tests/trace_tree/multicast.txtpb")
+    harness.loadPipeline(config)
+    // The P4 program hardcodes mcast_grp = 1. Install group 1 (used) and group 99 (unused).
+    harness.installEntry(buildMulticastGroup(groupId = 1, ports = listOf(1, 2, 3)))
+    harness.installEntry(buildMulticastGroup(groupId = 99, ports = listOf(4, 5)))
+
+    val payload = buildEthernetFrame(etherType = 0x0800)
+    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+
+    val mcastEntities =
+      reproducer.entitiesList
+        .filter { it.hasPacketReplicationEngineEntry() }
+        .map { it.packetReplicationEngineEntry.multicastGroupEntry.multicastGroupId }
+    assertEquals("should contain only group 1", listOf(1), mcastEntities)
+  }
+
+  @Test
   fun `ReproduceTrace includes modified default action`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -285,11 +285,12 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): TraceTree {
-    val group =
-      egressState.pipeline.tableStore.getMulticastGroup(multicastGroup)
-        ?: // BMv2 psa_switch: unknown multicast group → silently drop.
-        return buildDropTrace(emptyList())
+    val group = egressState.pipeline.tableStore.getMulticastGroup(multicastGroup)
+    if (group == null) {
+      return buildDropTrace(listOf(multicastGroupMissEvent(multicastGroup)))
+    }
 
+    val lookupEvent = multicastGroupLookupEvent(multicastGroup, group.replicasCount)
     val branches =
       group.replicasList.map { replica ->
         val port = replicaPort(replica)
@@ -309,6 +310,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           .build()
       }
     return TraceTree.newBuilder()
+      .addEvents(lookupEvent)
       .setForkOutcome(Fork.newBuilder().setReason(ForkReason.MULTICAST).addAllBranches(branches))
       .build()
   }

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -1,6 +1,5 @@
 package fourward.simulator
 
-import fourward.ForkReason
 import fourward.TraceEvent
 import fourward.TraceTree
 import p4.v1.P4RuntimeOuterClass.Entity
@@ -42,11 +41,7 @@ private fun collectEntities(
   }
   when (trace.outcomeCase) {
     TraceTree.OutcomeCase.FORK_OUTCOME -> {
-      val fork = trace.forkOutcome
-      if (fork.reason == ForkReason.MULTICAST) {
-        collectMulticastGroups(snapshot, out)
-      }
-      for (branch in fork.branchesList) {
+      for (branch in trace.forkOutcome.branchesList) {
         collectEntities(branch.subtree, snapshot, tableStore, staticEntries, out)
       }
     }
@@ -84,32 +79,28 @@ private fun collectFromEvent(
         }
       }
     }
+    TraceEvent.EventCase.MULTICAST_GROUP_LOOKUP -> {
+      val lookup = event.multicastGroupLookup
+      if (lookup.groupFound) {
+        snapshot.multicastGroups[lookup.multicastGroupId]?.let { group ->
+          out += buildPreEntity(group) { setMulticastGroupEntry(it) }
+        }
+      }
+    }
+    TraceEvent.EventCase.PACKET_INGRESS,
+    TraceEvent.EventCase.PIPELINE_STAGE,
     TraceEvent.EventCase.PARSER_TRANSITION,
     TraceEvent.EventCase.ACTION_EXECUTION,
     TraceEvent.EventCase.BRANCH,
+    TraceEvent.EventCase.ASSIGNMENT,
     TraceEvent.EventCase.EXTERN_CALL,
-    TraceEvent.EventCase.MARK_TO_DROP,
-    TraceEvent.EventCase.CLONE,
-    TraceEvent.EventCase.PACKET_INGRESS,
-    TraceEvent.EventCase.PIPELINE_STAGE,
     TraceEvent.EventCase.LOG_MESSAGE,
     TraceEvent.EventCase.ASSERTION,
+    TraceEvent.EventCase.CLONE,
+    TraceEvent.EventCase.MARK_TO_DROP,
     TraceEvent.EventCase.DEPARSER_EMIT,
-    TraceEvent.EventCase.ASSIGNMENT,
     TraceEvent.EventCase.EVENT_NOT_SET,
     null -> {}
-  }
-}
-
-private fun collectMulticastGroups(
-  snapshot: TableStore.ForwardingSnapshot,
-  out: MutableSet<Entity>,
-) {
-  // TODO: Extract the specific multicast group ID from the Fork proto once the
-  // architecture records it there. For now, include all multicast groups from the
-  // snapshot — the typical reproducer involves at most one or two.
-  for ((_, group) in snapshot.multicastGroups) {
-    out += buildPreEntity(group) { setMulticastGroupEntry(it) }
   }
 }
 

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -426,8 +426,18 @@ class ReproducerExtractorTest {
     assertTrue("unmodified default should not be extracted", entities.isEmpty())
   }
 
+  private fun multicastGroupLookup(groupId: Int): TraceEvent =
+    TraceEvent.newBuilder()
+      .setMulticastGroupLookup(
+        fourward.MulticastGroupLookupEvent.newBuilder()
+          .setMulticastGroupId(groupId)
+          .setGroupFound(true)
+          .setReplicaCount(2)
+      )
+      .build()
+
   @Test
-  fun `multicast fork extracts multicast groups`() {
+  fun `multicast group lookup extracts multicast group entity`() {
     val group =
       P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
         .setMulticastGroupId(1)
@@ -446,20 +456,8 @@ class ReproducerExtractorTest {
 
     val trace =
       TraceTree.newBuilder()
-        .setForkOutcome(
-          Fork.newBuilder()
-            .setReason(ForkReason.MULTICAST)
-            .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("replica 0")
-                .setSubtree(TraceTree.newBuilder().setPacketOutcome(dropOutcome()))
-            )
-            .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("replica 1")
-                .setSubtree(TraceTree.newBuilder().setPacketOutcome(dropOutcome()))
-            )
-        )
+        .addEvents(multicastGroupLookup(groupId = 1))
+        .setPacketOutcome(dropOutcome())
         .build()
 
     val entities = extract(trace, store)
@@ -467,5 +465,24 @@ class ReproducerExtractorTest {
     assertEquals(1, entities.size)
     assertTrue(entities[0].hasPacketReplicationEngineEntry())
     assertEquals(group, entities[0].packetReplicationEngineEntry.multicastGroupEntry)
+  }
+
+  @Test
+  fun `multicast group miss produces no entities`() {
+    val trace =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setMulticastGroupLookup(
+              fourward.MulticastGroupLookupEvent.newBuilder()
+                .setMulticastGroupId(99)
+                .setGroupFound(false)
+            )
+        )
+        .setPacketOutcome(dropOutcome())
+        .build()
+
+    val entities = extract(trace, emptyTableStore())
+    assertTrue(entities.isEmpty())
   }
 }

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -5,6 +5,7 @@ import fourward.DropReason
 import fourward.Fork
 import fourward.ForkBranch
 import fourward.ForkReason
+import fourward.MulticastGroupLookupEvent
 import fourward.PacketIngressEvent
 import fourward.PacketOutcome
 import fourward.PipelineStage
@@ -79,6 +80,25 @@ internal fun stageEvent(
         .setStageKind(stage.kind)
         .setDirection(direction)
         .apply { if (dataplanePort != null) setDataplanePort(dataplanePort) }
+    )
+    .build()
+
+/** Creates a [TraceEvent] recording a successful multicast group lookup. */
+internal fun multicastGroupLookupEvent(groupId: Int, replicaCount: Int): TraceEvent =
+  TraceEvent.newBuilder()
+    .setMulticastGroupLookup(
+      MulticastGroupLookupEvent.newBuilder()
+        .setMulticastGroupId(groupId)
+        .setGroupFound(true)
+        .setReplicaCount(replicaCount)
+    )
+    .build()
+
+/** Creates a [TraceEvent] recording a failed multicast group lookup. */
+internal fun multicastGroupMissEvent(groupId: Int): TraceEvent =
+  TraceEvent.newBuilder()
+    .setMulticastGroupLookup(
+      MulticastGroupLookupEvent.newBuilder().setMulticastGroupId(groupId).setGroupFound(false)
     )
     .build()
 

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -825,6 +825,7 @@ class V1ModelArchitecture(
     if (mcastGrp != 0) {
       val group = ctx.tableStore.getMulticastGroup(mcastGrp)
       if (group != null) {
+        s.packetCtx.addTraceEvent(multicastGroupLookupEvent(mcastGrp, group.replicasCount))
         val replicas = group.replicasList.map { r -> Replica(r.instance, replicaPort(r)) }
         throw MulticastFork(
           replicas,
@@ -834,6 +835,7 @@ class V1ModelArchitecture(
           s.pendingOps.copy(),
         )
       }
+      s.packetCtx.addTraceEvent(multicastGroupMissEvent(mcastGrp))
     }
     // Normal unicast: copy egress_spec → egress_port.
     s.standardMetadata.fields["egress_port"] =

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -116,20 +116,34 @@ message Drop {
 
 message TraceEvent {
   oneof event {
+    // Pipeline lifecycle.
+    PacketIngressEvent packet_ingress = 8;
+    PipelineStageEvent pipeline_stage = 9;
+
+    // Parser.
     ParserTransitionEvent parser_transition = 1;
+
+    // Control flow.
     TableLookupEvent table_lookup = 2;
     ActionExecutionEvent action_execution = 3;
     BranchEvent branch = 4;
+    AssignmentEvent assignment = 14;
+
+    // Externs.
     ExternCallEvent extern_call = 5;
-    MarkToDropEvent mark_to_drop = 6;
-    CloneEvent clone = 7;
-    PacketIngressEvent packet_ingress = 8;
-    PipelineStageEvent pipeline_stage = 9;
-    CloneSessionLookupEvent clone_session_lookup = 10;
     LogMessageEvent log_message = 11;
     AssertionEvent assertion = 12;
+
+    // Packet replication engine (PRE).
+    CloneEvent clone = 7;
+    CloneSessionLookupEvent clone_session_lookup = 10;
+    MulticastGroupLookupEvent multicast_group_lookup = 15;
+
+    // Packet fate.
+    MarkToDropEvent mark_to_drop = 6;
+
+    // Deparser.
     DeparserEmitEvent deparser_emit = 13;
-    AssignmentEvent assignment = 14;
   }
 
   SourceInfo source_info = 100;
@@ -219,6 +233,16 @@ message CloneSessionLookupEvent {
   // Total number of replicas in the clone session. Multi-replica sessions
   // (e.g., mirror-and-punt) produce one clone branch per replica.
   uint32 replica_count = 6;
+}
+
+// Fired at the ingress→egress boundary when the traffic manager resolves a
+// multicast group. Analogous to CloneSessionLookupEvent.
+message MulticastGroupLookupEvent {
+  uint32 multicast_group_id = 1;
+  optional bool group_found =
+      2;  // false = group not configured, multicast silently skipped
+  uint32 replica_count =
+      3;  // number of replicas in the group; only meaningful when found
 }
 
 // Fired when a packet arrives at the pipeline — the very first event in any


### PR DESCRIPTION
## Summary

Adds a `MulticastGroupLookupEvent` trace event — the multicast analog of `CloneSessionLookupEvent`. Records which multicast group was resolved and whether it was found. Emitted by both v1model and PSA at the ingress→egress boundary.

The reproducer extractor now reads this event to extract the *specific* multicast group entity that the trace references, instead of including all multicast groups from the snapshot. Closes #673.

Also reorders `TraceEvent` oneof fields by semantic group (pipeline lifecycle → parser → control flow → externs → PRE → fate → deparser) while preserving wire numbers. Pre-1.0 is the time to do this.

### Changes

| Component | Change |
|---|---|
| `simulator.proto` | Add `MulticastGroupLookupEvent` message and oneof field; reorder events semantically |
| `V1ModelArchitecture.kt` | Emit lookup/miss events when resolving `mcast_grp` |
| `PSAArchitecture.kt` | Emit lookup/miss events when resolving multicast group |
| `TraceHelpers.kt` | Shared `multicastGroupLookupEvent` / `multicastGroupMissEvent` builders |
| `ReproducerExtractor.kt` | Extract specific group from event instead of dumping all groups |
| `ReproducerExtractorTest.kt` | Updated multicast test + new miss test |
| Golden files | 4 multicast golden traces updated with new event |
| `LIMITATIONS.md` | Removed multicast limitation |

## Test plan

- [x] Unit tests: multicast group lookup → extracts specific group; miss → no entities
- [x] E2E test: multicast reproducer extracts the right group (unchanged, still passes)
- [x] Golden trace tree tests updated and passing
- [x] Full test suite passes (79/79)

🤖 Generated with [Claude Code](https://claude.com/claude-code)