### PR TITLE
DataplaneClient: overloaded port types, streaming PacketWriter

### DIFF
--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -48,7 +48,6 @@ cc_library(
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/synchronization",
         "@abseil-cpp//absl/time",
-        "@abseil-cpp//absl/types:span",
         "@grpc//:grpc++",
     ],
 )
@@ -88,7 +87,6 @@ cc_test(
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/time",
-        "@abseil-cpp//absl/types:span",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/fourward_cc/dataplane_client.cc
+++ b/fourward_cc/dataplane_client.cc
@@ -8,9 +8,9 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
-#include <variant>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/status/status.h"
@@ -18,7 +18,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
-#include "absl/types/span.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/support/status.h"
 #include "grpcpp/support/sync_stream.h"
@@ -42,97 +41,180 @@ std::chrono::system_clock::time_point AbsoluteDeadline(
       std::chrono::system_clock::now() + absl::ToChronoNanoseconds(relative));
 }
 
-template <class... Ts>
-struct overloaded : Ts... { using Ts::operator()...; };
+InjectPacketRequest MakeRequest(DataplanePort ingress_port,
+                                std::string_view payload) {
+  InjectPacketRequest req;
+  req.set_dataplane_ingress_port(ingress_port.port);
+  req.set_payload(payload.data(), payload.size());
+  return req;
+}
 
-fourward::InjectPacketRequest ToProto(
-    const InjectPacketArgs& args) {
-  fourward::InjectPacketRequest req;
-  std::visit(overloaded{
-                 [&](const DataplanePort& p) {
-                   req.set_dataplane_ingress_port(p.port);
-                 },
-                 [&](const P4RuntimePort& p) {
-                   req.set_p4rt_ingress_port(p.port);
-                 },
-             },
-             args.ingress_port);
-  req.set_payload(args.payload);
+InjectPacketRequest MakeRequest(P4RuntimePort ingress_port,
+                                std::string_view payload) {
+  InjectPacketRequest req;
+  req.set_p4rt_ingress_port(std::move(ingress_port.port));
+  req.set_payload(payload.data(), payload.size());
   return req;
 }
 
 }  // namespace
 
+// -- DataplaneClient ----------------------------------------------------------
+
 DataplaneClient::DataplaneClient(const FourwardServer& server,
                                  absl::Duration default_timeout)
     : DataplaneClient(server.NewDataplaneStub(), default_timeout) {}
 
-DataplaneClient::DataplaneClient(
-    std::unique_ptr<fourward::Dataplane::Stub> stub,
-    absl::Duration default_timeout)
+DataplaneClient::DataplaneClient(std::unique_ptr<Dataplane::Stub> stub,
+                                 absl::Duration default_timeout)
     : stub_(std::move(stub)), default_timeout_(default_timeout) {}
 
 DataplaneClient::~DataplaneClient() = default;
 DataplaneClient::DataplaneClient(DataplaneClient&&) = default;
-DataplaneClient& DataplaneClient::operator=(DataplaneClient&&) =
-    default;
+DataplaneClient& DataplaneClient::operator=(DataplaneClient&&) = default;
 
-absl::StatusOr<fourward::InjectPacketResponse>
-DataplaneClient::InjectPacket(const InjectPacketArgs& args,
-                              std::optional<absl::Duration> timeout) {
+absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
+    DataplanePort ingress_port, std::string_view payload,
+    std::optional<absl::Duration> timeout) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
-  fourward::InjectPacketRequest req = ToProto(args);
-  fourward::InjectPacketResponse resp;
+  InjectPacketRequest req = MakeRequest(ingress_port, payload);
+  InjectPacketResponse resp;
   grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
   return resp;
 }
 
-absl::StatusOr<fourward::Reproducer>
-DataplaneClient::ReproduceTrace(const InjectPacketArgs& args,
-                                std::optional<absl::Duration> timeout) {
+absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
+    P4RuntimePort ingress_port, std::string_view payload,
+    std::optional<absl::Duration> timeout) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
-  fourward::InjectPacketRequest req = ToProto(args);
-  fourward::Reproducer resp;
+  InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload);
+  InjectPacketResponse resp;
+  grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
+  if (!status.ok()) return ToAbsl(status);
+  return resp;
+}
+
+absl::StatusOr<Reproducer> DataplaneClient::ReproduceTrace(
+    DataplanePort ingress_port, std::string_view payload,
+    std::optional<absl::Duration> timeout) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
+  InjectPacketRequest req = MakeRequest(ingress_port, payload);
+  Reproducer resp;
   grpc::Status status = stub_->ReproduceTrace(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
   return resp;
 }
 
-absl::Status DataplaneClient::InjectPackets(
-    absl::Span<const InjectPacketArgs> args,
+absl::StatusOr<Reproducer> DataplaneClient::ReproduceTrace(
+    P4RuntimePort ingress_port, std::string_view payload,
     std::optional<absl::Duration> timeout) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
-  fourward::InjectPacketsResponse resp;
-  std::unique_ptr<
-      grpc::ClientWriter<fourward::InjectPacketRequest>>
-      writer = stub_->InjectPackets(&ctx, &resp);
-  for (const InjectPacketArgs& arg : args) {
-    fourward::InjectPacketRequest req = ToProto(arg);
-    if (!writer->Write(req)) {
-      return ToAbsl(writer->Finish());
-    }
-  }
-  writer->WritesDone();
-  return ToAbsl(writer->Finish());
+  InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload);
+  Reproducer resp;
+  grpc::Status status = stub_->ReproduceTrace(&ctx, req, &resp);
+  if (!status.ok()) return ToAbsl(status);
+  return resp;
 }
+
+// -- PacketWriter -------------------------------------------------------------
+
+class PacketWriter::Impl {
+ public:
+  static std::unique_ptr<Impl> Create(
+      Dataplane::Stub* stub,
+      std::unique_ptr<grpc::ClientContext> context) {
+    std::unique_ptr<Impl> impl(new Impl);
+    impl->context_ = std::move(context);
+    impl->writer_ =
+        stub->InjectPackets(impl->context_.get(), &impl->response_);
+    return impl;
+  }
+
+  absl::Status Inject(InjectPacketRequest req) {
+    if (finished_) {
+      return finished_status_.ok()
+                 ? absl::FailedPreconditionError("PacketWriter is finished")
+                 : finished_status_;
+    }
+    if (!writer_->Write(req)) return DoFinish();
+    ++count_;
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<int> Finish() {
+    if (finished_) {
+      if (!finished_status_.ok()) return finished_status_;
+      return count_;
+    }
+    writer_->WritesDone();
+    absl::Status status = DoFinish();
+    if (!status.ok()) return status;
+    return count_;
+  }
+
+ private:
+  Impl() = default;
+
+  absl::Status DoFinish() {
+    finished_ = true;
+    finished_status_ = ToAbsl(writer_->Finish());
+    return finished_status_;
+  }
+
+  std::unique_ptr<grpc::ClientContext> context_;
+  InjectPacketsResponse response_;
+  std::unique_ptr<grpc::ClientWriter<InjectPacketRequest>> writer_;
+  bool finished_ = false;
+  int count_ = 0;
+  absl::Status finished_status_;
+};
+
+PacketWriter DataplaneClient::InjectPackets(
+    std::optional<absl::Duration> timeout) {
+  auto context = std::make_unique<grpc::ClientContext>();
+  context->set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
+  return PacketWriter(
+      PacketWriter::Impl::Create(stub_.get(), std::move(context)));
+}
+
+PacketWriter::~PacketWriter() {
+  if (impl_ != nullptr) (void)impl_->Finish();
+}
+PacketWriter::PacketWriter(PacketWriter&&) = default;
+PacketWriter& PacketWriter::operator=(PacketWriter&&) = default;
+PacketWriter::PacketWriter(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
+
+absl::Status PacketWriter::Inject(DataplanePort ingress_port,
+                                  std::string_view payload) {
+  return impl_->Inject(MakeRequest(ingress_port, payload));
+}
+
+absl::Status PacketWriter::Inject(P4RuntimePort ingress_port,
+                                  std::string_view payload) {
+  return impl_->Inject(MakeRequest(std::move(ingress_port), payload));
+}
+
+absl::StatusOr<int> PacketWriter::Finish() { return impl_->Finish(); }
+
+// -- ResultStream -------------------------------------------------------------
 
 class ResultStream::Impl {
  public:
   static absl::StatusOr<std::unique_ptr<Impl>> Create(
-      fourward::Dataplane::Stub* stub,
-      absl::Duration startup_timeout);
+      Dataplane::Stub* stub, absl::Duration startup_timeout);
 
   ~Impl();
 
   Impl(const Impl&) = delete;
   Impl& operator=(const Impl&) = delete;
 
-  absl::StatusOr<fourward::ProcessPacketResult> Next(
-      absl::Duration timeout);
+  absl::StatusOr<ProcessPacketResult> Next(absl::Duration timeout);
 
  private:
   Impl() = default;
@@ -148,26 +230,22 @@ class ResultStream::Impl {
   }
 
   std::unique_ptr<grpc::ClientContext> context_;
-  std::unique_ptr<
-      grpc::ClientReader<fourward::SubscribeResultsResponse>>
-      reader_;
+  std::unique_ptr<grpc::ClientReader<SubscribeResultsResponse>> reader_;
   std::thread thread_;
 
   absl::Mutex mu_;
   State state_ ABSL_GUARDED_BY(mu_) = State::kRunning;
   bool sentinel_received_ ABSL_GUARDED_BY(mu_) = false;
-  std::deque<fourward::ProcessPacketResult> queue_
-      ABSL_GUARDED_BY(mu_);
+  std::deque<ProcessPacketResult> queue_ ABSL_GUARDED_BY(mu_);
   absl::Status final_status_ ABSL_GUARDED_BY(mu_) =
       absl::InternalError("stream not yet finished");
 };
 
 absl::StatusOr<std::unique_ptr<ResultStream::Impl>> ResultStream::Impl::Create(
-    fourward::Dataplane::Stub* stub,
-    absl::Duration startup_timeout) {
+    Dataplane::Stub* stub, absl::Duration startup_timeout) {
   std::unique_ptr<Impl> impl(new Impl);
   impl->context_ = std::make_unique<grpc::ClientContext>();
-  fourward::SubscribeResultsRequest req;
+  SubscribeResultsRequest req;
   impl->reader_ = stub->SubscribeResults(impl->context_.get(), req);
 
   Impl* raw = impl.get();
@@ -202,7 +280,7 @@ ResultStream::Impl::~Impl() {
 }
 
 void ResultStream::Impl::ReadLoop() {
-  fourward::SubscribeResultsResponse first;
+  SubscribeResultsResponse first;
   if (!reader_->Read(&first) || !first.has_active()) {
     grpc::Status status = reader_->Finish();
     absl::MutexLock lock(&mu_);
@@ -222,7 +300,7 @@ void ResultStream::Impl::ReadLoop() {
     sentinel_received_ = true;
   }
 
-  fourward::SubscribeResultsResponse resp;
+  SubscribeResultsResponse resp;
   while (reader_->Read(&resp)) {
     if (!resp.has_result()) continue;
     absl::MutexLock lock(&mu_);
@@ -234,8 +312,8 @@ void ResultStream::Impl::ReadLoop() {
   final_status_ = ToAbsl(status);
 }
 
-absl::StatusOr<fourward::ProcessPacketResult>
-ResultStream::Impl::Next(absl::Duration timeout) {
+absl::StatusOr<ProcessPacketResult> ResultStream::Impl::Next(
+    absl::Duration timeout) {
   absl::MutexLock lock(&mu_);
   if (!mu_.AwaitWithTimeout(absl::Condition(this, &Impl::QueueOrFinished),
                             timeout)) {
@@ -243,7 +321,7 @@ ResultStream::Impl::Next(absl::Duration timeout) {
         "ResultStream::Next: no result within ", absl::FormatDuration(timeout)));
   }
   if (!queue_.empty()) {
-    fourward::ProcessPacketResult result = std::move(queue_.front());
+    ProcessPacketResult result = std::move(queue_.front());
     queue_.pop_front();
     return result;
   }
@@ -257,9 +335,10 @@ ResultStream::Impl::Next(absl::Duration timeout) {
 ResultStream::~ResultStream() = default;
 ResultStream::ResultStream(ResultStream&&) = default;
 ResultStream& ResultStream::operator=(ResultStream&&) = default;
-ResultStream::ResultStream(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+ResultStream::ResultStream(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
 
-absl::StatusOr<fourward::ProcessPacketResult> ResultStream::Next(
+absl::StatusOr<ProcessPacketResult> ResultStream::Next(
     absl::Duration timeout) {
   return impl_->Next(timeout);
 }

--- a/fourward_cc/dataplane_client.h
+++ b/fourward_cc/dataplane_client.h
@@ -11,31 +11,31 @@
 //   ASSIGN_OR_RETURN(fourward::FourwardServer server,
 //                    fourward::FourwardServer::Start());
 //
-//   // Use default 10s timeout for everything:
 //   fourward::DataplaneClient dataplane(server);
 //
-//   // Or configure a longer default for slow networks:
-//   fourward::DataplaneClient dataplane(server, absl::Seconds(30));
-//
 //   ASSIGN_OR_RETURN(auto response,
-//                    dataplane.InjectPacket({
-//                        .ingress_port = fourward::DataplanePort{.port = 0},
-//                        .payload = "...",
-//                    }));
+//                    dataplane.InjectPacket(
+//                        fourward::DataplanePort{0}, "..."));
 //
 //   // Override timeout per-call when needed:
-//   dataplane.InjectPacket(args, absl::Seconds(1));
+//   dataplane.InjectPacket(fourward::DataplanePort{0}, "...",
+//                          absl::Seconds(1));
+//
+//   // Streaming injection:
+//   auto writer = dataplane.InjectPackets();
+//   writer.Inject(fourward::DataplanePort{0}, payload1);
+//   writer.Inject(fourward::DataplanePort{1}, payload2);
+//   ASSIGN_OR_RETURN(int count, writer.Finish());
 
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
-#include <variant>
+#include <string_view>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
-#include "absl/types/span.h"
 #include "fourward_cc/fourward_server.h"
 #include "grpc/dataplane.grpc.pb.h"
 #include "grpc/dataplane.pb.h"
@@ -52,11 +52,29 @@ struct P4RuntimePort {
   std::string port;
 };
 
-// Mirrors fourward.InjectPacketRequest with the proto's
-// `ingress_port` oneof modeled as a std::variant.
-struct InjectPacketArgs {
-  std::variant<DataplanePort, P4RuntimePort> ingress_port;
-  std::string payload;
+// RAII handle for a client-streaming InjectPackets RPC. Destructor calls
+// Finish() if not already called.
+//
+// Not thread-safe: callers must serialize Inject/Finish calls.
+class PacketWriter {
+ public:
+  ~PacketWriter();
+  PacketWriter(PacketWriter&&);
+  PacketWriter& operator=(PacketWriter&&);
+  PacketWriter(const PacketWriter&) = delete;
+  PacketWriter& operator=(const PacketWriter&) = delete;
+
+  absl::Status Inject(DataplanePort ingress_port, std::string_view payload);
+  absl::Status Inject(P4RuntimePort ingress_port, std::string_view payload);
+
+  // Signals end-of-stream and returns the number of packets injected.
+  absl::StatusOr<int> Finish();
+
+ private:
+  friend class DataplaneClient;
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+  explicit PacketWriter(std::unique_ptr<Impl> impl);
 };
 
 // RAII handle for an open SubscribeResults stream. Destructor cancels and
@@ -73,7 +91,7 @@ class ResultStream {
 
   // Blocks up to `timeout` for the next result. Returns
   // DeadlineExceededError on timeout, CancelledError when the stream ends.
-  absl::StatusOr<fourward::ProcessPacketResult> Next(
+  absl::StatusOr<ProcessPacketResult> Next(
       absl::Duration timeout = absl::Seconds(10));
 
  private:
@@ -84,16 +102,16 @@ class ResultStream {
 };
 
 // Ergonomic C++ client for the 4ward Dataplane gRPC service. Wraps the
-// InjectPacket, InjectPackets, and SubscribeResults RPCs; names mirror
-// dataplane.proto one-to-one. RegisterPrePacketHook is intentionally not
-// wrapped — use the raw stub for advanced use cases.
+// InjectPacket, InjectPackets, SubscribeResults, and ReproduceTrace RPCs;
+// names mirror dataplane.proto one-to-one. RegisterPrePacketHook is
+// intentionally not wrapped — use the raw stub for advanced use cases.
 //
 // Thread-safe: each method uses its own ClientContext.
 class DataplaneClient {
  public:
   explicit DataplaneClient(const FourwardServer& server,
                            absl::Duration default_timeout = absl::Seconds(10));
-  explicit DataplaneClient(std::unique_ptr<fourward::Dataplane::Stub> stub,
+  explicit DataplaneClient(std::unique_ptr<Dataplane::Stub> stub,
                            absl::Duration default_timeout = absl::Seconds(10));
 
   ~DataplaneClient();
@@ -102,19 +120,23 @@ class DataplaneClient {
   DataplaneClient(const DataplaneClient&) = delete;
   DataplaneClient& operator=(const DataplaneClient&) = delete;
 
-  absl::StatusOr<fourward::InjectPacketResponse> InjectPacket(
-      const InjectPacketArgs& args,
+  absl::StatusOr<InjectPacketResponse> InjectPacket(
+      DataplanePort ingress_port, std::string_view payload,
+      std::optional<absl::Duration> timeout = std::nullopt);
+  absl::StatusOr<InjectPacketResponse> InjectPacket(
+      P4RuntimePort ingress_port, std::string_view payload,
       std::optional<absl::Duration> timeout = std::nullopt);
 
-  // Results are delivered via SubscribeResults, not in the response.
-  absl::Status InjectPackets(
-      absl::Span<const InjectPacketArgs> args,
+  // Returns a writer for streaming packet injection. Results are delivered
+  // via SubscribeResults, not inline.
+  PacketWriter InjectPackets(
       std::optional<absl::Duration> timeout = std::nullopt);
 
-  // Inject a packet and return a self-contained Reproducer for the
-  // resulting trace.
-  absl::StatusOr<fourward::Reproducer> ReproduceTrace(
-      const InjectPacketArgs& args,
+  absl::StatusOr<Reproducer> ReproduceTrace(
+      DataplanePort ingress_port, std::string_view payload,
+      std::optional<absl::Duration> timeout = std::nullopt);
+  absl::StatusOr<Reproducer> ReproduceTrace(
+      P4RuntimePort ingress_port, std::string_view payload,
       std::optional<absl::Duration> timeout = std::nullopt);
 
   // Blocks until the server confirms the subscription is active. The
@@ -127,7 +149,7 @@ class DataplaneClient {
     return override.value_or(default_timeout_);
   }
 
-  std::unique_ptr<fourward::Dataplane::Stub> stub_;
+  std::unique_ptr<Dataplane::Stub> stub_;
   absl::Duration default_timeout_;
 };
 

--- a/fourward_cc/dataplane_client_e2e_test.cc
+++ b/fourward_cc/dataplane_client_e2e_test.cc
@@ -12,7 +12,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -134,11 +133,8 @@ class DataplaneClientE2ETest : public ::testing::Test {
 TEST_F(DataplaneClientE2ETest, InjectPacketReturnsTraceAndOutputs) {
   DataplaneClient client(*server_);
 
-  absl::StatusOr<fourward::InjectPacketResponse> resp =
-      client.InjectPacket({
-          .ingress_port = DataplanePort{.port = 0},
-          .payload = MakeEthernetFrame(),
-      });
+  absl::StatusOr<InjectPacketResponse> resp =
+      client.InjectPacket(DataplanePort{0}, MakeEthernetFrame());
   ASSERT_TRUE(resp.ok()) << resp.status();
   EXPECT_THAT(*resp, ForwardsTo(1));
   EXPECT_FALSE(resp->trace().DebugString().empty());
@@ -151,15 +147,11 @@ TEST_F(DataplaneClientE2ETest, SubscribeResultsDeliversInjectedPacket) {
   ASSERT_TRUE(stream.ok()) << stream.status();
 
   // Inject via the unary RPC; the result should also appear on the stream.
-  absl::StatusOr<fourward::InjectPacketResponse> inject =
-      client.InjectPacket({
-          .ingress_port = DataplanePort{.port = 0},
-          .payload = MakeEthernetFrame(),
-      });
+  absl::StatusOr<InjectPacketResponse> inject =
+      client.InjectPacket(DataplanePort{0}, MakeEthernetFrame());
   ASSERT_TRUE(inject.ok()) << inject.status();
 
-  absl::StatusOr<fourward::ProcessPacketResult> result =
-      stream->Next();
+  absl::StatusOr<ProcessPacketResult> result = stream->Next();
   ASSERT_TRUE(result.ok()) << result.status();
   EXPECT_THAT(*result, ForwardsTo(1));
   EXPECT_THAT(*result, HasIngress(0));
@@ -171,18 +163,15 @@ TEST_F(DataplaneClientE2ETest, InjectPacketsResultsDeliveredViaSubscribe) {
   absl::StatusOr<ResultStream> stream = client.SubscribeResults();
   ASSERT_TRUE(stream.ok()) << stream.status();
 
-  std::vector<InjectPacketArgs> batch = {
-      {.ingress_port = DataplanePort{.port = 0},
-       .payload = MakeEthernetFrame()},
-      {.ingress_port = DataplanePort{.port = 2},
-       .payload = MakeEthernetFrame()},
-  };
-  absl::Status status = client.InjectPackets(absl::MakeConstSpan(batch));
-  ASSERT_TRUE(status.ok()) << status;
+  PacketWriter writer = client.InjectPackets();
+  ASSERT_TRUE(writer.Inject(DataplanePort{0}, MakeEthernetFrame()).ok());
+  ASSERT_TRUE(writer.Inject(DataplanePort{2}, MakeEthernetFrame()).ok());
+  absl::StatusOr<int> count = writer.Finish();
+  ASSERT_TRUE(count.ok()) << count.status();
+  ASSERT_EQ(*count, 2);
 
-  for (int i = 0; i < 2; ++i) {
-    absl::StatusOr<fourward::ProcessPacketResult> result =
-        stream->Next();
+  for (int i = 0; i < *count; ++i) {
+    absl::StatusOr<ProcessPacketResult> result = stream->Next();
     ASSERT_TRUE(result.ok()) << "result " << i << ": " << result.status();
     EXPECT_THAT(*result, ForwardsTo(1));
   }
@@ -194,11 +183,10 @@ TEST_F(DataplaneClientE2ETest,
 
   // The passthrough program has no @p4runtime_translation on its port type.
   // Injecting via P4RuntimePort must fail with FAILED_PRECONDITION.
-  absl::StatusOr<fourward::InjectPacketResponse> resp =
-      client.InjectPacket({
-          .ingress_port = P4RuntimePort{.port = std::string("\x00\x01", 2)},
-          .payload = MakeEthernetFrame(),
-      });
+  absl::StatusOr<InjectPacketResponse> resp =
+      client.InjectPacket(
+          P4RuntimePort{std::string("\x00\x01", 2)},
+          MakeEthernetFrame());
   ASSERT_FALSE(resp.ok());
   EXPECT_EQ(resp.status().code(), absl::StatusCode::kFailedPrecondition)
       << resp.status();

--- a/fourward_cc/dataplane_client_test.cc
+++ b/fourward_cc/dataplane_client_test.cc
@@ -6,12 +6,10 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
-#include "absl/types/span.h"
 #include "gtest/gtest.h"
 #include "grpc/dataplane.pb.h"
 #include "fourward_cc/fourward_server.h"
@@ -41,7 +39,7 @@ TEST_F(DataplaneClientTest, SubscribeResultsConfirmsActiveAndCancelsCleanly) {
   ASSERT_TRUE(stream.ok()) << stream.status();
 
   // No pipeline loaded — no results will arrive.
-  absl::StatusOr<fourward::ProcessPacketResult> next =
+  absl::StatusOr<ProcessPacketResult> next =
       stream->Next(absl::Milliseconds(50));
   ASSERT_FALSE(next.ok());
   EXPECT_EQ(next.status().code(), absl::StatusCode::kDeadlineExceeded)
@@ -63,10 +61,9 @@ TEST_F(DataplaneClientTest, SubscribeResultsRespectsStartupTimeout) {
 TEST_F(DataplaneClientTest, InjectPacketDataplanePortDeadlinePropagated) {
   DataplaneClient client(*server_);
 
-  absl::StatusOr<fourward::InjectPacketResponse> resp =
-      client.InjectPacket(
-          {.ingress_port = DataplanePort{.port = 0}, .payload = "x"},
-          absl::Nanoseconds(1));
+  absl::StatusOr<InjectPacketResponse> resp =
+      client.InjectPacket(DataplanePort{0}, "x",
+                          absl::Nanoseconds(1));
   ASSERT_FALSE(resp.ok());
   EXPECT_EQ(resp.status().code(), absl::StatusCode::kDeadlineExceeded)
       << resp.status();
@@ -75,37 +72,33 @@ TEST_F(DataplaneClientTest, InjectPacketDataplanePortDeadlinePropagated) {
 TEST_F(DataplaneClientTest, InjectPacketP4RuntimePortDeadlinePropagated) {
   DataplaneClient client(*server_);
 
-  absl::StatusOr<fourward::InjectPacketResponse> resp =
+  absl::StatusOr<InjectPacketResponse> resp =
       client.InjectPacket(
-          {.ingress_port = P4RuntimePort{.port = std::string("\x00\x01", 2)},
-           .payload = "x"},
+          P4RuntimePort{std::string("\x00\x01", 2)}, "x",
           absl::Nanoseconds(1));
   ASSERT_FALSE(resp.ok());
   EXPECT_EQ(resp.status().code(), absl::StatusCode::kDeadlineExceeded)
       << resp.status();
 }
 
-TEST_F(DataplaneClientTest, InjectPacketsAcceptsEmptyBatch) {
+TEST_F(DataplaneClientTest, InjectPacketsWriterFinishesCleanly) {
   DataplaneClient client(*server_);
 
-  std::vector<InjectPacketArgs> empty;
-  absl::Status status = client.InjectPackets(absl::MakeConstSpan(empty));
-  EXPECT_TRUE(status.ok()) << status;
+  PacketWriter writer = client.InjectPackets();
+  absl::StatusOr<int> count = writer.Finish();
+  ASSERT_TRUE(count.ok()) << count.status();
+  EXPECT_EQ(*count, 0);
 }
 
-TEST_F(DataplaneClientTest, InjectPacketsNonEmptyBatchDeadlinePropagated) {
+TEST_F(DataplaneClientTest, InjectPacketsDeadlinePropagated) {
   DataplaneClient client(*server_);
 
-  std::vector<InjectPacketArgs> batch = {
-      {.ingress_port = DataplanePort{.port = 0}, .payload = "a"},
-      {.ingress_port = DataplanePort{.port = 1}, .payload = "b"},
-      {.ingress_port = P4RuntimePort{.port = std::string("\x00\x02", 2)},
-       .payload = "c"},
-  };
-  absl::Status status =
-      client.InjectPackets(absl::MakeConstSpan(batch), absl::Nanoseconds(1));
-  ASSERT_FALSE(status.ok());
-  EXPECT_EQ(status.code(), absl::StatusCode::kDeadlineExceeded) << status;
+  PacketWriter writer = client.InjectPackets(absl::Nanoseconds(1));
+  absl::Status inject = writer.Inject(DataplanePort{0}, "a");
+  // Either the inject or finish will surface the deadline error.
+  absl::StatusOr<int> finish = writer.Finish();
+  EXPECT_TRUE(!inject.ok() || !finish.ok())
+      << "inject: " << inject << ", finish: " << finish.status();
 }
 
 TEST_F(DataplaneClientTest, MoveConstructionPreservesStub) {
@@ -123,7 +116,7 @@ TEST_F(DataplaneClientTest, ResultStreamMoveConstructionPreservesStream) {
 
   ResultStream moved = *std::move(original);
 
-  absl::StatusOr<fourward::ProcessPacketResult> next =
+  absl::StatusOr<ProcessPacketResult> next =
       moved.Next(absl::Milliseconds(50));
   ASSERT_FALSE(next.ok());
   EXPECT_EQ(next.status().code(), absl::StatusCode::kDeadlineExceeded)


### PR DESCRIPTION
## Summary

Replaces `InjectPacketArgs` with a simpler, more ergonomic API:

- **Overloaded methods** for `InjectPacket` and `ReproduceTrace` — callers pass `DataplanePort` or `P4RuntimePort` directly instead of wrapping in a struct with a `std::variant`. This eliminates `InjectPacketArgs`, the `overloaded` template, and the `ToProto` helper.

- **`PacketWriter`** for streaming injection — `InjectPackets()` returns an RAII handle instead of taking a pre-built span. Callers inject packets one at a time with `writer.Inject(port, payload)`, supporting mixed port types and caller-controlled pacing. `Finish()` returns the number of packets successfully injected. Symmetric with `ResultStream` on the output side.

- **Stripped redundant `fourward::` qualifiers** — we're inside `namespace fourward`.

Before:
```cpp
client.InjectPacket({
    .ingress_port = DataplanePort{.port = 0},
    .payload = "...",
});

std::vector<InjectPacketArgs> batch = { ... };
client.InjectPackets(absl::MakeConstSpan(batch));
```

After:
```cpp
client.InjectPacket(DataplanePort{0}, "...");

auto writer = client.InjectPackets();
writer.Inject(DataplanePort{0}, payload1);
writer.Inject(DataplanePort{1}, payload2);
ASSIGN_OR_RETURN(int count, writer.Finish());
```

Stacks on #688.

## Test plan

- [x] `bazel test //fourward_cc/...` — all 4 targets pass
- [x] Updated unit tests for new overload signatures
- [x] Updated e2e tests for `PacketWriter` streaming API
- [x] Verified no remaining references to `InjectPacketArgs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)