### PR TITLE
Align direct resource writes with P4Runtime

### DIFF
--- a/grpc/EntityReader.kt
+++ b/grpc/EntityReader.kt
@@ -41,7 +41,19 @@ private constructor(
       // false (default) → non-default entries only. true → default entry only.
       if (filter.isDefaultAction) {
         if (!hasMatchFilter && tables.isDefaultModified(tableName)) {
-          buildDefaultEntryEntity(tableName, tableId, tables)?.let { result.add(it) }
+          buildDefaultEntry(tableName, tableId, tables)?.let {
+            result.add(
+              buildTableEntryEntity(
+                it,
+                tables.hasDirectCounter(tableName),
+                tables.hasDirectMeter(tableName),
+                tables,
+                // TableStore keys default direct-resource state by the default-entry selector,
+                // not by the resolved default action returned in the TableEntry read response.
+                directResourceEntry = defaultDirectResourceEntry(tableId),
+              )
+            )
+          }
         }
       } else {
         val hasDirectCounter = tables.hasDirectCounter(tableName)
@@ -63,6 +75,7 @@ private constructor(
     hasDirectCounter: Boolean,
     hasDirectMeter: Boolean,
     tables: TableDataReader,
+    directResourceEntry: TableEntry = entry,
   ): Entity {
     if (!hasDirectCounter && !hasDirectMeter) {
       return Entity.newBuilder().setTableEntry(entry).build()
@@ -72,32 +85,33 @@ private constructor(
     val builder = entry.toBuilder()
     if (hasDirectCounter) {
       builder.counterData =
-        tables.getDirectCounterData(entry) ?: P4RuntimeOuterClass.CounterData.getDefaultInstance()
+        tables.getDirectCounterData(directResourceEntry)
+          ?: P4RuntimeOuterClass.CounterData.getDefaultInstance()
     }
     if (hasDirectMeter) {
-      tables.getDirectMeterData(entry)?.let { builder.meterConfig = it }
+      tables.getDirectMeterData(directResourceEntry)?.let { builder.meterConfig = it }
     }
     return Entity.newBuilder().setTableEntry(builder).build()
   }
 
-  /** Builds the default entry [Entity] for a table, or null if no default action is resolvable. */
-  private fun buildDefaultEntryEntity(
+  private fun defaultDirectResourceEntry(tableId: Int): TableEntry =
+    TableEntry.newBuilder().setTableId(tableId).setIsDefaultAction(true).build()
+
+  /** Builds the default [TableEntry] for a table, or null if no default action is resolvable. */
+  private fun buildDefaultEntry(
     tableName: String,
     tableId: Int,
     tables: TableDataReader,
-  ): Entity? {
+  ): TableEntry? {
     val default = tables.getDefaultAction(tableName)
     val actionId = default?.let { actionIdByName[it.name] } ?: noActionId
     if (actionId == 0) return null
     val actionBuilder = P4RuntimeOuterClass.Action.newBuilder().setActionId(actionId)
     default?.params?.forEach { actionBuilder.addParams(it) }
-    return Entity.newBuilder()
-      .setTableEntry(
-        TableEntry.newBuilder()
-          .setTableId(tableId)
-          .setIsDefaultAction(true)
-          .setAction(P4RuntimeOuterClass.TableAction.newBuilder().setAction(actionBuilder))
-      )
+    return TableEntry.newBuilder()
+      .setTableId(tableId)
+      .setIsDefaultAction(true)
+      .setAction(P4RuntimeOuterClass.TableAction.newBuilder().setAction(actionBuilder))
       .build()
   }
 

--- a/grpc/EntityReaderTest.kt
+++ b/grpc/EntityReaderTest.kt
@@ -227,6 +227,36 @@ class EntityReaderTest {
   }
 
   @Test
+  fun `default entry in table with direct counter includes counter data`() {
+    stub.directCounters += TABLE_A_NAME
+    stub.modifiedDefaults.add(TABLE_A_NAME)
+    stub.counterData[defaultEntry(TABLE_A_ID)] =
+      P4RuntimeOuterClass.CounterData.newBuilder().setByteCount(100).setPacketCount(5).build()
+
+    val result = readDefaultTable(TABLE_A_ID)
+
+    assertEquals(1, result.size)
+    assertTrue(result[0].tableEntry.hasCounterData())
+    assertEquals(100, result[0].tableEntry.counterData.byteCount)
+    assertEquals(5, result[0].tableEntry.counterData.packetCount)
+  }
+
+  @Test
+  fun `default entry in table with direct meter includes meter config`() {
+    stub.directMeters += TABLE_A_NAME
+    stub.modifiedDefaults.add(TABLE_A_NAME)
+    stub.meterData[defaultEntry(TABLE_A_ID)] =
+      P4RuntimeOuterClass.MeterConfig.newBuilder().setCir(1000).setCburst(500).build()
+
+    val result = readDefaultTable(TABLE_A_ID)
+
+    assertEquals(1, result.size)
+    assertTrue(result[0].tableEntry.hasMeterConfig())
+    assertEquals(1000, result[0].tableEntry.meterConfig.cir)
+    assertEquals(500, result[0].tableEntry.meterConfig.cburst)
+  }
+
+  @Test
   fun `entry in table without direct counter has no counter data`() {
     stub.addEntry(TABLE_A_NAME, TABLE_A_ID, byteArrayOf(1))
     val result = readTable(TABLE_A_ID)
@@ -275,6 +305,9 @@ class EntityReaderTest {
           )
       )
       .build()
+
+  private fun defaultEntry(tableId: Int): TableEntry =
+    TableEntry.newBuilder().setTableId(tableId).setIsDefaultAction(true).build()
 
   private fun matchValue(entity: Entity): List<Byte> =
     entity.tableEntry.getMatch(0).exact.value.toByteArray().toList()

--- a/grpc/P4RuntimeConformanceTest.kt
+++ b/grpc/P4RuntimeConformanceTest.kt
@@ -1581,6 +1581,70 @@ class P4RuntimeConformanceTest {
     )
   }
 
+  /** P4Runtime spec §9.1: default table entry reads include inline direct counter data. */
+  @Test
+  fun `71a - default table entry read includes direct counter data`() {
+    val config = loadConfigWithDirectCounter()
+    harness.loadPipeline(config)
+    val tableId = config.p4Info.tablesList.first().preamble.id
+    val dropActionId =
+      config.p4Info.actionsList.first { it.preamble.name.contains("drop") }.preamble.id
+    val defaultEntry = FourwardTestHarness.buildDefaultActionEntity(tableId, dropActionId)
+    val defaultWithCounter =
+      defaultEntry
+        .toBuilder()
+        .setTableEntry(
+          defaultEntry.tableEntry
+            .toBuilder()
+            .setCounterData(
+              P4RuntimeOuterClass.CounterData.newBuilder().setPacketCount(42).setByteCount(1000)
+            )
+        )
+        .build()
+
+    harness.modifyEntry(defaultWithCounter)
+
+    val results = harness.readDefaultEntries(tableId)
+    assertEquals(1, results.size)
+    assertTrue("should have counter_data", results[0].tableEntry.hasCounterData())
+    assertEquals(42, results[0].tableEntry.counterData.packetCount)
+    assertEquals(1000, results[0].tableEntry.counterData.byteCount)
+  }
+
+  /** P4Runtime spec §9.1: default table entry reads include inline direct meter config. */
+  @Test
+  fun `71b - default table entry read includes direct meter config`() {
+    val config = loadConfigWithDirectMeter()
+    harness.loadPipeline(config)
+    val tableId = config.p4Info.tablesList.first().preamble.id
+    val dropActionId =
+      config.p4Info.actionsList.first { it.preamble.name.contains("drop") }.preamble.id
+    val defaultEntry = FourwardTestHarness.buildDefaultActionEntity(tableId, dropActionId)
+    val defaultWithMeter =
+      defaultEntry
+        .toBuilder()
+        .setTableEntry(
+          defaultEntry.tableEntry
+            .toBuilder()
+            .setMeterConfig(
+              P4RuntimeOuterClass.MeterConfig.newBuilder()
+                .setCir(1000)
+                .setCburst(500)
+                .setPir(2000)
+                .setPburst(1000)
+            )
+        )
+        .build()
+
+    harness.modifyEntry(defaultWithMeter)
+
+    val results = harness.readDefaultEntries(tableId)
+    assertEquals(1, results.size)
+    assertTrue("should have meter_config", results[0].tableEntry.hasMeterConfig())
+    assertEquals(1000, results[0].tableEntry.meterConfig.cir)
+    assertEquals(2000, results[0].tableEntry.meterConfig.pir)
+  }
+
   // =========================================================================
   // Arbitration: demotion, promotion, zero election_id (scenarios 72-74)
   // =========================================================================

--- a/grpc/P4RuntimeWriteErrorTest.kt
+++ b/grpc/P4RuntimeWriteErrorTest.kt
@@ -104,10 +104,9 @@ class P4RuntimeWriteErrorTest {
     assertGrpcError(Status.Code.NOT_FOUND) { harness.deleteEntry(entry) }
   }
 
-  // P4Runtime spec §9.1.7: counter_data is invalid for any write to a table
-  // without a direct counter.
+  // P4Runtime spec §12: DELETE ignores non-key fields, including counter_data.
   @Test
-  fun `delete with counter data on table without direct counter returns INVALID_ARGUMENT`() {
+  fun `delete with counter data on table without direct counter succeeds`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
@@ -122,15 +121,12 @@ class P4RuntimeWriteErrorTest {
         )
         .build()
 
-    assertGrpcError(Status.Code.INVALID_ARGUMENT, "TableEntry contained counter_data") {
-      harness.deleteEntry(deleteEntry)
-    }
+    harness.deleteEntry(deleteEntry)
   }
 
-  // P4Runtime spec §9.1.7: meter_config is invalid for any write to a table
-  // without a direct meter.
+  // P4Runtime spec §12: DELETE ignores non-key fields, including meter_config.
   @Test
-  fun `delete with meter config on table without direct meter returns INVALID_ARGUMENT`() {
+  fun `delete with meter config on table without direct meter succeeds`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
@@ -145,9 +141,7 @@ class P4RuntimeWriteErrorTest {
         )
         .build()
 
-    assertGrpcError(Status.Code.INVALID_ARGUMENT, "TableEntry contained meter_config") {
-      harness.deleteEntry(deleteEntry)
-    }
+    harness.deleteEntry(deleteEntry)
   }
 
   // =========================================================================

--- a/simulator/DirectResourceUsageTest.kt
+++ b/simulator/DirectResourceUsageTest.kt
@@ -148,6 +148,102 @@ class DirectResourceUsageTest {
     assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
   }
 
+  @Test
+  fun `MODIFY with unset action validates counter data against existing action`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithDirectCounter(), device = deviceWithDirectCounterAction())
+    assertEquals(WriteResult.Success, store.writeAndPublish(insertUpdate(exactEntry(ACTION_20_ID))))
+    val modify = withCounterData(exactEntryBuilder().build())
+
+    val result = store.writeAndPublish(modifyUpdate(modify))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `DELETE ignores counter data on table without direct counter`() {
+    val store = TableStore()
+    store.loadMappings(
+      p4info = p4infoWithoutDirectResources(),
+      device = deviceWithDirectCounterAction(),
+    )
+    assertEquals(WriteResult.Success, store.writeAndPublish(insertUpdate(exactEntry(ACTION_20_ID))))
+    val delete = withCounterData(exactEntryBuilder().build())
+
+    val result = store.writeAndPublish(deleteUpdate(delete))
+
+    assertEquals(WriteResult.Success, result)
+    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+  }
+
+  @Test
+  fun `default entry direct counter data is stored and readable`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithDirectCounter(), device = deviceWithDirectCounterAction())
+    val defaultEntry = withCounterData(defaultEntry(actionId = ACTION_10_ID))
+
+    val result = store.writeAndPublish(modifyUpdate(defaultEntry))
+
+    assertEquals(WriteResult.Success, result)
+    val readBack =
+      store.readDirectCounterEntries(
+        P4RuntimeOuterClass.DirectCounterEntry.newBuilder()
+          .setTableEntry(TableEntry.newBuilder().setTableId(TABLE_ID).setIsDefaultAction(true))
+          .build()
+      )
+    assertEquals(1, readBack.size)
+    assertEquals(42, readBack[0].directCounterEntry.data.packetCount)
+  }
+
+  @Test
+  fun `default entry direct meter config is stored and readable`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithDirectMeter(), device = deviceWithDirectMeterAction())
+    val defaultEntry = withMeterConfig(defaultEntry(actionId = ACTION_10_ID))
+
+    val result = store.writeAndPublish(modifyUpdate(defaultEntry))
+
+    assertEquals(WriteResult.Success, result)
+    val readBack =
+      store.readDirectMeterEntries(
+        P4RuntimeOuterClass.DirectMeterEntry.newBuilder()
+          .setTableEntry(TableEntry.newBuilder().setTableId(TABLE_ID).setIsDefaultAction(true))
+          .build()
+      )
+    assertEquals(1, readBack.size)
+    assertEquals(1000, readBack[0].directMeterEntry.config.cir)
+  }
+
+  @Test
+  fun `resetting default entry resets direct counter data`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithDirectCounter(), device = deviceWithDirectCounterAction())
+    val defaultEntry = withCounterData(defaultEntry(actionId = ACTION_10_ID))
+    assertEquals(WriteResult.Success, store.writeAndPublish(modifyUpdate(defaultEntry)))
+
+    val result = store.writeAndPublish(modifyUpdate(defaultEntry()))
+
+    assertEquals(WriteResult.Success, result)
+    val readBack =
+      store.readDirectCounterEntries(
+        P4RuntimeOuterClass.DirectCounterEntry.newBuilder()
+          .setTableEntry(TableEntry.newBuilder().setTableId(TABLE_ID).setIsDefaultAction(true))
+          .build()
+      )
+    assertEquals(0, readBack[0].directCounterEntry.data.packetCount)
+  }
+
+  @Test
+  fun `default entry with unset action rejects counter data when initial default is NoAction`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithDirectCounter(), device = deviceWithDirectCounterAction())
+    val defaultEntry = withCounterData(defaultEntry())
+
+    val result = store.writeAndPublish(modifyUpdate(defaultEntry))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+  }
+
   private fun TableStore.writeAndPublish(update: Update): WriteResult =
     write(update).also { publishSnapshot() }
 
@@ -182,6 +278,16 @@ class DirectResourceUsageTest {
       )
       .build()
 
+  private fun defaultEntry(actionId: Int? = null): TableEntry {
+    val builder = TableEntry.newBuilder().setTableId(TABLE_ID).setIsDefaultAction(true)
+    if (actionId != null) {
+      builder.setAction(
+        TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId))
+      )
+    }
+    return builder.build()
+  }
+
   private fun exactEntryBuilder(): TableEntry.Builder =
     TableEntry.newBuilder()
       .setTableId(TABLE_ID)
@@ -203,11 +309,14 @@ class DirectResourceUsageTest {
       .setMeterConfig(P4RuntimeOuterClass.MeterConfig.newBuilder().setCir(1000))
       .build()
 
-  private fun insertUpdate(entry: TableEntry): Update =
-    Update.newBuilder()
-      .setType(Update.Type.INSERT)
-      .setEntity(Entity.newBuilder().setTableEntry(entry))
-      .build()
+  private fun insertUpdate(entry: TableEntry): Update = update(Update.Type.INSERT, entry)
+
+  private fun modifyUpdate(entry: TableEntry): Update = update(Update.Type.MODIFY, entry)
+
+  private fun deleteUpdate(entry: TableEntry): Update = update(Update.Type.DELETE, entry)
+
+  private fun update(type: Update.Type, entry: TableEntry): Update =
+    Update.newBuilder().setType(type).setEntity(Entity.newBuilder().setTableEntry(entry)).build()
 
   private fun writeMember(store: TableStore, memberId: Int, actionId: Int) {
     store.writeAndPublish(
@@ -275,6 +384,20 @@ class DirectResourceUsageTest {
       )
       .build()
 
+  private fun deviceWithDirectMeterAction(): DeviceConfig =
+    DeviceConfig.newBuilder()
+      .setBehavioral(
+        BehavioralConfig.newBuilder()
+          .addTables(TableBehavior.newBuilder().setName(TABLE_NAME))
+          .addActions(
+            ActionDecl.newBuilder()
+              .setName("action10")
+              .addBody(directResourceCall("dm", "direct_meter", "read"))
+          )
+          .addActions(ActionDecl.newBuilder().setName("action20"))
+      )
+      .build()
+
   private fun directResourceCall(instance: String, externType: String, method: String): Stmt =
     Stmt.newBuilder()
       .setMethodCall(
@@ -298,7 +421,12 @@ class DirectResourceUsageTest {
     baseP4InfoBuilder()
       .addDirectCounters(
         P4InfoOuterClass.DirectCounter.newBuilder()
-          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(DIRECT_COUNTER_ID))
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder()
+              .setId(DIRECT_COUNTER_ID)
+              .setName("dc")
+              .setAlias("dc")
+          )
           .setDirectTableId(TABLE_ID)
       )
       .build()
@@ -320,6 +448,8 @@ class DirectResourceUsageTest {
           .setDirectTableId(TABLE_ID)
       )
       .build()
+
+  private fun p4infoWithoutDirectResources(): P4InfoOuterClass.P4Info = baseP4InfoBuilder().build()
 
   private fun p4infoWithActionProfileDirectCounter(
     withSelector: Boolean = false
@@ -346,7 +476,12 @@ class DirectResourceUsageTest {
     baseP4InfoBuilder()
       .addDirectMeters(
         P4InfoOuterClass.DirectMeter.newBuilder()
-          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(DIRECT_METER_ID))
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder()
+              .setId(DIRECT_METER_ID)
+              .setName("dm")
+              .setAlias("dm")
+          )
           .setDirectTableId(TABLE_ID)
       )
       .build()

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -46,6 +46,12 @@ private data class InlineDirectResourceWriteContext(
   val writeState: TableStore.ForwardingSnapshot,
 )
 
+private data class ResolvedTableWrite(
+  val rawEntry: TableEntry,
+  val effectiveEntryForValidation: TableEntry?,
+  val storedEntry: TableEntry,
+)
+
 private fun applyInlineDirectResources(
   rawEntry: TableEntry,
   storedEntry: TableEntry,
@@ -67,6 +73,118 @@ private fun applyInlineDirectResources(
     if (rawEntry.hasMeterConfig()) {
       context.writeState.directMeterData[storedEntry] = rawEntry.meterConfig
     }
+  }
+}
+
+private fun defaultDirectResourceEntry(tableId: Int): TableEntry =
+  TableEntry.newBuilder().setTableId(tableId).setIsDefaultAction(true).build()
+
+private fun entryWithInitialDefaultActionForReset(
+  entry: TableEntry,
+  tableName: String,
+  initialDefaultActions: Map<String, DefaultAction>,
+  actionIdByName: Map<String, Int>,
+): TableEntry {
+  val default = initialDefaultActions[tableName] ?: DefaultAction("NoAction")
+  val actionId = actionIdByName[default.name] ?: return entry
+  return entry
+    .toBuilder()
+    .setAction(
+      P4RuntimeOuterClass.TableAction.newBuilder()
+        .setAction(
+          P4RuntimeOuterClass.Action.newBuilder().setActionId(actionId).addAllParams(default.params)
+        )
+    )
+    .build()
+}
+
+private fun resolveTableWrite(
+  rawEntry: TableEntry,
+  updateType: Update.Type,
+  tableName: String,
+  existingEntry: TableEntry?,
+  initialDefaultActions: Map<String, DefaultAction>,
+  actionIdByName: Map<String, Int>,
+): ResolvedTableWrite {
+  val effectiveEntry =
+    if (
+      updateType == Update.Type.MODIFY &&
+        rawEntry.action.typeCase == P4RuntimeOuterClass.TableAction.TypeCase.TYPE_NOT_SET
+    ) {
+      if (rawEntry.isDefaultAction) {
+        entryWithInitialDefaultActionForReset(
+          rawEntry,
+          tableName,
+          initialDefaultActions,
+          actionIdByName,
+        )
+      } else {
+        existingEntry?.let { rawEntry.toBuilder().setAction(it.action).build() }
+      }
+    } else {
+      rawEntry
+    }
+
+  val storedEntry =
+    if (!rawEntry.hasCounterData() && !rawEntry.hasMeterConfig()) {
+      effectiveEntry ?: rawEntry
+    } else {
+      // TableEntry carries direct extern data on reads, but forwarding entries are keyed only by
+      // match/action data. Store direct counter and meter state in their dedicated maps.
+      (effectiveEntry ?: rawEntry).toBuilder().clearCounterData().clearMeterConfig().build()
+    }
+
+  return ResolvedTableWrite(rawEntry, effectiveEntry, storedEntry)
+}
+
+private fun defaultActionForEntry(
+  entry: TableEntry,
+  tableName: String,
+  initialDefaultActions: Map<String, DefaultAction>,
+  actionNameById: Map<Int, String>,
+): DefaultAction {
+  if (entry.action.typeCase != P4RuntimeOuterClass.TableAction.TypeCase.ACTION) {
+    return initialDefaultActions[tableName] ?: DefaultAction("NoAction")
+  }
+  val action = entry.action.action
+  return DefaultAction(
+    actionNameById[action.actionId] ?: error("unknown action ID ${action.actionId}"),
+    action.paramsList,
+  )
+}
+
+private fun validateInlineDirectResourceWrite(
+  write: ResolvedTableWrite,
+  updateType: Update.Type,
+  tableName: String,
+  directCounterTables: Set<String>,
+  directMeterTables: Set<String>,
+  context: DirectResourceActionValidationContext,
+): WriteResult? {
+  if (updateType == Update.Type.DELETE) return null
+  val rawEntry = write.rawEntry
+  if (rawEntry.hasCounterData() && tableName !in directCounterTables) {
+    return WriteResult.InvalidArgument(
+      "table '$tableName' has no direct counter, but TableEntry contained counter_data"
+    )
+  }
+  if (rawEntry.hasMeterConfig() && tableName !in directMeterTables) {
+    return WriteResult.InvalidArgument(
+      "table '$tableName' has no direct meter, but TableEntry contained meter_config"
+    )
+  }
+  if (
+    (rawEntry.hasCounterData() || rawEntry.hasMeterConfig()) &&
+      write.effectiveEntryForValidation?.action?.typeCase ==
+        P4RuntimeOuterClass.TableAction.TypeCase.TYPE_NOT_SET
+  ) {
+    return WriteResult.InvalidArgument(
+      "TableEntry contained direct resource data, but the selected action for table " +
+        "'$tableName' does not execute a direct resource"
+    )
+  }
+  return write.effectiveEntryForValidation?.let {
+    validateInlineDirectResourceActions(it, tableName, context)
   }
 }
 
@@ -348,6 +466,7 @@ class TableStore : TableDataReader {
   private var directCounterActionsByTable: Map<String, Set<String>> = emptyMap()
   private var directMeterActionsByTable: Map<String, Set<String>> = emptyMap()
   private var tableActionOverrides: Map<String, Map<String, String>> = emptyMap()
+  private var initialDefaultActions: Map<String, DefaultAction> = emptyMap()
 
   // For unit tests: makes lookup() return hit=true with this action rather than searching entries.
   private val forcedHits: MutableMap<String, String> = mutableMapOf()
@@ -579,6 +698,7 @@ class TableStore : TableDataReader {
         setDefaultAction(tableName, actionName, params)
       }
     }
+    initialDefaultActions = writeState.defaultActions.toMap()
 
     // Install static table entries declared with `const entries` in the P4 source.
     for (update in device.staticEntries.updatesList) {
@@ -1045,6 +1165,10 @@ class TableStore : TableDataReader {
         )
     if (tableName !in knownTables)
       return WriteResult.InvalidArgument("table '$tableName' has no $entityName")
+    if (tableEntry.isDefaultAction) {
+      update(defaultDirectResourceEntry(tableEntry.tableId))
+      return WriteResult.Success
+    }
     val entries =
       writeState.tables[tableName]
         ?: return WriteResult.NotFound("no entries in table '$tableName'")
@@ -1071,6 +1195,19 @@ class TableStore : TableDataReader {
   ): List<P4RuntimeOuterClass.Entity> {
     val tableEntry = filter.tableEntry
     val tableNames = resolveTableNames(tableEntry.tableId, directCounterTables)
+    if (tableEntry.isDefaultAction) {
+      return tableNames.mapNotNull { tableName ->
+        val tableId = tableIdByName[tableName] ?: return@mapNotNull null
+        val entry = defaultDirectResourceEntry(tableId)
+        val data =
+          getDirectCounterData(entry) ?: P4RuntimeOuterClass.CounterData.getDefaultInstance()
+        P4RuntimeOuterClass.Entity.newBuilder()
+          .setDirectCounterEntry(
+            P4RuntimeOuterClass.DirectCounterEntry.newBuilder().setTableEntry(entry).setData(data)
+          )
+          .build()
+      }
+    }
     val matchFilter = if (tableEntry.matchCount > 0) tableEntry else null
     return tableNames.flatMap { tableName ->
       filteredEntries(tableName, matchFilter).map { entry ->
@@ -1103,6 +1240,15 @@ class TableStore : TableDataReader {
   ): List<P4RuntimeOuterClass.Entity> {
     val tableEntry = filter.tableEntry
     val tableNames = resolveTableNames(tableEntry.tableId, directMeterTables)
+    if (tableEntry.isDefaultAction) {
+      return tableNames.mapNotNull { tableName ->
+        val tableId = tableIdByName[tableName] ?: return@mapNotNull null
+        val entry = defaultDirectResourceEntry(tableId)
+        val builder = P4RuntimeOuterClass.DirectMeterEntry.newBuilder().setTableEntry(entry)
+        snapshot.directMeterData[entry]?.let { builder.setConfig(it) }
+        P4RuntimeOuterClass.Entity.newBuilder().setDirectMeterEntry(builder).build()
+      }
+    }
     val matchFilter = if (tableEntry.matchCount > 0) tableEntry else null
     return tableNames.flatMap { tableName ->
       filteredEntries(tableName, matchFilter).map { entry ->
@@ -1220,19 +1366,24 @@ class TableStore : TableDataReader {
               "'${it.value}' (${it.key})"
             })})"
         )
-    if (rawEntry.hasCounterData() && tableName !in directCounterTables) {
-      return WriteResult.InvalidArgument(
-        "table '$tableName' has no direct counter, but TableEntry contained counter_data"
-      )
-    }
-    if (rawEntry.hasMeterConfig() && tableName !in directMeterTables) {
-      return WriteResult.InvalidArgument(
-        "table '$tableName' has no direct meter, but TableEntry contained meter_config"
-      )
-    }
-    validateInlineDirectResourceActions(
+    val entries = writeState.tables.getOrPut(tableName) { mutableListOf() }
+    val existingIndex = entries.indexOfFirst { it.sameKey(rawEntry) }
+    val resolvedWrite =
+      resolveTableWrite(
         rawEntry,
+        update.type,
         tableName,
+        entries.getOrNull(existingIndex),
+        initialDefaultActions,
+        actionIdByName,
+      )
+
+    validateInlineDirectResourceWrite(
+        resolvedWrite,
+        update.type,
+        tableName,
+        directCounterTables,
+        directMeterTables,
         DirectResourceActionValidationContext(
           actionNameById,
           tableActionOverrides,
@@ -1245,14 +1396,7 @@ class TableStore : TableDataReader {
       ?.let {
         return it
       }
-    val entry =
-      if (!rawEntry.hasCounterData() && !rawEntry.hasMeterConfig()) {
-        rawEntry
-      } else {
-        // TableEntry carries direct extern data on reads, but forwarding entries are keyed only by
-        // match/action data. Store direct counter and meter state in their dedicated maps.
-        rawEntry.toBuilder().clearCounterData().clearMeterConfig().build()
-      }
+    val entry = resolvedWrite.storedEntry
     val directResourceContext =
       InlineDirectResourceWriteContext(
         directCounterTables,
@@ -1264,15 +1408,23 @@ class TableStore : TableDataReader {
     // P4Runtime spec §9.1: default entries are stored separately and only support MODIFY.
     // The WriteValidator already rejects INSERT/DELETE for defaults.
     if (entry.isDefaultAction) {
-      val actionName = resolveActionName(entry.action.action.actionId)
       writeState.defaultActions[tableName] =
-        DefaultAction(actionName, entry.action.action.paramsList)
+        defaultActionForEntry(entry, tableName, initialDefaultActions, actionNameById)
       writeState.modifiedDefaults.add(tableName)
+      val defaultResourceEntry = defaultDirectResourceEntry(entry.tableId)
+      if (rawEntry.action.typeCase == P4RuntimeOuterClass.TableAction.TypeCase.TYPE_NOT_SET) {
+        directCounterData.remove(defaultResourceEntry)
+        writeState.directMeterData.remove(defaultResourceEntry)
+      }
+      applyInlineDirectResources(
+        rawEntry,
+        defaultResourceEntry,
+        defaultResourceEntry,
+        tableName,
+        directResourceContext,
+      )
       return WriteResult.Success
     }
-
-    val entries = writeState.tables.getOrPut(tableName) { mutableListOf() }
-    val existingIndex = entries.indexOfFirst { it.sameKey(entry) }
 
     // P4Runtime spec §9.1: INSERT requires the entry not to exist, MODIFY and DELETE
     // require it to exist.

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -1878,25 +1878,25 @@ class TableStoreTest {
   }
 
   @Test
-  fun `delete rejects counter data for table without direct counter`() {
+  fun `delete ignores counter data for table without direct counter`() {
     val entry = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
     store.writeAndPublish(insertUpdate(entry))
 
     val result = store.writeAndPublish(deleteUpdate(withCounterData(entry)))
 
-    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
-    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+    assertEquals(WriteResult.Success, result)
+    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
   }
 
   @Test
-  fun `delete rejects meter config for table without direct meter`() {
+  fun `delete ignores meter config for table without direct meter`() {
     val entry = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
     store.writeAndPublish(insertUpdate(entry))
 
     val result = store.writeAndPublish(deleteUpdate(withMeterConfig(entry)))
 
-    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
-    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+    assertEquals(WriteResult.Success, result)
+    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
   }
 
   @Test


### PR DESCRIPTION
## Summary

Align `TableEntry` direct-resource handling with the P4Runtime v1.5.0 semantics audited in #718:

- validate inline direct resources on `MODIFY` with an unset action against the effective existing/default action
- treat `DELETE` as key-only and ignore non-key direct-resource fields
- support inline direct counter and meter state on default `TableEntry` writes and reads

Closes #728.
Closes #729.
Closes #730.

## Root Cause

`TableStore.writeTableEntry` validated direct-resource fields against the raw write entry. That missed the effective action for unset-action `MODIFY` requests, applied validation to `DELETE` fields that the spec says are ignored, and returned early for default entries before applying direct-resource state.

## Validation

- `./tools/format.sh`
- `bazel test //simulator:DirectResourceUsageTest //simulator:TableStoreTest //grpc:P4RuntimeWriteErrorTest //grpc:P4RuntimeConformanceTest --test_output=errors`
- `./tools/lint.sh`
