### PR TITLE
Validate direct resources against selected actions

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -85,13 +85,6 @@ guilt — just write it down so someone can find it later.
   written and read via P4Runtime, but the simulator does not perform
   real rate limiting — `direct_meter.read()` always returns the default
   color (GREEN).
-- **P4Runtime TableEntry direct-resource writes are not action-checked
-  (#718).** P4Runtime §9.1.7 requires `INVALID_ARGUMENT` when a
-  `TableEntry` provides direct counter or meter data for an action that
-  does not execute that direct resource. 4ward validates that the table
-  has the direct resource and stores valid inline data in the simulator's
-  direct counter/meter state, but it does not yet validate the selected
-  action's direct-resource execution.
 - **No digests or idle timeouts (by design).** Both are inherently
   time-dependent features that have no meaningful semantics in a reference
   simulator: there are no real packet rates to trigger digests, and no

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -226,6 +226,20 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "DirectResourceUsageTest",
+    srcs = ["DirectResourceUsageTest.kt"],
+    test_class = "fourward.simulator.DirectResourceUsageTest",
+    deps = [
+        ":ir_java_proto",
+        ":p4info_java_proto",
+        ":p4runtime_java_proto",
+        ":simulator",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "InterpreterPacketTest",
     srcs = ["InterpreterPacketTest.kt"],
     test_class = "fourward.simulator.InterpreterPacketTest",

--- a/simulator/DirectResourceUsage.kt
+++ b/simulator/DirectResourceUsage.kt
@@ -1,0 +1,278 @@
+package fourward.simulator
+
+import fourward.ActionDecl
+import fourward.BehavioralConfig
+import fourward.Expr
+import fourward.Expr.KindCase as ExprKind
+import fourward.Stmt
+import fourward.Stmt.KindCase as StmtKind
+import p4.config.v1.P4InfoOuterClass
+import p4.v1.P4RuntimeOuterClass
+import p4.v1.P4RuntimeOuterClass.TableEntry
+
+internal data class DirectResourceActions(
+  val counterActionsByTable: Map<String, Set<String>>,
+  val meterActionsByTable: Map<String, Set<String>>,
+)
+
+internal data class DirectResourceActionValidationContext(
+  val actionNameById: Map<Int, String>,
+  val tableActionOverrides: Map<String, Map<String, String>>,
+  val tableActionProfile: Map<String, Int>,
+  val writeState: TableStore.ForwardingSnapshot,
+  val counterActionsByTable: Map<String, Set<String>>,
+  val meterActionsByTable: Map<String, Set<String>>,
+)
+
+internal fun validateInlineDirectResourceActions(
+  entry: TableEntry,
+  tableName: String,
+  context: DirectResourceActionValidationContext,
+): WriteResult? {
+  if (!entry.hasCounterData() && !entry.hasMeterConfig()) return null
+  val actions = selectedActionNames(entry.action, tableName, context)
+  if (actions.isEmpty()) return null
+
+  context.counterActionsByTable[tableName]?.let { allowedActions ->
+    if (entry.hasCounterData()) {
+      actions
+        .firstOrNull { it !in allowedActions }
+        ?.let { action ->
+          return WriteResult.InvalidArgument(
+            "TableEntry contained counter_data, but action '$action' for table '$tableName' " +
+              "does not execute the table's direct counter"
+          )
+        }
+    }
+  }
+  context.meterActionsByTable[tableName]?.let { allowedActions ->
+    if (entry.hasMeterConfig()) {
+      actions
+        .firstOrNull { it !in allowedActions }
+        ?.let { action ->
+          return WriteResult.InvalidArgument(
+            "TableEntry contained meter_config, but action '$action' for table '$tableName' " +
+              "does not execute the table's direct meter"
+          )
+        }
+    }
+  }
+  return null
+}
+
+private fun selectedActionNames(
+  tableAction: P4RuntimeOuterClass.TableAction,
+  tableName: String,
+  context: DirectResourceActionValidationContext,
+): List<String> {
+  fun resolve(actionId: Int): String? =
+    context.actionNameById[actionId]?.let { name ->
+      context.tableActionOverrides[tableName]?.get(name) ?: name
+    }
+
+  val profileId = context.tableActionProfile[tableName]
+  return when (tableAction.typeCase) {
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION ->
+      listOfNotNull(resolve(tableAction.action.actionId))
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_MEMBER_ID ->
+      profileId
+        ?.let { context.writeState.profileMembers[it]?.get(tableAction.actionProfileMemberId) }
+        ?.let { listOfNotNull(resolve(it.action.actionId)) } ?: emptyList()
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_GROUP_ID -> {
+      val members =
+        profileId
+          ?.let { context.writeState.profileGroups[it]?.get(tableAction.actionProfileGroupId) }
+          ?.membersList ?: return emptyList()
+      members.mapNotNull { member ->
+        context.writeState.profileMembers[profileId]?.get(member.memberId)?.let {
+          resolve(it.action.actionId)
+        }
+      }
+    }
+    P4RuntimeOuterClass.TableAction.TypeCase.ACTION_PROFILE_ACTION_SET ->
+      tableAction.actionProfileActionSet.actionProfileActionsList.mapNotNull {
+        resolve(it.action.actionId)
+      }
+    P4RuntimeOuterClass.TableAction.TypeCase.TYPE_NOT_SET,
+    null -> emptyList()
+  }
+}
+
+internal fun deriveDirectResourceActions(
+  behavioral: BehavioralConfig,
+  p4info: P4InfoOuterClass.P4Info,
+  tableNameById: Map<Int, String>,
+  actionNameById: Map<Int, String>,
+  tableActionOverrides: Map<String, Map<String, String>>,
+): DirectResourceActions {
+  val actions = behavioral.actionsList + behavioral.controlsList.flatMap { it.localActionsList }
+  if (actions.isEmpty()) return DirectResourceActions(emptyMap(), emptyMap())
+
+  if (behavioral.architecture.name == "v1model") {
+    return deriveV1ModelDirectResourceActions(
+      p4info,
+      tableNameById,
+      actionNameById,
+      tableActionOverrides,
+      actions,
+    )
+  }
+
+  return deriveExplicitDirectResourceActions(p4info, tableNameById, actions)
+}
+
+private fun deriveV1ModelDirectResourceActions(
+  p4info: P4InfoOuterClass.P4Info,
+  tableNameById: Map<Int, String>,
+  actionNameById: Map<Int, String>,
+  tableActionOverrides: Map<String, Map<String, String>>,
+  actions: List<ActionDecl>,
+): DirectResourceActions {
+  val allActions = actions.flatMap { it.p4RuntimeNames() }.toSet()
+  val tableActions =
+    p4info.tablesList
+      .mapNotNull { table ->
+        val tableName = tableNameById[table.preamble.id] ?: return@mapNotNull null
+        val actionNames =
+          table.actionRefsList
+            .mapNotNull { ref -> actionNameById[ref.id] }
+            .map { actionName -> tableActionOverrides[tableName]?.get(actionName) ?: actionName }
+            .toSet()
+        tableName to (actionNames.ifEmpty { allActions })
+      }
+      .toMap()
+  val directCounterTables = p4info.directCountersList.mapNotNull { tableNameById[it.directTableId] }
+  val directMeterTables = p4info.directMetersList.mapNotNull { tableNameById[it.directTableId] }
+  return DirectResourceActions(
+    counterActionsByTable = directCounterTables.associateWith { tableActions[it].orEmpty() },
+    meterActionsByTable = directMeterTables.associateWith { tableActions[it].orEmpty() },
+  )
+}
+
+private fun deriveExplicitDirectResourceActions(
+  p4info: P4InfoOuterClass.P4Info,
+  tableNameById: Map<Int, String>,
+  actions: List<ActionDecl>,
+): DirectResourceActions {
+  val counterTableByInstance =
+    p4info.directCountersList.flatMap { counter ->
+      val tableName = tableNameById[counter.directTableId] ?: return@flatMap emptyList()
+      directResourceInstanceNames(counter.preamble).map { it to tableName }
+    }
+  val meterTableByInstance =
+    p4info.directMetersList.flatMap { meter ->
+      val tableName = tableNameById[meter.directTableId] ?: return@flatMap emptyList()
+      directResourceInstanceNames(meter.preamble).map { it to tableName }
+    }
+  val counterActionsByTable =
+    counterTableByInstance.map { it.second }.associateWith { mutableSetOf<String>() }
+  val meterActionsByTable =
+    meterTableByInstance.map { it.second }.associateWith { mutableSetOf<String>() }
+  val counterTableByInstanceName = counterTableByInstance.toMap()
+  val meterTableByInstanceName = meterTableByInstance.toMap()
+
+  for (action in actions) {
+    val names = action.p4RuntimeNames()
+    for (instance in action.directResourceCalls("direct_counter", "count")) {
+      counterTableByInstanceName[instance]?.let { tableName ->
+        counterActionsByTable.getValue(tableName).addAll(names)
+      }
+    }
+    for (instance in action.directResourceCalls("direct_meter", "read")) {
+      meterTableByInstanceName[instance]?.let { tableName ->
+        meterActionsByTable.getValue(tableName).addAll(names)
+      }
+    }
+  }
+  return DirectResourceActions(
+    counterActionsByTable.mapValues { it.value.toSet() },
+    meterActionsByTable.mapValues { it.value.toSet() },
+  )
+}
+
+private fun ActionDecl.p4RuntimeNames(): List<String> =
+  listOf(name, currentName).filter { it.isNotEmpty() }
+
+private fun directResourceInstanceNames(preamble: P4InfoOuterClass.Preamble): Set<String> =
+  buildSet {
+    for (name in listOf(preamble.name, preamble.alias)) {
+      if (name.isEmpty()) continue
+      add(name)
+      add(name.replace('.', '_'))
+      add(name.substringAfterLast('.'))
+    }
+  }
+
+private fun ActionDecl.directResourceCalls(externType: String, method: String): Set<String> =
+  buildSet {
+    fun scanExpr(expr: Expr) {
+      when (expr.kindCase) {
+        ExprKind.FIELD_ACCESS -> scanExpr(expr.fieldAccess.expr)
+        ExprKind.ARRAY_INDEX -> {
+          scanExpr(expr.arrayIndex.expr)
+          scanExpr(expr.arrayIndex.index)
+        }
+        ExprKind.SLICE -> scanExpr(expr.slice.expr)
+        ExprKind.CONCAT -> {
+          scanExpr(expr.concat.left)
+          scanExpr(expr.concat.right)
+        }
+        ExprKind.CAST -> scanExpr(expr.cast.expr)
+        ExprKind.BINARY_OP -> {
+          scanExpr(expr.binaryOp.left)
+          scanExpr(expr.binaryOp.right)
+        }
+        ExprKind.UNARY_OP -> scanExpr(expr.unaryOp.expr)
+        ExprKind.METHOD_CALL -> {
+          val call = expr.methodCall
+          if (
+            call.method == method &&
+              call.target.hasNameRef() &&
+              call.target.type.named == externType
+          ) {
+            add(call.target.nameRef.name)
+          }
+          scanExpr(call.target)
+          call.argsList.forEach(::scanExpr)
+        }
+        ExprKind.MUX -> {
+          scanExpr(expr.mux.condition)
+          scanExpr(expr.mux.thenExpr)
+          scanExpr(expr.mux.elseExpr)
+        }
+        ExprKind.STRUCT_EXPR -> expr.structExpr.fieldsList.map { it.value }.forEach(::scanExpr)
+        ExprKind.LITERAL,
+        ExprKind.NAME_REF,
+        ExprKind.TABLE_APPLY,
+        ExprKind.KIND_NOT_SET,
+        null -> Unit
+      }
+    }
+
+    fun scanStmt(stmt: Stmt) {
+      when (stmt.kindCase) {
+        StmtKind.ASSIGNMENT -> {
+          scanExpr(stmt.assignment.lhs)
+          scanExpr(stmt.assignment.rhs)
+        }
+        StmtKind.METHOD_CALL -> scanExpr(stmt.methodCall.call)
+        StmtKind.IF_STMT -> {
+          scanExpr(stmt.ifStmt.condition)
+          stmt.ifStmt.thenBlock.stmtsList.forEach(::scanStmt)
+          stmt.ifStmt.elseBlock.stmtsList.forEach(::scanStmt)
+        }
+        StmtKind.SWITCH_STMT -> {
+          scanExpr(stmt.switchStmt.subject)
+          stmt.switchStmt.casesList.flatMap { it.block.stmtsList }.forEach(::scanStmt)
+          stmt.switchStmt.defaultBlock.stmtsList.forEach(::scanStmt)
+        }
+        StmtKind.BLOCK -> stmt.block.stmtsList.forEach(::scanStmt)
+        StmtKind.RETURN_STMT -> scanExpr(stmt.returnStmt.value)
+        StmtKind.EXIT,
+        StmtKind.KIND_NOT_SET,
+        null -> Unit
+      }
+    }
+
+    bodyList.forEach(::scanStmt)
+  }

--- a/simulator/DirectResourceUsageTest.kt
+++ b/simulator/DirectResourceUsageTest.kt
@@ -1,0 +1,299 @@
+package fourward.simulator
+
+import com.google.protobuf.ByteString
+import fourward.ActionDecl
+import fourward.Architecture
+import fourward.BehavioralConfig
+import fourward.DeviceConfig
+import fourward.Expr
+import fourward.MethodCall
+import fourward.MethodCallStmt
+import fourward.NameRef
+import fourward.Stmt
+import fourward.TableBehavior
+import fourward.Type
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import p4.config.v1.P4InfoOuterClass
+import p4.v1.P4RuntimeOuterClass
+import p4.v1.P4RuntimeOuterClass.Action
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.TableAction
+import p4.v1.P4RuntimeOuterClass.TableEntry
+import p4.v1.P4RuntimeOuterClass.Update
+
+class DirectResourceUsageTest {
+  @Test
+  fun `v1model direct counter accepts inline data for action without explicit count`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithDirectCounter(), device = v1modelDevice())
+    val entry = withCounterData(exactEntry(actionId = ACTION_20_ID))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+  }
+
+  @Test
+  fun `v1model direct meter accepts inline config for action without explicit read`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithDirectMeter(), device = v1modelDevice())
+    val entry = withMeterConfig(exactEntry(actionId = ACTION_20_ID))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+  }
+
+  @Test
+  fun `action profile member with counter data rejects action without direct counter call`() {
+    val store = TableStore()
+    store.loadMappings(
+      p4info = p4infoWithActionProfileDirectCounter(),
+      device = deviceWithDirectCounterAction(),
+    )
+    writeMember(store, memberId = 1, actionId = ACTION_20_ID)
+    val entry = withCounterData(exactMemberEntry(memberId = 1))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+  }
+
+  @Test
+  fun `action profile member with counter data accepts action with direct counter call`() {
+    val store = TableStore()
+    store.loadMappings(
+      p4info = p4infoWithActionProfileDirectCounter(),
+      device = deviceWithDirectCounterAction(),
+    )
+    writeMember(store, memberId = 1, actionId = ACTION_10_ID)
+    val entry = withCounterData(exactMemberEntry(memberId = 1))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+  }
+
+  @Test
+  fun `action profile group with counter data rejects member action without direct counter call`() {
+    val store = TableStore()
+    store.loadMappings(
+      p4info = p4infoWithActionProfileDirectCounter(),
+      device = deviceWithDirectCounterAction(),
+    )
+    writeMember(store, memberId = 1, actionId = ACTION_10_ID)
+    writeMember(store, memberId = 2, actionId = ACTION_20_ID)
+    writeGroup(store, groupId = 1, memberIds = listOf(1, 2))
+    val entry = withCounterData(exactGroupEntry(groupId = 1))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+  }
+
+  private fun TableStore.writeAndPublish(update: Update): WriteResult =
+    write(update).also { publishSnapshot() }
+
+  private fun exactEntry(actionId: Int): TableEntry =
+    TableEntry.newBuilder()
+      .setTableId(TABLE_ID)
+      .addMatch(
+        FieldMatch.newBuilder()
+          .setFieldId(FIELD_ID)
+          .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(10))))
+      )
+      .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId)))
+      .build()
+
+  private fun exactMemberEntry(memberId: Int): TableEntry =
+    exactEntryBuilder()
+      .setAction(TableAction.newBuilder().setActionProfileMemberId(memberId))
+      .build()
+
+  private fun exactGroupEntry(groupId: Int): TableEntry =
+    exactEntryBuilder().setAction(TableAction.newBuilder().setActionProfileGroupId(groupId)).build()
+
+  private fun exactEntryBuilder(): TableEntry.Builder =
+    TableEntry.newBuilder()
+      .setTableId(TABLE_ID)
+      .addMatch(
+        FieldMatch.newBuilder()
+          .setFieldId(FIELD_ID)
+          .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(10))))
+      )
+
+  private fun withCounterData(entry: TableEntry): TableEntry =
+    entry
+      .toBuilder()
+      .setCounterData(P4RuntimeOuterClass.CounterData.newBuilder().setPacketCount(42))
+      .build()
+
+  private fun withMeterConfig(entry: TableEntry): TableEntry =
+    entry
+      .toBuilder()
+      .setMeterConfig(P4RuntimeOuterClass.MeterConfig.newBuilder().setCir(1000))
+      .build()
+
+  private fun insertUpdate(entry: TableEntry): Update =
+    Update.newBuilder()
+      .setType(Update.Type.INSERT)
+      .setEntity(Entity.newBuilder().setTableEntry(entry))
+      .build()
+
+  private fun writeMember(store: TableStore, memberId: Int, actionId: Int) {
+    store.writeAndPublish(
+      Update.newBuilder()
+        .setType(Update.Type.INSERT)
+        .setEntity(
+          Entity.newBuilder()
+            .setActionProfileMember(
+              P4RuntimeOuterClass.ActionProfileMember.newBuilder()
+                .setActionProfileId(PROFILE_ID)
+                .setMemberId(memberId)
+                .setAction(Action.newBuilder().setActionId(actionId))
+            )
+        )
+        .build()
+    )
+  }
+
+  private fun writeGroup(store: TableStore, groupId: Int, memberIds: List<Int>) {
+    store.writeAndPublish(
+      Update.newBuilder()
+        .setType(Update.Type.INSERT)
+        .setEntity(
+          Entity.newBuilder()
+            .setActionProfileGroup(
+              P4RuntimeOuterClass.ActionProfileGroup.newBuilder()
+                .setActionProfileId(PROFILE_ID)
+                .setGroupId(groupId)
+                .addAllMembers(
+                  memberIds.map { memberId ->
+                    P4RuntimeOuterClass.ActionProfileGroup.Member.newBuilder()
+                      .setMemberId(memberId)
+                      .setWeight(1)
+                      .build()
+                  }
+                )
+            )
+        )
+        .build()
+    )
+  }
+
+  private fun v1modelDevice(): DeviceConfig =
+    DeviceConfig.newBuilder()
+      .setBehavioral(
+        BehavioralConfig.newBuilder()
+          .setArchitecture(Architecture.newBuilder().setName("v1model"))
+          .addTables(TableBehavior.newBuilder().setName(TABLE_NAME))
+          .addActions(ActionDecl.newBuilder().setName("action10"))
+          .addActions(ActionDecl.newBuilder().setName("action20"))
+      )
+      .build()
+
+  private fun deviceWithDirectCounterAction(): DeviceConfig =
+    DeviceConfig.newBuilder()
+      .setBehavioral(
+        BehavioralConfig.newBuilder()
+          .addTables(TableBehavior.newBuilder().setName(TABLE_NAME))
+          .addActions(
+            ActionDecl.newBuilder()
+              .setName("action10")
+              .addBody(directResourceCall("dc", "direct_counter", "count"))
+          )
+          .addActions(ActionDecl.newBuilder().setName("action20"))
+      )
+      .build()
+
+  private fun directResourceCall(instance: String, externType: String, method: String): Stmt =
+    Stmt.newBuilder()
+      .setMethodCall(
+        MethodCallStmt.newBuilder()
+          .setCall(
+            Expr.newBuilder()
+              .setMethodCall(
+                MethodCall.newBuilder()
+                  .setTarget(
+                    Expr.newBuilder()
+                      .setNameRef(NameRef.newBuilder().setName(instance))
+                      .setType(Type.newBuilder().setNamed(externType))
+                  )
+                  .setMethod(method)
+              )
+          )
+      )
+      .build()
+
+  private fun p4infoWithDirectCounter(): P4InfoOuterClass.P4Info =
+    baseP4InfoBuilder()
+      .addDirectCounters(
+        P4InfoOuterClass.DirectCounter.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(DIRECT_COUNTER_ID))
+          .setDirectTableId(TABLE_ID)
+      )
+      .build()
+
+  private fun p4infoWithActionProfileDirectCounter(): P4InfoOuterClass.P4Info =
+    baseP4InfoBuilder(implementationId = PROFILE_ID)
+      .addActionProfiles(
+        P4InfoOuterClass.ActionProfile.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_ID))
+      )
+      .addDirectCounters(
+        P4InfoOuterClass.DirectCounter.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder()
+              .setId(DIRECT_COUNTER_ID)
+              .setName("dc")
+              .setAlias("dc")
+          )
+          .setDirectTableId(TABLE_ID)
+      )
+      .build()
+
+  private fun p4infoWithDirectMeter(): P4InfoOuterClass.P4Info =
+    baseP4InfoBuilder()
+      .addDirectMeters(
+        P4InfoOuterClass.DirectMeter.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(DIRECT_METER_ID))
+          .setDirectTableId(TABLE_ID)
+      )
+      .build()
+
+  private fun baseP4InfoBuilder(implementationId: Int = 0): P4InfoOuterClass.P4Info.Builder =
+    P4InfoOuterClass.P4Info.newBuilder()
+      .addTables(
+        P4InfoOuterClass.Table.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(TABLE_ID).setAlias(TABLE_NAME))
+          .setImplementationId(implementationId)
+          .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_10_ID))
+          .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_20_ID))
+      )
+      .addActions(action(ACTION_10_ID, "action10"))
+      .addActions(action(ACTION_20_ID, "action20"))
+
+  private fun action(id: Int, name: String): P4InfoOuterClass.Action =
+    P4InfoOuterClass.Action.newBuilder()
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setAlias(name))
+      .build()
+
+  companion object {
+    private const val TABLE_ID = 1
+    private const val TABLE_NAME = "myTable"
+    private const val FIELD_ID = 1
+    private const val PROFILE_ID = 100
+    private const val ACTION_10_ID = 10
+    private const val ACTION_20_ID = 20
+    private const val DIRECT_COUNTER_ID = 800
+    private const val DIRECT_METER_ID = 900
+  }
+}

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -344,6 +344,9 @@ class TableStore : TableDataReader {
   private val tableActionProfile: MutableMap<String, Int> = mutableMapOf()
   private var directCounterTables: Set<String> = emptySet()
   private var directMeterTables: Set<String> = emptySet()
+  private var directCounterActionsByTable: Map<String, Set<String>> = emptyMap()
+  private var directMeterActionsByTable: Map<String, Set<String>> = emptyMap()
+  private var tableActionOverrides: Map<String, Map<String, String>> = emptyMap()
 
   // For unit tests: makes lookup() return hit=true with this action rather than searching entries.
   private val forcedHits: MutableMap<String, String> = mutableMapOf()
@@ -498,6 +501,17 @@ class TableStore : TableDataReader {
       p4info.directCountersList.mapNotNull { tableNameById[it.directTableId] }.toSet()
     this.directMeterTables =
       p4info.directMetersList.mapNotNull { tableNameById[it.directTableId] }.toSet()
+    tableActionOverrides = behavioral.tablesList.associate { it.name to it.actionOverridesMap }
+    val directResourceActions =
+      deriveDirectResourceActions(
+        behavioral,
+        p4info,
+        tableNameById,
+        actionNameById,
+        tableActionOverrides,
+      )
+    directCounterActionsByTable = directResourceActions.counterActionsByTable
+    directMeterActionsByTable = directResourceActions.meterActionsByTable
     writeState = ForwardingSnapshot()
     directCounterData.clear()
     registers.clear()
@@ -1174,8 +1188,21 @@ class TableStore : TableDataReader {
         "table '$tableName' has no direct meter, but TableEntry contained meter_config"
       )
     }
-    // TODO(#718): Also reject direct resource data when the selected action does not execute
-    // that direct resource, as required by P4Runtime §9.1.7.
+    validateInlineDirectResourceActions(
+        rawEntry,
+        tableName,
+        DirectResourceActionValidationContext(
+          actionNameById,
+          tableActionOverrides,
+          tableActionProfile,
+          writeState,
+          directCounterActionsByTable,
+          directMeterActionsByTable,
+        ),
+      )
+      ?.let {
+        return it
+      }
     val entry =
       if (!rawEntry.hasCounterData() && !rawEntry.hasMeterConfig()) {
         rawEntry

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -1,6 +1,16 @@
 package fourward.simulator
 
 import com.google.protobuf.ByteString
+import fourward.ActionDecl
+import fourward.BehavioralConfig
+import fourward.DeviceConfig
+import fourward.Expr
+import fourward.MethodCall
+import fourward.MethodCallStmt
+import fourward.NameRef
+import fourward.Stmt
+import fourward.TableBehavior
+import fourward.Type
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -192,6 +202,37 @@ class TableStoreTest {
     entry
       .toBuilder()
       .setMeterConfig(P4RuntimeOuterClass.MeterConfig.newBuilder().setCir(cir).setCburst(cburst))
+      .build()
+
+  private fun actionDecl(name: String, vararg body: Stmt): ActionDecl =
+    ActionDecl.newBuilder().setName(name).addAllBody(body.toList()).build()
+
+  private fun directResourceCall(instance: String, externType: String, method: String): Stmt =
+    Stmt.newBuilder()
+      .setMethodCall(
+        MethodCallStmt.newBuilder()
+          .setCall(
+            Expr.newBuilder()
+              .setMethodCall(
+                MethodCall.newBuilder()
+                  .setTarget(
+                    Expr.newBuilder()
+                      .setNameRef(NameRef.newBuilder().setName(instance))
+                      .setType(Type.newBuilder().setNamed(externType))
+                  )
+                  .setMethod(method)
+              )
+          )
+      )
+      .build()
+
+  private fun deviceWithActions(vararg actions: ActionDecl): DeviceConfig =
+    DeviceConfig.newBuilder()
+      .setBehavioral(
+        BehavioralConfig.newBuilder()
+          .addTables(TableBehavior.newBuilder().setName(TABLE_NAME))
+          .addAllActions(actions.toList())
+      )
       .build()
 
   private fun write(entry: TableEntry) {
@@ -2251,6 +2292,35 @@ class TableStoreTest {
     return store
   }
 
+  private fun storeWithActionAwareDirectCounter(): TableStore {
+    val store = TableStore()
+    store.loadMappings(
+      p4info =
+        buildP4Info(
+          tables = listOf(p4infoTable(TABLE_ID, TABLE_NAME)),
+          actions = ACTION_LIST,
+          directCounters =
+            listOf(
+              P4InfoOuterClass.DirectCounter.newBuilder()
+                .setPreamble(
+                  P4InfoOuterClass.Preamble.newBuilder()
+                    .setId(DIRECT_COUNTER_ID)
+                    .setName("dc")
+                    .setAlias("dc")
+                )
+                .setDirectTableId(TABLE_ID)
+                .build()
+            ),
+        ),
+      device =
+        deviceWithActions(
+          actionDecl("action10", directResourceCall("dc", "direct_counter", "count")),
+          actionDecl("action20"),
+        ),
+    )
+    return store
+  }
+
   @Test
   fun `directCounterIncrement accumulates packet and byte counts`() {
     val s = storeWithDirectCounter()
@@ -2327,6 +2397,28 @@ class TableStoreTest {
       )
     assertEquals(42, readBack[0].directCounterEntry.data.packetCount)
     assertEquals(1000, readBack[0].directCounterEntry.data.byteCount)
+  }
+
+  @Test
+  fun `table entry INSERT with counter data rejects action that does not execute direct counter`() {
+    val s = storeWithActionAwareDirectCounter()
+    val entry = withCounterData(exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 20))
+
+    val result = s.writeAndPublish(insertUpdate(entry))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertTrue(s.getTableEntries(TABLE_NAME).isEmpty())
+  }
+
+  @Test
+  fun `table entry INSERT with counter data accepts action that executes direct counter`() {
+    val s = storeWithActionAwareDirectCounter()
+    val entry = withCounterData(exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 10))
+
+    val result = s.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    assertEquals(1, s.getTableEntries(TABLE_NAME).size)
   }
 
   @Test
@@ -2469,6 +2561,35 @@ class TableStoreTest {
     return store
   }
 
+  private fun storeWithActionAwareDirectMeter(): TableStore {
+    val store = TableStore()
+    store.loadMappings(
+      p4info =
+        buildP4Info(
+          tables = listOf(p4infoTable(TABLE_ID, TABLE_NAME)),
+          actions = ACTION_LIST,
+          directMeters =
+            listOf(
+              P4InfoOuterClass.DirectMeter.newBuilder()
+                .setPreamble(
+                  P4InfoOuterClass.Preamble.newBuilder()
+                    .setId(DIRECT_METER_ID)
+                    .setName("dm")
+                    .setAlias("dm")
+                )
+                .setDirectTableId(TABLE_ID)
+                .build()
+            ),
+        ),
+      device =
+        deviceWithActions(
+          actionDecl("action10", directResourceCall("dm", "direct_meter", "read")),
+          actionDecl("action20"),
+        ),
+    )
+    return store
+  }
+
   @Test
   fun `writeDirectMeterEntry MODIFY persists config`() {
     val s = storeWithDirectMeter()
@@ -2581,6 +2702,28 @@ class TableStoreTest {
       )
     assertEquals(1000, readBack[0].directMeterEntry.config.cir)
     assertEquals(100, readBack[0].directMeterEntry.config.cburst)
+  }
+
+  @Test
+  fun `table entry INSERT with meter config rejects action that does not execute direct meter`() {
+    val s = storeWithActionAwareDirectMeter()
+    val entry = withMeterConfig(exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 20))
+
+    val result = s.writeAndPublish(insertUpdate(entry))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertTrue(s.getTableEntries(TABLE_NAME).isEmpty())
+  }
+
+  @Test
+  fun `table entry INSERT with meter config accepts action that executes direct meter`() {
+    val s = storeWithActionAwareDirectMeter()
+    val entry = withMeterConfig(exactEntry(fieldId = 1, value = byteArrayOf(10), actionId = 10))
+
+    val result = s.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    assertEquals(1, s.getTableEntries(TABLE_NAME).size)
   }
 
   @Test


### PR DESCRIPTION
This completes the #718 follow-up by making inline `TableEntry` direct-resource writes action-aware, not only table-aware.

What changed:
- Derive, at pipeline load, which actions execute each table's attached direct counter or direct meter by scanning the behavioral IR action bodies.
- Reject `TableEntry.counter_data` / `meter_config` when the selected action, action-profile member/group, or one-shot action set can select an action that does not execute the corresponding direct resource.
- Preserve per-table action specialization handling by applying `TableBehavior.action_overrides` before validation.
- Remove the #718 limitation entry from `docs/LIMITATIONS.md`.

Tests:
- `./tools/format.sh`
- `./tools/lint.sh`
- `bazel test //grpc:P4RuntimeWriteErrorTest //simulator:TableStoreTest //grpc:P4RuntimeConformanceTest`

Closes #718