### PR TITLE
web: support default action edits

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -114,10 +114,8 @@ guilt — just write it down so someone can find it later.
   replica. Multi-replica cloning requires the gRPC API.
 - **No multicast group UI.** The backend supports multicast groups, but the
   web UI only exposes clone sessions.
-- **No MODIFY for table entries.** The UI only supports INSERT and DELETE.
-  To change an entry, delete and re-add it.
-- **No default action changes.** There is no UI to change a table's default
-  action.
+- **No MODIFY for non-default table entries.** The UI only supports INSERT and
+  DELETE for regular entries. To change an entry, delete and re-add it.
 - **No counters, meters, registers, or action profile UI.** These P4Runtime
   entities are supported by the backend but not exposed in the browser.
 - **Read API only returns table entries.** `GET /api/read` hard-codes a

--- a/e2e_tests/basic_table/BUILD.bazel
+++ b/e2e_tests/basic_table/BUILD.bazel
@@ -20,6 +20,7 @@ fourward_pipeline(
     visibility = [
         "//cli:__pkg__",
         "//grpc:__pkg__",
+        "//web:__pkg__",
     ],
 )
 

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -72,6 +72,7 @@ kt_jvm_test(
     srcs = ["WebServerTest.kt"],
     data = [
         ":cc_shim",
+        "//e2e_tests/basic_table",
         "//p4c_backend:p4c-4ward",
         "@p4c//p4include",
         "@p4c//p4include:core.p4",
@@ -87,6 +88,9 @@ kt_jvm_test(
         "//grpc",
         "//simulator",
         "//simulator:ir_java_proto",
+        "//simulator:p4info_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
         "@fourward_maven//:junit_junit",
         "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
     ],

--- a/web/WebServerTest.kt
+++ b/web/WebServerTest.kt
@@ -1,22 +1,31 @@
 package fourward.web
 
+import com.google.protobuf.TextFormat
 import fourward.BehavioralConfig
 import fourward.BitType
 import fourward.FieldDecl
 import fourward.HeaderDecl
 import fourward.IntType
+import fourward.PipelineConfig
 import fourward.Type
 import fourward.TypeDecl
 import fourward.VarbitType
 import fourward.bazel.repoRoot
+import fourward.grpc.P4RuntimeService
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.TableEntry
 
 class WebServerTest {
 
@@ -90,10 +99,18 @@ class WebServerTest {
   // Integration: static file serving + P4 compilation via runfiles
   // ---------------------------------------------------------------------------
 
+  private data class ServerContext(val port: Int, val service: P4RuntimeService)
+
   private fun <T> withServer(
     p4cPath: Path? = null,
     compileTimeout: Duration = WebServer.DEFAULT_COMPILE_TIMEOUT,
     block: (port: Int) -> T,
+  ): T = withServerContext(p4cPath, compileTimeout) { block(it.port) }
+
+  private fun <T> withServerContext(
+    p4cPath: Path? = null,
+    compileTimeout: Duration = WebServer.DEFAULT_COMPILE_TIMEOUT,
+    block: (context: ServerContext) -> T,
   ): T {
     val simulator = fourward.simulator.Simulator()
     val writeMutex = kotlinx.coroutines.sync.Mutex()
@@ -113,11 +130,73 @@ class WebServerTest {
         )
         .start()
     try {
-      return block(server.port())
+      return block(ServerContext(server.port(), service))
     } finally {
       server.stop()
       service.close()
     }
+  }
+
+  private fun loadPipeline(service: P4RuntimeService, config: PipelineConfig) = runBlocking {
+    service.setForwardingPipelineConfig(
+      SetForwardingPipelineConfigRequest.newBuilder()
+        .setDeviceId(1)
+        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+        .setConfig(
+          ForwardingPipelineConfig.newBuilder()
+            .setP4Info(config.p4Info)
+            .setP4DeviceConfig(config.device.toByteString())
+        )
+        .build()
+    )
+  }
+
+  private fun readDefaultEntries(service: P4RuntimeService, tableId: Int): List<Entity> =
+    runBlocking {
+      val entities = mutableListOf<Entity>()
+      service
+        .read(
+          ReadRequest.newBuilder()
+            .setDeviceId(1)
+            .addEntities(
+              Entity.newBuilder()
+                .setTableEntry(TableEntry.newBuilder().setTableId(tableId).setIsDefaultAction(true))
+            )
+            .build()
+        )
+        .collect { response -> entities.addAll(response.entitiesList) }
+      entities
+    }
+
+  private fun loadConfig(relativePath: String): PipelineConfig {
+    val builder = PipelineConfig.newBuilder()
+    TextFormat.merge(repoRoot.resolve(relativePath).toFile().readText(), builder)
+    return builder.build()
+  }
+
+  private fun findTable(config: PipelineConfig, alias: String) =
+    config.p4Info.tablesList.find { it.preamble.alias == alias }
+      ?: error("table '$alias' not found")
+
+  private fun findAction(config: PipelineConfig, alias: String) =
+    config.p4Info.actionsList.find { it.preamble.alias == alias }
+      ?: error("action '$alias' not found")
+
+  private data class HttpResponse(val status: Int, val body: String)
+
+  private fun postJson(port: Int, path: String, body: String): HttpResponse {
+    val conn =
+      java.net.URI("http://localhost:$port$path").toURL().openConnection()
+        as java.net.HttpURLConnection
+    conn.requestMethod = "POST"
+    conn.doOutput = true
+    conn.setRequestProperty("Content-Type", "application/json")
+    conn.outputStream.write(body.toByteArray())
+    val status = conn.responseCode
+    val responseBody =
+      (if (status in 200..299) conn.inputStream else conn.errorStream)?.bufferedReader()?.readText()
+        ?: ""
+    return HttpResponse(status, responseBody)
   }
 
   @Test
@@ -201,6 +280,50 @@ class WebServerTest {
   }
 
   @Test
+  fun `write endpoint accepts default action MODIFY updates`() = withServerContext { context ->
+    val config = loadConfig("e2e_tests/basic_table/basic_table.txtpb")
+    loadPipeline(context.service, config)
+    val table = findTable(config, "port_table")
+    val drop = findAction(config, "drop")
+
+    val response =
+      postJson(
+        context.port,
+        "/api/write",
+        """
+        {
+          "device_id": "1",
+          "updates": [
+            {
+              "type": "MODIFY",
+              "entity": {
+                "table_entry": {
+                  "table_id": ${table.preamble.id},
+                  "is_default_action": true,
+                  "action": {
+                    "action": {
+                      "action_id": ${drop.preamble.id}
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+        """
+          .trimIndent(),
+      )
+
+    assertEquals(response.body, 200, response.status)
+    val entries = readDefaultEntries(context.service, table.preamble.id)
+    assertEquals(entries.toString(), 1, entries.size)
+    val entry = entries.single().tableEntry
+    assertTrue(entry.isDefaultAction)
+    assertTrue(entry.matchList.isEmpty())
+    assertEquals(drop.preamble.id, entry.action.action.actionId)
+  }
+
+  @Test
   fun `frontend encodes and displays range match fields explicitly`() {
     val tablesJs = Files.readString(repoRoot.resolve("web/frontend/js/tables.js"))
     assertTrue(tablesJs.contains("case MATCH_TYPE.RANGE"))
@@ -216,6 +339,23 @@ class WebServerTest {
     assertTrue(traceRenderJs.contains("m.range"))
     assertTrue(traceRenderJs.contains("m.range.low"))
     assertTrue(traceRenderJs.contains("m.range.high"))
+  }
+
+  @Test
+  fun `frontend encodes default action changes as MODIFY table entries`() {
+    val indexHtml = Files.readString(repoRoot.resolve("web/frontend/index.html"))
+    assertTrue(indexHtml.contains("entry-default-action"))
+
+    val tablesJs = Files.readString(repoRoot.resolve("web/frontend/js/tables.js"))
+    assertTrue(tablesJs.contains("tableEntry.is_default_action = true"))
+    assertTrue(tablesJs.contains("type: isDefaultAction ? 'MODIFY' : 'INSERT'"))
+    assertTrue(tablesJs.contains("entry.isDefault"))
+
+    val mainJs = Files.readString(repoRoot.resolve("web/frontend/js/main.js"))
+    assertTrue(mainJs.contains("renderTableFields"))
+
+    val encodingJs = Files.readString(repoRoot.resolve("web/frontend/js/encoding.js"))
+    assertTrue(encodingJs.contains("rawEntry.is_default_action"))
   }
 
   // ---------------------------------------------------------------------------

--- a/web/frontend/index.html
+++ b/web/frontend/index.html
@@ -65,6 +65,10 @@
               <label for="entry-table">Table</label>
               <select id="entry-table" class="select-full"></select>
             </div>
+            <div class="form-row">
+              <label for="entry-default-action">Default action</label>
+              <input id="entry-default-action" type="checkbox">
+            </div>
             <div id="match-fields"></div>
             <div class="form-row">
               <label for="entry-action">Action</label>

--- a/web/frontend/js/encoding.js
+++ b/web/frontend/js/encoding.js
@@ -136,6 +136,7 @@ export function decodeTableEntry(p4info, rawEntry) {
       const pInfo = actionInfo?.params?.find(pp => pp.id === p.param_id);
       return { name: pInfo?.name || `param_${p.param_id}`, value: p.value ? decodeParamValue(p.value) : '' };
     }),
+    isDefault: !!rawEntry.is_default_action,
     raw: rawEntry,
   };
 }

--- a/web/frontend/js/main.js
+++ b/web/frontend/js/main.js
@@ -8,7 +8,7 @@ import { decodeTableEntry } from './encoding.js';
 import { setStatus, log, switchTab, updateButtonStates, updateTabBadges, initResize, initGraphResize } from './ui.js';
 import { initEditor, highlightCompileErrors, clearEditorDecorations } from './editor.js';
 import { renderControlGraph } from './graph.js';
-import { addTableEntry, deleteTableEntry, addCloneSession, deleteCloneSession, renderTablesPanel, renderEntriesList, renderCloneSessionsList } from './tables.js';
+import { addTableEntry, deleteTableEntry, addCloneSession, deleteCloneSession, renderTableFields, renderTablesPanel, renderEntriesList, renderCloneSessionsList } from './tables.js';
 import { sendPacket, applyPreset } from './packets.js';
 import { switchTraceView, stepForward, stepBack, resetPlayback, applyPlaybackState } from './trace.js';
 
@@ -91,6 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Buttons
   document.getElementById('btn-compile').addEventListener('click', compileAndLoad);
   document.getElementById('btn-add-entry').addEventListener('click', addTableEntry);
+  document.getElementById('entry-default-action').addEventListener('change', renderTableFields);
   document.getElementById('btn-add-clone').addEventListener('click', addCloneSession);
   document.getElementById('btn-send-packet').addEventListener('click', sendPacket);
 

--- a/web/frontend/js/tables.js
+++ b/web/frontend/js/tables.js
@@ -13,125 +13,165 @@ function tableNeedsPriority(table) {
   );
 }
 
+function buildMatchFields(table) {
+  const matchFields = [];
+  const matchDisplay = [];
+
+  for (const mf of table.match_fields || []) {
+    const input = document.getElementById(`match-${mf.id}`);
+    if (!input || !input.value.trim()) continue;
+    const rawValue = input.value.trim();
+    matchDisplay.push({ name: mf.name, value: rawValue });
+    const fieldMatch = { field_id: mf.id };
+
+    switch (mf.match_type) {
+      case MATCH_TYPE.EXACT:
+        fieldMatch.exact = { value: encodeValue(rawValue, mf.bitwidth) };
+        break;
+      case MATCH_TYPE.LPM: {
+        const parts = rawValue.split('/');
+        fieldMatch.lpm = {
+          value: encodeValue(parts[0], mf.bitwidth),
+          prefix_len: parseInt(parts[1] || mf.bitwidth, 10),
+        };
+        break;
+      }
+      case MATCH_TYPE.TERNARY: {
+        const parts = rawValue.split('&&&');
+        fieldMatch.ternary = {
+          value: encodeValue(parts[0].trim(), mf.bitwidth),
+          mask: parts[1] ? encodeValue(parts[1].trim(), mf.bitwidth) : allOnes(mf.bitwidth),
+        };
+        break;
+      }
+      case MATCH_TYPE.OPTIONAL:
+        fieldMatch.optional = { value: encodeValue(rawValue, mf.bitwidth) };
+        break;
+      case MATCH_TYPE.RANGE: {
+        const parts = rawValue.split('..').map(s => s.trim());
+        if (parts.length !== 2 || !parts[0] || !parts[1]) {
+          throw new Error(`${mf.name}: range matches use low..high`);
+        }
+        fieldMatch.range = {
+          low: encodeValue(parts[0], mf.bitwidth),
+          high: encodeValue(parts[1], mf.bitwidth),
+        };
+        break;
+      }
+      default:
+        throw new Error(`${mf.name}: unsupported match type ${mf.match_type}`);
+    }
+    matchFields.push(fieldMatch);
+  }
+
+  return { matchFields, matchDisplay };
+}
+
+function buildActionParams(action) {
+  const params = [];
+  const paramDisplay = [];
+
+  for (const param of action.params || []) {
+    const input = document.getElementById(`param-${param.id}`);
+    if (!input) continue;
+    paramDisplay.push({ name: param.name, value: input.value.trim() });
+    params.push({
+      param_id: param.id,
+      value: encodeValue(input.value.trim(), param.bitwidth),
+    });
+  }
+
+  return { params, paramDisplay };
+}
+
+function buildTableEntry({ table, action, params, matchFields, isDefaultAction }) {
+  const tableEntry = {
+    table_id: table.preamble.id,
+    action: {
+      action: {
+        action_id: action.preamble.id,
+        params,
+      },
+    },
+  };
+
+  if (isDefaultAction) {
+    tableEntry.is_default_action = true;
+  } else {
+    tableEntry.match = matchFields;
+    if (tableNeedsPriority(table)) {
+      tableEntry.priority = parseInt(document.getElementById('entry-priority').value, 10) || 1;
+    }
+  }
+
+  return tableEntry;
+}
+
+function upsertDisplayedEntry(displayEntry) {
+  if (!displayEntry.isDefault) {
+    state.entries.push(displayEntry);
+    return;
+  }
+
+  const existingDefaultIndex = state.entries.findIndex(
+    entry => entry.isDefault && entry.raw.table_id === displayEntry.raw.table_id
+  );
+  if (existingDefaultIndex >= 0) {
+    state.entries[existingDefaultIndex] = displayEntry;
+  } else {
+    state.entries.push(displayEntry);
+  }
+}
+
 export async function addTableEntry() {
   const p4info = state.p4info;
   if (!p4info) return;
 
   const tableSelect = document.getElementById('entry-table');
   const actionSelect = document.getElementById('entry-action');
+  const defaultActionInput = document.getElementById('entry-default-action');
   const table = p4info.tables[tableSelect.selectedIndex];
   const actionRef = table.action_refs[actionSelect.selectedIndex];
   const action = p4info.actions.find(a => a.preamble.id === actionRef.id);
+  const isDefaultAction = defaultActionInput.checked;
 
   try {
-    // Build match fields, capturing display values alongside proto values.
-    const matchFields = [];
-    const matchDisplay = [];
-    for (const mf of table.match_fields || []) {
-      const input = document.getElementById(`match-${mf.id}`);
-      if (!input || !input.value.trim()) continue;
-      const rawValue = input.value.trim();
-      matchDisplay.push({ name: mf.name, value: rawValue });
-      const fieldMatch = { field_id: mf.id };
-
-      switch (mf.match_type) {
-        case MATCH_TYPE.EXACT:
-          fieldMatch.exact = { value: encodeValue(rawValue, mf.bitwidth) };
-          break;
-        case MATCH_TYPE.LPM: {
-          const parts = rawValue.split('/');
-          fieldMatch.lpm = {
-            value: encodeValue(parts[0], mf.bitwidth),
-            prefix_len: parseInt(parts[1] || mf.bitwidth, 10),
-          };
-          break;
-        }
-        case MATCH_TYPE.TERNARY: {
-          const parts = rawValue.split('&&&');
-          fieldMatch.ternary = {
-            value: encodeValue(parts[0].trim(), mf.bitwidth),
-            mask: parts[1] ? encodeValue(parts[1].trim(), mf.bitwidth) : allOnes(mf.bitwidth),
-          };
-          break;
-        }
-        case MATCH_TYPE.OPTIONAL:
-          fieldMatch.optional = { value: encodeValue(rawValue, mf.bitwidth) };
-          break;
-        case MATCH_TYPE.RANGE: {
-          const parts = rawValue.split('..').map(s => s.trim());
-          if (parts.length !== 2 || !parts[0] || !parts[1]) {
-            throw new Error(`${mf.name}: range matches use low..high`);
-          }
-          fieldMatch.range = {
-            low: encodeValue(parts[0], mf.bitwidth),
-            high: encodeValue(parts[1], mf.bitwidth),
-          };
-          break;
-        }
-        default:
-          throw new Error(`${mf.name}: unsupported match type ${mf.match_type}`);
-      }
-      matchFields.push(fieldMatch);
-    }
-
-    // Build action params, capturing display values alongside proto values.
-    const params = [];
-    const paramDisplay = [];
-    for (const param of action.params || []) {
-      const input = document.getElementById(`param-${param.id}`);
-      if (!input) continue;
-      paramDisplay.push({ name: param.name, value: input.value.trim() });
-      params.push({
-        param_id: param.id,
-        value: encodeValue(input.value.trim(), param.bitwidth),
-      });
-    }
-
-    // Priority for ternary/range tables
-    const priorityInput = document.getElementById('entry-priority');
-    const needsPriority = tableNeedsPriority(table);
-
-    const tableEntry = {
-      table_id: table.preamble.id,
-      match: matchFields,
-      action: {
-        action: {
-          action_id: action.preamble.id,
-          params,
-        },
-      },
-    };
-
-    if (needsPriority) {
-      tableEntry.priority = parseInt(priorityInput.value, 10) || 1;
-    }
+    const { matchFields, matchDisplay } =
+      isDefaultAction ? { matchFields: [], matchDisplay: [] } : buildMatchFields(table);
+    const { params, paramDisplay } = buildActionParams(action);
+    const tableEntry = buildTableEntry({ table, action, params, matchFields, isDefaultAction });
 
     const writeRequest = {
       device_id: '1',
       updates: [{
-        type: 'INSERT',
+        type: isDefaultAction ? 'MODIFY' : 'INSERT',
         entity: { table_entry: tableEntry },
       }],
     };
 
     await api.write(writeRequest);
 
-    state.entries.push({
+    const displayEntry = {
       tableName: table.preamble.name,
       actionName: action.preamble.name,
       matchFields: matchDisplay,
       params: paramDisplay,
+      isDefault: isDefaultAction,
       raw: tableEntry,
-    });
+    };
+
+    upsertDisplayedEntry(displayEntry);
 
     renderEntriesList();
     updateTabBadges();
-    log(`Entry added to ${table.preamble.name}`, 'success');
+    log(`${isDefaultAction ? 'Default action updated' : 'Entry added'} for ${table.preamble.name}`, 'success');
 
     // Clear input fields for next entry
-    for (const mf of table.match_fields || []) {
-      const input = document.getElementById(`match-${mf.id}`);
-      if (input) input.value = '';
+    if (!isDefaultAction) {
+      for (const mf of table.match_fields || []) {
+        const input = document.getElementById(`match-${mf.id}`);
+        if (input) input.value = '';
+      }
     }
     for (const param of action.params || []) {
       const input = document.getElementById(`param-${param.id}`);
@@ -145,6 +185,7 @@ export async function addTableEntry() {
 export async function deleteTableEntry(index) {
   const entry = state.entries[index];
   if (!entry) return;
+  if (entry.isDefault) return;
 
   try {
     const deleteEntry = {
@@ -243,11 +284,12 @@ export function renderTablesPanel() {
     `<option value="${t.preamble.id}">${t.preamble.name}</option>`
   ).join('');
 
+  document.getElementById('entry-default-action').checked = false;
   tableSelect.onchange = () => renderTableFields();
   renderTableFields();
 }
 
-function renderTableFields() {
+export function renderTableFields() {
   const p4info = state.p4info;
   if (!p4info) return;
 
@@ -255,16 +297,22 @@ function renderTableFields() {
   const table = p4info.tables[tableSelect.selectedIndex];
   if (!table) return;
 
+  const defaultActionInput = document.getElementById('entry-default-action');
+  const isDefaultAction = defaultActionInput.checked;
+
   const matchDiv = document.getElementById('match-fields');
-  matchDiv.innerHTML = (table.match_fields || []).map(mf => {
-    const label = `${mf.name} (${mf.match_type.toLowerCase()}, ${mf.bitwidth}b)`;
-    const placeholder = matchPlaceholder(mf);
-    return `
-      <div class="form-row">
-        <label for="match-${mf.id}">${label}</label>
-        <input id="match-${mf.id}" class="input-full mono" placeholder="${placeholder}">
-      </div>`;
-  }).join('');
+  const matchFieldRows = (table.match_fields || [])
+    .map(mf => {
+      const label = `${mf.name} (${mf.match_type.toLowerCase()}, ${mf.bitwidth}b)`;
+      const placeholder = matchPlaceholder(mf);
+      return `
+        <div class="form-row">
+          <label for="match-${mf.id}">${label}</label>
+          <input id="match-${mf.id}" class="input-full mono" placeholder="${placeholder}">
+        </div>`;
+    })
+    .join('');
+  matchDiv.innerHTML = isDefaultAction ? '' : matchFieldRows;
 
   const actionSelect = document.getElementById('entry-action');
   const actionRefs = table.action_refs || [];
@@ -276,7 +324,10 @@ function renderTableFields() {
   actionSelect.onchange = () => renderActionParams();
   renderActionParams();
 
-  document.getElementById('priority-row').style.display = tableNeedsPriority(table) ? '' : 'none';
+  document.getElementById('priority-row').style.display =
+    !isDefaultAction && tableNeedsPriority(table) ? '' : 'none';
+  document.getElementById('btn-add-entry').textContent =
+    isDefaultAction ? 'Update Default Action' : 'Insert Entry';
 }
 
 function renderActionParams() {
@@ -322,11 +373,13 @@ export function renderEntriesList() {
   list.innerHTML = state.entries.map((entry, i) => {
     const staticCls = entry.isStatic ? ' static' : '';
     const staticBadge = entry.isStatic ? '<span class="entry-static-badge">const</span>' : '';
-    const deleteBtn = entry.isStatic ? '' : `<button class="btn btn-danger btn-delete" data-delete-entry="${i}">&#x2715;</button>`;
+    const defaultBadge = entry.isDefault ? '<span class="entry-static-badge">default</span>' : '';
+    const deleteBtn = entry.isStatic || entry.isDefault ? '' : `<button class="btn btn-danger btn-delete" data-delete-entry="${i}">&#x2715;</button>`;
+    const matchText = entry.isDefault ? 'default action' : entry.matchFields.map(m => `${m.name}=${m.value}`).join(', ');
     return `<div class="entry-card${staticCls}">
-      ${staticBadge}
+      ${staticBadge}${defaultBadge}
       <div class="entry-table">${entry.tableName}</div>
-      <div class="entry-match">${entry.matchFields.map(m => `${m.name}=${m.value}`).join(', ')}</div>
+      <div class="entry-match">${matchText}</div>
       <div class="entry-action">${'\u2192'} ${entry.actionName}(${entry.params.map(p => `${p.name}=${p.value}`).join(', ')})</div>
       ${deleteBtn}
     </div>`;


### PR DESCRIPTION
## What

Add web playground support for changing a table's default action.

This PR:
- adds a Default action checkbox to the table-entry form,
- emits P4Runtime `MODIFY` updates with `is_default_action: true`,
- hides match fields and priority for default-action updates,
- keeps the displayed default action unique per table, and
- updates the web limitations now that default actions are editable.

## Why

Default actions are core table behavior. The backend already supports them through the normal P4Runtime Write path, so the playground should expose that without a separate API.

## Checks

- `bazel test //web:WebServerTest --test_output=errors`
- `./tools/format.sh --check`
- `git diff --check`
- `./tools/lint.sh`

Note: attempted `node --check` for the touched frontend JS files, but `node` is not installed in this checkout environment.
