### PR TITLE
[codex] Expose semantic PacketBits bytes

### DIFF
--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -192,7 +192,7 @@ class DataplaneService(
                       // never forward-allocated), so a missing reverse mapping is expected.
                       pt?.dataplaneToP4rt(subResult.ingressPort)?.let { setP4RtIngressPort(it) }
                     }
-                    .setPayload(ByteString.copyFrom(subResult.payload))
+                    .setPayload(ByteString.copyFrom(subResult.packet.copySemanticBytes()))
                     .setTag(subResult.tag)
                 )
                 .addAllPossibleOutcomes(

--- a/grpc/PacketBroker.kt
+++ b/grpc/PacketBroker.kt
@@ -101,7 +101,7 @@ class PacketBroker(
   /** Delivered to each [subscribe] subscriber for every processed packet. */
   class SubscriptionResult(
     val ingressPort: Int,
-    val payload: ByteArray,
+    val packet: PacketBits,
     val possibleOutcomes: List<List<OutputPacket>>,
     val trace: TraceTree,
     val tag: Long = 0,
@@ -137,7 +137,7 @@ class PacketBroker(
   fun processPacket(ingressPort: Int, packet: PacketBits, tag: Long = 0): ProcessPacketResult {
     fireHookUnderMutex()
     val result = simulatorFn(ingressPort, packet)
-    dispatchToSubscribers(ingressPort, packet.copyPaddedBytes(), result, tag)
+    dispatchToSubscribers(ingressPort, packet, result, tag)
     return result
   }
 
@@ -149,8 +149,9 @@ class PacketBroker(
   fun <T> withHookOnce(block: (processor: (Int, ByteArray, Long) -> Unit) -> T): T {
     fireHookUnderMutex()
     return block { port, payload, tag ->
-      val result = simulatorFn(port, PacketBits.ofBytes(payload))
-      dispatchToSubscribers(port, payload, result, tag)
+      val packet = PacketBits.ofBytes(payload)
+      val result = simulatorFn(port, packet)
+      dispatchToSubscribers(port, packet, result, tag)
     }
   }
 
@@ -162,13 +163,13 @@ class PacketBroker(
 
   private fun dispatchToSubscribers(
     ingressPort: Int,
-    payload: ByteArray,
+    packet: PacketBits,
     result: ProcessPacketResult,
     tag: Long = 0,
   ) {
     if (subscribers.isEmpty()) return
     val subResult =
-      SubscriptionResult(ingressPort, payload, result.possibleOutcomes, result.trace, tag)
+      SubscriptionResult(ingressPort, packet, result.possibleOutcomes, result.trace, tag)
     for (subscriber in subscribers) {
       try {
         subscriber(subResult)

--- a/grpc/PacketBrokerTest.kt
+++ b/grpc/PacketBrokerTest.kt
@@ -81,6 +81,24 @@ class PacketBrokerTest {
   }
 
   @Test
+  fun `subscriber receives PacketBits for padded packet`() {
+    val broker = broker(0 to result(outputPacket(1)))
+    val received = mutableListOf<PacketBroker.SubscriptionResult>()
+    broker.subscribe { received.add(it) }
+
+    broker.processPacket(
+      0,
+      PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xFF.toByte(), 0xFF.toByte()), 10),
+    )
+
+    assertEquals(10, received.single().packet.validBitLength)
+    assertEquals(
+      byteArrayOf(0xAB.toByte(), 0xC0.toByte()).toList(),
+      received.single().packet.copySemanticBytes().toList(),
+    )
+  }
+
+  @Test
   fun `multiple subscribers each receive results`() {
     val broker = broker(0 to result(outputPacket(1)))
 

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -223,13 +223,7 @@ private class ParserCursor(
   private fun semanticBytesFrom(byteStart: Int): ByteArray {
     val byteEnd = (validBitLength + 7) / 8
     val bytes = data.copyOfRange(byteStart, byteEnd)
-    val finalPaddingBits = (Byte.SIZE_BITS - validBitLength % Byte.SIZE_BITS) % Byte.SIZE_BITS
-    if (bytes.isNotEmpty() && finalPaddingBits != 0) {
-      // PacketBits may carry arbitrary transport padding in the final byte. Byte-returning helpers
-      // expose semantic packet bytes, so clear the non-packet low bits before returning them.
-      val finalByteMask = 0xFF shl finalPaddingBits
-      bytes[bytes.lastIndex] = (bytes.last().toInt() and finalByteMask).toByte()
-    }
+    maskFinalPacketByteInPlace(bytes, validBitLength)
     return bytes
   }
 

--- a/simulator/PacketBits.kt
+++ b/simulator/PacketBits.kt
@@ -24,12 +24,17 @@ class PacketBits private constructor(private val paddedBytes: ByteArray, val val
     get() = paddedBytes.size
 
   /**
-   * Returns a copy of the whole transport buffer, including padding past [validBitLength].
+   * Returns packet bytes with non-semantic padding removed as far as a byte API can express.
    *
-   * This is for observability/debug surfaces that report the original injected buffer. Parser and
-   * deparser semantics must use [validBitLength] instead of treating these bytes as all meaningful.
+   * Byte-only callers cannot carry [validBitLength], so the best representation is the smallest
+   * byte array that covers the semantic packet bits, with any low padding bits in the final byte
+   * cleared. Use this for public observability surfaces that expose packets as bytes.
    */
-  fun copyPaddedBytes(): ByteArray = paddedBytes.copyOf()
+  fun copySemanticBytes(): ByteArray {
+    val bytes = paddedBytes.copyOf(packetByteLength)
+    maskFinalPacketByteInPlace(bytes, validBitLength)
+    return bytes
+  }
 
   /**
    * Returns the mutable backing buffer for parser internals.
@@ -63,10 +68,23 @@ class PacketBits private constructor(private val paddedBytes: ByteArray, val val
     /**
      * Builds a packet from a byte buffer whose final byte may contain transport padding.
      *
-     * Padding bits need not be zero. Consumers that return semantic packet bytes are responsible
-     * for masking the final partial byte.
+     * Padding bits need not be zero. Use [copySemanticBytes] when converting back to a byte-only
+     * packet view.
      */
     fun ofPaddedBytes(bytes: ByteArray, validBitLength: Int): PacketBits =
       PacketBits(bytes, validBitLength)
+  }
+}
+
+/**
+ * Clears transport padding bits from the final semantic packet byte.
+ *
+ * Packet bit order is MSB-first, so the non-packet bits in a partial final byte are the low bits.
+ */
+internal fun maskFinalPacketByteInPlace(bytes: ByteArray, validBitLength: Int) {
+  val finalPaddingBits = (Byte.SIZE_BITS - validBitLength % Byte.SIZE_BITS) % Byte.SIZE_BITS
+  if (bytes.isNotEmpty() && finalPaddingBits != 0) {
+    val finalByteMask = 0xFF shl finalPaddingBits
+    bytes[bytes.lastIndex] = (bytes.last().toInt() and finalByteMask).toByte()
   }
 }

--- a/simulator/PacketBitsTest.kt
+++ b/simulator/PacketBitsTest.kt
@@ -15,13 +15,21 @@ class PacketBitsTest {
   }
 
   @Test
-  fun `transport bytes are copied for public callers`() {
+  fun `semantic bytes are copied for public callers`() {
     val packet = PacketBits.ofPaddedBytes(byteArrayOf(0xA0.toByte()), 4)
 
-    val copy = packet.copyPaddedBytes()
+    val copy = packet.copySemanticBytes()
     copy[0] = 0x00
 
-    assertArrayEquals(byteArrayOf(0xA0.toByte()), packet.copyPaddedBytes())
+    assertArrayEquals(byteArrayOf(0xA0.toByte()), packet.copySemanticBytes())
+  }
+
+  @Test
+  fun `semantic bytes drop whole padding bytes and mask final partial byte`() {
+    val packet =
+      PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xFF.toByte(), 0xFF.toByte()), 10)
+
+    assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xC0.toByte()), packet.copySemanticBytes())
   }
 
   @Test
@@ -38,6 +46,6 @@ class PacketBitsTest {
     val truncated = packet.truncateToBytes(1)
 
     assertEquals(8, truncated.validBitLength)
-    assertArrayEquals(byteArrayOf(0xAB.toByte()), truncated.copyPaddedBytes())
+    assertArrayEquals(byteArrayOf(0xAB.toByte()), truncated.copySemanticBytes())
   }
 }


### PR DESCRIPTION
`PacketBits` was introduced so the simulator can distinguish the semantic packet from the byte-aligned transport buffer that carried it. That distinction is essential for non-byte-aligned PacketOut headers: the packet has a valid bit length, while the transport necessarily has whole bytes and may contain arbitrary padding.

This PR tightens the remaining boundary where that distinction was still being lost too early. `PacketBroker` subscriptions now carry `PacketBits` internally instead of immediately collapsing the input packet back to `ByteArray`. That keeps the valid-bit boundary available to every in-process observer and makes the broker match the simulator model: a packet is bytes plus a bit length, not just bytes.

Byte-only APIs still need bytes. The important change is that conversion now happens at those byte-only protocol edges, not in the broker. When `DataplaneService.SubscribeResults` builds the protobuf response, it uses `copySemanticBytes()`: the smallest byte array covering the semantic packet bits, with final padding bits cleared. That is the least surprising representation a byte-only API can provide, while preserving exact `PacketBits` semantics internally.

The final-padding masking rule is also centralized in an explicit in-place helper so parser remainder handling and byte-only packet observation cannot drift apart.

## Testing

- `./tools/format.sh`
- `./tools/lint.sh`
- `git diff --check`
- `bazel test //simulator:PacketBitsTest //simulator:EnvironmentTest //grpc:PacketBrokerTest //grpc:DataplaneServiceTest`
