### PR TITLE
support v1model truncate

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -53,10 +53,6 @@ guilt — just write it down so someone can find it later.
 
 ## v1model gaps
 
-- **`truncate()` not implemented.** The v1model extern
-  `truncate(in bit<32> length)` — which caps the output packet to the
-  given number of bytes after the deparser — is not handled. Calling it
-  will crash the simulator.
 - **`random()` not implemented.** The v1model free-function form
   `random(out bit<32> result, in bit<32> lo, in bit<32> hi)` is not
   handled and will crash at runtime. (PSA/PNA `Random.read()` works.)

--- a/e2e_tests/bmv2_diff/BUILD.bazel
+++ b/e2e_tests/bmv2_diff/BUILD.bazel
@@ -58,6 +58,7 @@ bmv2_diff_test_suite(
     local_tests = {
         "action_selector_3": "//e2e_tests/trace_tree",
         "selector_exit": "//e2e_tests/trace_tree",
+        "truncate_min": "//e2e_tests/truncate",
     },
     tests = [
         "arith-bmv2",

--- a/e2e_tests/truncate/BUILD.bazel
+++ b/e2e_tests/truncate/BUILD.bazel
@@ -1,0 +1,11 @@
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+    licenses = ["notice"],
+)
+
+# P4/STF files used by bmv2_diff tests (cross-package reference).
+exports_files([
+    "truncate_min.p4",
+    "truncate_min.stf",
+])

--- a/e2e_tests/truncate/truncate_min.p4
+++ b/e2e_tests/truncate/truncate_min.p4
@@ -1,0 +1,58 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct headers_t {}
+
+struct metadata_t {}
+
+parser MyParser(
+    packet_in packet,
+    out headers_t hdr,
+    inout metadata_t meta,
+    inout standard_metadata_t standard_metadata)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {}
+}
+
+control MyIngress(
+    inout headers_t hdr,
+    inout metadata_t meta,
+    inout standard_metadata_t standard_metadata)
+{
+    apply {
+        truncate(1);
+        truncate(3);
+        standard_metadata.egress_spec = 1;
+    }
+}
+
+control MyEgress(
+    inout headers_t hdr,
+    inout metadata_t meta,
+    inout standard_metadata_t standard_metadata)
+{
+    apply {}
+}
+
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {}
+}
+
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {}
+}
+
+V1Switch(
+    MyParser(),
+    MyVerifyChecksum(),
+    MyIngress(),
+    MyEgress(),
+    MyComputeChecksum(),
+    MyDeparser()
+) main;

--- a/e2e_tests/truncate/truncate_min.stf
+++ b/e2e_tests/truncate/truncate_min.stf
@@ -1,0 +1,4 @@
+# BMv2 preserves the shortest requested truncate() length across calls.
+
+packet 0 AABBCCDD
+expect 1 AA $

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -48,6 +48,17 @@ private fun evalIntArg(eval: ExternEvaluator, index: Int): Int =
     else -> error("expected integer argument at index $index, got: $arg")
   }
 
+private fun evalPacketLengthArg(eval: ExternEvaluator, index: Int): Int {
+  val value =
+    when (val arg = eval.evalArg(index)) {
+      is BitVal -> arg.bits.value
+      is InfIntVal -> arg.value
+      else -> error("expected integer argument at index $index, got: $arg")
+    }
+  require(value >= BigInteger.ZERO) { "packet length must be non-negative, got: $value" }
+  return if (value > BigInteger.valueOf(Int.MAX_VALUE.toLong())) Int.MAX_VALUE else value.toInt()
+}
+
 /**
  * Benchmark-only knob for measuring the scaling impact of intra-packet parallelism. Not a public
  * API — no user documentation, no CLI flag. Normal users should leave this at the default (`true`).
@@ -724,7 +735,7 @@ class V1ModelArchitecture(
       }
     }
 
-    val outputBytes = s.packetCtx.deparsedPayload()
+    val outputBytes = truncateOutput(s.packetCtx.deparsedPayload(), s.pendingOps.truncateBytes)
 
     if (s.pendingOps.recirculate) {
       throw RecirculateFork(
@@ -738,6 +749,9 @@ class V1ModelArchitecture(
       (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
     return buildOutputTrace(s.packetCtx.getEvents(), egressPort, outputBytes)
   }
+
+  private fun truncateOutput(bytes: ByteArray, maxBytes: Int?): ByteArray =
+    if (maxBytes != null && maxBytes < bytes.size) bytes.copyOf(maxBytes) else bytes
 
   private fun readEgressPort(s: PipelineState): Int =
     (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
@@ -1090,6 +1104,13 @@ class V1ModelArchitecture(
         }
         UnitVal
       }
+      // truncate(length): cap the output packet after the deparser. BMv2 preserves the shortest
+      // requested cap when truncate() is called more than once.
+      "truncate" -> {
+        val requestedBytes = evalPacketLengthArg(eval, 0)
+        pendingOps.truncateBytes = minOf(pendingOps.truncateBytes ?: requestedBytes, requestedBytes)
+        UnitVal
+      }
       // verify_checksum[_with_payload](condition, data, checksum, algo): v1model §14.
       // Computes hash over data fields (and optionally the unparsed packet body) and
       // compares with checksum; sets standard_metadata.checksum_error = 1 on mismatch.
@@ -1293,6 +1314,7 @@ internal data class V1ModelPendingOps(
   var resubmitFieldListId: Int? = null,
   var recirculate: Boolean = false,
   var recirculateFieldListId: Int? = null,
+  var truncateBytes: Int? = null,
 )
 
 // -------------------------------------------------------------------------

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -439,6 +439,88 @@ class V1ModelArchitectureTest {
   }
 
   @Test
+  fun `truncate caps output packet after deparser`() {
+    val config =
+      v1modelConfig(
+        externCall("truncate", intArg(2, 32)),
+        assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val payload = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].dataplaneEgressPort)
+    assertEquals(ByteString.copyFrom(byteArrayOf(0x01, 0x02)), outputs[0].payload)
+  }
+
+  @Test
+  fun `truncate zero emits empty packet`() {
+    val config =
+      v1modelConfig(
+        externCall("truncate", intArg(0, 32)),
+        assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val payload = byteArrayOf(0x01, 0x02, 0x03)
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].dataplaneEgressPort)
+    assertEquals(ByteString.EMPTY, outputs[0].payload)
+  }
+
+  @Test
+  fun `truncate longer than packet is a no-op`() {
+    val config =
+      v1modelConfig(
+        externCall("truncate", intArg(100, 32)),
+        assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val payload = byteArrayOf(0x01, 0x02)
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].dataplaneEgressPort)
+    assertEquals(ByteString.copyFrom(payload), outputs[0].payload)
+  }
+
+  @Test
+  fun `truncate preserves shortest requested length`() {
+    val config =
+      v1modelConfig(
+        externCall("truncate", intArg(1, 32)),
+        externCall("truncate", intArg(3, 32)),
+        assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val payload = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].dataplaneEgressPort)
+    assertEquals(ByteString.copyFrom(byteArrayOf(0x01)), outputs[0].payload)
+  }
+
+  @Test
+  fun `truncate uses shorter later requested length`() {
+    val config =
+      v1modelConfig(
+        externCall("truncate", intArg(3, 32)),
+        externCall("truncate", intArg(1, 32)),
+        assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val payload = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].dataplaneEgressPort)
+    assertEquals(ByteString.copyFrom(byteArrayOf(0x01)), outputs[0].payload)
+  }
+
+  @Test
   fun `mark_to_drop produces no output packets`() {
     val config =
       v1modelConfig(


### PR DESCRIPTION
## Summary

Support the v1model `truncate(in bit<32> length)` extern by recording the requested output length as a pending pipeline operation and applying it to the deparsed packet bytes before output or recirculation.

Repeated `truncate()` calls now preserve the shortest requested length, matching BMv2. This also removes the stale `truncate()` limitation now that the extern is handled.

## Testing

- `bazel test //simulator:V1ModelArchitectureTest --test_filter='truncate preserves shortest requested length'`
- `bazel test //simulator:V1ModelArchitectureTest`
- `bazel test //e2e_tests/bmv2_diff:bmv2_diff_test --test_filter=truncate_min`
- `./tools/format.sh --check`
- `git diff --check`
