### PR TITLE
compileInlineP4: use JCPP for preprocessing, drop cc dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,14 +16,15 @@ git worktree remove ../4ward-<branch>
 git worktree prune
 ```
 
-## Understand ideal before settling for less
+## Build the ideal, not "good enough"
 
 Before committing to any design or implementation, define what the ideal
 solution looks like — unconstrained by schedule, legacy, or expedience.
-You don't have to build the ideal, but YOU MUST UNDERSTAND IT. A pragmatic
-shortcut is a legitimate engineering choice; a shortcut you took because you
-never considered the alternative is just a blind spot. Name the north star,
-name what you're trading away, and name why.
+Then build it. "Good enough" is how mediocre code happens; aim for the
+optimum. A pragmatic shortcut is a legitimate engineering choice when
+you've considered the ideal and have a concrete reason to defer it — but
+the default should be to do the right thing, not to stop early. Name the
+north star, name what you're trading away, and name why.
 
 ## Test-driven development
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -123,6 +123,7 @@ maven.install(
         "io.grpc:grpc-stub:1.78.0",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
+        "org.anarres:jcpp:1.4.14",
     ],
     repositories = [
         "https://repo1.maven.org/maven2",

--- a/e2e_tests/BUILD.bazel
+++ b/e2e_tests/BUILD.bazel
@@ -55,6 +55,7 @@ kt_jvm_library(
         "//bazel:runfiles",
         "//simulator:ir_java_proto",
         "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:org_anarres_jcpp",
     ],
 )
 

--- a/e2e_tests/InlineP4Compiler.kt
+++ b/e2e_tests/InlineP4Compiler.kt
@@ -2,11 +2,21 @@ package fourward.e2e
 
 import com.google.protobuf.TextFormat
 import fourward.PipelineConfig
+import java.io.StringReader
 import java.nio.file.Files
+import org.anarres.cpp.DefaultPreprocessorListener
+import org.anarres.cpp.Feature
+import org.anarres.cpp.InputLexerSource
+import org.anarres.cpp.Preprocessor
+import org.anarres.cpp.Token
 
 /**
  * Compiles a P4 source string at test time using p4c-4ward. Useful for tests that need a custom P4
  * program without a dedicated BUILD target.
+ *
+ * Preprocessing (`#include`, `#define`, etc.) is handled by JCPP (a pure-Java C preprocessor), so
+ * no native `cc` binary is needed at test time. The preprocessed source is passed to p4c with
+ * `--nocpp`.
  *
  * Example:
  * ```
@@ -21,13 +31,8 @@ import java.nio.file.Files
  *
  * Requires the test's BUILD target to include:
  * ```
- * data = [
- *     "//e2e_tests:cc_shim",
- *     "//p4c_backend:p4c-4ward",
- *     "@p4c//p4include",
- * ],
+ * data = ["//p4c_backend:p4c-4ward", "@p4c//p4include"],
  * jvm_flags = [
- *     "-Dcc_shim=$(rlocationpath //e2e_tests:cc_shim)",
  *     "-Dp4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
  *     "-Dp4include=$(rlocationpath @p4c//p4include:core.p4)",
  * ],
@@ -36,25 +41,18 @@ import java.nio.file.Files
 fun compileInlineP4(source: String): PipelineConfig {
   val p4cBinary = fourward.bazel.resolveRunfileProperty("p4c_4ward")
   val p4includeDir = fourward.bazel.resolveRunfileProperty("p4include").parent
+  val preprocessed = preprocess(source, p4includeDir.toString())
 
   val tmpDir = Files.createTempDirectory("inline-p4")
   try {
     val srcFile = tmpDir.resolve("program.p4")
     val outFile = tmpDir.resolve("pipeline.txtpb")
-    Files.writeString(srcFile, source)
+    Files.writeString(srcFile, preprocessed)
 
-    val pb =
-      ProcessBuilder(
-          p4cBinary.toString(),
-          srcFile.toString(),
-          "-o",
-          outFile.toString(),
-          "-I",
-          p4includeDir.toString(),
-        )
+    val process =
+      ProcessBuilder(p4cBinary.toString(), srcFile.toString(), "-o", outFile.toString(), "--nocpp")
         .redirectErrorStream(true)
-    fourward.bazel.ensureCcOnPath(pb)
-    val process = pb.start()
+        .start()
 
     val output = process.inputStream.bufferedReader().readText()
     val exitCode = process.waitFor()
@@ -65,5 +63,24 @@ fun compileInlineP4(source: String): PipelineConfig {
     return builder.build()
   } finally {
     tmpDir.toFile().deleteRecursively()
+  }
+}
+
+/** Preprocesses P4 source using JCPP (pure-Java C preprocessor). */
+private fun preprocess(source: String, includeDir: String): String {
+  val pp = Preprocessor()
+  pp.listener = DefaultPreprocessorListener()
+  pp.addFeature(Feature.LINEMARKERS)
+  pp.systemIncludePath = listOf(includeDir)
+  pp.addInput(InputLexerSource(StringReader(source)))
+
+  return pp.use {
+    val out = StringBuilder()
+    while (true) {
+      val tok = it.token()
+      if (tok.type == Token.EOF) break
+      out.append(tok.text)
+    }
+    out.toString()
   }
 }

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -220,13 +220,11 @@ kt_jvm_test(
         "FourwardTestHarness.kt",
     ],
     data = [
-        "//e2e_tests:cc_shim",
         "//p4c_backend:p4c-4ward",
         "@p4c//p4include",
         "@p4c//p4include:core.p4",
     ],
     jvm_flags = [
-        "-Dcc_shim=$(rlocationpath //e2e_tests:cc_shim)",
         "-Dp4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
         "-Dp4include=$(rlocationpath @p4c//p4include:core.p4)",
     ],


### PR DESCRIPTION
## Summary

Replace the native `cc` preprocessor with JCPP (a pure-Java C
preprocessor, already available in google3 as `org.anarres:jcpp:1.4.14`).
The preprocessed source is passed to p4c with `--nocpp`.

This eliminates the entire class of architecture-mismatch bugs from #666.
The cc_shim needed a native `cc` matching the test machine's
architecture, but the CC toolchain only provides cross-compilers for the
build host — fundamentally incompatible with TAP's multi-arch test
execution.

JCPP runs on any JVM. No native binary, no architecture concerns, no
runfiles path resolution. Five files changed, net reduction in complexity.

The cc_shim remains for the web playground (runtime P4 compilation);
migrating that to JCPP is a natural follow-up.

Also updates AGENTS.md: "Build the ideal, not good enough."

Fixes #666.

## Test plan

- [x] All 79 non-heavy tests pass
- [x] Format + lint clean
- [ ] google3 verification (JCPP 1.4.14 already available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)