### PR TITLE
web: bound playground compilation time

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -136,8 +136,6 @@ guilt — just write it down so someone can find it later.
   server clears everything. Editor content is not saved across page refreshes.
 - **Single shared state.** All browser sessions share one simulator instance.
   Concurrent users will interfere with each other.
-- **No compilation timeout.** The p4c subprocess has no timeout. A
-  pathological P4 program could hang the server indefinitely.
 - **Monaco editor requires internet.** Loaded from `cdn.jsdelivr.net`.
   The playground does not work offline.
 - **Three bundled examples only.** `basic_table`, `passthrough`, `mirror`.

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -9,12 +9,16 @@ import fourward.bazel.repoRoot
 import fourward.bazel.resolveRunfileProperty
 import fourward.simulator.Simulator
 import java.io.File
+import java.io.IOException
 import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 import java.util.logging.Logger
+import kotlin.concurrent.thread
 import kotlinx.coroutines.runBlocking
 import p4.v1.P4RuntimeOuterClass.Entity
 import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
@@ -38,6 +42,8 @@ class WebServer(
   private val service: fourward.grpc.P4RuntimeService,
   private val httpPort: Int = DEFAULT_HTTP_PORT,
   private val staticDir: Path? = null,
+  private val p4cPath: Path? = null,
+  private val compileTimeout: Duration = DEFAULT_COMPILE_TIMEOUT,
 ) {
 
   private val logger = Logger.getLogger(WebServer::class.java.name)
@@ -48,6 +54,10 @@ class WebServer(
   private val textPrinter: TextFormat.Printer = TextFormat.printer().escapingNonAscii(false)
 
   @Volatile private var loadedP4Info: p4.config.v1.P4InfoOuterClass.P4Info? = null
+
+  init {
+    require(compileTimeout.toMillis() > 0) { "compileTimeout must be at least 1 ms" }
+  }
 
   fun start(): WebServer {
     server.createContext("/api/compile-and-load") { cors(it, ::handleCompileAndLoad) }
@@ -332,15 +342,48 @@ class WebServer(
     cmd += listOf("-o", outputPath.toString())
     cmd += source.toString()
 
+    return runP4c(cmd)
+  }
+
+  private fun runP4c(cmd: List<String>): CompileResult {
     val pb = ProcessBuilder(cmd).redirectErrorStream(true)
     fourward.bazel.ensureCcOnPath(pb, shimPropertyKey = "fourward.cc_shim")
     val process = pb.start()
-    val processOutput = process.inputStream.bufferedReader().readText()
-    val exitCode = process.waitFor()
-    return CompileResult(exitCode, processOutput)
+
+    val processOutput = StringBuilder()
+    val outputReader =
+      thread(name = "p4c-4ward-output", isDaemon = true) {
+        try {
+          process.inputStream.bufferedReader().use { processOutput.append(it.readText()) }
+        } catch (_: IOException) {
+          // The stream may close while destroying a timed-out compiler process.
+        }
+      }
+
+    val finished =
+      try {
+        process.waitFor(compileTimeout.toMillis(), TimeUnit.MILLISECONDS)
+      } catch (_: InterruptedException) {
+        destroyProcessTree(process)
+        Thread.currentThread().interrupt()
+        return CompileResult(1, "p4c-4ward interrupted")
+      }
+
+    if (!finished) {
+      destroyProcessTree(process)
+      outputReader.join(OUTPUT_READER_JOIN_TIMEOUT_MS)
+      val output = processOutput.toString().trim()
+      val suffix = if (output.isEmpty()) "" else "\n\nCompiler output before timeout:\n$output"
+      return CompileResult(1, "p4c-4ward timed out after ${compileTimeout.toMillis()} ms$suffix")
+    }
+
+    outputReader.join()
+    val exitCode = process.exitValue()
+    return CompileResult(exitCode, processOutput.toString())
   }
 
   private fun findP4c(): Path? {
+    p4cPath?.let { if (Files.isExecutable(it)) return it }
     repoRoot.resolve("p4c_backend/p4c-4ward").let { if (Files.isExecutable(it)) return it }
     val pathDirs = System.getenv("PATH")?.split(File.pathSeparator) ?: emptyList()
     for (dir in pathDirs) {
@@ -348,6 +391,12 @@ class WebServer(
       if (Files.isExecutable(candidate)) return candidate
     }
     return null
+  }
+
+  private fun destroyProcessTree(process: Process) {
+    process.descendants().forEach { it.destroyForcibly() }
+    process.destroyForcibly()
+    process.waitFor()
   }
 
   // ---------------------------------------------------------------------------
@@ -386,8 +435,10 @@ class WebServer(
 
   companion object {
     const val DEFAULT_HTTP_PORT = 8080
+    val DEFAULT_COMPILE_TIMEOUT: Duration = Duration.ofSeconds(30)
 
     private const val THREAD_POOL_SIZE = 4
+    private const val OUTPUT_READER_JOIN_TIMEOUT_MS = 1000L
     private const val HTTP_OK = 200
     private const val HTTP_NO_CONTENT = 204
     private const val HTTP_BAD_REQUEST = 400

--- a/web/WebServerTest.kt
+++ b/web/WebServerTest.kt
@@ -10,6 +10,8 @@ import fourward.TypeDecl
 import fourward.VarbitType
 import fourward.bazel.repoRoot
 import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -88,12 +90,24 @@ class WebServerTest {
   // Integration: static file serving + P4 compilation via runfiles
   // ---------------------------------------------------------------------------
 
-  private fun <T> withServer(block: (port: Int) -> T): T {
+  private fun <T> withServer(
+    p4cPath: Path? = null,
+    compileTimeout: Duration = WebServer.DEFAULT_COMPILE_TIMEOUT,
+    block: (port: Int) -> T,
+  ): T {
     val simulator = fourward.simulator.Simulator()
     val writeMutex = kotlinx.coroutines.sync.Mutex()
     val broker = fourward.grpc.PacketBroker(simulator::processPacket, writeMutex)
     val service = fourward.grpc.P4RuntimeService(simulator, broker, writeMutex = writeMutex)
-    val server = WebServer(simulator, service, httpPort = 0).start()
+    val server =
+      WebServer(
+          simulator,
+          service,
+          httpPort = 0,
+          p4cPath = p4cPath,
+          compileTimeout = compileTimeout,
+        )
+        .start()
     try {
       return block(server.port())
     } finally {
@@ -142,6 +156,44 @@ class WebServerTest {
       (if (status in 200..299) conn.inputStream else conn.errorStream)?.bufferedReader()?.readText()
         ?: ""
     assertTrue("compile should succeed (got $status); body: $body", status in 200..299)
+  }
+
+  @Test
+  fun `compile endpoint times out stuck p4c process`() {
+    val tempDir = Files.createTempDirectory("4ward-web-test-")
+    val fakeP4c = tempDir.resolve("p4c-4ward")
+    try {
+      Files.writeString(
+        fakeP4c,
+        """
+        #!/bin/sh
+        echo started
+        sleep 5
+        echo done
+        """
+          .trimIndent(),
+      )
+      fakeP4c.toFile().setExecutable(true)
+
+      withServer(p4cPath = fakeP4c, compileTimeout = Duration.ofMillis(100)) { port ->
+        val conn =
+          java.net.URI("http://localhost:$port/api/compile-and-load").toURL().openConnection()
+            as java.net.HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.readTimeout = 3000
+        conn.setRequestProperty("Content-Type", "application/json")
+        conn.outputStream.write("""{"source":"ignored"}""".toByteArray())
+
+        assertEquals(400, conn.responseCode)
+        val body = conn.errorStream.bufferedReader().readText()
+        assertTrue(body, body.contains("timed out"))
+        assertTrue(body, body.contains("100 ms"))
+      }
+    } finally {
+      Files.deleteIfExists(fakeP4c)
+      Files.deleteIfExists(tempDir)
+    }
   }
 
   @Test


### PR DESCRIPTION
## What

Add a timeout around the web playground's `p4c-4ward` subprocess so `/api/compile-and-load` fails with a clear compile error instead of hanging indefinitely.

This also:
- drains compiler output concurrently so a noisy compiler cannot block on a full pipe,
- kills the compiler process tree on timeout, and
- removes the stale `No compilation timeout` limitation.

## Why

A pathological or stuck compiler invocation could previously tie up a web server worker forever. The playground is still a development tool, but it should fail loudly and recoverably.

## Checks

- `bazel test //web:WebServerTest --test_output=errors`
- `./tools/format.sh --check`
- `git diff --check`
- `./tools/lint.sh`
