### PR TITLE
Enrich CPU-port outputs with decoded PacketIn

### DIFF
--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -665,6 +665,13 @@ kt_jvm_test(
         "//e2e_tests/basic_table",
         "//e2e_tests/passthrough",
         "//e2e_tests/trace_tree:multicast",
+        "//p4c_backend:p4c-4ward",
+        "@p4c//p4include",
+        "@p4c//p4include:core.p4",
+    ],
+    jvm_flags = [
+        "-Dp4c_4ward=$(rlocationpath //p4c_backend:p4c-4ward)",
+        "-Dp4include=$(rlocationpath @p4c//p4include:core.p4)",
     ],
     test_class = "fourward.grpc.DataplaneServiceTest",
     deps = [
@@ -673,6 +680,7 @@ kt_jvm_test(
         ":grpc",
         ":p4runtime_kt_grpc",
         "//bazel:runfiles",
+        "//e2e_tests:inline_p4_compiler",
         "//simulator",
         "//simulator:ir_java_proto",
         "//simulator:p4data_java_proto",

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -47,6 +47,7 @@ class DataplaneService(
     val config: PipelineConfig,
     val tableStore: TableStore,
     val typeTranslator: TypeTranslator?,
+    val packetHeaderCodec: PacketHeaderCodec?,
   )
 
   override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse {
@@ -118,6 +119,7 @@ class DataplaneService(
     try {
       val result = broker.processPacket(ingressPort, payload, request.tag)
       val pt = translator?.portTranslator
+      val codec = pipeline?.packetHeaderCodec
       val enrichedResult =
         EnrichedResult(
           ingressPort = ingressPort,
@@ -128,7 +130,9 @@ class DataplaneService(
           trace = enrichTrace(result.trace, translator),
           possibleOutcomes =
             result.possibleOutcomes.map { world ->
-              PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
+              PacketSet.newBuilder()
+                .addAllPackets(world.map { it.toDualEncoded(pt, codec, ingressPort) })
+                .build()
             },
         )
       return enrichedResult to pipeline
@@ -175,8 +179,10 @@ class DataplaneService(
       val handle =
         broker.subscribe { subResult ->
           try {
-            val translator = pipelineSnapshot()?.typeTranslator
+            val snapshot = pipelineSnapshot()
+            val translator = snapshot?.typeTranslator
             val pt = translator?.portTranslator
+            val codec = snapshot?.packetHeaderCodec
             val result =
               ProcessPacketResultProto.newBuilder()
                 .setInputPacket(
@@ -192,7 +198,11 @@ class DataplaneService(
                 )
                 .addAllPossibleOutcomes(
                   subResult.possibleOutcomes.map { world ->
-                    PacketSet.newBuilder().addAllPackets(world.map { it.toDualEncoded(pt) }).build()
+                    PacketSet.newBuilder()
+                      .addAllPackets(
+                        world.map { it.toDualEncoded(pt, codec, subResult.ingressPort) }
+                      )
+                      .build()
                   }
                 )
                 .setTrace(enrichTrace(subResult.trace, translator))
@@ -297,14 +307,18 @@ private fun enrichTrace(trace: TraceTree, translator: TypeTranslator?): TraceTre
   translator?.let { TraceEnricher.enrich(trace, it) } ?: trace
 
 /**
- * Returns a copy of this [OutputPacket] enriched with the P4Runtime port ID.
- *
- * When a [PortTranslator] is present, every egress port must have a reverse mapping — either from
- * an explicit `@p4runtime_translation_mappings` entry or auto-allocated by a prior P4Runtime Write.
+ * Returns a copy of this [OutputPacket] enriched with P4Runtime fields: the translated port ID, and
+ * for CPU-port outputs, the decoded [PacketIn][p4.v1.P4RuntimeOuterClass.PacketIn].
  */
-private fun OutputPacket.toDualEncoded(pt: PortTranslator?): OutputPacket =
-  OutputPacket.newBuilder()
+private fun OutputPacket.toDualEncoded(
+  pt: PortTranslator?,
+  codec: PacketHeaderCodec?,
+  ingressPort: Int,
+): OutputPacket {
+  val rawPayload = payload
+  return OutputPacket.newBuilder()
     .setDataplaneEgressPort(dataplaneEgressPort)
+    .setPayload(rawPayload)
     .apply {
       if (pt != null) {
         val p4rtPort =
@@ -316,6 +330,13 @@ private fun OutputPacket.toDualEncoded(pt: PortTranslator?): OutputPacket =
             )
         setP4RtEgressPort(p4rtPort)
       }
+      if (codec != null && dataplaneEgressPort == codec.cpuPort) {
+        setPacketIn(
+          p4.v1.P4RuntimeOuterClass.PacketIn.newBuilder()
+            .setPayload(codec.stripPacketInHeader(rawPayload))
+            .addAllMetadata(codec.buildPacketInMetadata(ingressPort, dataplaneEgressPort))
+        )
+      }
     }
-    .setPayload(payload)
     .build()
+}

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -118,7 +118,6 @@ class DataplaneService(
     @Suppress("TooGenericExceptionCaught")
     try {
       val result = broker.processPacket(ingressPort, payload, request.tag)
-      val pt = translator?.portTranslator
       val codec = pipeline?.packetHeaderCodec
       val enrichedResult =
         EnrichedResult(
@@ -131,7 +130,7 @@ class DataplaneService(
           possibleOutcomes =
             result.possibleOutcomes.map { world ->
               PacketSet.newBuilder()
-                .addAllPackets(world.map { it.toDualEncoded(pt, codec, ingressPort) })
+                .addAllPackets(world.map { it.toDualEncoded(translator, codec, ingressPort) })
                 .build()
             },
         )
@@ -200,7 +199,7 @@ class DataplaneService(
                   subResult.possibleOutcomes.map { world ->
                     PacketSet.newBuilder()
                       .addAllPackets(
-                        world.map { it.toDualEncoded(pt, codec, subResult.ingressPort) }
+                        world.map { it.toDualEncoded(translator, codec, subResult.ingressPort) }
                       )
                       .build()
                   }
@@ -311,11 +310,12 @@ private fun enrichTrace(trace: TraceTree, translator: TypeTranslator?): TraceTre
  * for CPU-port outputs, the decoded [PacketIn][p4.v1.P4RuntimeOuterClass.PacketIn].
  */
 private fun OutputPacket.toDualEncoded(
-  pt: PortTranslator?,
+  translator: TypeTranslator?,
   codec: PacketHeaderCodec?,
   ingressPort: Int,
 ): OutputPacket {
   val rawPayload = payload
+  val pt = translator?.portTranslator
   return OutputPacket.newBuilder()
     .setDataplaneEgressPort(dataplaneEgressPort)
     .setPayload(rawPayload)
@@ -331,11 +331,12 @@ private fun OutputPacket.toDualEncoded(
         setP4RtEgressPort(p4rtPort)
       }
       if (codec != null && dataplaneEgressPort == codec.cpuPort) {
-        setPacketIn(
+        val rawPacketIn =
           p4.v1.P4RuntimeOuterClass.PacketIn.newBuilder()
             .setPayload(codec.stripPacketInHeader(rawPayload))
             .addAllMetadata(codec.buildPacketInMetadata(ingressPort, dataplaneEgressPort))
-        )
+            .build()
+        setPacketIn(translator?.translatePacketIn(rawPacketIn) ?: rawPacketIn)
       }
     }
     .build()

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -507,6 +507,68 @@ class DataplaneServiceTest {
     }
   }
 
+  @Test
+  @Suppress("MagicNumber")
+  fun `PacketIn enrichment preserves payload with non-byte-aligned controller header`() {
+    // 5-bit @controller_header("packet_in") — not byte-aligned. Stripping must use bit-level
+    // extraction, not byte slicing, to avoid shifting the payload or introducing pad bits.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      @controller_header("packet_out")
+      header packet_out_t { bit<5> tag; }
+
+      @controller_header("packet_in")
+      header packet_in_t { bit<5> tag; }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { packet_out_t pkt_out; packet_in_t pkt_in; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 510; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { h.pkt_in.setValid(); h.pkt_in.tag = 0; }
+      }
+      control D(packet_out pkt, in headers_t h) {
+        apply { pkt.emit(h.pkt_in); pkt.emit(h.eth); }
+      }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val testHarness = FourwardTestHarness()
+    testHarness.use {
+      it.loadPipeline(config)
+      val payload = buildEthernetFrame(etherType = 0x0806)
+      val response = it.injectPacket(ingressPort = 0, payload = payload)
+
+      val output = response.possibleOutcomesList.single().getPackets(0)
+      assertEquals("should egress on CPU port", 510, output.dataplaneEgressPort)
+      assertTrue("should have packet_in", output.hasPacketIn())
+
+      assertEquals(
+        "PacketIn payload size should match original (no padding, no missing bits)",
+        payload.size,
+        output.packetIn.payload.size(),
+      )
+      assertEquals(
+        "PacketIn payload should be byte-for-byte identical to original",
+        ByteString.copyFrom(payload),
+        output.packetIn.payload,
+      )
+    }
+  }
+
   // =========================================================================
   // Pre-packet hook
   // =========================================================================

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -7,6 +7,7 @@ import fourward.PrePacketHookInvocation
 import fourward.PrePacketHookResponse
 import fourward.SubscribeResultsRequest
 import fourward.SubscribeResultsResponse
+import fourward.e2e.compileInlineP4
 import fourward.grpc.FourwardTestHarness.Companion.assertGrpcError
 import fourward.grpc.FourwardTestHarness.Companion.buildEthernetFrame
 import fourward.grpc.FourwardTestHarness.Companion.buildExactEntry
@@ -432,6 +433,79 @@ class DataplaneServiceTest {
 
   // Positive dual-encoding tests (P4RT port injection and response population) are in
   // SaiP4E2ETest, which uses a program with @controller_header and @p4runtime_translation.
+
+  // =========================================================================
+  // PacketIn enrichment
+  // =========================================================================
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `CPU-port output has PacketIn enrichment without translation`() {
+    // Vanilla v1model with @controller_header("packet_in") but no @p4runtime_translation.
+    // The program always forwards to CPU port 510.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      @controller_header("packet_out")
+      header packet_out_t { bit<9> egress_port; }
+
+      @controller_header("packet_in")
+      header packet_in_t { bit<9> ingress_port; bit<9> target_egress_port; }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { packet_out_t pkt_out; packet_in_t pkt_in; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 510; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          h.pkt_in.setValid();
+          h.pkt_in.ingress_port = sm.ingress_port;
+          h.pkt_in.target_egress_port = sm.egress_port;
+        }
+      }
+      control D(packet_out pkt, in headers_t h) {
+        apply { pkt.emit(h.pkt_in); pkt.emit(h.eth); }
+      }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val testHarness = FourwardTestHarness()
+    testHarness.use {
+      it.loadPipeline(config)
+      val payload = buildEthernetFrame(etherType = 0x0800)
+      val response = it.injectPacket(ingressPort = 7, payload = payload)
+
+      val output = response.possibleOutcomesList.single().getPackets(0)
+      assertEquals("should egress on CPU port", 510, output.dataplaneEgressPort)
+      assertTrue("should have packet_in", output.hasPacketIn())
+
+      val packetIn = output.packetIn
+      assertEquals(
+        "PacketIn payload should match original (controller header stripped)",
+        payload.size,
+        packetIn.payload.size(),
+      )
+      assertEquals(
+        "PacketIn payload bytes should match",
+        ByteString.copyFrom(payload),
+        packetIn.payload,
+      )
+      assertTrue("PacketIn should have metadata", packetIn.metadataCount > 0)
+      assertTrue("p4rt_egress_port should be empty (no translation)", output.p4RtEgressPort.isEmpty)
+    }
+  }
 
   // =========================================================================
   // Pre-packet hook

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -41,7 +41,12 @@ class FourwardServer(
     DataplaneService(broker) {
       val config = simulator.pipelineConfig ?: return@DataplaneService null
       val tableStore = simulator.tableStore ?: return@DataplaneService null
-      DataplaneService.PipelineSnapshot(config, tableStore, service.typeTranslator)
+      DataplaneService.PipelineSnapshot(
+        config,
+        tableStore,
+        service.typeTranslator,
+        service.packetHeaderCodec,
+      )
     }
 
   init {

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -79,7 +79,12 @@ class FourwardTestHarness(
     DataplaneService(broker) {
       val config = simulator.pipelineConfig ?: return@DataplaneService null
       val tableStore = simulator.tableStore ?: return@DataplaneService null
-      DataplaneService.PipelineSnapshot(config, tableStore, service.typeTranslator)
+      DataplaneService.PipelineSnapshot(
+        config,
+        tableStore,
+        service.typeTranslator,
+        service.packetHeaderCodec,
+      )
     }
 
   init {

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -102,6 +102,10 @@ class P4RuntimeService(
   val typeTranslator: TypeTranslator?
     get() = pipeline?.typeTranslator
 
+  /** Packet header codec for the currently loaded pipeline, or null if unavailable. */
+  val packetHeaderCodec: PacketHeaderCodec?
+    get() = pipeline?.packetHeaderCodec
+
   // Only accessed under writeMutex; @Volatile not needed.
   private var savedPipeline: PipelineState? = null
 

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -438,6 +438,43 @@ class SaiP4E2ETest {
   }
 
   @Test
+  fun `CPU-port output has PacketIn enrichment with stripped payload and metadata`() {
+    installRoutingChain()
+    installAclEntry(findAction("acl_trap"))
+    installCopyToCpuCloneSession()
+
+    val originalPacket = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
+    val result = harness.injectPacket(ingressPort = 0, payload = originalPacket)
+
+    val cpuOutput =
+      result.possibleOutcomesList
+        .flatMap { it.packetsList }
+        .find { it.dataplaneEgressPort == CPU_PORT }
+    assertNotNull("expected CPU-port output from ACL trap", cpuOutput)
+    assertTrue("CPU-port output should have packet_in", cpuOutput!!.hasPacketIn())
+
+    val packetIn = cpuOutput.packetIn
+    assertEquals(
+      "PacketIn payload should be the original packet (controller header stripped)",
+      originalPacket.size,
+      packetIn.payload.size(),
+    )
+    assertBytesEqual("PacketIn dst_mac", UNICAST_MAC, packetIn.payload.toByteArray(), 0)
+    assertBytesEqual("PacketIn src_mac", SRC_MAC, packetIn.payload.toByteArray(), MAC_LEN)
+    assertTrue("PacketIn should have metadata", packetIn.metadataCount > 0)
+  }
+
+  @Test
+  fun `non-CPU-port output has no PacketIn enrichment`() {
+    installForwardingEntries()
+    val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
+    val result = harness.injectPacket(ingressPort = 0, payload = packet)
+
+    val output = result.possibleOutcomesList.single().getPackets(0)
+    assertTrue("non-CPU output should not have packet_in", !output.hasPacketIn())
+  }
+
+  @Test
   fun `deprecated Replica egress_port with egress_rid delivers PacketIn via CPU`() {
     installRoutingChain()
     installAclEntry(findAction("acl_trap"))

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -462,6 +462,52 @@ class SaiP4E2ETest {
     assertBytesEqual("PacketIn dst_mac", UNICAST_MAC, packetIn.payload.toByteArray(), 0)
     assertBytesEqual("PacketIn src_mac", SRC_MAC, packetIn.payload.toByteArray(), MAC_LEN)
     assertTrue("PacketIn should have metadata", packetIn.metadataCount > 0)
+
+    // Metadata port values should be P4RT-translated strings, not raw dataplane bytes.
+    for (meta in packetIn.metadataList) {
+      val metaName = findPacketInMetadataName(meta.metadataId)
+      if (metaName == "ingress_port" || metaName == "target_egress_port") {
+        val str = meta.value.toStringUtf8()
+        assertTrue(
+          "PacketIn $metaName should be a valid decimal string, got bytes: ${meta.value}",
+          str.all { it.isDigit() },
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `PacketIn enrichment matches P4Runtime stream PacketIn`() {
+    installRoutingChain()
+    installAclEntry(findAction("acl_trap"))
+    installCopyToCpuCloneSession()
+
+    // Inject via InjectPacket with a P4Runtime stream open. The same injection produces
+    // both the enriched OutputPacket (in the InjectPacket response) and a PacketIn on the
+    // stream — letting us compare the two representations from the exact same packet.
+    val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
+    harness.openStream().use { session ->
+      session.arbitrate()
+      val result = harness.injectPacket(ingressPort = 0, payload = packet)
+
+      val cpuOutput =
+        result.possibleOutcomesList
+          .flatMap { it.packetsList }
+          .find { it.dataplaneEgressPort == CPU_PORT }
+      assertNotNull("expected CPU-port output", cpuOutput)
+      val enrichedPacketIn = cpuOutput!!.packetIn
+
+      val response = session.receiveNext()
+      assertNotNull("stream should deliver PacketIn", response)
+      val streamPacketIn = response!!.packet
+
+      assertEquals("payload should match", streamPacketIn.payload, enrichedPacketIn.payload)
+      assertEquals(
+        "metadata should match",
+        streamPacketIn.metadataList,
+        enrichedPacketIn.metadataList,
+      )
+    }
   }
 
   @Test

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -38,6 +38,9 @@ message OutputPacket {
   // never by the simulator.
   bytes p4rt_egress_port = 3;
   bytes payload = 2;
+  // P4Runtime PacketIn. Populated by enrichment layers for CPU-port outputs;
+  // never by the simulator.
+  p4.v1.PacketIn packet_in = 4;
 }
 
 // =============================================================================

--- a/web/PlaygroundServer.kt
+++ b/web/PlaygroundServer.kt
@@ -41,7 +41,12 @@ fun main(args: Array<String>) {
     DataplaneService(broker) {
       val config = simulator.pipelineConfig ?: return@DataplaneService null
       val tableStore = simulator.tableStore ?: return@DataplaneService null
-      DataplaneService.PipelineSnapshot(config, tableStore, service.typeTranslator)
+      DataplaneService.PipelineSnapshot(
+        config,
+        tableStore,
+        service.typeTranslator,
+        service.packetHeaderCodec,
+      )
     }
   broker.readAllEntities = { service.readAllEntities() }
   broker.readP4Info = { service.p4Info() }


### PR DESCRIPTION
## Summary

When using 4ward as a test oracle (e.g. DVaaS output prediction), clients need
to know what P4Runtime PacketIn messages a packet would produce. Rather than
requiring clients to subscribe to the P4Runtime stream (which introduces async
coordination and has no end-of-responses delimiter), enrich `OutputPacket`
directly: CPU-port outputs now carry a `packet_in` field with the controller
header stripped, metadata decoded, and port values translated to P4RT encoding.

Follows the existing enrichment pattern — the simulator stays pure (no P4Runtime
knowledge), and the service boundary adds the P4RT view. The enriched PacketIn
is identical to what the P4Runtime stream would deliver.

- `OutputPacket.packet_in` carries the stripped payload and decoded metadata
- Enrichment reuses the existing `PacketHeaderCodec` and `TypeTranslator`
  (same code paths that build PacketIn on the P4Runtime stream)
- `toDualEncoded()` now takes a `TypeTranslator` (not just `PortTranslator`)
  to apply `translatePacketIn()` for programs with `@p4runtime_translation`

## Test plan

- [x] `CPU-port output has PacketIn enrichment with stripped payload and metadata` --
  ACL trap produces CPU-port output with correct payload, metadata, and P4RT-translated
  port values (SaiP4E2ETest)
- [x] `PacketIn enrichment matches P4Runtime stream PacketIn` -- enriched `packet_in`
  is byte-for-byte identical to what the P4Runtime stream delivers for the same injection
  (SaiP4E2ETest)
- [x] `CPU-port output has PacketIn enrichment without translation` -- vanilla v1model
  with `@controller_header` but no `@p4runtime_translation` still gets correct
  `packet_in` with stripped payload and raw metadata (DataplaneServiceTest)
- [x] `non-CPU-port output has no PacketIn enrichment` -- regular data-plane
  outputs are not affected (SaiP4E2ETest)
- [x] All 24 `//grpc/...` tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)