### PR TITLE
Avoid macOS layering check breakage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,6 +26,11 @@ build:linux --repo_env=CC=clang
 # host_macos_minimum_os covers tool builds (e.g. p4c's ir-generator).
 build:macos --macos_minimum_os=10.15
 build:macos --host_macos_minimum_os=10.15
+# Apple Clang's strict module dependency check currently misfires on
+# libc++ headers pulled through external C++ dependencies such as Abseil.
+# Keep Linux layering checks, but do not make macOS builds depend on
+# Apple toolchain module-map details.
+build:macos --features=-layering_check
 
 # C++20 for the p4c backend.
 build --cxxopt=-std=c++20


### PR DESCRIPTION
## Win
Keep scheduled macOS cache warming from failing on Apple Clang/libc++ module-map strictness while preserving Linux layering checks.

## Context
The red scheduled CI run at head failed only in `Warm cache (macos-26)` while locally compiling Abseil under Bazel's Clang `layering_check`. The regular macOS build/test job passed on the same SHA, likely because it hit BuildBuddy instead of rebuilding that action locally.

## Change
Disable `layering_check` only for Bazel's macOS config:

```bazelrc
build:macos --features=-layering_check
```

## Verification
- `bazel info --announce_rc --config=macos` confirms the macOS config applies `--features=-layering_check`.
- `git diff --check`

Full validation needs GitHub's macOS runner because the failure depends on Apple Clang/Xcode.