### PR TITLE
Honor P4Runtime direct resource TableEntry writes

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -85,6 +85,13 @@ guilt — just write it down so someone can find it later.
   written and read via P4Runtime, but the simulator does not perform
   real rate limiting — `direct_meter.read()` always returns the default
   color (GREEN).
+- **P4Runtime TableEntry direct-resource writes are not action-checked
+  (#718).** P4Runtime §9.1.7 requires `INVALID_ARGUMENT` when a
+  `TableEntry` provides direct counter or meter data for an action that
+  does not execute that direct resource. 4ward validates that the table
+  has the direct resource and stores valid inline data in the simulator's
+  direct counter/meter state, but it does not yet validate the selected
+  action's direct-resource execution.
 - **No digests or idle timeouts (by design).** Both are inherently
   time-dependent features that have no meaningful semantics in a reference
   simulator: there are no real packet rates to trigger digests, and no

--- a/grpc/P4RuntimeWriteErrorTest.kt
+++ b/grpc/P4RuntimeWriteErrorTest.kt
@@ -9,8 +9,10 @@ import io.grpc.Status
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import p4.v1.P4RuntimeOuterClass.CounterData
 import p4.v1.P4RuntimeOuterClass.DigestEntry
 import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.MeterConfig
 import p4.v1.P4RuntimeOuterClass.TableEntry
 import p4.v1.P4RuntimeOuterClass.Update
 import p4.v1.P4RuntimeOuterClass.WriteRequest
@@ -100,6 +102,52 @@ class P4RuntimeWriteErrorTest {
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
 
     assertGrpcError(Status.Code.NOT_FOUND) { harness.deleteEntry(entry) }
+  }
+
+  // P4Runtime spec §9.1.7: counter_data is invalid for any write to a table
+  // without a direct counter.
+  @Test
+  fun `delete with counter data on table without direct counter returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(entry)
+    val deleteEntry =
+      entry
+        .toBuilder()
+        .setTableEntry(
+          entry.tableEntry
+            .toBuilder()
+            .setCounterData(CounterData.newBuilder().setPacketCount(42).setByteCount(1000))
+        )
+        .build()
+
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "TableEntry contained counter_data") {
+      harness.deleteEntry(deleteEntry)
+    }
+  }
+
+  // P4Runtime spec §9.1.7: meter_config is invalid for any write to a table
+  // without a direct meter.
+  @Test
+  fun `delete with meter config on table without direct meter returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
+    harness.installEntry(entry)
+    val deleteEntry =
+      entry
+        .toBuilder()
+        .setTableEntry(
+          entry.tableEntry
+            .toBuilder()
+            .setMeterConfig(MeterConfig.newBuilder().setCir(1000).setCburst(100))
+        )
+        .build()
+
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "TableEntry contained meter_config") {
+      harness.deleteEntry(deleteEntry)
+    }
   }
 
   // =========================================================================
@@ -260,6 +308,36 @@ class P4RuntimeWriteErrorTest {
         b.tableEntryBuilder.getMatchBuilder(0).clearExact().setFieldId(matchField.id)
       }
     assertGrpcError(Status.Code.INVALID_ARGUMENT, "no value set") { harness.installEntry(entity) }
+  }
+
+  // P4Runtime spec §9.1.7: counter_data is only valid for tables with a direct counter.
+  @Test
+  fun `insert with counter data on table without direct counter returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entity =
+      buildInvalidEntry(config) { b ->
+        b.tableEntryBuilder.setCounterData(
+          CounterData.newBuilder().setPacketCount(42).setByteCount(1000)
+        )
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "TableEntry contained counter_data") {
+      harness.installEntry(entity)
+    }
+  }
+
+  // P4Runtime spec §9.1.7: meter_config is only valid for tables with a direct meter.
+  @Test
+  fun `insert with meter config on table without direct meter returns INVALID_ARGUMENT`() {
+    val config = loadBasicTableConfig()
+    harness.loadPipeline(config)
+    val entity =
+      buildInvalidEntry(config) { b ->
+        b.tableEntryBuilder.setMeterConfig(MeterConfig.newBuilder().setCir(1000).setCburst(100))
+      }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "TableEntry contained meter_config") {
+      harness.installEntry(entity)
+    }
   }
 
   // P4Runtime spec §9.1.1: exact-only tables must have priority == 0.

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -39,6 +39,37 @@ fun matchesFieldMatch(bits: BitVector, match: P4RuntimeOuterClass.FieldMatch): B
   if (bits.width <= BitVector.LONG_WIDTH) matchLong(bits.longValue, bits.width, match)
   else matchBig(bits.value, bits.width, match)
 
+private data class InlineDirectResourceWriteContext(
+  val directCounterTables: Set<String>,
+  val directMeterTables: Set<String>,
+  val directCounterData: ConcurrentHashMap<TableEntry, AtomicLongArray>,
+  val writeState: TableStore.ForwardingSnapshot,
+)
+
+private fun applyInlineDirectResources(
+  rawEntry: TableEntry,
+  storedEntry: TableEntry,
+  oldEntry: TableEntry?,
+  tableName: String,
+  context: InlineDirectResourceWriteContext,
+) {
+  if (tableName in context.directCounterTables && rawEntry.hasCounterData()) {
+    oldEntry?.let { context.directCounterData.remove(it) }
+    val data = rawEntry.counterData
+    context.directCounterData[storedEntry] =
+      AtomicLongArray(longArrayOf(data.packetCount, data.byteCount))
+  } else if (tableName in context.directCounterTables && oldEntry != null) {
+    context.directCounterData.remove(oldEntry)?.let { context.directCounterData[storedEntry] = it }
+  }
+
+  if (tableName in context.directMeterTables) {
+    oldEntry?.let { context.writeState.directMeterData.remove(it) }
+    if (rawEntry.hasMeterConfig()) {
+      context.writeState.directMeterData[storedEntry] = rawEntry.meterConfig
+    }
+  }
+}
+
 private fun matchLong(bits: Long, width: Int, match: P4RuntimeOuterClass.FieldMatch): Boolean =
   when (match.fieldMatchTypeCase) {
     P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
@@ -1124,15 +1155,42 @@ class TableStore : TableDataReader {
   }
 
   private fun writeTableEntry(update: Update): WriteResult {
-    val entry = update.entity.tableEntry
+    val rawEntry = update.entity.tableEntry
     val tableName =
-      tableNameById[entry.tableId]
+      tableNameById[rawEntry.tableId]
         ?: return WriteResult.NotFound(
-          "unknown table ID ${entry.tableId} " +
+          "unknown table ID ${rawEntry.tableId} " +
             "(valid tables: ${formatOptions(tableNameById.entries.map {
               "'${it.value}' (${it.key})"
             })})"
         )
+    if (rawEntry.hasCounterData() && tableName !in directCounterTables) {
+      return WriteResult.InvalidArgument(
+        "table '$tableName' has no direct counter, but TableEntry contained counter_data"
+      )
+    }
+    if (rawEntry.hasMeterConfig() && tableName !in directMeterTables) {
+      return WriteResult.InvalidArgument(
+        "table '$tableName' has no direct meter, but TableEntry contained meter_config"
+      )
+    }
+    // TODO(#718): Also reject direct resource data when the selected action does not execute
+    // that direct resource, as required by P4Runtime §9.1.7.
+    val entry =
+      if (!rawEntry.hasCounterData() && !rawEntry.hasMeterConfig()) {
+        rawEntry
+      } else {
+        // TableEntry carries direct extern data on reads, but forwarding entries are keyed only by
+        // match/action data. Store direct counter and meter state in their dedicated maps.
+        rawEntry.toBuilder().clearCounterData().clearMeterConfig().build()
+      }
+    val directResourceContext =
+      InlineDirectResourceWriteContext(
+        directCounterTables,
+        directMeterTables,
+        directCounterData,
+        writeState,
+      )
 
     // P4Runtime spec §9.1: default entries are stored separately and only support MODIFY.
     // The WriteValidator already rejects INSERT/DELETE for defaults.
@@ -1161,6 +1219,13 @@ class TableStore : TableDataReader {
             WriteResult.ResourceExhausted("table '$tableName' is full ($limit entries)")
           } else {
             entries.add(entry)
+            applyInlineDirectResources(
+              rawEntry,
+              entry,
+              oldEntry = null,
+              tableName,
+              directResourceContext,
+            )
             WriteResult.Success
           }
         }
@@ -1174,8 +1239,7 @@ class TableStore : TableDataReader {
           // a remove in the DELETE branch below.
           val old = entries[existingIndex]
           entries[existingIndex] = entry
-          directCounterData.remove(old)?.let { directCounterData[entry] = it }
-          writeState.directMeterData.remove(old)?.let { writeState.directMeterData[entry] = it }
+          applyInlineDirectResources(rawEntry, entry, old, tableName, directResourceContext)
           WriteResult.Success
         }
       }

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -168,6 +168,32 @@ class TableStoreTest {
       .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId)))
       .build()
 
+  private fun withAction(entry: TableEntry, actionId: Int): TableEntry =
+    entry
+      .toBuilder()
+      .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId)))
+      .build()
+
+  private fun withCounterData(
+    entry: TableEntry,
+    packetCount: Long = 42,
+    byteCount: Long = 1000,
+  ): TableEntry =
+    entry
+      .toBuilder()
+      .setCounterData(
+        P4RuntimeOuterClass.CounterData.newBuilder()
+          .setPacketCount(packetCount)
+          .setByteCount(byteCount)
+      )
+      .build()
+
+  private fun withMeterConfig(entry: TableEntry, cir: Long = 1000, cburst: Long = 100): TableEntry =
+    entry
+      .toBuilder()
+      .setMeterConfig(P4RuntimeOuterClass.MeterConfig.newBuilder().setCir(cir).setCburst(cburst))
+      .build()
+
   private fun write(entry: TableEntry) {
     store.writeAndPublish(
       Update.newBuilder()
@@ -1732,6 +1758,62 @@ class TableStoreTest {
   }
 
   @Test
+  fun `insert rejects counter data for table without direct counter`() {
+    val entry = withCounterData(exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+  }
+
+  @Test
+  fun `insert rejects meter config for table without direct meter`() {
+    val entry = withMeterConfig(exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+  }
+
+  @Test
+  fun `modify rejects counter data for table without direct counter`() {
+    val original = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
+    store.writeAndPublish(insertUpdate(original))
+    val modified = withCounterData(withAction(original, actionId = 20))
+
+    val result = store.writeAndPublish(modifyUpdate(modified))
+
+    val entries = store.getTableEntries(TABLE_NAME)
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertEquals(1, entries.size)
+    assertEquals(10, entries[0].action.action.actionId)
+  }
+
+  @Test
+  fun `delete rejects counter data for table without direct counter`() {
+    val entry = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
+    store.writeAndPublish(insertUpdate(entry))
+
+    val result = store.writeAndPublish(deleteUpdate(withCounterData(entry)))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+  }
+
+  @Test
+  fun `delete rejects meter config for table without direct meter`() {
+    val entry = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
+    store.writeAndPublish(insertUpdate(entry))
+
+    val result = store.writeAndPublish(deleteUpdate(withMeterConfig(entry)))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+  }
+
+  @Test
   fun `getTableEntries returns empty for unknown table`() {
     val entry = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
     store.writeAndPublish(insertUpdate(entry))
@@ -1795,6 +1877,18 @@ class TableStoreTest {
   private fun insertUpdate(entry: TableEntry): Update =
     Update.newBuilder()
       .setType(Update.Type.INSERT)
+      .setEntity(Entity.newBuilder().setTableEntry(entry))
+      .build()
+
+  private fun modifyUpdate(entry: TableEntry): Update =
+    Update.newBuilder()
+      .setType(Update.Type.MODIFY)
+      .setEntity(Entity.newBuilder().setTableEntry(entry))
+      .build()
+
+  private fun deleteUpdate(entry: TableEntry): Update =
+    Update.newBuilder()
+      .setType(Update.Type.DELETE)
       .setEntity(Entity.newBuilder().setTableEntry(entry))
       .build()
 
@@ -2218,6 +2312,46 @@ class TableStoreTest {
   }
 
   @Test
+  fun `table entry INSERT with counter data initializes direct counter`() {
+    val s = storeWithDirectCounter()
+    val entry = withCounterData(exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 10))
+
+    val result = s.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    val stored = s.getTableEntries(TABLE_NAME).single()
+    assertFalse(stored.hasCounterData())
+    val readBack =
+      s.readDirectCounterEntries(
+        P4RuntimeOuterClass.DirectCounterEntry.newBuilder().setTableEntry(stored).build()
+      )
+    assertEquals(42, readBack[0].directCounterEntry.data.packetCount)
+    assertEquals(1000, readBack[0].directCounterEntry.data.byteCount)
+  }
+
+  @Test
+  fun `table entry MODIFY with counter data updates direct counter`() {
+    val s = storeWithDirectCounter()
+    val original = exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 10)
+    s.writeAndPublish(insertUpdate(original))
+    s.directCounterIncrement(TABLE_NAME, original, 100)
+    val modified = withCounterData(withAction(original, actionId = 20))
+
+    val result = s.writeAndPublish(modifyUpdate(modified))
+
+    assertEquals(WriteResult.Success, result)
+    val stored = s.getTableEntries(TABLE_NAME).single()
+    assertEquals(20, stored.action.action.actionId)
+    assertFalse(stored.hasCounterData())
+    val readBack =
+      s.readDirectCounterEntries(
+        P4RuntimeOuterClass.DirectCounterEntry.newBuilder().setTableEntry(stored).build()
+      )
+    assertEquals(42, readBack[0].directCounterEntry.data.packetCount)
+    assertEquals(1000, readBack[0].directCounterEntry.data.byteCount)
+  }
+
+  @Test
   fun `writeDirectCounterEntry MODIFY updates counter data`() {
     val s = storeWithDirectCounter()
     val entry = exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 10)
@@ -2429,6 +2563,44 @@ class TableStoreTest {
       "unconfigured direct meter should have no config",
       results[0].directMeterEntry.hasConfig(),
     )
+  }
+
+  @Test
+  fun `table entry INSERT with meter config initializes direct meter`() {
+    val s = storeWithDirectMeter()
+    val entry = withMeterConfig(exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 10))
+
+    val result = s.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    val stored = s.getTableEntries(TABLE_NAME).single()
+    assertFalse(stored.hasMeterConfig())
+    val readBack =
+      s.readDirectMeterEntries(
+        P4RuntimeOuterClass.DirectMeterEntry.newBuilder().setTableEntry(stored).build()
+      )
+    assertEquals(1000, readBack[0].directMeterEntry.config.cir)
+    assertEquals(100, readBack[0].directMeterEntry.config.cburst)
+  }
+
+  @Test
+  fun `table entry MODIFY without meter config resets direct meter`() {
+    val s = storeWithDirectMeter()
+    val original = withMeterConfig(exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 10))
+    s.writeAndPublish(insertUpdate(original))
+    val modified = withAction(original, actionId = 20).toBuilder().clearMeterConfig().build()
+
+    val result = s.writeAndPublish(modifyUpdate(modified))
+
+    assertEquals(WriteResult.Success, result)
+    val stored = s.getTableEntries(TABLE_NAME).single()
+    assertEquals(20, stored.action.action.actionId)
+    assertFalse(stored.hasMeterConfig())
+    val readBack =
+      s.readDirectMeterEntries(
+        P4RuntimeOuterClass.DirectMeterEntry.newBuilder().setTableEntry(stored).build()
+      )
+    assertFalse("direct meter should reset to default", readBack[0].directMeterEntry.hasConfig())
   }
 
   @Test


### PR DESCRIPTION
This fixes the P4Runtime TableEntry direct-resource path so inline direct counter and meter data no longer leaks into stored forwarding entries or gets accepted for tables that cannot own it.

Root cause: `TableStore.writeTableEntry()` stored the raw `TableEntry` from the write request. P4Runtime uses `counter_data` and `meter_config` on `TableEntry` as direct-resource read/write fields, but 4ward treated them as ordinary table-entry identity. That made writes to tables without direct resources reach lower validation paths, and valid direct-resource writes were not applied to the simulator's dedicated direct counter/meter state.

Changes:
- Reject `counter_data` on tables without a direct counter and `meter_config` on tables without a direct meter with `INVALID_ARGUMENT`.
- Apply valid inline `TableEntry` direct counter/meter writes to the simulator's direct-resource state.
- Normalize stored forwarding entries by clearing inline direct-resource fields.
- Match P4Runtime MODIFY behavior: unset direct counter data preserves existing counter state, while unset direct meter config resets to default.
- Document the remaining action-level direct-resource validation gap in `docs/LIMITATIONS.md` and track it in #718.

Tests:
- `./tools/format.sh`
- `bazel test //grpc:P4RuntimeWriteErrorTest //simulator:TableStoreTest //grpc:P4RuntimeConformanceTest`

Fixes #717