### PR TITLE
Add tag field to InjectPacketRequest for request-response correlation

### DIFF
--- a/fourward_cc/dataplane_client.cc
+++ b/fourward_cc/dataplane_client.cc
@@ -42,18 +42,20 @@ std::chrono::system_clock::time_point AbsoluteDeadline(
 }
 
 InjectPacketRequest MakeRequest(DataplanePort ingress_port,
-                                std::string_view payload) {
+                                std::string_view payload, Tag tag) {
   InjectPacketRequest req;
   req.set_dataplane_ingress_port(ingress_port.port);
   req.set_payload(payload.data(), payload.size());
+  req.set_tag(tag.value);
   return req;
 }
 
 InjectPacketRequest MakeRequest(P4RuntimePort ingress_port,
-                                std::string_view payload) {
+                                std::string_view payload, Tag tag) {
   InjectPacketRequest req;
   req.set_p4rt_ingress_port(std::move(ingress_port.port));
   req.set_payload(payload.data(), payload.size());
+  req.set_tag(tag.value);
   return req;
 }
 
@@ -74,11 +76,10 @@ DataplaneClient::DataplaneClient(DataplaneClient&&) = default;
 DataplaneClient& DataplaneClient::operator=(DataplaneClient&&) = default;
 
 absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
-    DataplanePort ingress_port, std::string_view payload,
-    std::optional<absl::Duration> timeout) {
+    DataplanePort ingress_port, std::string_view payload, Tag tag) {
   grpc::ClientContext ctx;
-  ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
-  InjectPacketRequest req = MakeRequest(ingress_port, payload);
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  InjectPacketRequest req = MakeRequest(ingress_port, payload, tag);
   InjectPacketResponse resp;
   grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
@@ -86,11 +87,10 @@ absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
 }
 
 absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
-    P4RuntimePort ingress_port, std::string_view payload,
-    std::optional<absl::Duration> timeout) {
+    P4RuntimePort ingress_port, std::string_view payload, Tag tag) {
   grpc::ClientContext ctx;
-  ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
-  InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload);
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload, tag);
   InjectPacketResponse resp;
   grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
@@ -98,11 +98,10 @@ absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
 }
 
 absl::StatusOr<Reproducer> DataplaneClient::GetReproducer(
-    DataplanePort ingress_port, std::string_view payload,
-    std::optional<absl::Duration> timeout) {
+    DataplanePort ingress_port, std::string_view payload, Tag tag) {
   grpc::ClientContext ctx;
-  ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
-  InjectPacketRequest req = MakeRequest(ingress_port, payload);
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  InjectPacketRequest req = MakeRequest(ingress_port, payload, tag);
   Reproducer resp;
   grpc::Status status = stub_->GetReproducer(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
@@ -110,11 +109,10 @@ absl::StatusOr<Reproducer> DataplaneClient::GetReproducer(
 }
 
 absl::StatusOr<Reproducer> DataplaneClient::GetReproducer(
-    P4RuntimePort ingress_port, std::string_view payload,
-    std::optional<absl::Duration> timeout) {
+    P4RuntimePort ingress_port, std::string_view payload, Tag tag) {
   grpc::ClientContext ctx;
-  ctx.set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
-  InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload);
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload, tag);
   Reproducer resp;
   grpc::Status status = stub_->GetReproducer(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
@@ -174,10 +172,9 @@ class PacketWriter::Impl {
   absl::Status finished_status_;
 };
 
-PacketWriter DataplaneClient::InjectPackets(
-    std::optional<absl::Duration> timeout) {
+PacketWriter DataplaneClient::InjectPackets() {
   auto context = std::make_unique<grpc::ClientContext>();
-  context->set_deadline(AbsoluteDeadline(ResolveTimeout(timeout)));
+  context->set_deadline(AbsoluteDeadline(default_timeout_));
   return PacketWriter(
       PacketWriter::Impl::Create(stub_.get(), std::move(context)));
 }
@@ -191,13 +188,13 @@ PacketWriter::PacketWriter(std::unique_ptr<Impl> impl)
     : impl_(std::move(impl)) {}
 
 absl::Status PacketWriter::Inject(DataplanePort ingress_port,
-                                  std::string_view payload) {
-  return impl_->Inject(MakeRequest(ingress_port, payload));
+                                  std::string_view payload, Tag tag) {
+  return impl_->Inject(MakeRequest(ingress_port, payload, tag));
 }
 
 absl::Status PacketWriter::Inject(P4RuntimePort ingress_port,
-                                  std::string_view payload) {
-  return impl_->Inject(MakeRequest(std::move(ingress_port), payload));
+                                  std::string_view payload, Tag tag) {
+  return impl_->Inject(MakeRequest(std::move(ingress_port), payload, tag));
 }
 
 absl::StatusOr<int> PacketWriter::Finish() { return impl_->Finish(); }
@@ -346,7 +343,8 @@ absl::StatusOr<ProcessPacketResult> ResultStream::Next(
 absl::StatusOr<ResultStream> DataplaneClient::SubscribeResults(
     std::optional<absl::Duration> startup_timeout) {
   absl::StatusOr<std::unique_ptr<ResultStream::Impl>> impl =
-      ResultStream::Impl::Create(stub_.get(), ResolveTimeout(startup_timeout));
+      ResultStream::Impl::Create(stub_.get(),
+                                startup_timeout.value_or(default_timeout_));
   if (!impl.ok()) return impl.status();
   return ResultStream(*std::move(impl));
 }

--- a/fourward_cc/dataplane_client.h
+++ b/fourward_cc/dataplane_client.h
@@ -17,10 +17,6 @@
 //                    dataplane.InjectPacket(
 //                        fourward::DataplanePort{0}, "..."));
 //
-//   // Override timeout per-call when needed:
-//   dataplane.InjectPacket(fourward::DataplanePort{0}, "...",
-//                          absl::Seconds(1));
-//
 //   // Streaming injection:
 //   auto writer = dataplane.InjectPackets();
 //   writer.Inject(fourward::DataplanePort{0}, payload1);
@@ -52,6 +48,10 @@ struct P4RuntimePort {
   std::string port;
 };
 
+struct Tag {
+  int64_t value = 0;
+};
+
 // RAII handle for a client-streaming InjectPackets RPC. Destructor calls
 // Finish() if not already called.
 //
@@ -64,8 +64,10 @@ class PacketWriter {
   PacketWriter(const PacketWriter&) = delete;
   PacketWriter& operator=(const PacketWriter&) = delete;
 
-  absl::Status Inject(DataplanePort ingress_port, std::string_view payload);
-  absl::Status Inject(P4RuntimePort ingress_port, std::string_view payload);
+  absl::Status Inject(DataplanePort ingress_port, std::string_view payload,
+                      Tag tag = {});
+  absl::Status Inject(P4RuntimePort ingress_port, std::string_view payload,
+                      Tag tag = {});
 
   // Signals end-of-stream and returns the number of packets injected.
   absl::StatusOr<int> Finish();
@@ -121,16 +123,13 @@ class DataplaneClient {
   DataplaneClient& operator=(const DataplaneClient&) = delete;
 
   absl::StatusOr<InjectPacketResponse> InjectPacket(
-      DataplanePort ingress_port, std::string_view payload,
-      std::optional<absl::Duration> timeout = std::nullopt);
+      DataplanePort ingress_port, std::string_view payload, Tag tag = {});
   absl::StatusOr<InjectPacketResponse> InjectPacket(
-      P4RuntimePort ingress_port, std::string_view payload,
-      std::optional<absl::Duration> timeout = std::nullopt);
+      P4RuntimePort ingress_port, std::string_view payload, Tag tag = {});
 
   // Returns a writer for streaming packet injection. Results are delivered
   // via SubscribeResults, not inline.
-  PacketWriter InjectPackets(
-      std::optional<absl::Duration> timeout = std::nullopt);
+  PacketWriter InjectPackets();
 
   // Blocks until the server confirms the subscription is active. The
   // ResultStream is then long-lived; cancel via destruction.
@@ -138,17 +137,11 @@ class DataplaneClient {
       std::optional<absl::Duration> startup_timeout = std::nullopt);
 
   absl::StatusOr<Reproducer> GetReproducer(
-      DataplanePort ingress_port, std::string_view payload,
-      std::optional<absl::Duration> timeout = std::nullopt);
+      DataplanePort ingress_port, std::string_view payload, Tag tag = {});
   absl::StatusOr<Reproducer> GetReproducer(
-      P4RuntimePort ingress_port, std::string_view payload,
-      std::optional<absl::Duration> timeout = std::nullopt);
+      P4RuntimePort ingress_port, std::string_view payload, Tag tag = {});
 
  private:
-  absl::Duration ResolveTimeout(std::optional<absl::Duration> override) const {
-    return override.value_or(default_timeout_);
-  }
-
   std::unique_ptr<Dataplane::Stub> stub_;
   absl::Duration default_timeout_;
 };

--- a/fourward_cc/dataplane_client_test.cc
+++ b/fourward_cc/dataplane_client_test.cc
@@ -58,24 +58,21 @@ TEST_F(DataplaneClientTest, SubscribeResultsRespectsStartupTimeout) {
       << stream.status();
 }
 
-TEST_F(DataplaneClientTest, InjectPacketDataplanePortDeadlinePropagated) {
-  DataplaneClient client(*server_);
+TEST_F(DataplaneClientTest, InjectPacketRespectsDefaultTimeout) {
+  DataplaneClient client(*server_, absl::Nanoseconds(1));
 
   absl::StatusOr<InjectPacketResponse> resp =
-      client.InjectPacket(DataplanePort{0}, "x",
-                          absl::Nanoseconds(1));
+      client.InjectPacket(DataplanePort{0}, "x");
   ASSERT_FALSE(resp.ok());
   EXPECT_EQ(resp.status().code(), absl::StatusCode::kDeadlineExceeded)
       << resp.status();
 }
 
-TEST_F(DataplaneClientTest, InjectPacketP4RuntimePortDeadlinePropagated) {
-  DataplaneClient client(*server_);
+TEST_F(DataplaneClientTest, InjectPacketP4RuntimePortRespectsDefaultTimeout) {
+  DataplaneClient client(*server_, absl::Nanoseconds(1));
 
   absl::StatusOr<InjectPacketResponse> resp =
-      client.InjectPacket(
-          P4RuntimePort{std::string("\x00\x01", 2)}, "x",
-          absl::Nanoseconds(1));
+      client.InjectPacket(P4RuntimePort{std::string("\x00\x01", 2)}, "x");
   ASSERT_FALSE(resp.ok());
   EXPECT_EQ(resp.status().code(), absl::StatusCode::kDeadlineExceeded)
       << resp.status();
@@ -90,10 +87,10 @@ TEST_F(DataplaneClientTest, InjectPacketsWriterFinishesCleanly) {
   EXPECT_EQ(*count, 0);
 }
 
-TEST_F(DataplaneClientTest, InjectPacketsDeadlinePropagated) {
-  DataplaneClient client(*server_);
+TEST_F(DataplaneClientTest, InjectPacketsRespectsDefaultTimeout) {
+  DataplaneClient client(*server_, absl::Nanoseconds(1));
 
-  PacketWriter writer = client.InjectPackets(absl::Nanoseconds(1));
+  PacketWriter writer = client.InjectPackets();
   absl::Status inject = writer.Inject(DataplanePort{0}, "a");
   // Either the inject or finish will surface the deadline error.
   absl::StatusOr<int> finish = writer.Finish();

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -85,6 +85,7 @@ class DataplaneService(
   private class EnrichedResult(
     val ingressPort: Int,
     val payload: ByteArray,
+    val tag: Long,
     val rawTrace: TraceTree,
     val forwardingSnapshot: TableStore.ForwardingSnapshot,
     val trace: TraceTree,
@@ -96,6 +97,7 @@ class DataplaneService(
           InputPacket.newBuilder()
             .setDataplaneIngressPort(ingressPort)
             .setPayload(ByteString.copyFrom(payload))
+            .setTag(tag)
         )
         .setTrace(trace)
         .addAllPossibleOutcomes(possibleOutcomes)
@@ -114,12 +116,13 @@ class DataplaneService(
     // description, so the client never sees a bare UNKNOWN. See #499.
     @Suppress("TooGenericExceptionCaught")
     try {
-      val result = broker.processPacket(ingressPort, payload)
+      val result = broker.processPacket(ingressPort, payload, request.tag)
       val pt = translator?.portTranslator
       val enrichedResult =
         EnrichedResult(
           ingressPort = ingressPort,
           payload = payload,
+          tag = request.tag,
           rawTrace = result.trace,
           forwardingSnapshot = result.forwardingSnapshot,
           trace = enrichTrace(result.trace, translator),
@@ -148,8 +151,11 @@ class DataplaneService(
         requests.collect { request ->
           val port = resolveIngressPort(request, translator)
           val payload = request.payload.toByteArray()
+          val tag = request.tag
           futures.add(
-            java.util.concurrent.ForkJoinPool.commonPool().submit { processPacket(port, payload) }
+            java.util.concurrent.ForkJoinPool.commonPool().submit {
+              processPacket(port, payload, tag)
+            }
           )
         }
       }
@@ -182,6 +188,7 @@ class DataplaneService(
                       pt?.dataplaneToP4rt(subResult.ingressPort)?.let { setP4RtIngressPort(it) }
                     }
                     .setPayload(ByteString.copyFrom(subResult.payload))
+                    .setTag(subResult.tag)
                 )
                 .addAllPossibleOutcomes(
                   subResult.possibleOutcomes.map { world ->

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -258,6 +258,20 @@ class DataplaneServiceTest {
     job.cancel()
   }
 
+  @Test
+  fun `SubscribeResults echoes tag from InjectPacket`() = runBlocking {
+    harness.loadPipeline(loadPassthroughConfig())
+    val stub = DataplaneCoroutineStub(harness.channel)
+    val (job, results) = subscribeAndAwaitActive(stub)
+
+    harness.injectPacket(ingressPort = 0, payload = byteArrayOf(0x01), tag = 42)
+
+    val result = withTimeout(5000) { results.receive() }
+    assertEquals(42L, result.result.inputPacket.tag)
+
+    job.cancel()
+  }
+
   // =========================================================================
   // Cross-source SubscribeResults
   // =========================================================================

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -160,14 +160,16 @@ class FourwardTestHarness(
   // ---------------------------------------------------------------------------
 
   /** Injects a packet via the InjectPacket RPC. Returns outputs + trace. */
-  fun injectPacket(ingressPort: Int, payload: ByteArray): InjectPacketResponse = runBlocking {
-    dataplaneStub.injectPacket(
-      InjectPacketRequest.newBuilder()
-        .setDataplaneIngressPort(ingressPort)
-        .setPayload(ByteString.copyFrom(payload))
-        .build()
-    )
-  }
+  fun injectPacket(ingressPort: Int, payload: ByteArray, tag: Long = 0): InjectPacketResponse =
+    runBlocking {
+      dataplaneStub.injectPacket(
+        InjectPacketRequest.newBuilder()
+          .setDataplaneIngressPort(ingressPort)
+          .setPayload(ByteString.copyFrom(payload))
+          .setTag(tag)
+          .build()
+      )
+    }
 
   /** Injects a packet and returns a self-contained Reproducer for the trace. */
   fun getReproducer(ingressPort: Int, payload: ByteArray): fourward.Reproducer = runBlocking {

--- a/grpc/PacketBroker.kt
+++ b/grpc/PacketBroker.kt
@@ -103,6 +103,7 @@ class PacketBroker(
     val payload: ByteArray,
     val possibleOutcomes: List<List<OutputPacket>>,
     val trace: TraceTree,
+    val tag: Long = 0,
   )
 
   /** Handle returned by [subscribe]; call [unsubscribe] to stop receiving results. */
@@ -129,10 +130,10 @@ class PacketBroker(
     }
   }
 
-  fun processPacket(ingressPort: Int, payload: ByteArray): ProcessPacketResult {
+  fun processPacket(ingressPort: Int, payload: ByteArray, tag: Long = 0): ProcessPacketResult {
     fireHookUnderMutex()
     val result = simulatorFn(ingressPort, payload)
-    dispatchToSubscribers(ingressPort, payload, result)
+    dispatchToSubscribers(ingressPort, payload, result, tag)
     return result
   }
 
@@ -141,11 +142,11 @@ class PacketBroker(
    *
    * Used by [DataplaneService.injectPackets] to stream packets without buffering the entire batch.
    */
-  fun <T> withHookOnce(block: (processor: (Int, ByteArray) -> Unit) -> T): T {
+  fun <T> withHookOnce(block: (processor: (Int, ByteArray, Long) -> Unit) -> T): T {
     fireHookUnderMutex()
-    return block { port, payload ->
+    return block { port, payload, tag ->
       val result = simulatorFn(port, payload)
-      dispatchToSubscribers(port, payload, result)
+      dispatchToSubscribers(port, payload, result, tag)
     }
   }
 
@@ -159,9 +160,11 @@ class PacketBroker(
     ingressPort: Int,
     payload: ByteArray,
     result: ProcessPacketResult,
+    tag: Long = 0,
   ) {
     if (subscribers.isEmpty()) return
-    val subResult = SubscriptionResult(ingressPort, payload, result.possibleOutcomes, result.trace)
+    val subResult =
+      SubscriptionResult(ingressPort, payload, result.possibleOutcomes, result.trace, tag)
     for (subscriber in subscribers) {
       try {
         subscriber(subResult)

--- a/grpc/PacketBrokerTest.kt
+++ b/grpc/PacketBrokerTest.kt
@@ -99,6 +99,18 @@ class PacketBrokerTest {
   }
 
   @Test
+  fun `subscriber receives tag from processPacket`() {
+    val broker = broker(0 to result(outputPacket(1)))
+    val received = mutableListOf<PacketBroker.SubscriptionResult>()
+    broker.subscribe { received.add(it) }
+
+    broker.processPacket(0, byteArrayOf(), tag = 42)
+
+    assertEquals(1, received.size)
+    assertEquals(42L, received[0].tag)
+  }
+
+  @Test
   fun `throwing subscriber does not crash caller or block other subscribers`() {
     val broker = broker(0 to result(outputPacket(1)))
 
@@ -186,9 +198,9 @@ class PacketBrokerTest {
     val hookCount = registerAutoRespondHook(broker)
 
     broker.withHookOnce { processPacket ->
-      processPacket(0, byteArrayOf())
-      processPacket(0, byteArrayOf())
-      processPacket(0, byteArrayOf())
+      processPacket(0, byteArrayOf(), 0)
+      processPacket(0, byteArrayOf(), 0)
+      processPacket(0, byteArrayOf(), 0)
     }
 
     assertEquals("hook should fire exactly once for the batch", 1, hookCount.get())
@@ -201,7 +213,7 @@ class PacketBrokerTest {
     val processed = AtomicInteger(0)
 
     broker.withHookOnce { processPacket ->
-      processPacket(0, byteArrayOf())
+      processPacket(0, byteArrayOf(), 0)
       processed.incrementAndGet()
     }
 

--- a/grpc/dataplane.proto
+++ b/grpc/dataplane.proto
@@ -70,6 +70,11 @@ message InjectPacketRequest {
     bytes p4rt_ingress_port = 2;
   }
   bytes payload = 3;
+
+  // Opaque caller-provided tag, echoed back in
+  // ProcessPacketResult.input_packet. Useful for correlating results with
+  // requests when using InjectPackets + SubscribeResults.
+  int64 tag = 4;
 }
 
 // A set of output packets from one possible real execution.

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -27,6 +27,9 @@ message InputPacket {
   // P4Runtime port ID. Populated by enrichment layers (e.g. DataplaneService),
   // never by the simulator.
   bytes p4rt_ingress_port = 3;
+
+  // Opaque caller-provided tag, copied from InjectPacketRequest.tag.
+  int64 tag = 4;
 }
 
 message OutputPacket {


### PR DESCRIPTION
## Summary

When using `InjectPackets` + `SubscribeResults`, callers had no way to match results back to specific requests. The `SubscribeResults` stream is global (all injection sources) and doesn't guarantee ordering, so matching by payload content is fragile and matching by position is incorrect.

Adds an `int64 tag` field to `InjectPacketRequest` that the server echoes back in `ProcessPacketResult.input_packet`. Callers set a sequence number (or any identifier) on the request and find it on the result — zero-overhead, zero-interpretation by the server.

```proto
message InjectPacketRequest {
  ...
  int64 tag = 4;
}

message InputPacket {
  ...
  int64 tag = 4;
}
```

The tag flows through the full pipeline: `InjectPacketRequest` → `PacketBroker` → `SubscriptionResult` → `InputPacket` in `ProcessPacketResult`. Defaults to 0, so existing callers are unaffected.

### C++ API

The C++ client wraps the tag in a `Tag` struct for type safety, consistent with `DataplanePort` and `P4RuntimePort`:

```cpp
client.InjectPacket(DataplanePort{0}, payload, Tag{42});
writer.Inject(DataplanePort{0}, payload, Tag{1});
```

Also removed per-call timeout overrides from `InjectPacket`, `InjectPackets`, and `GetReproducer` — callers set the timeout once at construction. `SubscribeResults` keeps its `startup_timeout` parameter (different semantic: how long to wait for the sentinel).

## Test plan

- [x] `SubscribeResults echoes tag from InjectPacket` (DataplaneServiceTest) — e2e round-trip
- [x] `subscriber receives tag from processPacket` (PacketBrokerTest) — unit-level propagation
- [x] `bazel test //grpc:DataplaneServiceTest //grpc:PacketBrokerTest //fourward_cc/...` — all targets pass
- [x] Format and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)