### PR TITLE
grpc: Increase maximum gRPC header/metadata size limit to 10MB

### DIFF
--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -252,8 +252,11 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   absl::StatusOr<int> port = ReadPortFile(port_file);
   if (!port.ok()) return std::move(port).status();
 
-  auto channel = grpc::CreateChannel(absl::StrCat("localhost:", *port),
-                                     grpc::InsecureChannelCredentials());
+  grpc::ChannelArguments channel_args;
+  channel_args.SetInt("grpc.max_metadata_size", 10 * 1024 * 1024);
+  auto channel = grpc::CreateCustomChannel(absl::StrCat("localhost:", *port),
+                                           grpc::InsecureChannelCredentials(),
+                                           channel_args);
 
   std::move(guard).Cancel();
   return FourwardServer(pid, *port, options.device_id, std::move(*scratch),

--- a/fourward_cc/fourward_server_test.cc
+++ b/fourward_cc/fourward_server_test.cc
@@ -54,6 +54,24 @@ TEST(FourwardServerTest, StartExposesLiveGrpcEndpoint) {
   ExpectHealthy(*server);
 }
 
+TEST(FourwardServerTest, LargeHeaderSucceeds) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+  ASSERT_TRUE(server.ok()) << server.status();
+
+  auto stub = server->NewP4RuntimeStub();
+  p4::v1::CapabilitiesRequest req;
+  p4::v1::CapabilitiesResponse resp;
+  grpc::ClientContext ctx;
+
+  // 5MB header is well above default 8KB but below our 10MB limit.
+  std::string large_value(5 * 1024 * 1024, 'a');
+  ctx.AddMetadata("large-header", large_value);
+
+  grpc::Status status = stub->Capabilities(&ctx, req, &resp);
+  EXPECT_TRUE(status.ok()) << "Capabilities failed with large header: code=" << status.error_code()
+                           << " msg=" << status.error_message();
+}
+
 TEST(FourwardServerTest, CustomDeviceIdFlowsThroughToP4Runtime) {
   absl::StatusOr<FourwardServer> server =
       FourwardServer::Start({.device_id = 42});

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -70,6 +70,7 @@ class FourwardServer(
         // awaiting the next client message) can prevent other RPCs on the same
         // HTTP/2 connection from being dispatched.
         .executor(Executors.newCachedThreadPool())
+        .maxHeaderListSize(10 * 1024 * 1024)
         .addService(service)
         .addService(dataplaneService)
         .build()


### PR DESCRIPTION
Large P4Runtime batch errors return individual status updates for every entity in the batch, wrapped inside the gRPC Status details. For large batches, this easily exceeds the default 8KB limit, causing Netty/gRPC to reset the HTTP/2 stream with PROTOCOL_ERROR. This change increases the maximum header limit to 10MB on both the Kotlin server and C++ client to allow descriptive errors to bubble up cleanly.