### PR TITLE
[codex] Document current-packet PNA mirrors

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -26,7 +26,7 @@ Legend:
 | Parser select ranges/masks | Supported | Supported | Supported | Covered by parser/interpreter and corpus tests. |
 | Table match kinds | Supported | Supported | Supported | Exact, LPM, ternary, optional, and range are supported in the simulator/P4Runtime layers. UI coverage is listed separately below. |
 | Action selectors | Supported | Supported | N/A | PSA selector hits produce fork-based trace trees; PNA does not use the same selector model. |
-| Clone/mirror | Supported | Supported | Partial | PNA `mirror_packet` uses original pre-parse bytes; DPDK mirrors current packet state. |
+| Clone/mirror | Supported | Supported | Supported | PNA `mirror_packet` emits the deparsed current packet state, matching DPDK SoftNIC behavior. |
 | Multicast | Supported | Supported | N/A | v1model forks one branch per configured PRE replica and sets `egress_port`/`egress_rid`. |
 | Resubmit | Supported | Supported | N/A | Produces trace tree forks where applicable. |
 | Recirculate | Supported | Supported | Supported | PNA recirculate tracks pass count. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -32,12 +32,6 @@ guilt — just write it down so someone can find it later.
   counters (stub no-op), and `Random.read()`. Add-on-miss externs (`add_entry`,
   `allocate_flow_id`, `set_entry_expire_time`, `restart_expire_timer`) are stubs.
   37 STF corpus tests, 31 compile-only tests, 33 p4testgen symbolic tests.
-- **PNA mirror_packet uses original (pre-parse) bytes.** The DPDK SoftNIC
-  mirrors the packet at its current state when `mirror_packet()` executes
-  (post-modification). The PNA spec is underspecified on this point. Our
-  approach matches PSA's I2E clone semantics but may diverge from DPDK for
-  programs that modify headers before mirroring.
-
 ## Externs
 
 - **No user-defined extern functions.** Extern functions declared in P4

--- a/simulator/InterpreterTestDsl.kt
+++ b/simulator/InterpreterTestDsl.kt
@@ -53,6 +53,12 @@ fun bitType(width: Int): Type =
 
 fun namedType(name: String): Type = Type.newBuilder().setNamed(name).build()
 
+fun fieldAccess(expr: Expr, fieldName: String, type: Type? = null): Expr =
+  Expr.newBuilder()
+    .setFieldAccess(FieldAccess.newBuilder().setExpr(expr).setFieldName(fieldName))
+    .apply { if (type != null) setType(type) }
+    .build()
+
 fun ifStmt(
   condition: Expr,
   thenStmts: List<Stmt> = emptyList(),
@@ -134,6 +140,10 @@ fun assign(varName: String, rhs: Expr): Stmt =
     )
     .build()
 
+/** Assignment statement with an arbitrary expression [lhs], e.g. `hdr.eth.dst = rhs`. */
+fun assign(lhs: Expr, rhs: Expr): Stmt =
+  Stmt.newBuilder().setAssignment(AssignmentStmt.newBuilder().setLhs(lhs).setRhs(rhs)).build()
+
 /**
  * Statement that calls a free extern function: `name(args...)`.
  *
@@ -159,6 +169,20 @@ fun methodCallStmt(
                 .setTarget(nameRef(target, targetType))
                 .setMethod(method)
                 .addAllArgs(args.toList())
+            )
+        )
+    )
+    .build()
+
+/** Statement that calls `target.method(args...)` where [target] is already an expression. */
+fun methodCallStmt(target: Expr, method: String, vararg args: Expr): Stmt =
+  Stmt.newBuilder()
+    .setMethodCall(
+      MethodCallStmt.newBuilder()
+        .setCall(
+          Expr.newBuilder()
+            .setMethodCall(
+              MethodCall.newBuilder().setTarget(target).setMethod(method).addAllArgs(args.toList())
             )
         )
     )

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -9,6 +9,7 @@ import fourward.EnumDecl
 import fourward.ExternInstanceDecl
 import fourward.FieldDecl
 import fourward.ForkReason
+import fourward.HeaderDecl
 import fourward.ParamDecl
 import fourward.ParserDecl
 import fourward.ParserState
@@ -200,12 +201,6 @@ class PNAArchitectureTest {
       "ostd" to "pna_main_output_metadata_t",
     )
 
-  private fun noopControl(name: String, params: List<Pair<String, String>>): ControlDecl =
-    ControlDecl.newBuilder()
-      .setName(name)
-      .addAllParams(params.map { (n, t) -> param(n, t) })
-      .build()
-
   private fun control(
     name: String,
     params: List<Pair<String, String>>,
@@ -222,21 +217,39 @@ class PNAArchitectureTest {
   /**
    * Builds a minimal PNA [BehavioralConfig].
    *
-   * All stages default to no-op; override [mainControlStmts] to add behaviour to the main control.
+   * All stages default to no-op; override stage statement lists to add behaviour.
    */
   private fun pnaConfig(
     preControlStmts: List<Stmt> = emptyList(),
+    parserStmts: List<Stmt> = emptyList(),
     mainControlStmts: List<Stmt> = emptyList(),
+    mainDeparserStmts: List<Stmt> = emptyList(),
     mainControlExterns: List<ExternInstanceDecl> = emptyList(),
+    extraTypes: List<TypeDecl> = emptyList(),
   ): BehavioralConfig =
     BehavioralConfig.newBuilder()
       .setArchitecture(pnaArch)
-      .addAllTypes(allTypes)
-      .addParsers(noopParser)
+      .addAllTypes(allTypes + extraTypes)
+      .addParsers(parser(parserStmts))
       .addControls(control("PreControl", preControlParams, preControlStmts))
       .addControls(control("MainControl", mainControlParams, mainControlStmts, mainControlExterns))
-      .addControls(noopControl("MainDeparser", mainDeparserParams))
+      .addControls(control("MainDeparser", mainDeparserParams, mainDeparserStmts))
       .build()
+
+  private fun parser(stmts: List<Stmt>): ParserDecl =
+    if (stmts.isEmpty()) {
+      noopParser
+    } else {
+      ParserDecl.newBuilder(noopParser)
+        .clearStates()
+        .addStates(
+          ParserState.newBuilder()
+            .setName("start")
+            .addAllStmts(stmts)
+            .setTransition(Transition.newBuilder().setNextState("accept"))
+        )
+        .build()
+    }
 
   /** send_to_port(port) — PNA free function with a single port argument. */
   private fun sendToPort(port: Long): Stmt = externCall("send_to_port", bit(port, 32))
@@ -407,6 +420,46 @@ class PNAArchitectureTest {
 
     assertEquals(1, outputs.size)
     assertEquals(7, outputs[0].dataplaneEgressPort)
+  }
+
+  @Test
+  fun `mirror_packet mirrors deparsed packet after header modification`() {
+    val oneByteHeaderType =
+      TypeDecl.newBuilder()
+        .setName("one_byte_t")
+        .setHeader(HeaderDecl.newBuilder().addFields(field("value", 8)))
+        .build()
+    val headersWithOneByte =
+      TypeDecl.newBuilder()
+        .setName("headers_t")
+        .setStruct(
+          StructDecl.newBuilder()
+            .addFields(FieldDecl.newBuilder().setName("h").setType(namedType("one_byte_t")))
+        )
+        .build()
+    val headerRef = fieldAccess(nameRef("hdr"), "h", namedType("one_byte_t"))
+    val config =
+      pnaConfig(
+        parserStmts = listOf(methodCallStmt(nameRef("pkt"), "extract", headerRef)),
+        mainControlStmts =
+          listOf(
+            assign(fieldAccess(headerRef, "value", bitType(8)), bit(0x42, 8)),
+            sendToPort(2),
+            mirrorPacket(0, 100),
+          ),
+        mainDeparserStmts = listOf(methodCallStmt(nameRef("pkt"), "emit", headerRef)),
+        extraTypes = listOf(oneByteHeaderType, headersWithOneByte),
+      )
+    val store = TableStore()
+    writeCloneSession(store, 100, listOf(0 to 5))
+
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x11), store)
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(2, outputs.size)
+    assertTrue(outputs.all { it.payload == ByteString.copyFrom(byteArrayOf(0x42)) })
+    assertTrue(outputs.any { it.dataplaneEgressPort == 2 })
+    assertTrue(outputs.any { it.dataplaneEgressPort == 5 })
   }
 
   @Test


### PR DESCRIPTION
## What changed

PNA mirror compatibility now has a focused regression test proving `mirror_packet` emits the deparsed current packet after header modification.

The compatibility dashboard now marks PNA Clone/mirror as supported, and the stale limitation about pre-parse mirror bytes is removed.

## Why

`PNAArchitecture` already mirrors `ctx.deparsedPayload()`, matching DPDK SoftNIC behavior, but the dashboard and limitations doc still described the old gap. The new test locks in that behavior so the documentation can accurately move the gap to supported.

## Validation

- `./tools/format.sh`
- `bazel test //simulator:PNAArchitectureTest`
