### PR TITLE
Rename ReproduceTrace RPC to GetReproducer

### DIFF
--- a/fourward_cc/dataplane_client.cc
+++ b/fourward_cc/dataplane_client.cc
@@ -97,26 +97,26 @@ absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
   return resp;
 }
 
-absl::StatusOr<Reproducer> DataplaneClient::ReproduceTrace(
+absl::StatusOr<Reproducer> DataplaneClient::GetReproducer(
     DataplanePort ingress_port, std::string_view payload,
     std::optional<absl::Duration> timeout) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
   InjectPacketRequest req = MakeRequest(ingress_port, payload);
   Reproducer resp;
-  grpc::Status status = stub_->ReproduceTrace(&ctx, req, &resp);
+  grpc::Status status = stub_->GetReproducer(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
   return resp;
 }
 
-absl::StatusOr<Reproducer> DataplaneClient::ReproduceTrace(
+absl::StatusOr<Reproducer> DataplaneClient::GetReproducer(
     P4RuntimePort ingress_port, std::string_view payload,
     std::optional<absl::Duration> timeout) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
   InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload);
   Reproducer resp;
-  grpc::Status status = stub_->ReproduceTrace(&ctx, req, &resp);
+  grpc::Status status = stub_->GetReproducer(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
   return resp;
 }

--- a/fourward_cc/dataplane_client.h
+++ b/fourward_cc/dataplane_client.h
@@ -102,7 +102,7 @@ class ResultStream {
 };
 
 // Ergonomic C++ client for the 4ward Dataplane gRPC service. Wraps the
-// InjectPacket, InjectPackets, SubscribeResults, and ReproduceTrace RPCs;
+// InjectPacket, InjectPackets, SubscribeResults, and GetReproducer RPCs;
 // names mirror dataplane.proto one-to-one. RegisterPrePacketHook is
 // intentionally not wrapped — use the raw stub for advanced use cases.
 //
@@ -132,17 +132,17 @@ class DataplaneClient {
   PacketWriter InjectPackets(
       std::optional<absl::Duration> timeout = std::nullopt);
 
-  absl::StatusOr<Reproducer> ReproduceTrace(
-      DataplanePort ingress_port, std::string_view payload,
-      std::optional<absl::Duration> timeout = std::nullopt);
-  absl::StatusOr<Reproducer> ReproduceTrace(
-      P4RuntimePort ingress_port, std::string_view payload,
-      std::optional<absl::Duration> timeout = std::nullopt);
-
   // Blocks until the server confirms the subscription is active. The
   // ResultStream is then long-lived; cancel via destruction.
   absl::StatusOr<ResultStream> SubscribeResults(
       std::optional<absl::Duration> startup_timeout = std::nullopt);
+
+  absl::StatusOr<Reproducer> GetReproducer(
+      DataplanePort ingress_port, std::string_view payload,
+      std::optional<absl::Duration> timeout = std::nullopt);
+  absl::StatusOr<Reproducer> GetReproducer(
+      P4RuntimePort ingress_port, std::string_view payload,
+      std::optional<absl::Duration> timeout = std::nullopt);
 
  private:
   absl::Duration ResolveTimeout(std::optional<absl::Duration> override) const {

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -57,14 +57,14 @@ class DataplaneService(
       .build()
   }
 
-  override suspend fun reproduceTrace(request: InjectPacketRequest): Reproducer {
+  override suspend fun getReproducer(request: InjectPacketRequest): Reproducer {
     if (pipelineSnapshot() == null) {
       throw Status.FAILED_PRECONDITION.withDescription(
           "No pipeline loaded — call SetForwardingPipelineConfig first"
         )
         .asException()
     }
-    val (enrichedResult, pipeline) = processAndEnrich(request, "ReproduceTrace")
+    val (enrichedResult, pipeline) = processAndEnrich(request, "GetReproducer")
     // pipeline is non-null: the pre-check above rejects the no-pipeline case, and pipeline
     // unload between the check and here requires a concurrent SetForwardingPipelineConfig
     // that replaces the pipeline (not unloads it — there's no "unload" API).

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -109,15 +109,15 @@ class DataplaneServiceTest {
   }
 
   // =========================================================================
-  // ReproduceTrace
+  // GetReproducer
   // =========================================================================
 
   @Test
-  fun `ReproduceTrace is self-contained`() {
+  fun `GetReproducer is self-contained`() {
     val config = loadPassthroughConfig()
     harness.loadPipeline(config)
     val payload = byteArrayOf(0x01)
-    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+    val reproducer = harness.getReproducer(ingressPort = 0, payload = payload)
 
     assertEquals("pipeline config", config, reproducer.pipelineConfig)
     assertTrue("result", reproducer.hasResult())
@@ -128,38 +128,38 @@ class DataplaneServiceTest {
   }
 
   @Test
-  fun `ReproduceTrace contains matched table entry`() {
+  fun `GetReproducer contains matched table entry`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
     harness.installEntry(entry)
 
     val payload = buildEthernetFrame(etherType = 0x0800)
-    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+    val reproducer = harness.getReproducer(ingressPort = 0, payload = payload)
 
     val tableEntities = reproducer.entitiesList.filter { it.hasTableEntry() }
     assertTrue("reproducer should contain the matched entry", tableEntities.isNotEmpty())
   }
 
   @Test
-  fun `ReproduceTrace excludes entries on table miss`() {
+  fun `GetReproducer excludes entries on table miss`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val payload = buildEthernetFrame(etherType = 0x0800)
-    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+    val reproducer = harness.getReproducer(ingressPort = 0, payload = payload)
 
     assertTrue("reproducer should have no entities on miss", reproducer.entitiesList.isEmpty())
   }
 
   @Test
-  fun `ReproduceTrace fails without loaded pipeline`() {
+  fun `GetReproducer fails without loaded pipeline`() {
     assertGrpcError(Status.Code.FAILED_PRECONDITION) {
-      harness.reproduceTrace(ingressPort = 0, payload = byteArrayOf(0x01))
+      harness.getReproducer(ingressPort = 0, payload = byteArrayOf(0x01))
     }
   }
 
   @Test
-  fun `ReproduceTrace round-trip produces same trace as InjectPacket`() {
+  fun `GetReproducer round-trip produces same trace as InjectPacket`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
@@ -167,7 +167,7 @@ class DataplaneServiceTest {
 
     val payload = buildEthernetFrame(etherType = 0x0800)
     val injectResponse = harness.injectPacket(ingressPort = 0, payload = payload)
-    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+    val reproducer = harness.getReproducer(ingressPort = 0, payload = payload)
 
     assertEquals("trace should match InjectPacket", injectResponse.trace, reproducer.result.trace)
     assertEquals(
@@ -178,13 +178,13 @@ class DataplaneServiceTest {
   }
 
   @Test
-  fun `ReproduceTrace includes multicast group entities`() {
+  fun `GetReproducer includes multicast group entities`() {
     val config = loadConfig("e2e_tests/trace_tree/multicast.txtpb")
     harness.loadPipeline(config)
     harness.installEntry(buildMulticastGroup(groupId = 1, ports = listOf(1, 2, 3)))
 
     val payload = buildEthernetFrame(etherType = 0x0800)
-    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+    val reproducer = harness.getReproducer(ingressPort = 0, payload = payload)
 
     val preEntities = reproducer.entitiesList.filter { it.hasPacketReplicationEngineEntry() }
     assertTrue("reproducer should contain multicast group", preEntities.isNotEmpty())
@@ -195,7 +195,7 @@ class DataplaneServiceTest {
   }
 
   @Test
-  fun `ReproduceTrace extracts only the multicast group used by the trace`() {
+  fun `GetReproducer extracts only the multicast group used by the trace`() {
     val config = loadConfig("e2e_tests/trace_tree/multicast.txtpb")
     harness.loadPipeline(config)
     // The P4 program hardcodes mcast_grp = 1. Install group 1 (used) and group 99 (unused).
@@ -203,7 +203,7 @@ class DataplaneServiceTest {
     harness.installEntry(buildMulticastGroup(groupId = 99, ports = listOf(4, 5)))
 
     val payload = buildEthernetFrame(etherType = 0x0800)
-    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+    val reproducer = harness.getReproducer(ingressPort = 0, payload = payload)
 
     val mcastEntities =
       reproducer.entitiesList
@@ -213,7 +213,7 @@ class DataplaneServiceTest {
   }
 
   @Test
-  fun `ReproduceTrace includes modified default action`() {
+  fun `GetReproducer includes modified default action`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val table = config.p4Info.tablesList.first()
@@ -223,7 +223,7 @@ class DataplaneServiceTest {
     )
 
     val payload = buildEthernetFrame(etherType = 0x0800)
-    val reproducer = harness.reproduceTrace(ingressPort = 0, payload = payload)
+    val reproducer = harness.getReproducer(ingressPort = 0, payload = payload)
 
     val defaultEntities =
       reproducer.entitiesList.filter { it.hasTableEntry() && it.tableEntry.isDefaultAction }

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -170,8 +170,8 @@ class FourwardTestHarness(
   }
 
   /** Injects a packet and returns a self-contained Reproducer for the trace. */
-  fun reproduceTrace(ingressPort: Int, payload: ByteArray): fourward.Reproducer = runBlocking {
-    dataplaneStub.reproduceTrace(
+  fun getReproducer(ingressPort: Int, payload: ByteArray): fourward.Reproducer = runBlocking {
+    dataplaneStub.getReproducer(
       InjectPacketRequest.newBuilder()
         .setDataplaneIngressPort(ingressPort)
         .setPayload(ByteString.copyFrom(payload))

--- a/grpc/dataplane.proto
+++ b/grpc/dataplane.proto
@@ -31,12 +31,6 @@ service Dataplane {
   rpc SubscribeResults(SubscribeResultsRequest)
       returns (stream SubscribeResultsResponse);
 
-  // Inject a packet and return a self-contained Reproducer for the resulting
-  // trace. The Reproducer bundles the pipeline config, relevant entities,
-  // input packet, trace, and possible outcomes — everything needed to replay
-  // the trace in another 4ward instance.
-  rpc ReproduceTrace(InjectPacketRequest) returns (Reproducer);
-
   // Registers a pre-packet hook that fires before every dataplane RPC.
   //
   // Some systems need to update P4 state in response to external
@@ -56,6 +50,12 @@ service Dataplane {
   // the lifetime of the hook registration.
   rpc RegisterPrePacketHook(stream PrePacketHookResponse)
       returns (stream PrePacketHookInvocation);
+
+  // Inject a packet and return a self-contained Reproducer for the resulting
+  // trace. The Reproducer bundles the pipeline config, relevant entities,
+  // input packet, trace, and possible outcomes — everything needed to replay
+  // the trace in another 4ward instance.
+  rpc GetReproducer(InjectPacketRequest) returns (Reproducer);
 }
 
 message InjectPacketsResponse {}


### PR DESCRIPTION
## Summary

\`ReproduceTrace\` is misleading — the RPC doesn't reproduce anything. It injects a packet and bundles the result into a \`Reproducer\`. The actual reproducing happens later, by whoever loads and replays it. \`GetReproducer\` follows the standard gRPC \`Get<Resource>\` convention.

Mechanical rename across proto, Kotlin, and C++ — no logic changes.

## Test plan

- [x] \`bazel build //fourward_cc/... //grpc/...\` passes
- [x] \`bazel test //fourward_cc/... //grpc:DataplaneServiceTest\` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)