### PR TITLE
P4Runtime error reporting: spec compliance fixes

### DIFF
--- a/grpc/GoldenErrorTest.kt
+++ b/grpc/GoldenErrorTest.kt
@@ -1179,12 +1179,20 @@ class GoldenErrorTest(private val testName: String) {
     }
   }
 
-  private fun triggerDigestStreamNotSupported() = runBlocking {
-    val request =
-      P4RuntimeOuterClass.StreamMessageRequest.newBuilder()
-        .setDigestAck(P4RuntimeOuterClass.DigestListAck.newBuilder().setDigestId(1))
-        .build()
-    harness.stub.streamChannel(flowOf(request)).collect {}
+  private fun triggerDigestStreamNotSupported() {
+    harness.openStream().use { stream ->
+      stream.arbitrate()
+      val request =
+        P4RuntimeOuterClass.StreamMessageRequest.newBuilder()
+          .setDigestAck(P4RuntimeOuterClass.DigestListAck.newBuilder().setDigestId(1))
+          .build()
+      val response =
+        stream.sendRaw(request)
+          ?: throw AssertionError("expected StreamError response for digest ack")
+      if (!response.hasError()) throw AssertionError("expected StreamError, got: $response")
+      val err = response.error
+      throw Status.fromCodeValue(err.canonicalCode).withDescription(err.message).asException()
+    }
   }
 
   @Suppress("MagicNumber")

--- a/grpc/P4RuntimeConformanceTest.kt
+++ b/grpc/P4RuntimeConformanceTest.kt
@@ -2134,17 +2134,24 @@ class P4RuntimeConformanceTest {
     }
   }
 
-  /** StreamChannel: digest ack is not supported and must be explicitly rejected. */
+  /** StreamChannel: digest ack is not supported: returns StreamError, does not terminate stream. */
   @Test
-  fun `101 - digest ack via stream returns UNIMPLEMENTED`() {
-    assertGrpcError(Status.Code.UNIMPLEMENTED, "digest") {
-      runBlocking {
-        val request =
-          StreamMessageRequest.newBuilder()
-            .setDigestAck(P4RuntimeOuterClass.DigestListAck.newBuilder().setDigestId(1))
-            .build()
-        harness.stub.streamChannel(flowOf(request)).collect {}
-      }
+  fun `101 - digest ack via stream returns StreamError`() {
+    harness.openStream().use { stream ->
+      stream.arbitrate()
+      val request =
+        StreamMessageRequest.newBuilder()
+          .setDigestAck(P4RuntimeOuterClass.DigestListAck.newBuilder().setDigestId(1))
+          .build()
+      val response = stream.sendRaw(request)
+      assertNotNull("expected a StreamError response", response)
+      assertTrue("should be a StreamError", response!!.hasError())
+      assertEquals(com.google.rpc.Code.UNIMPLEMENTED_VALUE, response.error.canonicalCode)
+      assertTrue(
+        "message should mention digest",
+        response.error.message.contains("digest", ignoreCase = true),
+      )
+      assertTrue("details should use digest_list_ack oneof", response.error.hasDigestListAck())
     }
   }
 

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -655,9 +655,18 @@ class P4RuntimeService(
           when (msg.updateCase) {
             StreamMessageRequest.UpdateCase.ARBITRATION ->
               send(handleArbitration(streamId, msg.arbitration, notifications))
-            StreamMessageRequest.UpdateCase.PACKET -> handlePacketOut(msg.packet)
+            StreamMessageRequest.UpdateCase.PACKET -> handlePacketOut(msg.packet)?.let { send(it) }
             StreamMessageRequest.UpdateCase.DIGEST_ACK ->
-              throw Status.UNIMPLEMENTED.withDescription(DIGEST_NOT_SUPPORTED).asException()
+              send(
+                StreamMessageResponse.newBuilder()
+                  .setError(
+                    P4RuntimeOuterClass.StreamError.newBuilder()
+                      .setCanonicalCode(Code.UNIMPLEMENTED_VALUE)
+                      .setMessage(DIGEST_NOT_SUPPORTED)
+                      .setDigestListAck(P4RuntimeOuterClass.DigestListAckError.getDefaultInstance())
+                  )
+                  .build()
+              )
             // P4Runtime spec §16: unrecognized stream messages get an error response.
             StreamMessageRequest.UpdateCase.OTHER,
             StreamMessageRequest.UpdateCase.UPDATE_NOT_SET,
@@ -687,30 +696,49 @@ class P4RuntimeService(
    * Processes a PacketOut: translates metadata, serializes the packet header, and runs the packet
    * through the broker. PacketIn delivery is handled by the broker subscription in [streamChannel],
    * not here. The broker handles locking and the pre-packet hook.
+   *
+   * Returns a [StreamError] response on failure (P4Runtime spec §16.6), or null on success. A
+   * single bad PacketOut must not terminate arbitration or PacketIn delivery on the stream.
    */
-  private fun handlePacketOut(packet: p4.v1.P4RuntimeOuterClass.PacketOut) {
-    val state = pipeline ?: return
-    val translator = state.typeTranslator?.takeIf { it.hasTranslations }
-    val codec = state.packetHeaderCodec
-    val packetOut = translator?.translatePacketOut(packet) ?: packet
+  private fun handlePacketOut(packet: p4.v1.P4RuntimeOuterClass.PacketOut): StreamMessageResponse? {
+    val state = pipeline ?: return null
 
-    // If the pipeline has a packet_out header, serialize metadata into a binary
-    // header and prepend it. The parser expects the packet to arrive on the CPU
-    // port with the header prepended.
-    val (ingressPort, payload) =
-      if (codec != null) {
-        codec.cpuPort to
-          codec.packPacketOut(packetOut.metadataList, packetOut.payload.toByteArray())
-      } else {
-        extractIngressPort(packetOut.metadataList) to packetOut.payload.toByteArray()
-      }
+    fun packetOutError(code: Int, message: String?): StreamMessageResponse =
+      StreamMessageResponse.newBuilder()
+        .setError(
+          P4RuntimeOuterClass.StreamError.newBuilder()
+            .setCanonicalCode(code)
+            .setMessage("PacketOut processing failed: ${message ?: "unknown error"}")
+            .setPacketOut(P4RuntimeOuterClass.PacketOutError.newBuilder().setPacketOut(packet))
+        )
+        .build()
 
-    try {
+    return try {
+      val translator = state.typeTranslator?.takeIf { it.hasTranslations }
+      val codec = state.packetHeaderCodec
+      val packetOut = translator?.translatePacketOut(packet) ?: packet
+
+      // If the pipeline has a packet_out header, serialize metadata into a binary
+      // header and prepend it. The parser expects the packet to arrive on the CPU
+      // port with the header prepended.
+      val (ingressPort, payload) =
+        if (codec != null) {
+          codec.cpuPort to
+            codec.packPacketOut(packetOut.metadataList, packetOut.payload.toByteArray())
+        } else {
+          extractIngressPort(packetOut.metadataList) to packetOut.payload.toByteArray()
+        }
+
       broker.processPacket(ingressPort, payload)
-    } catch (e: IllegalStateException) {
-      throw Status.INTERNAL.withDescription("PacketOut processing failed: ${e.message}")
-        .withCause(e)
-        .asException()
+      null
+    } catch (e: IllegalArgumentException) {
+      packetOutError(Code.INVALID_ARGUMENT_VALUE, e.message)
+    } catch (e: TranslationException) {
+      packetOutError(Code.INVALID_ARGUMENT_VALUE, e.message)
+    } catch (
+      @Suppress("TooGenericExceptionCaught") // Report as StreamError, don't crash the stream.
+      e: Exception) {
+      packetOutError(Code.INTERNAL_VALUE, e.message)
     }
   }
 

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -597,6 +597,51 @@ class SaiP4E2ETest {
     }
   }
 
+  @Test
+  fun `PacketOut with invalid translated metadata returns StreamError and keeps stream open`() {
+    config =
+      withPortMappings(
+        FourwardTestHarness.loadConfig("e2e_tests/sai_p4/sai_middleblock.txtpb"),
+        mapOf(
+          "0" to 0,
+          "1" to 1,
+          MIRROR_PORT.toString() to MIRROR_PORT,
+          CPU_PORT.toString() to CPU_PORT,
+        ),
+        autoAllocate = false,
+      )
+    harness.loadPipeline(config)
+    val packetOutMeta =
+      config.p4Info.controllerPacketMetadataList.find { it.preamble.name == "packet_out" }!!
+    val egressPortId = packetOutMeta.metadataList.find { it.name == "egress_port" }!!.id
+    val badPacketOut =
+      buildCpuPacketOut(submitToIngress = false)
+        .toBuilder()
+        .removeMetadata(0)
+        .addMetadata(
+          0,
+          P4RuntimeOuterClass.PacketMetadata.newBuilder()
+            .setMetadataId(egressPortId)
+            .setValue(ByteString.copyFromUtf8("Ethernet999"))
+            .build(),
+        )
+        .build()
+
+    harness.openStream().use { session ->
+      session.arbitrate()
+      val response = session.sendPacketOut(badPacketOut)
+      assertNotNull("invalid PacketOut should produce StreamError", response)
+      assertTrue("response should be StreamError", response!!.hasError())
+      assertEquals(com.google.rpc.Code.INVALID_ARGUMENT_VALUE, response.error.canonicalCode)
+      assertTrue("details should use packet_out oneof", response.error.hasPacketOut())
+
+      val stillOpen = session.sendRaw(P4RuntimeOuterClass.StreamMessageRequest.getDefaultInstance())
+      assertNotNull("stream should remain usable after PacketOut StreamError", stillOpen)
+      assertTrue("follow-up response should be StreamError", stillOpen!!.hasError())
+      assertEquals(com.google.rpc.Code.INVALID_ARGUMENT_VALUE, stillOpen.error.canonicalCode)
+    }
+  }
+
   // =========================================================================
   // PacketIO: ACL trap/copy → PacketIn via StreamChannel
   // =========================================================================
@@ -2070,9 +2115,13 @@ class SaiP4E2ETest {
      * architecture-defined ports like the CPU port need fixed P4RT ↔ dataplane mappings that
      * auto-allocation alone can't provide.
      */
-    private fun withPortMappings(config: PipelineConfig, ports: Map<String, Int>): PipelineConfig {
+    private fun withPortMappings(
+      config: PipelineConfig,
+      ports: Map<String, Int>,
+      autoAllocate: Boolean = true,
+    ): PipelineConfig {
       val portTranslation =
-        TypeTranslation.newBuilder().setTypeName("port_id_t").setAutoAllocate(true)
+        TypeTranslation.newBuilder().setTypeName("port_id_t").setAutoAllocate(autoAllocate)
       for ((name, dpValue) in ports) {
         portTranslation.addEntries(
           TranslationEntry.newBuilder().setSdnStr(name).setDataplaneValue(encodeMinWidth(dpValue))


### PR DESCRIPTION
Closes #705.

## Summary
After #707 handled structured Write/Read batch errors, this PR keeps the remaining P4Runtime StreamChannel compliance fixes:

- Return `StreamError` for unsupported `DIGEST_ACK` instead of terminating the stream, using the `digest_list_ack` detail oneof.
- Return `packet_out` `StreamError` for PacketOut translation, metadata packing, ingress extraction, and processing failures instead of terminating the stream.
- Classify PacketOut metadata/translation failures as `INVALID_ARGUMENT`; reserve `INTERNAL` for unexpected processing failures.
- Add regression coverage proving the stream stays usable after PacketOut errors.

## Tests
- `bazel test //grpc:P4RuntimeConformanceTest //grpc:GoldenErrorTest //grpc:SaiP4E2ETest`
- `bazel test //grpc/...`
- `./tools/format.sh`
- `./tools/lint.sh`
