### PR TITLE
Fix lint: dep ordering + surface detekt output on failure

### DIFF
--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -316,10 +316,10 @@ kt_jvm_test(
     test_class = "fourward.grpc.BytestringsTest",
     deps = [
         ":grpc",
+        "//simulator:p4runtime_java_proto",
         "@fourward_maven//:com_google_protobuf_protobuf_java",
         "@fourward_maven//:io_grpc_grpc_api",
         "@fourward_maven//:junit_junit",
-        "//simulator:p4runtime_java_proto",
     ],
 )
 

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -84,9 +84,15 @@ else
 fi
 
 echo "Running detekt..."
-bazel run //:detekt -- \
+detekt_output=$(mktemp)
+if ! bazel run //:detekt -- \
   --input "${REPO_ROOT}/simulator,${REPO_ROOT}/grpc,${REPO_ROOT}/e2e_tests,${REPO_ROOT}/cli,${REPO_ROOT}/web" \
   --config "${REPO_ROOT}/detekt.yml" \
-  --build-upon-default-config || rc=1
+  --build-upon-default-config 2>&1 | tee "$detekt_output"; then
+  echo "ERROR: detekt found issues:"
+  cat "$detekt_output"
+  rc=1
+fi
+rm -f "$detekt_output"
 
 exit $rc


### PR DESCRIPTION
## Summary

Two fixes:

1. **buildifier dep ordering** in `BytestringsTest` BUILD target (introduced in #701) — `//simulator:p4runtime_java_proto` was out of alphabetical order.

2. **Surface detekt output on CI failure.** The lint script was swallowing detekt's violation report — CI showed "exit code 1" with no context about what was wrong. Now the output is tee'd to a temp file and echoed on failure.

## Test plan

- [x] `./tools/lint.sh` passes locally
- [x] `./tools/format.sh --check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)