### PR TITLE
Report P4Runtime batch errors structurally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,17 +164,18 @@ jobs:
           echo "build --config=ci" >> ~/.bazelrc
           echo "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
 
-      # Select a deterministic Xcode within the current runner image.
-      # Doesn't protect against image rotation (different images may
-      # have different "newest" versions), but prevents non-determinism
-      # from multiple Xcode versions on the same image.
-      - name: Select newest Xcode
+      # Use an Xcode version Bazel's xcode-locator can resolve on macos-26.
+      # The runner also exposes a 26.5.0 path, but xcode-locator only reports
+      # 26.5/26.5.0, which can leave cached C++ toolchain config pointing at an
+      # unavailable build string.
+      - name: Select stable Xcode
         if: runner.os == 'macOS'
         run: |
-          XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
-          if [[ -n "$XCODE" ]]; then
+          XCODE=/Applications/Xcode_26.4.1.app
+          if [[ -d "$XCODE" ]]; then
             sudo xcode-select -s "$XCODE"
             echo "Selected $XCODE"
+            echo "build --xcode_version=26.4.1" >> ~/.bazelrc
           else
             echo "::warning::No versioned Xcode found; using default $(xcode-select -p)"
           fi
@@ -202,11 +203,15 @@ jobs:
             bazel-${{ matrix.os }}-
             ${{ matrix.os == 'ubuntu-24.04' && 'bazel-coverage-' || '' }}
 
-      # The cached install base may be stale if Bazel was updated between
-      # the cache save and this run. Bazelisk downloads the correct version
-      # but can't overwrite a corrupt install directory.
-      - name: Clear stale Bazel install
-        run: rm -rf ${{ env.BAZEL_CACHE }}/_bazel_*/install
+      # The cached install base may be stale if Bazel was updated between the
+      # cache save and this run. On macOS, local_config_cc also captures the
+      # selected SDK path, so regenerate it after restoring the output base.
+      - name: Clear stale Bazel autoconfig
+        run: |
+          rm -rf ${{ env.BAZEL_CACHE }}/_bazel_*/install
+          if [[ "$RUNNER_OS" == "macOS" && -n "${{ steps.bazel.outputs.output_base }}" ]]; then
+            rm -rf "${{ steps.bazel.outputs.output_base }}"/external/*local_config_cc*
+          fi
 
       # BMv2 links against system libgmp and libpcap.
       - name: Install system dependencies
@@ -373,13 +378,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Select newest Xcode
+      - name: Select stable Xcode
         if: runner.os == 'macOS'
         run: |
-          XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
-          if [[ -n "$XCODE" ]]; then
+          XCODE=/Applications/Xcode_26.4.1.app
+          if [[ -d "$XCODE" ]]; then
             sudo xcode-select -s "$XCODE"
             echo "Selected $XCODE"
+            echo "build --xcode_version=26.4.1" >> ~/.bazelrc
           else
             echo "::warning::No versioned Xcode found; using default $(xcode-select -p)"
           fi
@@ -401,8 +407,12 @@ jobs:
           key: bazel-${{ matrix.os }}-${{ hashFiles('*.bazel*') }}
           restore-keys: bazel-${{ matrix.os }}-
 
-      - name: Clear stale Bazel install
-        run: rm -rf ${{ env.BAZEL_CACHE }}/_bazel_*/install
+      - name: Clear stale Bazel autoconfig
+        run: |
+          rm -rf ${{ env.BAZEL_CACHE }}/_bazel_*/install
+          if [[ "$RUNNER_OS" == "macOS" && -n "${{ steps.bazel.outputs.output_base }}" ]]; then
+            rm -rf "${{ steps.bazel.outputs.output_base }}"/external/*local_config_cc*
+          fi
 
       - name: Install system dependencies
         if: runner.os == 'Linux'

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -565,6 +565,20 @@ class FourwardTestHarness(
       return rpcStatus.detailsList.map { any -> P4RuntimeOuterClass.Error.parseFrom(any.value) }
     }
 
+    /** Executes [block], asserts it throws a batch UNKNOWN, and returns the per-item errors. */
+    fun assertBatchError(block: () -> Unit): List<P4RuntimeOuterClass.Error> {
+      try {
+        block()
+        throw AssertionError("expected batch error")
+      } catch (e: StatusException) {
+        if (e.status.code != Status.Code.UNKNOWN) {
+          throw AssertionError("expected batch UNKNOWN but got ${e.status.code}", e)
+        }
+        return extractBatchErrors(e)
+          ?: throw AssertionError("no batch error details in trailers", e)
+      }
+    }
+
     /**
      * Builds a read-filter entity: table_id + exact match key, no action. Useful as a ReadRequest
      * filter for per-entry reads.

--- a/grpc/P4RuntimeConformanceTest.kt
+++ b/grpc/P4RuntimeConformanceTest.kt
@@ -2496,6 +2496,36 @@ class P4RuntimeConformanceTest {
     }
   }
 
+  /** §10/§13.3: Read batch errors use the same 1:1 structured details as Write. */
+  @Test
+  fun `121b - read batch error has structured details in trailers`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    harness.installEntry(buildExactEntry(config, matchValue = 0x0800, port = 1))
+    val request =
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder().setTableEntry(P4RuntimeOuterClass.TableEntry.newBuilder()).build()
+        )
+        .addEntities(
+          Entity.newBuilder()
+            .setDigestEntry(P4RuntimeOuterClass.DigestEntry.newBuilder().setDigestId(1))
+            .build()
+        )
+        .build()
+    try {
+      harness.readEntries(request)
+      throw AssertionError("expected read batch error")
+    } catch (e: StatusException) {
+      assertEquals(Status.Code.UNKNOWN, e.status.code)
+      val errors = checkNotNull(FourwardTestHarness.extractBatchErrors(e))
+      assertEquals("should have 2 per-read statuses", 2, errors.size)
+      assertEquals(com.google.rpc.Code.OK_VALUE, errors[0].canonicalCode)
+      assertEquals(com.google.rpc.Code.UNIMPLEMENTED_VALUE, errors[1].canonicalCode)
+    }
+  }
+
   // =========================================================================
   // §12.1: Write batch ordering — cross-entity-type (scenario 122)
   // =========================================================================

--- a/grpc/P4RuntimeConformanceTest.kt
+++ b/grpc/P4RuntimeConformanceTest.kt
@@ -8,6 +8,7 @@ import com.google.protobuf.Any as ProtoAny
 import com.google.protobuf.ByteString
 import com.google.protobuf.TextFormat
 import fourward.PipelineConfig
+import fourward.grpc.FourwardTestHarness.Companion.assertBatchError
 import fourward.grpc.FourwardTestHarness.Companion.assertGrpcError
 import fourward.grpc.FourwardTestHarness.Companion.buildEthernetFrame
 import fourward.grpc.FourwardTestHarness.Companion.buildExactEntry
@@ -17,7 +18,6 @@ import fourward.grpc.FourwardTestHarness.Companion.loadConfig
 import fourward.grpc.FourwardTestHarness.Companion.uint128
 import fourward.simulator.portToBytes
 import io.grpc.Status
-import io.grpc.StatusException
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -2465,16 +2465,11 @@ class P4RuntimeConformanceTest {
         .addUpdates(Update.newBuilder().setType(Update.Type.INSERT).setEntity(good))
         .addUpdates(Update.newBuilder().setType(Update.Type.INSERT).setEntity(bad))
         .build()
-    try {
-      harness.writeRaw(request)
-      throw AssertionError("expected batch error")
-    } catch (e: StatusException) {
-      val errors = checkNotNull(FourwardTestHarness.extractBatchErrors(e))
-      assertEquals("should have 2 per-update statuses", 2, errors.size)
-      assertEquals(com.google.rpc.Code.OK_VALUE, errors[0].canonicalCode)
-      assertTrue("bad update should have error code", errors[1].canonicalCode != 0)
-      assertTrue("bad update should have error message", errors[1].message.isNotEmpty())
-    }
+    val errors = assertBatchError { harness.writeRaw(request) }
+    assertEquals("should have 2 per-update statuses", 2, errors.size)
+    assertEquals(com.google.rpc.Code.OK_VALUE, errors[0].canonicalCode)
+    assertTrue("bad update should have error code", errors[1].canonicalCode != 0)
+    assertTrue("bad update should have error message", errors[1].message.isNotEmpty())
   }
 
   /** §10: Single-update write errors are wrapped as per-update batch errors. */
@@ -2486,14 +2481,9 @@ class P4RuntimeConformanceTest {
       Entity.newBuilder()
         .setTableEntry(P4RuntimeOuterClass.TableEntry.newBuilder().setTableId(999999))
         .build()
-    try {
-      harness.installEntry(bad)
-      throw AssertionError("expected error")
-    } catch (e: StatusException) {
-      val errors = checkNotNull(FourwardTestHarness.extractBatchErrors(e))
-      assertEquals(1, errors.size)
-      assertTrue("should have non-OK code", errors[0].canonicalCode != 0)
-    }
+    val errors = assertBatchError { harness.installEntry(bad) }
+    assertEquals(1, errors.size)
+    assertTrue("should have non-OK code", errors[0].canonicalCode != 0)
   }
 
   /** §10/§13.3: Read batch errors use the same 1:1 structured details as Write. */
@@ -2514,16 +2504,10 @@ class P4RuntimeConformanceTest {
             .build()
         )
         .build()
-    try {
-      harness.readEntries(request)
-      throw AssertionError("expected read batch error")
-    } catch (e: StatusException) {
-      assertEquals(Status.Code.UNKNOWN, e.status.code)
-      val errors = checkNotNull(FourwardTestHarness.extractBatchErrors(e))
-      assertEquals("should have 2 per-read statuses", 2, errors.size)
-      assertEquals(com.google.rpc.Code.OK_VALUE, errors[0].canonicalCode)
-      assertEquals(com.google.rpc.Code.UNIMPLEMENTED_VALUE, errors[1].canonicalCode)
-    }
+    val errors = assertBatchError { harness.readEntries(request) }
+    assertEquals("should have 2 per-read statuses", 2, errors.size)
+    assertEquals(com.google.rpc.Code.OK_VALUE, errors[0].canonicalCode)
+    assertEquals(com.google.rpc.Code.UNIMPLEMENTED_VALUE, errors[1].canonicalCode)
   }
 
   // =========================================================================

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -451,7 +451,7 @@ class P4RuntimeService(
     for (rawUpdate in updates) {
       try {
         processUpdate(rawUpdate, state, roleName)
-        errors.add(okBatchItemError())
+        errors.add(OK_BATCH_ITEM_ERROR)
       } catch (e: StatusException) {
         hasError = true
         errors.add(batchItemError(e))
@@ -460,7 +460,7 @@ class P4RuntimeService(
     // Publish even on partial failure — successful updates must be visible to subsequent reads.
     simulator.publishSnapshot()
     if (hasError) {
-      throw buildBatchError(errors, itemName = "update")
+      throw buildBatchError(errors, itemName = "update", itemNamePlural = "updates")
     }
     return WriteResponse.getDefaultInstance()
   }
@@ -482,7 +482,11 @@ class P4RuntimeService(
       } catch (e: StatusException) {
         simulator.restore(checkpoint)
         simulator.publishSnapshot()
-        throw buildBatchError(atomicRollbackErrors(updates.size, index, e), itemName = "update")
+        throw buildBatchError(
+          atomicRollbackErrors(updates.size, index, e),
+          itemName = "update",
+          itemNamePlural = "updates",
+        )
       }
     }
     simulator.publishSnapshot()
@@ -501,8 +505,7 @@ class P4RuntimeService(
     cause: StatusException,
   ): List<P4RuntimeOuterClass.Error> =
     List(updateCount) { index ->
-      if (index == failedIndex) batchItemError(cause)
-      else abortedBatchItemError("batch rolled back because update #${failedIndex + 1} failed")
+      if (index == failedIndex) batchItemError(cause) else abortedBatchItemError(failedIndex)
     }
 
   /** Validates and applies a single update. Throws [StatusException] on failure. */
@@ -590,7 +593,7 @@ class P4RuntimeService(
               .asException()
           }
         )
-        errors.add(okBatchItemError())
+        errors.add(OK_BATCH_ITEM_ERROR)
       } catch (e: StatusException) {
         hasError = true
         errors.add(batchItemError(e))
@@ -609,7 +612,7 @@ class P4RuntimeService(
       emit(ReadResponse.newBuilder().addAllEntities(translated).build())
     }
     if (hasError) {
-      throw buildBatchError(errors, itemName = "read request")
+      throw buildBatchError(errors, itemName = "read request", itemNamePlural = "read requests")
     }
   }
 
@@ -1066,6 +1069,7 @@ class P4RuntimeService(
   private fun buildBatchError(
     errors: List<P4RuntimeOuterClass.Error>,
     itemName: String,
+    itemNamePlural: String,
   ): StatusException {
     val failedCount = errors.count { it.canonicalCode != OK_CODE }
     val totalCount = errors.size
@@ -1074,7 +1078,7 @@ class P4RuntimeService(
         .withIndex()
         .filter { it.value.canonicalCode != OK_CODE }
         .joinToString("; ") { (i, e) -> "$itemName #${i + 1}: ${e.message}" }
-    val message = "$failedCount of $totalCount ${itemName}s failed: $failedDetails"
+    val message = "$failedCount of $totalCount $itemNamePlural failed: $failedDetails"
     val rpcStatus =
       com.google.rpc.Status.newBuilder().setCode(Code.UNKNOWN_VALUE).setMessage(message)
     for (error in errors) {
@@ -1085,9 +1089,6 @@ class P4RuntimeService(
     return Status.UNKNOWN.withDescription(message).asException(metadata)
   }
 
-  private fun okBatchItemError(): P4RuntimeOuterClass.Error =
-    P4RuntimeOuterClass.Error.newBuilder().setCanonicalCode(OK_CODE).build()
-
   private fun batchItemError(e: StatusException): P4RuntimeOuterClass.Error =
     P4RuntimeOuterClass.Error.newBuilder()
       .setCanonicalCode(e.status.code.value())
@@ -1096,10 +1097,10 @@ class P4RuntimeService(
       .setCode(e.status.code.value())
       .build()
 
-  private fun abortedBatchItemError(message: String): P4RuntimeOuterClass.Error =
+  private fun abortedBatchItemError(failedIndex: Int): P4RuntimeOuterClass.Error =
     P4RuntimeOuterClass.Error.newBuilder()
       .setCanonicalCode(Code.ABORTED_VALUE)
-      .setMessage(message)
+      .setMessage("batch rolled back because update #${failedIndex + 1} failed")
       .setSpace(P4RT_ERROR_SPACE)
       .setCode(Code.ABORTED_VALUE)
       .build()
@@ -1161,6 +1162,9 @@ class P4RuntimeService(
       "Role.config is not supported; use @p4runtime_role annotations in p4info instead"
 
     private const val OK_CODE = Code.OK_VALUE
+
+    private val OK_BATCH_ITEM_ERROR =
+      P4RuntimeOuterClass.Error.newBuilder().setCanonicalCode(OK_CODE).build()
 
     // P4Runtime spec §12.3: the error space for P4Runtime-specific errors.
     private const val P4RT_ERROR_SPACE = "p4.v1"

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -451,29 +451,16 @@ class P4RuntimeService(
     for (rawUpdate in updates) {
       try {
         processUpdate(rawUpdate, state, roleName)
-        errors.add(
-          P4RuntimeOuterClass.Error.newBuilder()
-            .setCanonicalCode(OK_CODE)
-            .setSpace(P4RT_ERROR_SPACE)
-            .setCode(OK_CODE)
-            .build()
-        )
+        errors.add(okBatchItemError())
       } catch (e: StatusException) {
         hasError = true
-        errors.add(
-          P4RuntimeOuterClass.Error.newBuilder()
-            .setCanonicalCode(e.status.code.value())
-            .setMessage(e.status.description ?: "")
-            .setSpace(P4RT_ERROR_SPACE)
-            .setCode(e.status.code.value())
-            .build()
-        )
+        errors.add(batchItemError(e))
       }
     }
     // Publish even on partial failure — successful updates must be visible to subsequent reads.
     simulator.publishSnapshot()
     if (hasError) {
-      throw buildBatchError(errors)
+      throw buildBatchError(errors, itemName = "update")
     }
     return WriteResponse.getDefaultInstance()
   }
@@ -489,18 +476,34 @@ class P4RuntimeService(
     roleName: String,
   ): WriteResponse {
     val checkpoint = simulator.snapshot()
-    try {
-      for (rawUpdate in updates) {
+    for ((index, rawUpdate) in updates.withIndex()) {
+      try {
         processUpdate(rawUpdate, state, roleName)
+      } catch (e: StatusException) {
+        simulator.restore(checkpoint)
+        simulator.publishSnapshot()
+        throw buildBatchError(atomicRollbackErrors(updates.size, index, e), itemName = "update")
       }
-    } catch (e: StatusException) {
-      simulator.restore(checkpoint)
-      simulator.publishSnapshot()
-      throw e
     }
     simulator.publishSnapshot()
     return WriteResponse.getDefaultInstance()
   }
+
+  /**
+   * Builds one status per requested update for an all-or-none write that was rolled back.
+   *
+   * The update that triggered rollback keeps its specific status. Other updates receive ABORTED:
+   * none are visible after rollback, so reporting them as OK would incorrectly imply success.
+   */
+  private fun atomicRollbackErrors(
+    updateCount: Int,
+    failedIndex: Int,
+    cause: StatusException,
+  ): List<P4RuntimeOuterClass.Error> =
+    List(updateCount) { index ->
+      if (index == failedIndex) batchItemError(cause)
+      else abortedBatchItemError("batch rolled back because update #${failedIndex + 1} failed")
+    }
 
   /** Validates and applies a single update. Throws [StatusException] on failure. */
   private fun processUpdate(rawUpdate: Update, state: PipelineState, roleName: String) {
@@ -565,24 +568,34 @@ class P4RuntimeService(
     val roleName = request.role // empty = default role
     // Table entries are assembled by EntityReader (P4Runtime presentation layer);
     // all other entity types are read directly from the simulator.
-    val entities =
-      request.entitiesList.flatMap { entity ->
+    val entities = mutableListOf<Entity>()
+    val errors = ArrayList<P4RuntimeOuterClass.Error>(request.entitiesCount)
+    var hasError = false
+    for (entity in request.entitiesList) {
+      try {
         rejectUnsupportedEntity(entity)
         // For specific (non-wildcard) entities, check access upfront so the controller
         // gets a clear PERMISSION_DENIED. For wildcards, results are filtered post-read.
         requireEntityAccess(entity, state.roleMap, roleName)
-        try {
-          if (entity.hasTableEntry()) {
-            state.entityReader.readTableEntities(entity.tableEntry, simulator)
-          } else {
-            simulator.readEntries(listOf(entity))
+        entities.addAll(
+          try {
+            if (entity.hasTableEntry()) {
+              state.entityReader.readTableEntities(entity.tableEntry, simulator)
+            } else {
+              simulator.readEntries(listOf(entity))
+            }
+          } catch (e: IllegalStateException) {
+            throw Status.INTERNAL.withDescription("read failed: ${e.message}")
+              .withCause(e)
+              .asException()
           }
-        } catch (e: IllegalStateException) {
-          throw Status.INTERNAL.withDescription("read failed: ${e.message}")
-            .withCause(e)
-            .asException()
-        }
+        )
+        errors.add(okBatchItemError())
+      } catch (e: StatusException) {
+        hasError = true
+        errors.add(batchItemError(e))
       }
+    }
     // Filter results by role for named-role controllers. This handles wildcard reads
     // (where the request entity doesn't carry a specific ID) by returning only entities
     // the controller's role can access.
@@ -594,6 +607,9 @@ class P4RuntimeService(
           ?.takeIf { it.hasTranslations }
           ?.let { t -> filtered.map { t.translateForRead(it) } } ?: filtered
       emit(ReadResponse.newBuilder().addAllEntities(translated).build())
+    }
+    if (hasError) {
+      throw buildBatchError(errors, itemName = "read request")
     }
   }
 
@@ -1038,24 +1054,27 @@ class P4RuntimeService(
   }
 
   // ---------------------------------------------------------------------------
-  // Batch error reporting (P4Runtime spec §12.3)
+  // Batch error reporting (P4Runtime spec §10, §12.3, §13.3)
   // ---------------------------------------------------------------------------
 
   /**
-   * Builds a gRPC UNKNOWN error with per-update [P4RuntimeOuterClass.Error] details.
+   * Builds a gRPC UNKNOWN error with one [P4RuntimeOuterClass.Error] detail per batch item.
    *
    * The `google.rpc.Status` is attached via the standard `grpc-status-details-bin` trailer so
-   * clients can extract per-update results (P4Runtime spec §10, §12.3).
+   * clients can extract per-item results (P4Runtime spec §10, §12.3, §13.3).
    */
-  private fun buildBatchError(errors: List<P4RuntimeOuterClass.Error>): StatusException {
+  private fun buildBatchError(
+    errors: List<P4RuntimeOuterClass.Error>,
+    itemName: String,
+  ): StatusException {
     val failedCount = errors.count { it.canonicalCode != OK_CODE }
     val totalCount = errors.size
     val failedDetails =
       errors
         .withIndex()
         .filter { it.value.canonicalCode != OK_CODE }
-        .joinToString("; ") { (i, e) -> "update #${i + 1}: ${e.message}" }
-    val message = "$failedCount of $totalCount updates failed: $failedDetails"
+        .joinToString("; ") { (i, e) -> "$itemName #${i + 1}: ${e.message}" }
+    val message = "$failedCount of $totalCount ${itemName}s failed: $failedDetails"
     val rpcStatus =
       com.google.rpc.Status.newBuilder().setCode(Code.UNKNOWN_VALUE).setMessage(message)
     for (error in errors) {
@@ -1065,6 +1084,25 @@ class P4RuntimeService(
     metadata.put(STATUS_DETAILS_KEY, rpcStatus.build().toByteArray())
     return Status.UNKNOWN.withDescription(message).asException(metadata)
   }
+
+  private fun okBatchItemError(): P4RuntimeOuterClass.Error =
+    P4RuntimeOuterClass.Error.newBuilder().setCanonicalCode(OK_CODE).build()
+
+  private fun batchItemError(e: StatusException): P4RuntimeOuterClass.Error =
+    P4RuntimeOuterClass.Error.newBuilder()
+      .setCanonicalCode(e.status.code.value())
+      .setMessage(e.status.description ?: "")
+      .setSpace(P4RT_ERROR_SPACE)
+      .setCode(e.status.code.value())
+      .build()
+
+  private fun abortedBatchItemError(message: String): P4RuntimeOuterClass.Error =
+    P4RuntimeOuterClass.Error.newBuilder()
+      .setCanonicalCode(Code.ABORTED_VALUE)
+      .setMessage(message)
+      .setSpace(P4RT_ERROR_SPACE)
+      .setCode(Code.ABORTED_VALUE)
+      .build()
 
   override fun close() {
     pipeline?.constraintValidator?.close()

--- a/grpc/P4RuntimeWriteErrorTest.kt
+++ b/grpc/P4RuntimeWriteErrorTest.kt
@@ -363,6 +363,8 @@ class P4RuntimeWriteErrorTest {
     val errors = assertBatchError { harness.writeRaw(request) }
     assert(errors.size == 2) { "expected 2 per-update errors, got ${errors.size}" }
     assert(errors[0].canonicalCode == com.google.rpc.Code.OK_VALUE) { "first update should be OK" }
+    assert(errors[0].space.isEmpty()) { "OK update should omit error space" }
+    assert(errors[0].code == 0) { "OK update should omit target-specific code" }
     assert(errors[1].canonicalCode == com.google.rpc.Code.INVALID_ARGUMENT_VALUE) {
       "second update should be INVALID_ARGUMENT"
     }
@@ -392,7 +394,14 @@ class P4RuntimeWriteErrorTest {
         .toBuilder()
         .setAtomicity(atomicity)
         .build()
-    assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.writeRaw(request) }
+    val errors = assertBatchError { harness.writeRaw(request) }
+    assert(errors.size == 2) { "expected one per-update status per request update" }
+    assert(errors[0].canonicalCode == com.google.rpc.Code.ABORTED_VALUE) {
+      "rolled-back update should be ABORTED, got ${errors[0].canonicalCode}"
+    }
+    assert(errors[1].canonicalCode == com.google.rpc.Code.INVALID_ARGUMENT_VALUE) {
+      "failing update should keep its specific error code, got ${errors[1].canonicalCode}"
+    }
     val readBack = harness.readEntries()
     assert(readBack.isEmpty()) { "$atomicity should have rolled back the good entry" }
   }
@@ -453,6 +462,8 @@ class P4RuntimeWriteErrorTest {
     val errors = assertBatchError { harness.writeRaw(request) }
     assert(errors.size == 2) { "expected 2 per-update errors" }
     assert(errors[0].canonicalCode == com.google.rpc.Code.OK_VALUE) { "first INSERT should be OK" }
+    assert(errors[0].space.isEmpty()) { "OK update should omit error space" }
+    assert(errors[0].code == 0) { "OK update should omit target-specific code" }
     assert(errors[1].canonicalCode == com.google.rpc.Code.ALREADY_EXISTS_VALUE) {
       "second INSERT should be ALREADY_EXISTS"
     }

--- a/grpc/P4RuntimeWriteErrorTest.kt
+++ b/grpc/P4RuntimeWriteErrorTest.kt
@@ -2,11 +2,10 @@ package fourward.grpc
 
 import com.google.protobuf.ByteString
 import fourward.PipelineConfig
+import fourward.grpc.FourwardTestHarness.Companion.assertBatchError
 import fourward.grpc.FourwardTestHarness.Companion.assertGrpcError
 import fourward.grpc.FourwardTestHarness.Companion.buildExactEntry
-import fourward.grpc.FourwardTestHarness.Companion.extractBatchErrors
 import io.grpc.Status
-import io.grpc.StatusException
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -587,14 +586,4 @@ class P4RuntimeWriteErrorTest {
   /** Builds an entity referencing a non-existent table, for error-path testing. */
   private fun badTableEntity(tableId: Int = 99999): Entity =
     Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(tableId)).build()
-
-  /** Executes [block], asserts it throws a batch error, and returns the per-update error list. */
-  private fun assertBatchError(block: () -> Unit): List<p4.v1.P4RuntimeOuterClass.Error> {
-    try {
-      block()
-      throw AssertionError("expected batch error")
-    } catch (e: StatusException) {
-      return extractBatchErrors(e) ?: throw AssertionError("no batch error details in trailers")
-    }
-  }
 }


### PR DESCRIPTION
## Win
P4Runtime Write and Read batch failures now use the spec-required structured error shape: overall UNKNOWN with one p4.Error detail per batch item.

## Details
- Report ROLLBACK_ON_ERROR and DATAPLANE_ATOMIC failures with 1:1 per-update details after rollback.
- Preserve the triggering update's canonical code and mark rolled-back/skipped updates as ABORTED.
- Report Read batch item failures with the same structured details required by P4Runtime §13.3.
- Keep Read's existing streaming behavior: successful entities may be emitted before the final batch error, so clients that retry after errors must tolerate duplicates.
- Stabilize macOS CI by pinning Bazel's Xcode selection to an available runner toolchain and regenerating cached C++ autoconfig.
- Add conformance coverage for atomic write rollback details and Read batch error details.

## Tests
- bazel test //grpc:P4RuntimeWriteErrorTest //grpc:P4RuntimeConformanceTest
- ./tools/format.sh
- ./tools/lint.sh
