### PR TITLE
web: encode range match entries explicitly

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -121,8 +121,6 @@ guilt — just write it down so someone can find it later.
   To change an entry, delete and re-add it.
 - **No default action changes.** There is no UI to change a table's default
   action.
-- **RANGE match type not supported.** The match field input falls through to
-  exact-match encoding — range values will be silently misinterpreted.
 - **No counters, meters, registers, or action profile UI.** These P4Runtime
   entities are supported by the backend but not exposed in the browser.
 - **Read API only returns table entries.** `GET /api/read` hard-codes a

--- a/userdocs/reference/playground.md
+++ b/userdocs/reference/playground.md
@@ -42,7 +42,7 @@ Manage control-plane state for the loaded pipeline.
 **Add entry:**
 
 1. Select a table from the dropdown.
-2. Fill in match fields (supports exact, LPM, ternary, optional).
+2. Fill in match fields (supports exact, LPM, ternary, optional, and range).
 3. Select an action and fill in parameters.
 4. Set priority (for ternary/range tables).
 5. Click **Add Entry**.

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -83,6 +83,7 @@ kt_jvm_test(
     test_class = "fourward.web.WebServerTest",
     deps = [
         ":web",
+        "//bazel:runfiles",
         "//grpc",
         "//simulator",
         "//simulator:ir_java_proto",

--- a/web/WebServerTest.kt
+++ b/web/WebServerTest.kt
@@ -8,6 +8,8 @@ import fourward.IntType
 import fourward.Type
 import fourward.TypeDecl
 import fourward.VarbitType
+import fourward.bazel.repoRoot
+import java.nio.file.Files
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -140,6 +142,24 @@ class WebServerTest {
       (if (status in 200..299) conn.inputStream else conn.errorStream)?.bufferedReader()?.readText()
         ?: ""
     assertTrue("compile should succeed (got $status); body: $body", status in 200..299)
+  }
+
+  @Test
+  fun `frontend encodes and displays range match fields explicitly`() {
+    val tablesJs = Files.readString(repoRoot.resolve("web/frontend/js/tables.js"))
+    assertTrue(tablesJs.contains("case MATCH_TYPE.RANGE"))
+    assertTrue(tablesJs.contains("fieldMatch.range = {"))
+    assertTrue(tablesJs.contains("unsupported match type"))
+
+    val encodingJs = Files.readString(repoRoot.resolve("web/frontend/js/encoding.js"))
+    assertTrue(encodingJs.contains("m.range"))
+    assertTrue(encodingJs.contains("m.range.low"))
+    assertTrue(encodingJs.contains("m.range.high"))
+
+    val traceRenderJs = Files.readString(repoRoot.resolve("web/frontend/js/trace-render.js"))
+    assertTrue(traceRenderJs.contains("m.range"))
+    assertTrue(traceRenderJs.contains("m.range.low"))
+    assertTrue(traceRenderJs.contains("m.range.high"))
   }
 
   // ---------------------------------------------------------------------------

--- a/web/frontend/js/encoding.js
+++ b/web/frontend/js/encoding.js
@@ -122,8 +122,15 @@ export function decodeTableEntry(p4info, rawEntry) {
     actionName: actionInfo?.preamble.name || 'unknown',
     matchFields: (rawEntry.match || []).map(m => {
       const mfInfo = table?.match_fields?.find(f => f.id === m.field_id);
+      const name = mfInfo?.name || `field_${m.field_id}`;
+      if (m.range) {
+        return {
+          name,
+          value: `${base64ToHex(m.range.low)}..${base64ToHex(m.range.high)}`,
+        };
+      }
       const val = m.exact?.value || m.lpm?.value || m.ternary?.value || m.optional?.value || '';
-      return { name: mfInfo?.name || `field_${m.field_id}`, value: val ? base64ToHex(val) : '' };
+      return { name, value: val ? base64ToHex(val) : '' };
     }),
     params: (action?.params || []).map(p => {
       const pInfo = actionInfo?.params?.find(pp => pp.id === p.param_id);

--- a/web/frontend/js/tables.js
+++ b/web/frontend/js/tables.js
@@ -33,11 +33,10 @@ export async function addTableEntry() {
       const rawValue = input.value.trim();
       matchDisplay.push({ name: mf.name, value: rawValue });
       const fieldMatch = { field_id: mf.id };
-      const value = encodeValue(rawValue, mf.bitwidth);
 
       switch (mf.match_type) {
         case MATCH_TYPE.EXACT:
-          fieldMatch.exact = { value };
+          fieldMatch.exact = { value: encodeValue(rawValue, mf.bitwidth) };
           break;
         case MATCH_TYPE.LPM: {
           const parts = rawValue.split('/');
@@ -56,10 +55,21 @@ export async function addTableEntry() {
           break;
         }
         case MATCH_TYPE.OPTIONAL:
-          fieldMatch.optional = { value };
+          fieldMatch.optional = { value: encodeValue(rawValue, mf.bitwidth) };
           break;
+        case MATCH_TYPE.RANGE: {
+          const parts = rawValue.split('..').map(s => s.trim());
+          if (parts.length !== 2 || !parts[0] || !parts[1]) {
+            throw new Error(`${mf.name}: range matches use low..high`);
+          }
+          fieldMatch.range = {
+            low: encodeValue(parts[0], mf.bitwidth),
+            high: encodeValue(parts[1], mf.bitwidth),
+          };
+          break;
+        }
         default:
-          fieldMatch.exact = { value };
+          throw new Error(`${mf.name}: unsupported match type ${mf.match_type}`);
       }
       matchFields.push(fieldMatch);
     }

--- a/web/frontend/js/trace-render.js
+++ b/web/frontend/js/trace-render.js
@@ -253,6 +253,8 @@ function formatMatchedEntry(tl) {
       parts.push(`${name} = ${base64ToHex(m.ternary.value)} & ${base64ToHex(m.ternary.mask)}`);
     } else if (m.optional) {
       parts.push(`${name} = ${base64ToHex(m.optional.value)}`);
+    } else if (m.range) {
+      parts.push(`${name} = ${base64ToHex(m.range.low)}..${base64ToHex(m.range.high)}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- encode playground RANGE match inputs as P4Runtime range matches instead of falling through
- reject unsupported match types explicitly in the table-entry form
- display range matches in installed-entry decode and trace matched-entry details
- remove the stale RANGE limitation from docs and update playground reference

## Testing

- `./tools/format.sh --check`
- `git diff --check`
- `bazel test //web:WebServerTest`