### PR TITLE
test: pin ValueSetEntry P4Runtime oracle gap

### DIFF
--- a/designs/p4runtime_diff.md
+++ b/designs/p4runtime_diff.md
@@ -69,9 +69,10 @@ Pipeline fixture: `basic_table.p4` compiled both ways
 for BMv2 `.json`). Each scenario sets the pipeline config on both
 servers, runs gRPC operations, diffs responses.
 
-Two fixtures: `basic_table.p4` (single exact-match table, scenarios
-1-7) and `action_selector_3.p4` (exact-match table with action
-selector, scenarios 8-10).
+Fixtures: `basic_table.p4` (single exact-match table plus PRE
+multicast, scenarios 1-7 and 11), `action_selector_3.p4`
+(exact-match table with action selector, scenarios 8-10), and
+`value_set.p4` (parser value_set oracle-gap coverage).
 
 | # | Scenario | Fixture | Status |
 |---|----------|---------|--------|
@@ -85,6 +86,20 @@ selector, scenarios 8-10).
 | 8 | Action profile member CRUD | action_selector | ✓ pass |
 | 9 | Action profile group with members | action_selector | ✓ pass |
 | 10 | Table entry referencing action profile group | action_selector | ✓ pass |
+| 11 | PRE multicast group CRUD/read-back | basic_table | ✓ pass |
+
+## Oracle Gaps
+
+The harness targets the intersection where BMv2's P4Runtime server can
+act as an external oracle. Some 4ward-supported P4Runtime surfaces are
+outside that intersection. `ValueSetEntry` is one: 4ward implements
+P4Runtime §9.6 (`MODIFY` and read supported, `INSERT`/`DELETE`
+rejected), while p4lang/PI's `DeviceMgr` used by
+`simple_switch_grpc` returns "ValueSet reads/writes are not supported
+yet". `P4RuntimeDiffValueSetTest` keeps this gap executable by testing
+4ward's behavior on the same fixture and asserting BMv2's unsupported
+read/write path, instead of pretending there is a strict differential
+oracle for that entity.
 
 ## Canonicalizations before diff
 

--- a/e2e_tests/p4runtime_diff/BUILD.bazel
+++ b/e2e_tests/p4runtime_diff/BUILD.bazel
@@ -70,6 +70,21 @@ p4_library(
     target_out = "action_selector.json",
 )
 
+# --- value_set: parser value_set (scenarios 12-13) ---
+
+fourward_pipeline(
+    name = "value_set_fourward",
+    src = "value_set.p4",
+    out = "value_set_fourward.txtpb",
+)
+
+p4_library(
+    name = "value_set_bmv2_json",
+    src = "value_set.p4",
+    target = "bmv2",
+    target_out = "value_set.json",
+)
+
 # =============================================================================
 # Diff harness — spawns simple_switch_grpc + 4ward, runs P4Runtime scenarios.
 # =============================================================================
@@ -88,6 +103,18 @@ kt_jvm_library(
         "//simulator:p4runtime_java_proto",
         "@fourward_maven//:io_grpc_grpc_api",
         "@fourward_maven//:io_grpc_grpc_netty",
+    ],
+)
+
+kt_jvm_library(
+    name = "p4runtime_status",
+    srcs = ["P4RuntimeStatus.kt"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//simulator:p4runtime_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:io_grpc_grpc_api",
+        "@googleapis//google/rpc:rpc_java_proto",
     ],
 )
 
@@ -152,6 +179,20 @@ kt_jvm_test(
     target_compatible_with = ["@platforms//os:linux"],
     test_class = "fourward.e2e.p4runtimediff.P4RuntimeDiffActionProfileTest",
     deps = _DIFF_TEST_DEPS,
+)
+
+kt_jvm_test(
+    name = "P4RuntimeDiffValueSetTest",
+    srcs = ["P4RuntimeDiffValueSetTest.kt"],
+    data = [
+        ":simple_switch_grpc",
+        ":value_set_bmv2_json",
+        ":value_set_fourward",
+    ],
+    tags = ["heavy"],
+    target_compatible_with = ["@platforms//os:linux"],
+    test_class = "fourward.e2e.p4runtimediff.P4RuntimeDiffValueSetTest",
+    deps = _DIFF_TEST_DEPS + [":p4runtime_status"],
 )
 
 # =============================================================================

--- a/e2e_tests/p4runtime_diff/P4RuntimeDiffValueSetTest.kt
+++ b/e2e_tests/p4runtime_diff/P4RuntimeDiffValueSetTest.kt
@@ -1,0 +1,217 @@
+package fourward.e2e.p4runtimediff
+
+import com.google.protobuf.ByteString
+import fourward.bazel.repoRoot
+import fourward.stf.loadPipelineConfig
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assume
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import p4.config.v1.P4InfoOuterClass.MatchField
+import p4.config.v1.P4InfoOuterClass.P4Info
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.ReadResponse
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.Update
+import p4.v1.P4RuntimeOuterClass.ValueSetEntry
+import p4.v1.P4RuntimeOuterClass.ValueSetMember
+import p4.v1.P4RuntimeOuterClass.WriteRequest
+
+/**
+ * P4Runtime ValueSetEntry oracle-gap coverage, using a minimal v1model parser fixture.
+ *
+ * P4Runtime §9.6 allows MODIFY and read, while INSERT and DELETE are invalid operations. 4ward
+ * implements that surface. BMv2's simple_switch_grpc path cannot be used as an oracle here because
+ * p4lang/PI's DeviceMgr returns "ValueSet reads/writes are not supported yet" for ValueSetEntry.
+ */
+class P4RuntimeDiffValueSetTest {
+
+  @Before
+  fun resetState() {
+    writeEntity(fourward, Update.Type.MODIFY, valueSetEntity(members = emptyList()))
+  }
+
+  @Test
+  fun `12 — ValueSetEntry MODIFY and read-back — 4ward supports, BMv2 cannot oracle`() {
+    val first =
+      valueSetEntity(
+        members = listOf(exactMember(0x0800), exactMember(0x0806), exactMember(0x86DD))
+      )
+    writeEntity(fourward, Update.Type.MODIFY, first)
+    assertValueSetReadEquals(first)
+
+    val second = valueSetEntity(members = listOf(exactMember(0x8847)))
+    writeEntity(fourward, Update.Type.MODIFY, second)
+    assertValueSetReadEquals(second)
+
+    val empty = valueSetEntity(members = emptyList())
+    writeEntity(fourward, Update.Type.MODIFY, empty)
+    assertValueSetReadEquals(empty)
+
+    assertEquals(Status.Code.UNIMPLEMENTED, writeStatus(bmv2, Update.Type.MODIFY, first))
+    assertEquals(Status.Code.UNIMPLEMENTED, readStatus(bmv2, valueSetReadRequest()))
+  }
+
+  @Test
+  fun `13 — ValueSetEntry INSERT and DELETE — 4ward rejects, BMv2 cannot oracle`() {
+    val entry = valueSetEntity(members = listOf(exactMember(0x0800)))
+    assertEquals(Status.Code.INVALID_ARGUMENT, writeStatus(fourward, Update.Type.INSERT, entry))
+    assertEquals(Status.Code.INVALID_ARGUMENT, writeStatus(fourward, Update.Type.DELETE, entry))
+    assertEquals(Status.Code.UNIMPLEMENTED, writeStatus(bmv2, Update.Type.INSERT, entry))
+    assertEquals(Status.Code.UNIMPLEMENTED, writeStatus(bmv2, Update.Type.DELETE, entry))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private fun writeEntity(runner: P4RuntimeRunner, type: Update.Type, entity: Entity) {
+    runner.stub.write(
+      WriteRequest.newBuilder()
+        .setDeviceId(DEVICE_ID)
+        .addUpdates(Update.newBuilder().setType(type).setEntity(entity))
+        .build()
+    )
+  }
+
+  private fun writeStatus(runner: P4RuntimeRunner, type: Update.Type, entity: Entity): Status.Code =
+    try {
+      writeEntity(runner, type, entity)
+      Status.Code.OK
+    } catch (e: StatusRuntimeException) {
+      e.singleBatchItemStatusCode() ?: e.status.code
+    }
+
+  private fun readStatus(runner: P4RuntimeRunner, req: ReadRequest): Status.Code =
+    try {
+      readAll(runner, req)
+      Status.Code.OK
+    } catch (e: StatusRuntimeException) {
+      e.status.code
+    }
+
+  private fun assertValueSetReadEquals(entity: Entity) {
+    val response = readAll(fourward, valueSetReadRequest())
+    assertEquals(1, response.entitiesCount)
+    assertEquals(entity, response.getEntities(0))
+  }
+
+  private fun valueSetReadRequest(): ReadRequest =
+    ReadRequest.newBuilder()
+      .setDeviceId(DEVICE_ID)
+      .addEntities(
+        Entity.newBuilder().setValueSetEntry(ValueSetEntry.newBuilder().setValueSetId(schema.id))
+      )
+      .build()
+
+  private fun readAll(runner: P4RuntimeRunner, req: ReadRequest): ReadResponse {
+    val builder = ReadResponse.newBuilder()
+    val stream = runner.stub.read(req)
+    while (stream.hasNext()) builder.addAllEntities(stream.next().entitiesList)
+    return builder.build()
+  }
+
+  private fun valueSetEntity(members: List<ValueSetMember>): Entity =
+    Entity.newBuilder()
+      .setValueSetEntry(ValueSetEntry.newBuilder().setValueSetId(schema.id).addAllMembers(members))
+      .build()
+
+  private fun exactMember(value: Int): ValueSetMember =
+    ValueSetMember.newBuilder()
+      .addMatch(
+        FieldMatch.newBuilder()
+          .setFieldId(schema.matchFieldId)
+          .setExact(
+            FieldMatch.Exact.newBuilder()
+              .setValue(ByteString.copyFrom(byteArrayOf((value shr 8).toByte(), value.toByte())))
+          )
+      )
+      .build()
+
+  // ---------------------------------------------------------------------------
+  // Class-scoped fixture
+  // ---------------------------------------------------------------------------
+
+  data class ValueSetSchema(val id: Int, val matchFieldId: Int) {
+    companion object {
+      fun discover(p4Info: P4Info): ValueSetSchema {
+        val valueSet = p4Info.valueSetsList.single()
+        val matchField = valueSet.matchList.single()
+        require(matchField.bitwidth == 16) {
+          "expected 16-bit value_set match field; got ${matchField.bitwidth}"
+        }
+        require(matchField.matchType == MatchField.MatchType.EXACT) {
+          "expected EXACT value_set match field; got ${matchField.matchType}"
+        }
+        return ValueSetSchema(id = valueSet.preamble.id, matchFieldId = matchField.id)
+      }
+    }
+  }
+
+  companion object {
+    private const val DEVICE_ID = 1L
+    private const val SET_CONFIG_TIMEOUT_S = 30L
+
+    private lateinit var fourward: FourwardP4RuntimeRunner
+    private lateinit var bmv2: Bmv2P4RuntimeRunner
+    private lateinit var schema: ValueSetSchema
+
+    @BeforeClass
+    @JvmStatic
+    fun spawnServers() {
+      val pkg = "e2e_tests/p4runtime_diff"
+      val binary = repoRoot.resolve("$pkg/simple_switch_grpc")
+      val fourwardPath = repoRoot.resolve("$pkg/value_set_fourward.txtpb")
+      val bmv2JsonPath = repoRoot.resolve("$pkg/value_set.json")
+      Assume.assumeTrue(
+        "simple_switch_grpc binary or P4 fixtures missing — see e2e_tests/p4runtime_diff/README.md",
+        Files.exists(binary) && Files.exists(fourwardPath) && Files.exists(bmv2JsonPath),
+      )
+
+      val fourwardPipeline = loadPipelineConfig(fourwardPath)
+      val p4Info = fourwardPipeline.p4Info
+      schema = ValueSetSchema.discover(p4Info)
+
+      fourward = FourwardP4RuntimeRunner(deviceId = DEVICE_ID)
+      bmv2 = Bmv2P4RuntimeRunner(binary = binary, deviceId = DEVICE_ID)
+      pushPipelineConfig(fourward, p4Info, fourwardPipeline.device.toByteString())
+      pushPipelineConfig(bmv2, p4Info, ByteString.copyFrom(Files.readAllBytes(bmv2JsonPath)))
+    }
+
+    @AfterClass
+    @JvmStatic
+    fun shutdownServers() {
+      if (::bmv2.isInitialized) bmv2.close()
+      if (::fourward.isInitialized) fourward.close()
+    }
+
+    private fun pushPipelineConfig(
+      runner: P4RuntimeRunner,
+      p4Info: P4Info,
+      deviceConfig: ByteString,
+    ) {
+      runner.stub
+        .withDeadlineAfter(SET_CONFIG_TIMEOUT_S, TimeUnit.SECONDS)
+        .setForwardingPipelineConfig(
+          SetForwardingPipelineConfigRequest.newBuilder()
+            .setDeviceId(DEVICE_ID)
+            .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+            .setConfig(
+              ForwardingPipelineConfig.newBuilder()
+                .setP4Info(p4Info)
+                .setP4DeviceConfig(deviceConfig)
+            )
+            .build()
+        )
+    }
+  }
+}

--- a/e2e_tests/p4runtime_diff/P4RuntimeStatus.kt
+++ b/e2e_tests/p4runtime_diff/P4RuntimeStatus.kt
@@ -1,0 +1,18 @@
+package fourward.e2e.p4runtimediff
+
+import com.google.rpc.Status as RpcStatus
+import io.grpc.Metadata
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import p4.v1.P4RuntimeOuterClass
+
+/** Returns the single per-item canonical status from a P4Runtime batch error, if present. */
+fun StatusRuntimeException.singleBatchItemStatusCode(): Status.Code? {
+  val trailers = trailers ?: return null
+  val key = Metadata.Key.of("grpc-status-details-bin", Metadata.BINARY_BYTE_MARSHALLER)
+  val bytes = trailers.get(key) ?: return null
+  val rpcStatus = RpcStatus.parseFrom(bytes)
+  if (rpcStatus.detailsCount != 1) return null
+  val error = P4RuntimeOuterClass.Error.parseFrom(rpcStatus.getDetails(0).value)
+  return Status.Code.values().find { it.value() == error.canonicalCode }
+}

--- a/e2e_tests/p4runtime_diff/README.md
+++ b/e2e_tests/p4runtime_diff/README.md
@@ -29,6 +29,8 @@ Top-level targets:
   compiled for both backends (scenarios 1-7 and 11).
 - `:action_selector_fourward` / `:action_selector_bmv2_json` —
   `action_selector_3.p4` compiled for both backends (scenarios 8-10).
+- `:value_set_fourward` / `:value_set_bmv2_json` — `value_set.p4`
+  compiled for both backends (ValueSetEntry oracle-gap coverage).
 
 Test targets:
 
@@ -41,3 +43,6 @@ Test targets:
   multicast groups).
 - `:P4RuntimeDiffActionProfileTest` — action profile scenarios
   (member CRUD, groups, table entries referencing groups).
+- `:P4RuntimeDiffValueSetTest` — parser value_set oracle-gap scenarios:
+  4ward's `ValueSetEntry` `MODIFY`/read behavior, plus BMv2 PI's
+  unsupported `ValueSetEntry` read/write path.

--- a/e2e_tests/p4runtime_diff/value_set.p4
+++ b/e2e_tests/p4runtime_diff/value_set.p4
@@ -1,0 +1,44 @@
+// Minimal v1model program with a parser value_set.
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+struct metadata_t {}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    value_set<bit<16>>(4) my_value_set;
+
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            my_value_set: accept;
+            default: accept;
+        }
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t standard_metadata) {
+    apply {}
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) { apply {} }
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;


### PR DESCRIPTION
## Summary

- add a minimal parser `value_set` fixture to the P4Runtime diff suite
- add executable coverage for 4ward `ValueSetEntry` MODIFY/read and INSERT/DELETE rejection
- assert BMv2/PI reports ValueSetEntry read/write as unsupported, so this surface is documented as an oracle gap rather than a strict diff scenario
- update the diff-suite README and design doc with the ValueSetEntry limitation

## Testing

- `./tools/format.sh --check`
- `git diff --check`
- `bazel test //e2e_tests/p4runtime_diff:P4RuntimeDiffValueSetTest --test_output=errors`
- `bazel test //e2e_tests/p4runtime_diff:ResponseDiffTest --test_output=errors`
- `bazel test //e2e_tests/p4runtime_diff/... --test_output=errors`