### PR TITLE
[codex] Fix PacketOut padding accounting

### DIFF
--- a/grpc/BitLevelSerializationTest.kt
+++ b/grpc/BitLevelSerializationTest.kt
@@ -593,6 +593,109 @@ class BitLevelSerializationTest {
   }
 
   @Test
+  @Suppress("MagicNumber")
+  fun `PacketOut with SAI-shaped 10-bit header does not leak padding into payload`() {
+    // SAI's packet_out header is 10 bits: 9-bit egress_port plus 1-bit submit_to_ingress.
+    // PacketOut has to be byte-padded before it enters the simulator, but those transport padding
+    // bits are not packet bits. They must not become an extra byte on the PacketIn payload.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      @controller_header("packet_out")
+      header packet_out_t {
+        bit<9> egress_port;
+        bit<1> submit_to_ingress;
+      }
+
+      @controller_header("packet_in")
+      header packet_in_t { bit<5> tag; }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { packet_out_t pkt_out; packet_in_t pkt_in; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start {
+          pkt.extract(hdr.pkt_out);
+          pkt.extract(hdr.eth);
+          transition accept;
+        }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 510; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          h.pkt_out.setInvalid();
+          h.pkt_in.setValid();
+          h.pkt_in.tag = 0;
+        }
+      }
+      control D(packet_out pkt, in headers_t h) {
+        apply {
+          pkt.emit(h.pkt_out);
+          pkt.emit(h.pkt_in);
+          pkt.emit(h.eth);
+        }
+      }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+
+      it.openStream().use { session ->
+        session.arbitrate()
+
+        val originalPayload =
+          byteArrayOf(
+            0xAA.toByte(),
+            0xAA.toByte(),
+            0xAA.toByte(),
+            0xAA.toByte(),
+            0xAA.toByte(),
+            0xAA.toByte(),
+            0xBB.toByte(),
+            0xBB.toByte(),
+            0xBB.toByte(),
+            0xBB.toByte(),
+            0xBB.toByte(),
+            0xBB.toByte(),
+            0x08,
+            0x06,
+          )
+        val packetOut =
+          p4.v1.P4RuntimeOuterClass.PacketOut.newBuilder()
+            .setPayload(com.google.protobuf.ByteString.copyFrom(originalPayload))
+            .addMetadata(
+              p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
+                .setMetadataId(1)
+                .setValue(com.google.protobuf.ByteString.copyFrom(byteArrayOf(123)))
+            )
+            .addMetadata(
+              p4.v1.P4RuntimeOuterClass.PacketMetadata.newBuilder()
+                .setMetadataId(2)
+                .setValue(com.google.protobuf.ByteString.copyFrom(byteArrayOf(1)))
+            )
+            .build()
+
+        val response = session.sendPacketOut(packetOut)
+
+        assertNotNull("should get PacketIn response from CPU port", response)
+        assertTrue("response should be PacketIn", response!!.hasPacket())
+        assertEquals(originalPayload.toList(), response.packet.payload.toByteArray().toList())
+      }
+    }
+  }
+
+  @Test
   fun `field_list_ids emitted for enum-valued field_list annotations`() {
     val config =
       compileInlineP4(

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -25,7 +25,13 @@ class FourwardServer(
    */
   val simulator = Simulator()
   private val writeMutex = Mutex()
-  private val broker = PacketBroker(simulator::processPacket, writeMutex)
+  private val broker =
+    PacketBroker(
+      { ingressPort, payload, payloadBitLength ->
+        simulator.processPacket(ingressPort, payload, payloadBitLength)
+      },
+      writeMutex,
+    )
   private val service =
     P4RuntimeService(
       simulator,

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -27,9 +27,7 @@ class FourwardServer(
   private val writeMutex = Mutex()
   private val broker =
     PacketBroker(
-      { ingressPort, payload, payloadBitLength ->
-        simulator.processPacket(ingressPort, payload, payloadBitLength)
-      },
+      { ingressPort, packet -> simulator.processPacket(ingressPort, packet) },
       writeMutex,
     )
   private val service =

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -65,9 +65,7 @@ class FourwardTestHarness(
   private val writeMutex = kotlinx.coroutines.sync.Mutex()
   private val broker =
     PacketBroker(
-      { ingressPort, payload, payloadBitLength ->
-        simulator.processPacket(ingressPort, payload, payloadBitLength)
-      },
+      { ingressPort, packet -> simulator.processPacket(ingressPort, packet) },
       writeMutex,
     )
   private val service =

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -63,7 +63,13 @@ class FourwardTestHarness(
   private val serverName = InProcessServerBuilder.generateName()
   private val simulator = Simulator()
   private val writeMutex = kotlinx.coroutines.sync.Mutex()
-  private val broker = PacketBroker(simulator::processPacket, writeMutex)
+  private val broker =
+    PacketBroker(
+      { ingressPort, payload, payloadBitLength ->
+        simulator.processPacket(ingressPort, payload, payloadBitLength)
+      },
+      writeMutex,
+    )
   private val service =
     P4RuntimeService(
       simulator,

--- a/grpc/GoldenErrorTest.kt
+++ b/grpc/GoldenErrorTest.kt
@@ -190,7 +190,7 @@ class GoldenErrorTest(private val testName: String) {
     // reproduce here; what this golden protects is the *translation format*.
     val throwingBroker =
       PacketBroker(
-        simulatorFn = { _, _ -> throw ArithmeticException("simulated failure") },
+        simulatorFn = { _, _, _ -> throw ArithmeticException("simulated failure") },
         writeMutex = kotlinx.coroutines.sync.Mutex(),
       )
     val service = DataplaneService(throwingBroker)

--- a/grpc/GoldenErrorTest.kt
+++ b/grpc/GoldenErrorTest.kt
@@ -190,7 +190,7 @@ class GoldenErrorTest(private val testName: String) {
     // reproduce here; what this golden protects is the *translation format*.
     val throwingBroker =
       PacketBroker(
-        simulatorFn = { _, _, _ -> throw ArithmeticException("simulated failure") },
+        simulatorFn = { _, _ -> throw ArithmeticException("simulated failure") },
         writeMutex = kotlinx.coroutines.sync.Mutex(),
       )
     val service = DataplaneService(throwingBroker)

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -721,15 +721,24 @@ class P4RuntimeService(
       // If the pipeline has a packet_out header, serialize metadata into a binary
       // header and prepend it. The parser expects the packet to arrive on the CPU
       // port with the header prepended.
-      val (ingressPort, payload) =
+      val (ingressPort, payload, payloadBitLength) =
         if (codec != null) {
-          codec.cpuPort to
-            codec.packPacketOut(packetOut.metadataList, packetOut.payload.toByteArray())
+          val packetOutPayload = packetOut.payload.toByteArray()
+          Triple(
+            codec.cpuPort,
+            codec.packPacketOut(packetOut.metadataList, packetOutPayload),
+            codec.packedPacketOutBitLength(packetOutPayload.size),
+          )
         } else {
-          extractIngressPort(packetOut.metadataList) to packetOut.payload.toByteArray()
+          val packetOutPayload = packetOut.payload.toByteArray()
+          Triple(
+            extractIngressPort(packetOut.metadataList),
+            packetOutPayload,
+            packetOutPayload.size * Byte.SIZE_BITS,
+          )
         }
 
-      broker.processPacket(ingressPort, payload)
+      broker.processPacket(ingressPort, payload, payloadBitLength = payloadBitLength)
       null
     } catch (e: IllegalArgumentException) {
       packetOutError(Code.INVALID_ARGUMENT_VALUE, e.message)

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -727,7 +727,7 @@ class P4RuntimeService(
           val packetOutPayload = packetOut.payload.toByteArray()
           Pair(
             codec.cpuPort,
-            PacketBits.of(
+            PacketBits.ofPaddedBytes(
               codec.packPacketOut(packetOut.metadataList, packetOutPayload),
               codec.packedPacketOutBitLength(packetOutPayload.size),
             ),

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -8,6 +8,7 @@ import com.google.rpc.Code
 import fourward.DeviceConfig
 import fourward.OutputPacket
 import fourward.PipelineConfig
+import fourward.simulator.PacketBits
 import fourward.simulator.Simulator
 import fourward.simulator.WriteResult
 import io.grpc.Metadata
@@ -721,24 +722,22 @@ class P4RuntimeService(
       // If the pipeline has a packet_out header, serialize metadata into a binary
       // header and prepend it. The parser expects the packet to arrive on the CPU
       // port with the header prepended.
-      val (ingressPort, payload, payloadBitLength) =
+      val (ingressPort, packetBits) =
         if (codec != null) {
           val packetOutPayload = packetOut.payload.toByteArray()
-          Triple(
+          Pair(
             codec.cpuPort,
-            codec.packPacketOut(packetOut.metadataList, packetOutPayload),
-            codec.packedPacketOutBitLength(packetOutPayload.size),
+            PacketBits.of(
+              codec.packPacketOut(packetOut.metadataList, packetOutPayload),
+              codec.packedPacketOutBitLength(packetOutPayload.size),
+            ),
           )
         } else {
           val packetOutPayload = packetOut.payload.toByteArray()
-          Triple(
-            extractIngressPort(packetOut.metadataList),
-            packetOutPayload,
-            packetOutPayload.size * Byte.SIZE_BITS,
-          )
+          Pair(extractIngressPort(packetOut.metadataList), PacketBits.ofBytes(packetOutPayload))
         }
 
-      broker.processPacket(ingressPort, payload, payloadBitLength = payloadBitLength)
+      broker.processPacket(ingressPort, packetBits)
       null
     } catch (e: IllegalArgumentException) {
       packetOutError(Code.INVALID_ARGUMENT_VALUE, e.message)

--- a/grpc/PacketBroker.kt
+++ b/grpc/PacketBroker.kt
@@ -137,7 +137,7 @@ class PacketBroker(
   fun processPacket(ingressPort: Int, packet: PacketBits, tag: Long = 0): ProcessPacketResult {
     fireHookUnderMutex()
     val result = simulatorFn(ingressPort, packet)
-    dispatchToSubscribers(ingressPort, packet.bytes, result, tag)
+    dispatchToSubscribers(ingressPort, packet.copyPaddedBytesForTransport(), result, tag)
     return result
   }
 

--- a/grpc/PacketBroker.kt
+++ b/grpc/PacketBroker.kt
@@ -4,6 +4,7 @@ import fourward.OutputPacket
 import fourward.PrePacketHookInvocation
 import fourward.PrePacketHookResponse
 import fourward.TraceTree
+import fourward.simulator.PacketBits
 import fourward.simulator.ProcessPacketResult
 import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Level
@@ -32,8 +33,7 @@ import p4.v1.P4RuntimeOuterClass
  *   acquired when a pre-packet hook is registered (to apply hook updates atomically).
  */
 class PacketBroker(
-  private val simulatorFn:
-    (ingressPort: Int, payload: ByteArray, payloadBitLength: Int) -> ProcessPacketResult,
+  private val simulatorFn: (ingressPort: Int, packet: PacketBits) -> ProcessPacketResult,
   private val writeMutex: Mutex,
 ) {
 
@@ -116,12 +116,6 @@ class PacketBroker(
     java.util.concurrent.CopyOnWriteArrayList<(SubscriptionResult) -> Unit>()
 
   /**
-   * Processes a packet: fires the hook (if registered), runs the simulator, and dispatches results
-   * to subscribers. Lock-free on the hot path — the simulator reads from the published forwarding
-   * snapshot. Only acquires the [writeMutex] when a hook is registered (to fire the hook and apply
-   * its updates atomically).
-   */
-  /**
    * If a hook is registered, acquires the [writeMutex] and fires it. The hook may apply P4Runtime
    * updates that publish a new forwarding snapshot. No-op if no hook is registered.
    */
@@ -131,15 +125,19 @@ class PacketBroker(
     }
   }
 
-  fun processPacket(
-    ingressPort: Int,
-    payload: ByteArray,
-    tag: Long = 0,
-    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
-  ): ProcessPacketResult {
+  fun processPacket(ingressPort: Int, payload: ByteArray, tag: Long = 0): ProcessPacketResult =
+    processPacket(ingressPort, PacketBits.ofBytes(payload), tag)
+
+  /**
+   * Processes a packet: fires the hook (if registered), runs the simulator, and dispatches results
+   * to subscribers. Lock-free on the hot path — the simulator reads from the published forwarding
+   * snapshot. Only acquires the [writeMutex] when a hook is registered (to fire the hook and apply
+   * its updates atomically).
+   */
+  fun processPacket(ingressPort: Int, packet: PacketBits, tag: Long = 0): ProcessPacketResult {
     fireHookUnderMutex()
-    val result = simulatorFn(ingressPort, payload, payloadBitLength)
-    dispatchToSubscribers(ingressPort, payload, result, tag)
+    val result = simulatorFn(ingressPort, packet)
+    dispatchToSubscribers(ingressPort, packet.bytes, result, tag)
     return result
   }
 
@@ -151,7 +149,7 @@ class PacketBroker(
   fun <T> withHookOnce(block: (processor: (Int, ByteArray, Long) -> Unit) -> T): T {
     fireHookUnderMutex()
     return block { port, payload, tag ->
-      val result = simulatorFn(port, payload, payload.size * Byte.SIZE_BITS)
+      val result = simulatorFn(port, PacketBits.ofBytes(payload))
       dispatchToSubscribers(port, payload, result, tag)
     }
   }

--- a/grpc/PacketBroker.kt
+++ b/grpc/PacketBroker.kt
@@ -137,7 +137,7 @@ class PacketBroker(
   fun processPacket(ingressPort: Int, packet: PacketBits, tag: Long = 0): ProcessPacketResult {
     fireHookUnderMutex()
     val result = simulatorFn(ingressPort, packet)
-    dispatchToSubscribers(ingressPort, packet.copyPaddedBytesForTransport(), result, tag)
+    dispatchToSubscribers(ingressPort, packet.copyPaddedBytes(), result, tag)
     return result
   }
 

--- a/grpc/PacketBroker.kt
+++ b/grpc/PacketBroker.kt
@@ -32,7 +32,8 @@ import p4.v1.P4RuntimeOuterClass
  *   acquired when a pre-packet hook is registered (to apply hook updates atomically).
  */
 class PacketBroker(
-  private val simulatorFn: (ingressPort: Int, payload: ByteArray) -> ProcessPacketResult,
+  private val simulatorFn:
+    (ingressPort: Int, payload: ByteArray, payloadBitLength: Int) -> ProcessPacketResult,
   private val writeMutex: Mutex,
 ) {
 
@@ -130,9 +131,14 @@ class PacketBroker(
     }
   }
 
-  fun processPacket(ingressPort: Int, payload: ByteArray, tag: Long = 0): ProcessPacketResult {
+  fun processPacket(
+    ingressPort: Int,
+    payload: ByteArray,
+    tag: Long = 0,
+    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
+  ): ProcessPacketResult {
     fireHookUnderMutex()
-    val result = simulatorFn(ingressPort, payload)
+    val result = simulatorFn(ingressPort, payload, payloadBitLength)
     dispatchToSubscribers(ingressPort, payload, result, tag)
     return result
   }
@@ -145,7 +151,7 @@ class PacketBroker(
   fun <T> withHookOnce(block: (processor: (Int, ByteArray, Long) -> Unit) -> T): T {
     fireHookUnderMutex()
     return block { port, payload, tag ->
-      val result = simulatorFn(port, payload)
+      val result = simulatorFn(port, payload, payload.size * Byte.SIZE_BITS)
       dispatchToSubscribers(port, payload, result, tag)
     }
   }

--- a/grpc/PacketBrokerTest.kt
+++ b/grpc/PacketBrokerTest.kt
@@ -30,9 +30,9 @@ class PacketBrokerTest {
 
   private fun fakeProcessor(
     vararg results: Pair<Int, ProcessPacketResult>
-  ): (Int, ByteArray) -> ProcessPacketResult {
+  ): (Int, ByteArray, Int) -> ProcessPacketResult {
     val map = results.toMap()
-    return { port, _ -> map[port] ?: result() }
+    return { port, _, _ -> map[port] ?: result() }
   }
 
   private fun broker(vararg results: Pair<Int, ProcessPacketResult>) =
@@ -45,6 +45,23 @@ class PacketBrokerTest {
 
     val actual = broker.processPacket(0, byteArrayOf(0x01))
     assertEquals(expected.possibleOutcomes, actual.possibleOutcomes)
+  }
+
+  @Test
+  fun `processPacket forwards explicit payload bit length`() {
+    var capturedBitLength = -1
+    val broker =
+      PacketBroker(
+        { _, _, payloadBitLength ->
+          capturedBitLength = payloadBitLength
+          result()
+        },
+        kotlinx.coroutines.sync.Mutex(),
+      )
+
+    broker.processPacket(0, byteArrayOf(0xA0.toByte()), payloadBitLength = 4)
+
+    assertEquals(4, capturedBitLength)
   }
 
   @Test

--- a/grpc/PacketBrokerTest.kt
+++ b/grpc/PacketBrokerTest.kt
@@ -4,6 +4,7 @@ import fourward.OutputPacket
 import fourward.PrePacketHookInvocation
 import fourward.PrePacketHookResponse
 import fourward.TraceTree
+import fourward.simulator.PacketBits
 import fourward.simulator.ProcessPacketResult
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.channels.Channel
@@ -30,9 +31,9 @@ class PacketBrokerTest {
 
   private fun fakeProcessor(
     vararg results: Pair<Int, ProcessPacketResult>
-  ): (Int, ByteArray, Int) -> ProcessPacketResult {
+  ): (Int, PacketBits) -> ProcessPacketResult {
     val map = results.toMap()
-    return { port, _, _ -> map[port] ?: result() }
+    return { port, _ -> map[port] ?: result() }
   }
 
   private fun broker(vararg results: Pair<Int, ProcessPacketResult>) =
@@ -48,18 +49,18 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `processPacket forwards explicit payload bit length`() {
+  fun `processPacket forwards packet bit length`() {
     var capturedBitLength = -1
     val broker =
       PacketBroker(
-        { _, _, payloadBitLength ->
-          capturedBitLength = payloadBitLength
+        { _, packet ->
+          capturedBitLength = packet.validBitLength
           result()
         },
         kotlinx.coroutines.sync.Mutex(),
       )
 
-    broker.processPacket(0, byteArrayOf(0xA0.toByte()), payloadBitLength = 4)
+    broker.processPacket(0, PacketBits.of(byteArrayOf(0xA0.toByte()), 4))
 
     assertEquals(4, capturedBitLength)
   }

--- a/grpc/PacketBrokerTest.kt
+++ b/grpc/PacketBrokerTest.kt
@@ -60,7 +60,7 @@ class PacketBrokerTest {
         kotlinx.coroutines.sync.Mutex(),
       )
 
-    broker.processPacket(0, PacketBits.of(byteArrayOf(0xA0.toByte()), 4))
+    broker.processPacket(0, PacketBits.ofPaddedBytes(byteArrayOf(0xA0.toByte()), 4))
 
     assertEquals(4, capturedBitLength)
   }

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -151,6 +151,10 @@ private constructor(
     return acc.toByteArray()
   }
 
+  /** Number of meaningful packet bits in [packPacketOut]'s byte-aligned output. */
+  fun packedPacketOutBitLength(payloadBytes: Int): Int =
+    packetOutHeaderBits + payloadBytes * Byte.SIZE_BITS
+
   /**
    * Builds PacketIn metadata from ingress and egress port values.
    *

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -28,12 +28,10 @@ interface Architecture {
    * - Handling architecture-specific operations (clone, resubmit, etc.).
    * - Returning the trace tree (with packet outcomes at leaves).
    */
-  fun processPacket(
-    ingressPort: UInt,
-    payload: ByteArray,
-    tableStore: TableStore,
-    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
-  ): PipelineResult
+  fun processPacket(ingressPort: UInt, payload: ByteArray, tableStore: TableStore): PipelineResult =
+    processPacket(ingressPort, PacketBits.ofBytes(payload), tableStore)
+
+  fun processPacket(ingressPort: UInt, packet: PacketBits, tableStore: TableStore): PipelineResult
 }
 
 /**

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -28,7 +28,12 @@ interface Architecture {
    * - Handling architecture-specific operations (clone, resubmit, etc.).
    * - Returning the trace tree (with packet outcomes at leaves).
    */
-  fun processPacket(ingressPort: UInt, payload: ByteArray, tableStore: TableStore): PipelineResult
+  fun processPacket(
+    ingressPort: UInt,
+    payload: ByteArray,
+    tableStore: TableStore,
+    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
+  ): PipelineResult
 }
 
 /**

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -250,6 +250,16 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "PacketBitsTest",
+    srcs = ["PacketBitsTest.kt"],
+    test_class = "fourward.simulator.PacketBitsTest",
+    deps = [
+        ":simulator",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "InterpreterInlineActionTest",
     srcs = ["InterpreterInlineActionTest.kt"],
     test_class = "fourward.simulator.InterpreterInlineActionTest",

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -96,7 +96,7 @@ class PacketContext(packet: PacketBits, initialOffset: Int = 0) {
 
   /** Remaining bytes in the input packet, consumed by parser extract(). */
   private val buffer: ParserCursor =
-    ParserCursor(packet.bytes, initialOffset, packet.validBitLength)
+    ParserCursor(packet.backingBytesForParser(), initialOffset, packet.validBitLength)
 
   /** Number of bytes consumed from the input buffer so far (parser extract position). */
   val bytesConsumed: Int

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -80,21 +80,23 @@ class Environment {
  * Holds the input packet buffer, the output (emit) buffer, and the execution trace. Created once
  * per packet in the architecture's [processPacket] and threaded through the interpreter.
  */
-class PacketContext(
-  payload: ByteArray,
-  initialOffset: Int = 0,
-  payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
-) {
+class PacketContext(packet: PacketBits, initialOffset: Int = 0) {
+
+  constructor(
+    payload: ByteArray,
+    initialOffset: Int = 0,
+  ) : this(PacketBits.ofBytes(payload), initialOffset)
 
   /** Original ingress packet length in bytes (for direct counter byte counts). */
-  val payloadSize: Int = payload.size
+  val payloadSize: Int = packet.byteLength
 
   // -------------------------------------------------------------------------
   // Packet buffer
   // -------------------------------------------------------------------------
 
   /** Remaining bytes in the input packet, consumed by parser extract(). */
-  private val buffer: ParserCursor = ParserCursor(payload, initialOffset, payloadBitLength)
+  private val buffer: ParserCursor =
+    ParserCursor(packet.bytes, initialOffset, packet.validBitLength)
 
   /** Number of bytes consumed from the input buffer so far (parser extract position). */
   val bytesConsumed: Int

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -210,16 +210,25 @@ private class ParserCursor(
   /** Returns all bytes from the next byte boundary to the end (sub-byte remainder is discarded). */
   fun readAll(): ByteArray {
     val byteStart = (bitOffset + 7) / 8
-    val byteEnd = (validBitLength + 7) / 8
     bitOffset = validBitLength
-    return data.copyOfRange(byteStart, byteEnd)
+    return semanticBytesFrom(byteStart)
   }
 
   /** Returns all bytes from the current byte-aligned position without advancing. */
   fun peekAll(): ByteArray {
     val byteStart = (bitOffset + 7) / 8
+    return semanticBytesFrom(byteStart)
+  }
+
+  private fun semanticBytesFrom(byteStart: Int): ByteArray {
     val byteEnd = (validBitLength + 7) / 8
-    return data.copyOfRange(byteStart, byteEnd)
+    val bytes = data.copyOfRange(byteStart, byteEnd)
+    val finalPaddingBits = (Byte.SIZE_BITS - validBitLength % Byte.SIZE_BITS) % Byte.SIZE_BITS
+    if (bytes.isNotEmpty() && finalPaddingBits != 0) {
+      val finalByteMask = 0xFF shl finalPaddingBits
+      bytes[bytes.lastIndex] = (bytes.last().toInt() and finalByteMask).toByte()
+    }
+    return bytes
   }
 
   /** Reads [count] bytes from the current position (must be byte-aligned). */

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -225,6 +225,8 @@ private class ParserCursor(
     val bytes = data.copyOfRange(byteStart, byteEnd)
     val finalPaddingBits = (Byte.SIZE_BITS - validBitLength % Byte.SIZE_BITS) % Byte.SIZE_BITS
     if (bytes.isNotEmpty() && finalPaddingBits != 0) {
+      // PacketBits may carry arbitrary transport padding in the final byte. Byte-returning helpers
+      // expose semantic packet bytes, so clear the non-packet low bits before returning them.
       val finalByteMask = 0xFF shl finalPaddingBits
       bytes[bytes.lastIndex] = (bytes.last().toInt() and finalByteMask).toByte()
     }

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -88,7 +88,7 @@ class PacketContext(packet: PacketBits, initialOffset: Int = 0) {
   ) : this(PacketBits.ofBytes(payload), initialOffset)
 
   /** Original ingress packet length in bytes (for direct counter byte counts). */
-  val payloadSize: Int = packet.byteLength
+  val payloadSize: Int = packet.packetByteLength
 
   // -------------------------------------------------------------------------
   // Packet buffer

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -80,7 +80,11 @@ class Environment {
  * Holds the input packet buffer, the output (emit) buffer, and the execution trace. Created once
  * per packet in the architecture's [processPacket] and threaded through the interpreter.
  */
-class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
+class PacketContext(
+  payload: ByteArray,
+  initialOffset: Int = 0,
+  payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
+) {
 
   /** Original ingress packet length in bytes (for direct counter byte counts). */
   val payloadSize: Int = payload.size
@@ -90,7 +94,7 @@ class PacketContext(payload: ByteArray, initialOffset: Int = 0) {
   // -------------------------------------------------------------------------
 
   /** Remaining bytes in the input packet, consumed by parser extract(). */
-  private val buffer: ParserCursor = ParserCursor(payload, initialOffset)
+  private val buffer: ParserCursor = ParserCursor(payload, initialOffset, payloadBitLength)
 
   /** Number of bytes consumed from the input buffer so far (parser extract position). */
   val bytesConsumed: Int
@@ -170,35 +174,50 @@ open class ParserErrorException(val errorName: String, message: String) : Except
  * length) consume exactly the right number of bits without over-reading.
  */
 @Suppress("MagicNumber")
-private class ParserCursor(private val data: ByteArray, initialByteOffset: Int = 0) {
+private class ParserCursor(
+  private val data: ByteArray,
+  initialByteOffset: Int = 0,
+  private val validBitLength: Int = data.size * Byte.SIZE_BITS,
+) {
+  init {
+    require(validBitLength in 0..data.size * Byte.SIZE_BITS) {
+      "validBitLength must be between 0 and ${data.size * Byte.SIZE_BITS}, got $validBitLength"
+    }
+    require(initialByteOffset * Byte.SIZE_BITS <= validBitLength) {
+      "initialByteOffset $initialByteOffset is past validBitLength $validBitLength"
+    }
+  }
+
   private var bitOffset: Int = initialByteOffset * 8
 
   /** Number of whole bytes consumed from the start of the buffer. */
   val bytesConsumed: Int
     get() = (bitOffset + 7) / 8
 
-  fun hasRemaining(): Boolean = bitOffset < data.size * 8
+  fun hasRemaining(): Boolean = bitOffset < validBitLength
 
   val isByteAligned: Boolean
     get() = bitOffset % 8 == 0
 
   fun appendRemainingTo(acc: BitAccumulator) {
-    acc.appendRawBytes(data, bitOffset, data.size * 8 - bitOffset)
+    acc.appendRawBytes(data, bitOffset, validBitLength - bitOffset)
   }
 
-  private fun remainingBits(): Int = data.size * 8 - bitOffset
+  private fun remainingBits(): Int = validBitLength - bitOffset
 
   /** Returns all bytes from the next byte boundary to the end (sub-byte remainder is discarded). */
   fun readAll(): ByteArray {
     val byteStart = (bitOffset + 7) / 8
-    bitOffset = data.size * 8
-    return data.copyOfRange(byteStart, data.size)
+    val byteEnd = (validBitLength + 7) / 8
+    bitOffset = validBitLength
+    return data.copyOfRange(byteStart, byteEnd)
   }
 
   /** Returns all bytes from the current byte-aligned position without advancing. */
   fun peekAll(): ByteArray {
     val byteStart = (bitOffset + 7) / 8
-    return data.copyOfRange(byteStart, data.size)
+    val byteEnd = (validBitLength + 7) / 8
+    return data.copyOfRange(byteStart, byteEnd)
   }
 
   /** Reads [count] bytes from the current position (must be byte-aligned). */

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -110,7 +110,8 @@ class EnvironmentTest {
   fun `deparsedPayload ignores padding beyond valid packet bits`() {
     // Only the first 10 bits are meaningful: 1010_101111. The final 6 zeros only byte-align the
     // transport buffer and must not become packet data.
-    val pktCtx = PacketContext(PacketBits.of(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), 10))
+    val pktCtx =
+      PacketContext(PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), 10))
     assertEquals(BigInteger.TEN, pktCtx.extractBits(4))
 
     assertArrayEquals(byteArrayOf(0xBC.toByte()), pktCtx.deparsedPayload())

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -107,11 +107,39 @@ class EnvironmentTest {
 
   @Test
   @Suppress("MagicNumber")
+  fun `drainRemainingInput masks padding bits in final semantic byte`() {
+    val pktCtx =
+      PacketContext(PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xFF.toByte()), 10))
+
+    assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), pktCtx.drainRemainingInput())
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `peekRemainingInput masks padding bits in final semantic byte`() {
+    val pktCtx =
+      PacketContext(PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xFF.toByte()), 10))
+
+    assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), pktCtx.peekRemainingInput())
+    assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), pktCtx.drainRemainingInput())
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `deparsedPayload masks padding bits in byte-aligned remainder fast path`() {
+    val pktCtx =
+      PacketContext(PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xFF.toByte()), 10))
+
+    assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), pktCtx.deparsedPayload())
+  }
+
+  @Test
+  @Suppress("MagicNumber")
   fun `deparsedPayload ignores padding beyond valid packet bits`() {
-    // Only the first 10 bits are meaningful: 1010_101111. The final 6 zeros only byte-align the
+    // Only the first 10 bits are meaningful: 1010_101111. The final 6 bits only byte-align the
     // transport buffer and must not become packet data.
     val pktCtx =
-      PacketContext(PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), 10))
+      PacketContext(PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xFF.toByte()), 10))
     assertEquals(BigInteger.TEN, pktCtx.extractBits(4))
 
     assertArrayEquals(byteArrayOf(0xBC.toByte()), pktCtx.deparsedPayload())

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -106,6 +106,17 @@ class EnvironmentTest {
   }
 
   @Test
+  @Suppress("MagicNumber")
+  fun `deparsedPayload ignores padding beyond valid packet bits`() {
+    // Only the first 10 bits are meaningful: 1010_101111. The final 6 zeros only byte-align the
+    // transport buffer and must not become packet data.
+    val pktCtx = PacketContext(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), payloadBitLength = 10)
+    assertEquals(BigInteger.TEN, pktCtx.extractBits(4))
+
+    assertArrayEquals(byteArrayOf(0xBC.toByte()), pktCtx.deparsedPayload())
+  }
+
+  @Test
   fun `extractBytes throws when fewer bytes remain than requested`() {
     val pktCtx = PacketContext(byteArrayOf(0x01))
     assertThrows(PacketTooShortException::class.java) { pktCtx.extractBytes(2) }

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -110,7 +110,7 @@ class EnvironmentTest {
   fun `deparsedPayload ignores padding beyond valid packet bits`() {
     // Only the first 10 bits are meaningful: 1010_101111. The final 6 zeros only byte-align the
     // transport buffer and must not become packet data.
-    val pktCtx = PacketContext(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), payloadBitLength = 10)
+    val pktCtx = PacketContext(PacketBits.of(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), 10))
     assertEquals(BigInteger.TEN, pktCtx.extractBits(4))
 
     assertArrayEquals(byteArrayOf(0xBC.toByte()), pktCtx.deparsedPayload())

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -80,6 +80,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     ingressPort: UInt,
     payload: ByteArray,
     tableStore: TableStore,
+    payloadBitLength: Int,
   ): PipelineResult {
     val pipeline =
       PipelineConfig(
@@ -101,6 +102,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
         payload,
         ingressPort,
         PACKET_PATH_FROM_NET_PORT,
+        payloadBitLength,
         passNumber = 0,
         depth = 0,
       )
@@ -120,6 +122,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     payload: ByteArray,
     ingressPort: UInt,
     packetPath: String,
+    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
     passNumber: Int,
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
@@ -128,7 +131,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       "PNA recirculation depth exceeded ($MAX_RECIRCULATIONS) — possible infinite recirculate loop"
     }
 
-    val ctx = PacketContext(payload)
+    val ctx = PacketContext(payload, payloadBitLength = payloadBitLength)
     val env = Environment()
     val values = createDefaultValues(pipeline.config, pipeline.typesByName)
     val forwardingState = ForwardingState()
@@ -179,9 +182,10 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
           payload,
           ingressPort,
           packetPath,
-          passNumber,
-          depth,
-          newSelectors,
+          payloadBitLength = payloadBitLength,
+          passNumber = passNumber,
+          depth = depth,
+          selectorMembers = newSelectors,
         )
       }
     }
@@ -214,8 +218,8 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
           deparsedBytes,
           ingressPort,
           PACKET_PATH_FROM_NET_RECIRCULATED,
-          passNumber + 1,
-          depth + 1,
+          passNumber = passNumber + 1,
+          depth = depth + 1,
         )
       val recircBranch =
         ForkBranch.newBuilder().setLabel("recirculate").setSubtree(recircTree).build()

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -78,9 +78,8 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
 
   override fun processPacket(
     ingressPort: UInt,
-    payload: ByteArray,
+    packet: PacketBits,
     tableStore: TableStore,
-    payloadBitLength: Int,
   ): PipelineResult {
     val pipeline =
       PipelineConfig(
@@ -99,10 +98,9 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     val tree =
       processPacketRecursive(
         pipeline,
-        payload,
+        packet,
         ingressPort,
         PACKET_PATH_FROM_NET_PORT,
-        payloadBitLength,
         passNumber = 0,
         depth = 0,
       )
@@ -119,10 +117,9 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
   @Suppress("LongParameterList")
   private fun processPacketRecursive(
     pipeline: PipelineConfig,
-    payload: ByteArray,
+    packet: PacketBits,
     ingressPort: UInt,
     packetPath: String,
-    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
     passNumber: Int,
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
@@ -131,7 +128,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       "PNA recirculation depth exceeded ($MAX_RECIRCULATIONS) — possible infinite recirculate loop"
     }
 
-    val ctx = PacketContext(payload, payloadBitLength = payloadBitLength)
+    val ctx = PacketContext(packet)
     val env = Environment()
     val values = createDefaultValues(pipeline.config, pipeline.typesByName)
     val forwardingState = ForwardingState()
@@ -179,10 +176,9 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       return handleActionSelectorFork(fork, selectorMembers) { newSelectors ->
         processPacketRecursive(
           pipeline,
-          payload,
+          packet,
           ingressPort,
           packetPath,
-          payloadBitLength = payloadBitLength,
           passNumber = passNumber,
           depth = depth,
           selectorMembers = newSelectors,
@@ -215,7 +211,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       val recircTree =
         processPacketRecursive(
           pipeline,
-          deparsedBytes,
+          PacketBits.ofBytes(deparsedBytes),
           ingressPort,
           PACKET_PATH_FROM_NET_RECIRCULATED,
           passNumber = passNumber + 1,

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -70,9 +70,8 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
   override fun processPacket(
     ingressPort: UInt,
-    payload: ByteArray,
+    packet: PacketBits,
     tableStore: TableStore,
-    payloadBitLength: Int,
   ): PipelineResult {
     val pipeline =
       PipelineConfig(
@@ -90,15 +89,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         egressDeparser,
       )
 
-    val tree =
-      processPacketRecursive(
-        pipeline,
-        payload,
-        ingressPort,
-        PACKET_PATH_NORMAL,
-        payloadBitLength = payloadBitLength,
-        depth = 0,
-      )
+    val tree = processPacketRecursive(pipeline, packet, ingressPort, PACKET_PATH_NORMAL, depth = 0)
     return PipelineResult(tree)
   }
 
@@ -111,10 +102,9 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
    */
   private fun processPacketRecursive(
     pipeline: PipelineConfig,
-    payload: ByteArray,
+    packet: PacketBits,
     ingressPort: UInt,
     packetPath: String,
-    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): TraceTree {
@@ -125,23 +115,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     // === Ingress pipeline ===
     val ingress: IngressResult
     try {
-      ingress =
-        runIngressPipeline(
-          pipeline,
-          payload,
-          ingressPort,
-          packetPath,
-          payloadBitLength,
-          selectorMembers,
-        )
+      ingress = runIngressPipeline(pipeline, packet, ingressPort, packetPath, selectorMembers)
     } catch (fork: ActionSelectorFork) {
       return handleActionSelectorFork(fork, selectorMembers) { newSelectors ->
         processPacketRecursive(
           pipeline,
-          payload,
+          packet,
           ingressPort,
           packetPath,
-          payloadBitLength = payloadBitLength,
           depth = depth,
           selectorMembers = newSelectors,
         )
@@ -154,7 +135,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     if (ingress.dropped) {
       val i2eCloneBranches =
-        buildI2ECloneBranches(pipeline, payload, ingress.output, selectorMembers)
+        buildI2ECloneBranches(pipeline, packet.bytes, ingress.output, selectorMembers)
       if (i2eCloneBranches.isNotEmpty()) {
         return buildForkTree(ingress.events, ForkReason.CLONE, i2eCloneBranches)
       }
@@ -167,10 +148,9 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       val resubmitTree =
         processPacketRecursive(
           pipeline,
-          payload,
+          packet,
           ingressPort,
           PACKET_PATH_RESUBMIT,
-          payloadBitLength = payloadBitLength,
           depth = depth + 1,
         )
       return buildForkTree(
@@ -181,7 +161,8 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     }
 
     // === Traffic Manager: I2E clone + multicast/unicast ===
-    val i2eCloneBranches = buildI2ECloneBranches(pipeline, payload, ingress.output, selectorMembers)
+    val i2eCloneBranches =
+      buildI2ECloneBranches(pipeline, packet.bytes, ingress.output, selectorMembers)
     val originalTree = buildOriginalEgressPath(pipeline, ingress, depth, selectorMembers)
 
     if (i2eCloneBranches.isNotEmpty()) {
@@ -247,13 +228,12 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
   private fun runIngressPipeline(
     pipeline: PipelineConfig,
-    payload: ByteArray,
+    packet: PacketBits,
     ingressPort: UInt,
     packetPath: String,
-    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): IngressResult {
-    val ctx = PacketContext(payload, payloadBitLength = payloadBitLength)
+    val ctx = PacketContext(packet)
     val env = Environment()
     val values = createDefaultValues(pipeline.config, pipeline.typesByName)
 
@@ -414,7 +394,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         val recircTree =
           processPacketRecursive(
             state.pipeline,
-            core.deparsedBytes,
+            PacketBits.ofBytes(core.deparsedBytes),
             PSA_PORT_RECIRCULATE_UINT,
             PACKET_PATH_RECIRCULATE,
             depth = depth + 1,

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -72,6 +72,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     ingressPort: UInt,
     payload: ByteArray,
     tableStore: TableStore,
+    payloadBitLength: Int,
   ): PipelineResult {
     val pipeline =
       PipelineConfig(
@@ -89,7 +90,15 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         egressDeparser,
       )
 
-    val tree = processPacketRecursive(pipeline, payload, ingressPort, PACKET_PATH_NORMAL, depth = 0)
+    val tree =
+      processPacketRecursive(
+        pipeline,
+        payload,
+        ingressPort,
+        PACKET_PATH_NORMAL,
+        payloadBitLength = payloadBitLength,
+        depth = 0,
+      )
     return PipelineResult(tree)
   }
 
@@ -105,6 +114,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     payload: ByteArray,
     ingressPort: UInt,
     packetPath: String,
+    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): TraceTree {
@@ -115,10 +125,26 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     // === Ingress pipeline ===
     val ingress: IngressResult
     try {
-      ingress = runIngressPipeline(pipeline, payload, ingressPort, packetPath, selectorMembers)
+      ingress =
+        runIngressPipeline(
+          pipeline,
+          payload,
+          ingressPort,
+          packetPath,
+          payloadBitLength,
+          selectorMembers,
+        )
     } catch (fork: ActionSelectorFork) {
       return handleActionSelectorFork(fork, selectorMembers) { newSelectors ->
-        processPacketRecursive(pipeline, payload, ingressPort, packetPath, depth, newSelectors)
+        processPacketRecursive(
+          pipeline,
+          payload,
+          ingressPort,
+          packetPath,
+          payloadBitLength = payloadBitLength,
+          depth = depth,
+          selectorMembers = newSelectors,
+        )
       }
     }
 
@@ -139,7 +165,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val resubmit = (ingress.output?.fields?.get("resubmit") as? BoolVal)?.value == true
     if (resubmit) {
       val resubmitTree =
-        processPacketRecursive(pipeline, payload, ingressPort, PACKET_PATH_RESUBMIT, depth + 1)
+        processPacketRecursive(
+          pipeline,
+          payload,
+          ingressPort,
+          PACKET_PATH_RESUBMIT,
+          payloadBitLength = payloadBitLength,
+          depth = depth + 1,
+        )
       return buildForkTree(
         ingress.events,
         ForkReason.RESUBMIT,
@@ -217,9 +250,10 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     payload: ByteArray,
     ingressPort: UInt,
     packetPath: String,
+    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): IngressResult {
-    val ctx = PacketContext(payload)
+    val ctx = PacketContext(payload, payloadBitLength = payloadBitLength)
     val env = Environment()
     val values = createDefaultValues(pipeline.config, pipeline.typesByName)
 
@@ -383,7 +417,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
             core.deparsedBytes,
             PSA_PORT_RECIRCULATE_UINT,
             PACKET_PATH_RECIRCULATE,
-            depth + 1,
+            depth = depth + 1,
           )
         TraceTree.newBuilder()
           .addAllEvents(core.events)

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -135,7 +135,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     if (ingress.dropped) {
       val i2eCloneBranches =
-        buildI2ECloneBranches(pipeline, packet.bytes, ingress.output, selectorMembers)
+        buildI2ECloneBranches(pipeline, packet, ingress.output, selectorMembers)
       if (i2eCloneBranches.isNotEmpty()) {
         return buildForkTree(ingress.events, ForkReason.CLONE, i2eCloneBranches)
       }
@@ -161,8 +161,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     }
 
     // === Traffic Manager: I2E clone + multicast/unicast ===
-    val i2eCloneBranches =
-      buildI2ECloneBranches(pipeline, packet.bytes, ingress.output, selectorMembers)
+    val i2eCloneBranches = buildI2ECloneBranches(pipeline, packet, ingress.output, selectorMembers)
     val originalTree = buildOriginalEgressPath(pipeline, ingress, depth, selectorMembers)
 
     if (i2eCloneBranches.isNotEmpty()) {
@@ -362,7 +361,15 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   ): TraceTree {
     val core: EgressCoreResult
     try {
-      core = runEgressCore(state, deparsedBytes, egressPort, instance, packetPath, selectorMembers)
+      core =
+        runEgressCore(
+          state,
+          PacketBits.ofBytes(deparsedBytes),
+          egressPort,
+          instance,
+          packetPath,
+          selectorMembers,
+        )
     } catch (fork: ActionSelectorFork) {
       return handleActionSelectorFork(fork, selectorMembers) { newSelectors ->
         runEgressWithPostProcessing(
@@ -426,14 +433,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
    */
   private fun runEgressCore(
     state: EgressState,
-    deparsedBytes: ByteArray,
+    packet: PacketBits,
     egressPort: Int,
     instance: Int,
     packetPath: String,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): EgressCoreResult {
     val p = state.pipeline
-    val egressCtx = PacketContext(deparsedBytes)
+    val egressCtx = PacketContext(packet)
     val egressEnv = Environment()
     val egressValues = createDefaultValues(p.config, p.typesByName)
 
@@ -490,7 +497,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
    */
   private fun buildI2ECloneBranches(
     pipeline: PipelineConfig,
-    originalPayload: ByteArray,
+    originalPacket: PacketBits,
     ingressOutput: StructVal?,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): List<ForkBranch> =
@@ -499,7 +506,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     buildCloneBranches(
       pipeline,
       ingressOutput,
-      originalPayload,
+      originalPacket,
       PACKET_PATH_CLONE_I2E,
       selectorMembers,
     )
@@ -519,7 +526,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     buildCloneBranches(
       pipeline,
       core.output,
-      core.deparsedBytes,
+      PacketBits.ofBytes(core.deparsedBytes),
       PACKET_PATH_CLONE_E2E,
       selectorMembers,
     )
@@ -534,7 +541,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   private fun buildCloneBranches(
     pipeline: PipelineConfig,
     cloneMetadata: StructVal?,
-    clonePayload: ByteArray,
+    clonePacket: PacketBits,
     packetPath: String,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): List<ForkBranch> {
@@ -547,14 +554,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     return session.replicasList.map { replica ->
       val port = replicaPort(replica)
       val subtree =
-        runCloneEgress(
-          cloneState,
-          clonePayload,
-          port,
-          replica.instance,
-          packetPath,
-          selectorMembers,
-        )
+        runCloneEgress(cloneState, clonePacket, port, replica.instance, packetPath, selectorMembers)
       ForkBranch.newBuilder().setLabel("clone_port_$port").setSubtree(subtree).build()
     }
   }
@@ -567,7 +567,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
    */
   private fun runCloneEgress(
     cloneState: EgressState,
-    clonePayload: ByteArray,
+    clonePacket: PacketBits,
     egressPort: Int,
     instance: Int,
     packetPath: String,
@@ -578,11 +578,11 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       else buildOutputTrace(result.events, egressPort, result.deparsedBytes)
     return try {
       egressToTrace(
-        runEgressCore(cloneState, clonePayload, egressPort, instance, packetPath, selectorMembers)
+        runEgressCore(cloneState, clonePacket, egressPort, instance, packetPath, selectorMembers)
       )
     } catch (fork: ActionSelectorFork) {
       handleActionSelectorFork(fork, selectorMembers) { newSelectors ->
-        runCloneEgress(cloneState, clonePayload, egressPort, instance, packetPath, newSelectors)
+        runCloneEgress(cloneState, clonePacket, egressPort, instance, packetPath, newSelectors)
       }
     }
   }

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -30,6 +30,7 @@ import fourward.StructExprField
 import fourward.Transition
 import fourward.Type
 import fourward.TypeDecl
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -902,6 +903,24 @@ class PSAArchitectureTest {
     // Original on port 2, clone on port 5.
     assertTrue(outputs.any { it.dataplaneEgressPort == 2 })
     assertTrue(outputs.any { it.dataplaneEgressPort == 5 })
+  }
+
+  @Test
+  fun `I2E clone preserves non-byte-aligned packet boundary`() {
+    val config = psaConfig(ingressStmts = cloneStmts(100) + listOf(sendToPort(2)))
+    val store = TableStore()
+    writeCloneSession(store, 100, listOf(0 to 5))
+
+    // The first 10 bits are packet data; the final 14 bits are transport padding.
+    val packet = PacketBits.of(byteArrayOf(0xAB.toByte(), 0xC0.toByte(), 0x00), 10)
+
+    val result = PSAArchitecture(config).processPacket(0u, packet, store)
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(2, outputs.size)
+    for (output in outputs) {
+      assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), output.payload.toByteArray())
+    }
   }
 
   @Test

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -912,7 +912,7 @@ class PSAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 5))
 
     // The first 10 bits are packet data; the final 14 bits are transport padding.
-    val packet = PacketBits.of(byteArrayOf(0xAB.toByte(), 0xC0.toByte(), 0x00), 10)
+    val packet = PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xC0.toByte(), 0x00), 10)
 
     val result = PSAArchitecture(config).processPacket(0u, packet, store)
     val outputs = result.possibleOutcomes.single()

--- a/simulator/PacketBits.kt
+++ b/simulator/PacketBits.kt
@@ -7,22 +7,31 @@ package fourward.simulator
  * width is not a multiple of eight. The transport still carries whole bytes, so callers must keep
  * the valid bit length alongside the padded byte buffer.
  */
-class PacketBits private constructor(
-  val bytes: ByteArray,
-  val validBitLength: Int,
-) {
+class PacketBits private constructor(private val paddedBytes: ByteArray, val validBitLength: Int) {
   init {
-    require(validBitLength in 0..bytes.size * Byte.SIZE_BITS) {
-      "validBitLength must be between 0 and ${bytes.size * Byte.SIZE_BITS}, got $validBitLength"
+    require(validBitLength in 0..paddedBytes.size * Byte.SIZE_BITS) {
+      "validBitLength must be between 0 and ${paddedBytes.size * Byte.SIZE_BITS}, " +
+        "got $validBitLength"
     }
   }
 
   val byteLength: Int
-    get() = bytes.size
+    get() = paddedBytes.size
+
+  /** Returns a copy of the whole transport buffer, including padding past [validBitLength]. */
+  fun copyPaddedBytesForTransport(): ByteArray = paddedBytes.copyOf()
+
+  /**
+   * Returns the mutable backing buffer for parser internals.
+   *
+   * Keep this internal so public callers cannot accidentally use the padded byte array while
+   * dropping [validBitLength].
+   */
+  internal fun backingBytesForParser(): ByteArray = paddedBytes
 
   fun truncateToBytes(maxBytes: Int): PacketBits =
-    if (maxBytes > 0 && maxBytes < bytes.size) {
-      PacketBits(bytes.copyOf(maxBytes), minOf(validBitLength, maxBytes * Byte.SIZE_BITS))
+    if (maxBytes > 0 && maxBytes < paddedBytes.size) {
+      PacketBits(paddedBytes.copyOf(maxBytes), minOf(validBitLength, maxBytes * Byte.SIZE_BITS))
     } else {
       this
     }
@@ -30,12 +39,12 @@ class PacketBits private constructor(
   override fun equals(other: Any?): Boolean =
     other is PacketBits &&
       validBitLength == other.validBitLength &&
-      bytes.contentEquals(other.bytes)
+      paddedBytes.contentEquals(other.paddedBytes)
 
-  override fun hashCode(): Int = 31 * bytes.contentHashCode() + validBitLength
+  override fun hashCode(): Int = 31 * paddedBytes.contentHashCode() + validBitLength
 
   override fun toString(): String =
-    "PacketBits(byteLength=${bytes.size}, validBitLength=$validBitLength)"
+    "PacketBits(byteLength=${paddedBytes.size}, validBitLength=$validBitLength)"
 
   companion object {
     fun ofBytes(bytes: ByteArray): PacketBits = PacketBits(bytes, bytes.size * Byte.SIZE_BITS)

--- a/simulator/PacketBits.kt
+++ b/simulator/PacketBits.kt
@@ -1,0 +1,45 @@
+package fourward.simulator
+
+/**
+ * Packet bytes plus the number of meaningful bits they contain.
+ *
+ * Most packets are byte-aligned, but P4Runtime PacketOut can prepend controller metadata whose
+ * width is not a multiple of eight. The transport still carries whole bytes, so callers must keep
+ * the valid bit length alongside the padded byte buffer.
+ */
+class PacketBits private constructor(
+  val bytes: ByteArray,
+  val validBitLength: Int,
+) {
+  init {
+    require(validBitLength in 0..bytes.size * Byte.SIZE_BITS) {
+      "validBitLength must be between 0 and ${bytes.size * Byte.SIZE_BITS}, got $validBitLength"
+    }
+  }
+
+  val byteLength: Int
+    get() = bytes.size
+
+  fun truncateToBytes(maxBytes: Int): PacketBits =
+    if (maxBytes > 0 && maxBytes < bytes.size) {
+      PacketBits(bytes.copyOf(maxBytes), minOf(validBitLength, maxBytes * Byte.SIZE_BITS))
+    } else {
+      this
+    }
+
+  override fun equals(other: Any?): Boolean =
+    other is PacketBits &&
+      validBitLength == other.validBitLength &&
+      bytes.contentEquals(other.bytes)
+
+  override fun hashCode(): Int = 31 * bytes.contentHashCode() + validBitLength
+
+  override fun toString(): String =
+    "PacketBits(byteLength=${bytes.size}, validBitLength=$validBitLength)"
+
+  companion object {
+    fun ofBytes(bytes: ByteArray): PacketBits = PacketBits(bytes, bytes.size * Byte.SIZE_BITS)
+
+    fun of(bytes: ByteArray, validBitLength: Int): PacketBits = PacketBits(bytes, validBitLength)
+  }
+}

--- a/simulator/PacketBits.kt
+++ b/simulator/PacketBits.kt
@@ -15,11 +15,14 @@ class PacketBits private constructor(private val paddedBytes: ByteArray, val val
     }
   }
 
-  val byteLength: Int
+  val packetByteLength: Int
+    get() = (validBitLength + Byte.SIZE_BITS - 1) / Byte.SIZE_BITS
+
+  private val paddedByteLength: Int
     get() = paddedBytes.size
 
   /** Returns a copy of the whole transport buffer, including padding past [validBitLength]. */
-  fun copyPaddedBytesForTransport(): ByteArray = paddedBytes.copyOf()
+  fun copyPaddedBytes(): ByteArray = paddedBytes.copyOf()
 
   /**
    * Returns the mutable backing buffer for parser internals.
@@ -30,7 +33,7 @@ class PacketBits private constructor(private val paddedBytes: ByteArray, val val
   internal fun backingBytesForParser(): ByteArray = paddedBytes
 
   fun truncateToBytes(maxBytes: Int): PacketBits =
-    if (maxBytes > 0 && maxBytes < paddedBytes.size) {
+    if (maxBytes > 0 && maxBytes < packetByteLength) {
       PacketBits(paddedBytes.copyOf(maxBytes), minOf(validBitLength, maxBytes * Byte.SIZE_BITS))
     } else {
       this
@@ -44,11 +47,13 @@ class PacketBits private constructor(private val paddedBytes: ByteArray, val val
   override fun hashCode(): Int = 31 * paddedBytes.contentHashCode() + validBitLength
 
   override fun toString(): String =
-    "PacketBits(byteLength=${paddedBytes.size}, validBitLength=$validBitLength)"
+    "PacketBits(packetByteLength=$packetByteLength, paddedByteLength=$paddedByteLength, " +
+      "validBitLength=$validBitLength)"
 
   companion object {
     fun ofBytes(bytes: ByteArray): PacketBits = PacketBits(bytes, bytes.size * Byte.SIZE_BITS)
 
-    fun of(bytes: ByteArray, validBitLength: Int): PacketBits = PacketBits(bytes, validBitLength)
+    fun ofPaddedBytes(bytes: ByteArray, validBitLength: Int): PacketBits =
+      PacketBits(bytes, validBitLength)
   }
 }

--- a/simulator/PacketBits.kt
+++ b/simulator/PacketBits.kt
@@ -5,7 +5,9 @@ package fourward.simulator
  *
  * Most packets are byte-aligned, but P4Runtime PacketOut can prepend controller metadata whose
  * width is not a multiple of eight. The transport still carries whole bytes, so callers must keep
- * the valid bit length alongside the padded byte buffer.
+ * the valid bit length alongside the padded byte buffer. [validBitLength], not the backing array
+ * size, defines the packet; bytes beyond that boundary are transport padding and must not be
+ * interpreted as packet data.
  */
 class PacketBits private constructor(private val paddedBytes: ByteArray, val validBitLength: Int) {
   init {
@@ -21,7 +23,12 @@ class PacketBits private constructor(private val paddedBytes: ByteArray, val val
   private val paddedByteLength: Int
     get() = paddedBytes.size
 
-  /** Returns a copy of the whole transport buffer, including padding past [validBitLength]. */
+  /**
+   * Returns a copy of the whole transport buffer, including padding past [validBitLength].
+   *
+   * This is for observability/debug surfaces that report the original injected buffer. Parser and
+   * deparser semantics must use [validBitLength] instead of treating these bytes as all meaningful.
+   */
   fun copyPaddedBytes(): ByteArray = paddedBytes.copyOf()
 
   /**
@@ -53,6 +60,12 @@ class PacketBits private constructor(private val paddedBytes: ByteArray, val val
   companion object {
     fun ofBytes(bytes: ByteArray): PacketBits = PacketBits(bytes, bytes.size * Byte.SIZE_BITS)
 
+    /**
+     * Builds a packet from a byte buffer whose final byte may contain transport padding.
+     *
+     * Padding bits need not be zero. Consumers that return semantic packet bytes are responsible
+     * for masking the final partial byte.
+     */
     fun ofPaddedBytes(bytes: ByteArray, validBitLength: Int): PacketBits =
       PacketBits(bytes, validBitLength)
   }

--- a/simulator/PacketBitsTest.kt
+++ b/simulator/PacketBitsTest.kt
@@ -9,26 +9,35 @@ class PacketBitsTest {
 
   @Test
   fun `valid bit length must fit in transport buffer`() {
-    assertThrows(IllegalArgumentException::class.java) { PacketBits.of(byteArrayOf(0x00), 9) }
+    assertThrows(IllegalArgumentException::class.java) {
+      PacketBits.ofPaddedBytes(byteArrayOf(0x00), 9)
+    }
   }
 
   @Test
   fun `transport bytes are copied for public callers`() {
-    val packet = PacketBits.of(byteArrayOf(0xA0.toByte()), 4)
+    val packet = PacketBits.ofPaddedBytes(byteArrayOf(0xA0.toByte()), 4)
 
-    val copy = packet.copyPaddedBytesForTransport()
+    val copy = packet.copyPaddedBytes()
     copy[0] = 0x00
 
-    assertArrayEquals(byteArrayOf(0xA0.toByte()), packet.copyPaddedBytesForTransport())
+    assertArrayEquals(byteArrayOf(0xA0.toByte()), packet.copyPaddedBytes())
+  }
+
+  @Test
+  fun `packet byte length ignores whole padding bytes`() {
+    val packet = PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xC0.toByte(), 0x00), 10)
+
+    assertEquals(2, packet.packetByteLength)
   }
 
   @Test
   fun `truncate caps valid bit length at truncated buffer size`() {
-    val packet = PacketBits.of(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), 10)
+    val packet = PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), 10)
 
     val truncated = packet.truncateToBytes(1)
 
     assertEquals(8, truncated.validBitLength)
-    assertArrayEquals(byteArrayOf(0xAB.toByte()), truncated.copyPaddedBytesForTransport())
+    assertArrayEquals(byteArrayOf(0xAB.toByte()), truncated.copyPaddedBytes())
   }
 }

--- a/simulator/PacketBitsTest.kt
+++ b/simulator/PacketBitsTest.kt
@@ -1,0 +1,34 @@
+package fourward.simulator
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class PacketBitsTest {
+
+  @Test
+  fun `valid bit length must fit in transport buffer`() {
+    assertThrows(IllegalArgumentException::class.java) { PacketBits.of(byteArrayOf(0x00), 9) }
+  }
+
+  @Test
+  fun `transport bytes are copied for public callers`() {
+    val packet = PacketBits.of(byteArrayOf(0xA0.toByte()), 4)
+
+    val copy = packet.copyPaddedBytesForTransport()
+    copy[0] = 0x00
+
+    assertArrayEquals(byteArrayOf(0xA0.toByte()), packet.copyPaddedBytesForTransport())
+  }
+
+  @Test
+  fun `truncate caps valid bit length at truncated buffer size`() {
+    val packet = PacketBits.of(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), 10)
+
+    val truncated = packet.truncateToBytes(1)
+
+    assertEquals(8, truncated.validBitLength)
+    assertArrayEquals(byteArrayOf(0xAB.toByte()), truncated.copyPaddedBytesForTransport())
+  }
+}

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -119,16 +119,11 @@ class Simulator : TableDataReader {
    *
    * @throws IllegalStateException if no pipeline is loaded.
    */
-  fun processPacket(
-    ingressPort: Int,
-    payload: ByteArray,
-    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
-  ): ProcessPacketResult {
+  fun processPacket(ingressPort: Int, payload: ByteArray): ProcessPacketResult =
+    processPacket(ingressPort, PacketBits.ofBytes(payload))
+
+  fun processPacket(ingressPort: Int, packet: PacketBits): ProcessPacketResult {
     val loaded = loaded()
-    require(payloadBitLength in 0..payload.size * Byte.SIZE_BITS) {
-      "payloadBitLength must be between 0 and ${payload.size * Byte.SIZE_BITS}, " +
-        "got $payloadBitLength"
-    }
     // Pin the forwarding snapshot before processing so the reproducer's entity extraction
     // uses the exact same state the packet saw — no race with concurrent publishSnapshot().
     val snapshot = loaded.tableStore.snapshot
@@ -136,9 +131,8 @@ class Simulator : TableDataReader {
     val result =
       loaded.architecture.processPacket(
         ingressPort = ingressPort.toUInt(),
-        payload = payload,
+        packet = packet,
         tableStore = loaded.tableStore,
-        payloadBitLength = payloadBitLength,
       )
 
     // Output packets are extracted from trace tree leaves — the tree is the single source

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -119,8 +119,16 @@ class Simulator : TableDataReader {
    *
    * @throws IllegalStateException if no pipeline is loaded.
    */
-  fun processPacket(ingressPort: Int, payload: ByteArray): ProcessPacketResult {
+  fun processPacket(
+    ingressPort: Int,
+    payload: ByteArray,
+    payloadBitLength: Int = payload.size * Byte.SIZE_BITS,
+  ): ProcessPacketResult {
     val loaded = loaded()
+    require(payloadBitLength in 0..payload.size * Byte.SIZE_BITS) {
+      "payloadBitLength must be between 0 and ${payload.size * Byte.SIZE_BITS}, " +
+        "got $payloadBitLength"
+    }
     // Pin the forwarding snapshot before processing so the reproducer's entity extraction
     // uses the exact same state the packet saw — no race with concurrent publishSnapshot().
     val snapshot = loaded.tableStore.snapshot
@@ -130,6 +138,7 @@ class Simulator : TableDataReader {
         ingressPort = ingressPort.toUInt(),
         payload = payload,
         tableStore = loaded.tableStore,
+        payloadBitLength = payloadBitLength,
       )
 
     // Output packets are extracted from trace tree leaves — the tree is the single source

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -457,7 +457,7 @@ class V1ModelArchitecture(
           s.standardMetadata.setBitField("instance_type", instanceType)
           s.standardMetadata.setBitField("egress_port", replica.port.toLong())
           s.standardMetadata.setBitField("egress_rid", replica.rid.toLong())
-          s.standardMetadata.setBitField("packet_length", ctx.packet.byteLength.toLong())
+          s.standardMetadata.setBitField("packet_length", ctx.packet.packetByteLength.toLong())
           applyPreservedMetadata(ctx, s.env, preservedMetadata)
         },
         pipelineTail = pipelineTail,
@@ -572,7 +572,7 @@ class V1ModelArchitecture(
       "$standardMetaTypeName has no packet_length"
     }
     standardMetadata.setBitField("ingress_port", ctx.ingressPort.toLong())
-    standardMetadata.setBitField("packet_length", ctx.packet.byteLength.toLong())
+    standardMetadata.setBitField("packet_length", ctx.packet.packetByteLength.toLong())
     standardMetadata.fields["parser_error"] = ErrorVal.NO_ERROR
     setTimestampField(
       standardMetadata,
@@ -994,7 +994,7 @@ class V1ModelArchitecture(
 
   /** Returns [ctx] with payload truncated to [maxBytes], or [ctx] unchanged if no truncation. */
   private fun truncatePayload(ctx: PipelineContext, maxBytes: Int): PipelineContext =
-    if (maxBytes > 0 && maxBytes < ctx.packet.byteLength) {
+    if (maxBytes > 0 && maxBytes < ctx.packet.packetByteLength) {
       ctx.copy(packet = ctx.packet.truncateToBytes(maxBytes))
     } else {
       ctx

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -85,6 +85,7 @@ class V1ModelArchitecture(
   private data class PipelineContext(
     val ingressPort: UInt,
     val payload: ByteArray,
+    val payloadBitLength: Int,
     val config: BehavioralConfig,
     val tableStore: TableStore,
     val interpreter: Interpreter,
@@ -124,8 +125,10 @@ class V1ModelArchitecture(
     ingressPort: UInt,
     payload: ByteArray,
     tableStore: TableStore,
+    payloadBitLength: Int,
   ): PipelineResult {
-    val ctx = PipelineContext(ingressPort, payload, config, tableStore, interpreter)
+    val ctx =
+      PipelineContext(ingressPort, payload, payloadBitLength, config, tableStore, interpreter)
     return buildTraceTree(ctx, V1ModelDecisions())
   }
 
@@ -204,7 +207,7 @@ class V1ModelArchitecture(
     snapshotPendingOps: V1ModelPendingOps? = null,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): PipelineState {
-    val packetCtx = PacketContext(ctx.payload, bytesConsumed)
+    val packetCtx = PacketContext(ctx.payload, bytesConsumed, ctx.payloadBitLength)
     val env = snapshotEnv.deepCopy()
     val pendingOps = snapshotPendingOps?.copy() ?: V1ModelPendingOps()
     val standardMetadata = resolveStandardMetadata(ctx, env)
@@ -606,7 +609,13 @@ class V1ModelArchitecture(
       }
     }
 
-    return finishPipelineState(ctx, decisions, PacketContext(ctx.payload), env, standardMetadata)
+    return finishPipelineState(
+      ctx,
+      decisions,
+      PacketContext(ctx.payload, payloadBitLength = ctx.payloadBitLength),
+      env,
+      standardMetadata,
+    )
   }
 
   /**
@@ -993,7 +1002,10 @@ class V1ModelArchitecture(
   /** Returns [ctx] with payload truncated to [maxBytes], or [ctx] unchanged if no truncation. */
   private fun truncatePayload(ctx: PipelineContext, maxBytes: Int): PipelineContext =
     if (maxBytes > 0 && maxBytes < ctx.payload.size) {
-      ctx.copy(payload = ctx.payload.copyOf(maxBytes))
+      ctx.copy(
+        payload = ctx.payload.copyOf(maxBytes),
+        payloadBitLength = minOf(ctx.payloadBitLength, maxBytes * Byte.SIZE_BITS),
+      )
     } else {
       ctx
     }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -84,8 +84,7 @@ class V1ModelArchitecture(
   /** Invariant inputs to the pipeline, shared across fork re-executions. */
   private data class PipelineContext(
     val ingressPort: UInt,
-    val payload: ByteArray,
-    val payloadBitLength: Int,
+    val packet: PacketBits,
     val config: BehavioralConfig,
     val tableStore: TableStore,
     val interpreter: Interpreter,
@@ -123,12 +122,10 @@ class V1ModelArchitecture(
 
   override fun processPacket(
     ingressPort: UInt,
-    payload: ByteArray,
+    packet: PacketBits,
     tableStore: TableStore,
-    payloadBitLength: Int,
   ): PipelineResult {
-    val ctx =
-      PipelineContext(ingressPort, payload, payloadBitLength, config, tableStore, interpreter)
+    val ctx = PipelineContext(ingressPort, packet, config, tableStore, interpreter)
     return buildTraceTree(ctx, V1ModelDecisions())
   }
 
@@ -207,7 +204,7 @@ class V1ModelArchitecture(
     snapshotPendingOps: V1ModelPendingOps? = null,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): PipelineState {
-    val packetCtx = PacketContext(ctx.payload, bytesConsumed, ctx.payloadBitLength)
+    val packetCtx = PacketContext(ctx.packet, bytesConsumed)
     val env = snapshotEnv.deepCopy()
     val pendingOps = snapshotPendingOps?.copy() ?: V1ModelPendingOps()
     val standardMetadata = resolveStandardMetadata(ctx, env)
@@ -460,7 +457,7 @@ class V1ModelArchitecture(
           s.standardMetadata.setBitField("instance_type", instanceType)
           s.standardMetadata.setBitField("egress_port", replica.port.toLong())
           s.standardMetadata.setBitField("egress_rid", replica.rid.toLong())
-          s.standardMetadata.setBitField("packet_length", ctx.payload.size.toLong())
+          s.standardMetadata.setBitField("packet_length", ctx.packet.byteLength.toLong())
           applyPreservedMetadata(ctx, s.env, preservedMetadata)
         },
         pipelineTail = pipelineTail,
@@ -530,7 +527,9 @@ class V1ModelArchitecture(
     val branch =
       ForkBranch.newBuilder()
         .setLabel("recirculate")
-        .setSubtree(buildTraceTree(ctx.copy(payload = fork.deparsedBytes), decisions).trace)
+        .setSubtree(
+          buildTraceTree(ctx.copy(packet = PacketBits.ofBytes(fork.deparsedBytes)), decisions).trace
+        )
         .build()
     return PipelineResult(
       buildForkTree(fork.eventsBeforeFork, ForkReason.RECIRCULATE, listOf(branch))
@@ -573,7 +572,7 @@ class V1ModelArchitecture(
       "$standardMetaTypeName has no packet_length"
     }
     standardMetadata.setBitField("ingress_port", ctx.ingressPort.toLong())
-    standardMetadata.setBitField("packet_length", ctx.payload.size.toLong())
+    standardMetadata.setBitField("packet_length", ctx.packet.byteLength.toLong())
     standardMetadata.fields["parser_error"] = ErrorVal.NO_ERROR
     setTimestampField(
       standardMetadata,
@@ -609,13 +608,7 @@ class V1ModelArchitecture(
       }
     }
 
-    return finishPipelineState(
-      ctx,
-      decisions,
-      PacketContext(ctx.payload, payloadBitLength = ctx.payloadBitLength),
-      env,
-      standardMetadata,
-    )
+    return finishPipelineState(ctx, decisions, PacketContext(ctx.packet), env, standardMetadata)
   }
 
   /**
@@ -1001,11 +994,8 @@ class V1ModelArchitecture(
 
   /** Returns [ctx] with payload truncated to [maxBytes], or [ctx] unchanged if no truncation. */
   private fun truncatePayload(ctx: PipelineContext, maxBytes: Int): PipelineContext =
-    if (maxBytes > 0 && maxBytes < ctx.payload.size) {
-      ctx.copy(
-        payload = ctx.payload.copyOf(maxBytes),
-        payloadBitLength = minOf(ctx.payloadBitLength, maxBytes * Byte.SIZE_BITS),
-      )
+    if (maxBytes > 0 && maxBytes < ctx.packet.byteLength) {
+      ctx.copy(packet = ctx.packet.truncateToBytes(maxBytes))
     } else {
       ctx
     }

--- a/web/PlaygroundServer.kt
+++ b/web/PlaygroundServer.kt
@@ -28,7 +28,13 @@ fun main(args: Array<String>) {
 
   val simulator = Simulator()
   val writeMutex = kotlinx.coroutines.sync.Mutex()
-  val broker = PacketBroker(simulator::processPacket, writeMutex)
+  val broker =
+    PacketBroker(
+      { ingressPort, payload, payloadBitLength ->
+        simulator.processPacket(ingressPort, payload, payloadBitLength)
+      },
+      writeMutex,
+    )
   val service =
     P4RuntimeService(
       simulator,

--- a/web/PlaygroundServer.kt
+++ b/web/PlaygroundServer.kt
@@ -30,9 +30,7 @@ fun main(args: Array<String>) {
   val writeMutex = kotlinx.coroutines.sync.Mutex()
   val broker =
     PacketBroker(
-      { ingressPort, payload, payloadBitLength ->
-        simulator.processPacket(ingressPort, payload, payloadBitLength)
-      },
+      { ingressPort, packet -> simulator.processPacket(ingressPort, packet) },
       writeMutex,
     )
   val service =

--- a/web/WebServerTest.kt
+++ b/web/WebServerTest.kt
@@ -91,7 +91,13 @@ class WebServerTest {
   private fun <T> withServer(block: (port: Int) -> T): T {
     val simulator = fourward.simulator.Simulator()
     val writeMutex = kotlinx.coroutines.sync.Mutex()
-    val broker = fourward.grpc.PacketBroker(simulator::processPacket, writeMutex)
+    val broker =
+      fourward.grpc.PacketBroker(
+        { ingressPort, payload, payloadBitLength ->
+          simulator.processPacket(ingressPort, payload, payloadBitLength)
+        },
+        writeMutex,
+      )
     val service = fourward.grpc.P4RuntimeService(simulator, broker, writeMutex = writeMutex)
     val server = WebServer(simulator, service, httpPort = 0).start()
     try {

--- a/web/WebServerTest.kt
+++ b/web/WebServerTest.kt
@@ -93,9 +93,7 @@ class WebServerTest {
     val writeMutex = kotlinx.coroutines.sync.Mutex()
     val broker =
       fourward.grpc.PacketBroker(
-        { ingressPort, payload, payloadBitLength ->
-          simulator.processPacket(ingressPort, payload, payloadBitLength)
-        },
+        { ingressPort, packet -> simulator.processPacket(ingressPort, packet) },
         writeMutex,
       )
     val service = fourward.grpc.P4RuntimeService(simulator, broker, writeMutex = writeMutex)


### PR DESCRIPTION
Fixes #709.

PacketOut packing for non-byte-aligned controller headers already bit-packed header fields and payload continuously, but the byte array handed to the simulator still included transport padding at the end. With SAI's 10-bit `packet_out` header, those padding bits could survive as an extra zero byte in the emitted packet.

This change makes packet bit length an explicit simulator value with `PacketBits`. Raw `ByteArray` entry points now mean byte-aligned packet data; PacketOut uses `PacketBits.ofPaddedBytes` to carry `packet_out_header_bits + payload_bits` through the broker, simulator, architecture, and parser cursor. The public API no longer exposes the padded backing bytes directly, `packetByteLength` names the semantic packet length, PSA clone paths keep the same `PacketBits` boundary instead of peeling it back to plain bytes, and remaining-byte helpers mask padding in the final partial byte.

Validation:
- `./tools/format.sh`
- `./tools/lint.sh`
- `bazel test //grpc:BitLevelSerializationTest //grpc:PacketBrokerTest //simulator:EnvironmentTest //simulator:PacketBitsTest //simulator:PSAArchitectureTest`
