### PR TITLE
Add .clang-format (Google style)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google


### PR DESCRIPTION
One-line config so bare `clang-format -i` uses Google style without needing `--style=google`. Prevents the LLVM-vs-Google formatting mismatch from #692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)