### PR TITLE
test: diff PRE multicast groups against BMv2

### DIFF
--- a/e2e_tests/p4runtime_diff/BUILD.bazel
+++ b/e2e_tests/p4runtime_diff/BUILD.bazel
@@ -40,7 +40,7 @@ kt_jvm_test(
 # Test fixtures — P4 programs compiled for both backends.
 # =============================================================================
 
-# --- basic_table: single exact-match table (scenarios 1-6) ---
+# --- basic_table: single exact-match table (scenarios 1-7 and 11) ---
 
 fourward_pipeline(
     name = "basic_table_fourward",
@@ -55,7 +55,7 @@ p4_library(
     target_out = "basic_table.json",
 )
 
-# --- action_selector_3: exact-match table with action selector (scenarios 7+) ---
+# --- action_selector_3: exact-match table with action selector (scenarios 8-10) ---
 
 fourward_pipeline(
     name = "action_selector_fourward",

--- a/e2e_tests/p4runtime_diff/P4RuntimeDiffScenariosTest.kt
+++ b/e2e_tests/p4runtime_diff/P4RuntimeDiffScenariosTest.kt
@@ -16,8 +16,11 @@ import p4.v1.P4RuntimeOuterClass.Action
 import p4.v1.P4RuntimeOuterClass.Entity
 import p4.v1.P4RuntimeOuterClass.FieldMatch
 import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.MulticastGroupEntry
+import p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry
 import p4.v1.P4RuntimeOuterClass.ReadRequest
 import p4.v1.P4RuntimeOuterClass.ReadResponse
+import p4.v1.P4RuntimeOuterClass.Replica
 import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
 import p4.v1.P4RuntimeOuterClass.TableAction
 import p4.v1.P4RuntimeOuterClass.TableEntry
@@ -41,6 +44,8 @@ class P4RuntimeDiffScenariosTest {
   fun resetState() {
     deleteAllEntries(fourward)
     deleteAllEntries(bmv2)
+    deleteAllMulticastGroups(fourward)
+    deleteAllMulticastGroups(bmv2)
   }
 
   // ===========================================================================
@@ -144,6 +149,24 @@ class P4RuntimeDiffScenariosTest {
     assertReadAgrees()
   }
 
+  // ===========================================================================
+  // Scenario 11: PRE multicast group CRUD/read-back
+  // ===========================================================================
+
+  @Test
+  fun `11 — PRE multicast group CRUD — both servers agree on read-back`() {
+    val group = multicastGroupEntity(groupId = 1, replicas = listOf(1 to 101, 2 to 102))
+    writeEntityOnBoth(Update.Type.INSERT, group)
+    assertMulticastReadAgrees()
+
+    val modified = multicastGroupEntity(groupId = 1, replicas = listOf(3 to 201))
+    writeEntityOnBoth(Update.Type.MODIFY, modified)
+    assertMulticastReadAgrees()
+
+    writeEntityOnBoth(Update.Type.DELETE, modified)
+    assertMulticastReadAgrees()
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
@@ -154,10 +177,19 @@ class P4RuntimeDiffScenariosTest {
   }
 
   private fun writeUpdate(runner: P4RuntimeRunner, type: Update.Type, entry: TableEntry) {
+    writeRawEntity(runner, type, asEntity(entry))
+  }
+
+  private fun writeEntityOnBoth(type: Update.Type, entity: Entity) {
+    writeRawEntity(fourward, type, entity)
+    writeRawEntity(bmv2, type, entity)
+  }
+
+  private fun writeRawEntity(runner: P4RuntimeRunner, type: Update.Type, entity: Entity) {
     val req =
       WriteRequest.newBuilder()
         .setDeviceId(DEVICE_ID)
-        .addUpdates(Update.newBuilder().setType(type).setEntity(asEntity(entry)))
+        .addUpdates(Update.newBuilder().setType(type).setEntity(entity))
         .build()
     runner.stub.write(req)
   }
@@ -165,6 +197,8 @@ class P4RuntimeDiffScenariosTest {
   private fun assertReadAgrees() = assertReadAgrees(wildcardTableReadRequest())
 
   private fun assertDefaultReadAgrees() = assertReadAgrees(defaultTableReadRequest())
+
+  private fun assertMulticastReadAgrees() = assertReadAgrees(multicastReadRequest())
 
   private fun assertReadAgrees(req: ReadRequest) {
     assertProtosEqual(
@@ -190,6 +224,18 @@ class P4RuntimeDiffScenariosTest {
         Entity.newBuilder()
           .setTableEntry(
             TableEntry.newBuilder().setTableId(schema.tableId).setIsDefaultAction(true)
+          )
+      )
+      .build()
+
+  private fun multicastReadRequest(): ReadRequest =
+    ReadRequest.newBuilder()
+      .setDeviceId(DEVICE_ID)
+      .addEntities(
+        Entity.newBuilder()
+          .setPacketReplicationEngineEntry(
+            PacketReplicationEngineEntry.newBuilder()
+              .setMulticastGroupEntry(MulticastGroupEntry.getDefaultInstance())
           )
       )
       .build()
@@ -241,12 +287,44 @@ class P4RuntimeDiffScenariosTest {
       )
       .build()
 
+  private fun multicastGroupEntity(groupId: Int, replicas: List<Pair<Int, Int>>): Entity =
+    Entity.newBuilder()
+      .setPacketReplicationEngineEntry(
+        PacketReplicationEngineEntry.newBuilder()
+          .setMulticastGroupEntry(
+            MulticastGroupEntry.newBuilder()
+              .setMulticastGroupId(groupId)
+              .addAllReplicas(
+                replicas.map { (port, instance) ->
+                  Replica.newBuilder()
+                    .setPort(ByteString.copyFrom(byteArrayOf(port.toByte())))
+                    .setInstance(instance)
+                    .build()
+                }
+              )
+          )
+      )
+      .build()
+
   private fun deleteAllEntries(runner: P4RuntimeRunner) {
     val deletes =
       readAll(runner, wildcardTableReadRequest()).entitiesList.mapNotNull { entity ->
         if (entity.tableEntry.tableId == schema.tableId && !entity.tableEntry.isDefaultAction) {
           Update.newBuilder().setType(Update.Type.DELETE).setEntity(entity).build()
         } else null
+      }
+    if (deletes.isEmpty()) return
+    ignoreGrpcStatus {
+      runner.stub.write(
+        WriteRequest.newBuilder().setDeviceId(DEVICE_ID).addAllUpdates(deletes).build()
+      )
+    }
+  }
+
+  private fun deleteAllMulticastGroups(runner: P4RuntimeRunner) {
+    val deletes =
+      readAll(runner, multicastReadRequest()).entitiesList.map { entity ->
+        Update.newBuilder().setType(Update.Type.DELETE).setEntity(entity).build()
       }
     if (deletes.isEmpty()) return
     ignoreGrpcStatus {

--- a/e2e_tests/p4runtime_diff/README.md
+++ b/e2e_tests/p4runtime_diff/README.md
@@ -26,7 +26,7 @@ Top-level targets:
 - `:libbmpi` — bmv2's Thrift-free PI integration adapter
   (sources from `@behavioral_model//:libbmpi_srcs`).
 - `:basic_table_fourward` / `:basic_table_bmv2_json` — `basic_table.p4`
-  compiled for both backends (scenarios 1-7).
+  compiled for both backends (scenarios 1-7 and 11).
 - `:action_selector_fourward` / `:action_selector_bmv2_json` —
   `action_selector_3.p4` compiled for both backends (scenarios 8-10).
 
@@ -36,7 +36,8 @@ Test targets:
   helpers ([`ResponseDiff.kt`](ResponseDiff.kt)). Always runnable.
 - `:P4RuntimeDiffSmokeTest` — spawns both servers, exercises
   `Capabilities` RPC. Skipped via `Assume` if the binary isn't built.
-- `:P4RuntimeDiffScenariosTest` — table entry scenarios (encoding,
-  error semantics, wildcard reads, default actions).
+- `:P4RuntimeDiffScenariosTest` — table entry and PRE scenarios
+  (encoding, error semantics, wildcard reads, default actions,
+  multicast groups).
 - `:P4RuntimeDiffActionProfileTest` — action profile scenarios
   (member CRUD, groups, table entries referencing groups).

--- a/e2e_tests/p4runtime_diff/ResponseDiff.kt
+++ b/e2e_tests/p4runtime_diff/ResponseDiff.kt
@@ -1,11 +1,15 @@
 package fourward.e2e.p4runtimediff
 
+import com.google.protobuf.ByteString
 import com.google.protobuf.Message
 import com.google.protobuf.TextFormat
 import fourward.grpc.canonicalizeTableEntry as canonicalizeTableEntryBytestrings
 import p4.v1.P4RuntimeOuterClass.Entity
 import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.MulticastGroupEntry
+import p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry
 import p4.v1.P4RuntimeOuterClass.ReadResponse
+import p4.v1.P4RuntimeOuterClass.Replica
 import p4.v1.P4RuntimeOuterClass.TableEntry
 
 /**
@@ -29,6 +33,42 @@ fun sortMatchesByFieldId(entry: TableEntry): TableEntry {
   return entry.toBuilder().clearMatch().addAllMatch(sortedMatches).build()
 }
 
+/** Returns a copy of [entry] with replicas sorted by `(port, instance)`. */
+fun sortReplicasByPortAndInstance(entry: MulticastGroupEntry): MulticastGroupEntry {
+  val sortedReplicas =
+    entry.replicasList.sortedWith { left, right -> compareReplicasByPortAndInstance(left, right) }
+  if (sortedReplicas == entry.replicasList) return entry
+  return entry.toBuilder().clearReplicas().addAllReplicas(sortedReplicas).build()
+}
+
+private fun compareReplicasByPortAndInstance(left: Replica, right: Replica): Int {
+  val portOrder = compareByteStrings(left.port, right.port)
+  if (portOrder != 0) return portOrder
+  return left.instance.compareTo(right.instance)
+}
+
+private fun compareByteStrings(left: ByteString, right: ByteString): Int {
+  for (index in 0 until minOf(left.size(), right.size())) {
+    val byteOrder =
+      (left.byteAt(index).toInt() and 0xff).compareTo(right.byteAt(index).toInt() and 0xff)
+    if (byteOrder != 0) return byteOrder
+  }
+  return left.size().compareTo(right.size())
+}
+
+fun canonicalizePacketReplicationEngineEntry(
+  entry: PacketReplicationEngineEntry
+): PacketReplicationEngineEntry =
+  when (entry.typeCase) {
+    PacketReplicationEngineEntry.TypeCase.MULTICAST_GROUP_ENTRY -> {
+      val sortedGroup = sortReplicasByPortAndInstance(entry.multicastGroupEntry)
+      if (sortedGroup === entry.multicastGroupEntry) entry
+      else entry.toBuilder().setMulticastGroupEntry(sortedGroup).build()
+    }
+    PacketReplicationEngineEntry.TypeCase.CLONE_SESSION_ENTRY,
+    PacketReplicationEngineEntry.TypeCase.TYPE_NOT_SET -> entry
+  }
+
 /**
  * Applies both spec §8.3 bytestring canonicalization (via `fourward.grpc`'s helper) and match-list
  * ordering. Either or both may differ between server implementations; both are documented
@@ -42,6 +82,11 @@ fun canonicalizeEntity(entity: Entity): Entity =
       val withCanonicalBytes = canonicalizeTableEntryBytestrings(withSortedMatches)
       if (withCanonicalBytes === entity.tableEntry) entity
       else entity.toBuilder().setTableEntry(withCanonicalBytes).build()
+    }
+    Entity.EntityCase.PACKET_REPLICATION_ENGINE_ENTRY -> {
+      val canonical = canonicalizePacketReplicationEngineEntry(entity.packetReplicationEngineEntry)
+      if (canonical === entity.packetReplicationEngineEntry) entity
+      else entity.toBuilder().setPacketReplicationEngineEntry(canonical).build()
     }
     else -> entity
   }

--- a/e2e_tests/p4runtime_diff/ResponseDiffTest.kt
+++ b/e2e_tests/p4runtime_diff/ResponseDiffTest.kt
@@ -8,7 +8,10 @@ import org.junit.Assert.assertThrows
 import org.junit.Test
 import p4.v1.P4RuntimeOuterClass.Entity
 import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.MulticastGroupEntry
+import p4.v1.P4RuntimeOuterClass.PacketReplicationEngineEntry
 import p4.v1.P4RuntimeOuterClass.ReadResponse
+import p4.v1.P4RuntimeOuterClass.Replica
 import p4.v1.P4RuntimeOuterClass.TableEntry
 
 /**
@@ -53,6 +56,20 @@ class ResponseDiffTest {
   }
 
   @Test
+  fun `canonicalizeReadResponse sorts multicast replicas`() {
+    val resp =
+      ReadResponse.newBuilder()
+        .addEntities(multicastGroupEntity(groupId = 1, replicas = listOf(2 to 102, 1 to 101)))
+        .build()
+    val canonical = canonicalizeReadResponse(resp)
+    val replicas =
+      canonical.getEntities(0).packetReplicationEngineEntry.multicastGroupEntry.replicasList.map {
+        it.port.byteAt(0).toInt() to it.instance
+      }
+    assertEquals(listOf(1 to 101, 2 to 102), replicas)
+  }
+
+  @Test
   fun `assertProtosEqual passes on equal messages`() {
     val a = entry(matches = listOf(exact(1, 0xBEEF)))
     val b = entry(matches = listOf(exact(1, 0xBEEF)))
@@ -91,4 +108,23 @@ class ResponseDiffTest {
       .build()
 
   private fun asEntity(entry: TableEntry): Entity = Entity.newBuilder().setTableEntry(entry).build()
+
+  private fun multicastGroupEntity(groupId: Int, replicas: List<Pair<Int, Int>>): Entity =
+    Entity.newBuilder()
+      .setPacketReplicationEngineEntry(
+        PacketReplicationEngineEntry.newBuilder()
+          .setMulticastGroupEntry(
+            MulticastGroupEntry.newBuilder()
+              .setMulticastGroupId(groupId)
+              .addAllReplicas(
+                replicas.map { (port, instance) ->
+                  Replica.newBuilder()
+                    .setPort(ByteString.copyFrom(byteArrayOf(port.toByte())))
+                    .setInstance(instance)
+                    .build()
+                }
+              )
+          )
+      )
+      .build()
 }


### PR DESCRIPTION
## Summary

- add a P4Runtime differential scenario for PRE multicast group insert/modify/delete read-back
- reset multicast groups between differential scenarios
- canonicalize multicast replica ordering before response diffs
- update the diff-suite README to include PRE multicast coverage

## Testing

- `./tools/format.sh --check`
- `git diff --check`
- `bazel test //e2e_tests/p4runtime_diff:ResponseDiffTest --test_output=errors`
- `bazel test //e2e_tests/p4runtime_diff:P4RuntimeDiffScenariosTest --test_output=errors`