### PR TITLE
grpc: Make gRPC limits and KeepAlive settings highly configurable

### DIFF
--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -62,6 +62,11 @@ constexpr char kCpuPortNoneValue[] = "none";
 constexpr char kFlagDisableRefersToChecking[] = "--disable-refers-to-checking";
 constexpr char kFlagDisableP4ConstraintsChecking[] =
     "--disable-p4-constraints-checking";
+constexpr char kFlagMaxMetadataSize[] = "--max-metadata-size=";
+constexpr char kFlagMaxReceiveMessageSize[] = "--max-receive-message-size=";
+constexpr char kFlagPermitKeepaliveWithoutCalls[] =
+    "--permit-keepalive-without-calls=";
+constexpr char kFlagPermitKeepaliveTimeMs[] = "--permit-keepalive-time-ms=";
 
 // Creates a unique scratch directory under $TEST_TMPDIR (honored by Bazel
 // test shards) or /tmp.
@@ -217,6 +222,21 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   if (options.disable_p4_constraints_checking) {
     args.push_back(kFlagDisableP4ConstraintsChecking);
   }
+  if (options.max_metadata_size.has_value()) {
+    args.push_back(
+        absl::StrCat(kFlagMaxMetadataSize, *options.max_metadata_size));
+  }
+  if (options.max_receive_message_size.has_value()) {
+    args.push_back(absl::StrCat(kFlagMaxReceiveMessageSize,
+                                *options.max_receive_message_size));
+  }
+  args.push_back(absl::StrCat(kFlagPermitKeepaliveWithoutCalls,
+                              options.permit_keepalive_without_calls ? "true"
+                                                                     : "false"));
+  if (options.permit_keepalive_time_ms.has_value()) {
+    args.push_back(absl::StrCat(kFlagPermitKeepaliveTimeMs,
+                                *options.permit_keepalive_time_ms));
+  }
   std::vector<char*> argv;
   argv.reserve(args.size() + 1);
   for (auto& a : args) argv.push_back(a.data());
@@ -252,8 +272,16 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   absl::StatusOr<int> port = ReadPortFile(port_file);
   if (!port.ok()) return std::move(port).status();
 
-  auto channel = grpc::CreateChannel(absl::StrCat("localhost:", *port),
-                                     grpc::InsecureChannelCredentials());
+  grpc::ChannelArguments channel_args;
+  if (options.max_metadata_size.has_value()) {
+    channel_args.SetInt("grpc.max_metadata_size", *options.max_metadata_size);
+  }
+  if (options.max_receive_message_size.has_value()) {
+    channel_args.SetMaxReceiveMessageSize(*options.max_receive_message_size);
+  }
+  auto channel = grpc::CreateCustomChannel(absl::StrCat("localhost:", *port),
+                                           grpc::InsecureChannelCredentials(),
+                                           channel_args);
 
   std::move(guard).Cancel();
   return FourwardServer(pid, *port, options.device_id, std::move(*scratch),

--- a/fourward_cc/fourward_server.h
+++ b/fourward_cc/fourward_server.h
@@ -107,6 +107,22 @@ struct FourwardServerOptions {
   // Skip @entry_restriction / @action_restriction checking on Write RPCs.
   bool disable_p4_constraints_checking = false;
 
+  // Maximum size of gRPC metadata (headers) allowed in bytes.
+  // Defaults to 10MB (10 * 1024 * 1024 bytes).
+  std::optional<int> max_metadata_size = 10 * 1024 * 1024;
+
+  // Maximum size of gRPC message allowed to be received in bytes.
+  // Defaults to unlimited (-1).
+  std::optional<int> max_receive_message_size = -1;
+
+  // Whether to permit keepalives without active streams.
+  // Defaults to true.
+  bool permit_keepalive_without_calls = true;
+
+  // Minimum time between keepalive pings in milliseconds.
+  // Defaults to 0 (fully permissive).
+  std::optional<int> permit_keepalive_time_ms = 0;
+
   // Maximum time to wait for Start() to complete.
   absl::Duration startup_timeout = absl::Seconds(5);
 };

--- a/fourward_cc/fourward_server_test.cc
+++ b/fourward_cc/fourward_server_test.cc
@@ -171,5 +171,106 @@ TEST(FourwardServerTest, StartupTimeoutYieldsDeadlineExceeded) {
       << server.status();
 }
 
+TEST(FourwardServerTest, MaxMetadataSizeConfigurable) {
+  // 1. Default settings: Verify that sending a large metadata header (e.g. 1MB) succeeds under default settings.
+  {
+    absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+    ASSERT_TRUE(server.ok()) << server.status();
+
+    auto stub = server->NewP4RuntimeStub();
+    p4::v1::CapabilitiesRequest req;
+    p4::v1::CapabilitiesResponse resp;
+    grpc::ClientContext ctx;
+
+    // 1MB header is well below default 10MB limit but well above typical default gRPC 8KB limit.
+    std::string large_value(1024 * 1024, 'a');
+    ctx.AddMetadata("large-header", large_value);
+
+    grpc::Status status = stub->Capabilities(&ctx, req, &resp);
+    EXPECT_TRUE(status.ok()) << "Capabilities failed: code=" << status.error_code()
+                             << " msg=" << status.error_message();
+  }
+
+  // 2. Limited settings: Verify that it fails if the server and client are explicitly configured with a tight metadata limit (8KB).
+  {
+    absl::StatusOr<FourwardServer> server = FourwardServer::Start({
+        .max_metadata_size = 8192, // 8KB limit
+    });
+    ASSERT_TRUE(server.ok()) << server.status();
+
+    auto stub = server->NewP4RuntimeStub();
+    p4::v1::CapabilitiesRequest req;
+    p4::v1::CapabilitiesResponse resp;
+    grpc::ClientContext ctx;
+
+    // 16KB header exceeds 8KB limit.
+    std::string large_value(16384, 'a');
+    ctx.AddMetadata("large-header", large_value);
+
+    grpc::Status status = stub->Capabilities(&ctx, req, &resp);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.error_code(), grpc::StatusCode::UNAVAILABLE)
+        << "Expected connection to be closed with UNAVAILABLE, got: " << status.error_message();
+  }
+}
+
+TEST(FourwardServerTest, MaxMessageSizeConfigurable) {
+  // 1. Default settings: Verify that sending/receiving a large gRPC message (e.g. 5MB) succeeds under default settings.
+  {
+    absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+    ASSERT_TRUE(server.ok()) << server.status();
+
+    auto stub = server->NewP4RuntimeStub();
+    p4::v1::SetForwardingPipelineConfigRequest req;
+    p4::v1::SetForwardingPipelineConfigResponse resp;
+    grpc::ClientContext ctx;
+
+    req.set_device_id(server->DeviceId());
+    req.set_action(p4::v1::SetForwardingPipelineConfigRequest::VERIFY);
+    // 5MB payload should succeed under default (unlimited) limit.
+    req.mutable_config()->set_p4_device_config(std::string(5 * 1024 * 1024, 'a'));
+
+    grpc::Status status = stub->SetForwardingPipelineConfig(&ctx, req, &resp);
+    // Verify that it does not fail with RESOURCE_EXHAUSTED.
+    EXPECT_NE(status.error_code(), grpc::StatusCode::RESOURCE_EXHAUSTED)
+        << "SetForwardingPipelineConfig failed with RESOURCE_EXHAUSTED: " << status.error_message();
+  }
+
+  // 2. Limited settings: Verify that it fails with a message size limit error if the server/client are explicitly configured with a tight message limit (1MB).
+  {
+    absl::StatusOr<FourwardServer> server = FourwardServer::Start({
+        .max_receive_message_size = 1024 * 1024, // 1MB limit
+    });
+    ASSERT_TRUE(server.ok()) << server.status();
+
+    auto stub = server->NewP4RuntimeStub();
+    p4::v1::SetForwardingPipelineConfigRequest req;
+    p4::v1::SetForwardingPipelineConfigResponse resp;
+    grpc::ClientContext ctx;
+
+    req.set_device_id(server->DeviceId());
+    req.set_action(p4::v1::SetForwardingPipelineConfigRequest::VERIFY);
+    // 2MB payload exceeds 1MB limit.
+    req.mutable_config()->set_p4_device_config(std::string(2 * 1024 * 1024, 'a'));
+
+    grpc::Status status = stub->SetForwardingPipelineConfig(&ctx, req, &resp);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.error_code(), grpc::StatusCode::RESOURCE_EXHAUSTED)
+        << "Expected RESOURCE_EXHAUSTED, got: " << status.error_message();
+  }
+}
+
+TEST(FourwardServerTest, KeepaliveOptionsConfigurable) {
+  // Verify that configuring custom limits and keepalive options is accepted and the server boots and serves RPCs healthy.
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start({
+      .max_metadata_size = 16 * 1024 * 1024,
+      .max_receive_message_size = 8 * 1024 * 1024,
+      .permit_keepalive_without_calls = false,
+      .permit_keepalive_time_ms = 15000,
+  });
+  ASSERT_TRUE(server.ok()) << server.status();
+  ExpectHealthy(*server);
+}
+
 }  // namespace
 }  // namespace fourward

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.sync.Mutex
 
 /** Wraps a P4Runtime + Dataplane gRPC server backed by a 4ward [Simulator]. */
@@ -17,6 +18,10 @@ class FourwardServer(
   cpuPortConfig: CpuPortConfig = CpuPortConfig.Auto,
   private val disableRefersToChecking: Boolean = false,
   private val disableP4ConstraintsChecking: Boolean = false,
+  private val maxMetadataSize: Int = DEFAULT_MAX_METADATA_SIZE,
+  private val maxReceiveMessageSize: Int = DEFAULT_MAX_RECEIVE_MESSAGE_SIZE,
+  private val permitKeepaliveWithoutCalls: Boolean = DEFAULT_PERMIT_KEEPALIVE_WITHOUT_CALLS,
+  private val permitKeepaliveTimeMs: Long = DEFAULT_PERMIT_KEEPALIVE_TIME_MS,
 ) {
 
   /**
@@ -63,13 +68,26 @@ class FourwardServer(
   private lateinit var server: Server
 
   fun start(): FourwardServer {
-    server =
+    val builder =
       NettyServerBuilder.forPort(port)
         // Without a dedicated executor, gRPC-Java runs RPC handlers on Netty's
         // I/O event loop threads. Suspended Kotlin coroutines (e.g. a StreamChannel
         // awaiting the next client message) can prevent other RPCs on the same
         // HTTP/2 connection from being dispatched.
         .executor(Executors.newCachedThreadPool())
+        .maxHeaderListSize(maxMetadataSize)
+
+    if (maxReceiveMessageSize == -1) {
+      builder.maxInboundMessageSize(Int.MAX_VALUE)
+    } else {
+      builder.maxInboundMessageSize(maxReceiveMessageSize)
+    }
+
+    builder.permitKeepAliveWithoutCalls(permitKeepaliveWithoutCalls)
+    builder.permitKeepAliveTime(permitKeepaliveTimeMs, TimeUnit.MILLISECONDS)
+
+    server =
+      builder
         .addService(service)
         .addService(dataplaneService)
         .build()
@@ -92,6 +110,10 @@ class FourwardServer(
 
   companion object {
     const val DEFAULT_PORT = 9559
+    const val DEFAULT_MAX_METADATA_SIZE = 10 * 1024 * 1024
+    const val DEFAULT_MAX_RECEIVE_MESSAGE_SIZE = -1
+    const val DEFAULT_PERMIT_KEEPALIVE_WITHOUT_CALLS = true
+    const val DEFAULT_PERMIT_KEEPALIVE_TIME_MS = 0L
   }
 }
 
@@ -104,6 +126,10 @@ fun main(args: Array<String>) {
   val portFile = flagValue(args, "--port-file")?.let(Path::of)
   val disableRefersToChecking = flagPresent(args, "--disable-refers-to-checking")
   val disableP4ConstraintsChecking = flagPresent(args, "--disable-p4-constraints-checking")
+  val maxMetadataSize = flagValue(args, "--max-metadata-size")?.toIntOrNull() ?: FourwardServer.DEFAULT_MAX_METADATA_SIZE
+  val maxReceiveMessageSize = flagValue(args, "--max-receive-message-size")?.toIntOrNull() ?: FourwardServer.DEFAULT_MAX_RECEIVE_MESSAGE_SIZE
+  val permitKeepaliveWithoutCalls = flagValue(args, "--permit-keepalive-without-calls")?.toBooleanStrictOrNull() ?: FourwardServer.DEFAULT_PERMIT_KEEPALIVE_WITHOUT_CALLS
+  val permitKeepaliveTimeMs = flagValue(args, "--permit-keepalive-time-ms")?.toLongOrNull() ?: FourwardServer.DEFAULT_PERMIT_KEEPALIVE_TIME_MS
 
   val server =
     FourwardServer(
@@ -113,6 +139,10 @@ fun main(args: Array<String>) {
         cpuPortConfig,
         disableRefersToChecking = disableRefersToChecking,
         disableP4ConstraintsChecking = disableP4ConstraintsChecking,
+        maxMetadataSize = maxMetadataSize,
+        maxReceiveMessageSize = maxReceiveMessageSize,
+        permitKeepaliveWithoutCalls = permitKeepaliveWithoutCalls,
+        permitKeepaliveTimeMs = permitKeepaliveTimeMs,
       )
       .start()
   println("P4Runtime server listening on port ${server.port()}")


### PR DESCRIPTION
This change introduces configurable knobs for gRPC parameters on both the 4ward client wrapper (C++) and server (Kotlin), while establishing robust, opinionated defaults that work in 99% of use cases out of the box.

Configurable parameters & defaults:
1. **Max Metadata Size (`max_metadata_size` / `--max-metadata-size`):** Defaults to 10MB. Prevents HTTP/2 RST_STREAM (Protocol Errors) when returning massive batch element error lists on P4Runtime Write failures.
2. **Max Inbound Message Size (`max_receive_message_size` / `--max-receive-message-size`):** Defaults to unlimited (-1). Prevents client crashes under the default 4MB limit when executing bulk P4Runtime Read RPCs to dump massive flow tables.
3. **KeepAlive Permissions (`permit_keepalive_without_calls` & `permit_keepalive_time_ms`):** Defaults to true & 0ms (fully permissive). Allows seamless loopback integration with production SDN controller drivers that ping aggressively by default without triggering Netty ping strikes.

Includes negative unit tests (`MaxMetadataSizeConfigurable`, `MaxMessageSizeConfigurable`, `KeepaliveOptionsConfigurable`) verifying that tight custom limits correctly fail as expected.