### PR TITLE
grpc: Configure permissive gRPC limits for SDN controller compatibility

### DIFF
--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -120,12 +120,17 @@ cc_test(
 cc_test(
     name = "fourward_server_test",
     srcs = ["fourward_server_test.cc"],
+    data = ["//e2e_tests/passthrough:passthrough_p4runtime"],
+    local_defines = [
+        'PASSTHROUGH_PIPELINE_RLOCATION=\\"$(rlocationpath //e2e_tests/passthrough:passthrough_p4runtime)\\"',
+    ],
     deps = [
         ":fourward_server",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
+        "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@grpc//:grpc++",

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -32,6 +32,7 @@
 #include "absl/time/time.h"
 #include "grpcpp/create_channel.h"
 #include "grpcpp/security/credentials.h"
+#include "grpcpp/support/channel_arguments.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
 #ifndef FOURWARD_SERVER_RLOCATION
@@ -62,6 +63,11 @@ constexpr char kCpuPortNoneValue[] = "none";
 constexpr char kFlagDisableRefersToChecking[] = "--disable-refers-to-checking";
 constexpr char kFlagDisableP4ConstraintsChecking[] =
     "--disable-p4-constraints-checking";
+constexpr char kFlagMaxMetadataSize[] = "--max-metadata-size=";
+constexpr char kFlagMaxReceiveMessageSize[] = "--max-receive-message-size=";
+constexpr char kFlagPermitKeepaliveWithoutCalls[] =
+    "--permit-keepalive-without-calls=";
+constexpr char kFlagPermitKeepaliveTimeMs[] = "--permit-keepalive-time-ms=";
 
 // Creates a unique scratch directory under $TEST_TMPDIR (honored by Bazel
 // test shards) or /tmp.
@@ -217,6 +223,16 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   if (options.disable_p4_constraints_checking) {
     args.push_back(kFlagDisableP4ConstraintsChecking);
   }
+  args.push_back(
+      absl::StrCat(kFlagMaxMetadataSize, options.max_metadata_size));
+  args.push_back(absl::StrCat(kFlagMaxReceiveMessageSize,
+                               options.max_receive_message_size));
+  args.push_back(absl::StrCat(kFlagPermitKeepaliveWithoutCalls,
+                               options.permit_keepalive_without_calls
+                                   ? "true"
+                                   : "false"));
+  args.push_back(absl::StrCat(kFlagPermitKeepaliveTimeMs,
+                               options.permit_keepalive_time_ms));
   std::vector<char*> argv;
   argv.reserve(args.size() + 1);
   for (auto& a : args) argv.push_back(a.data());
@@ -252,8 +268,12 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   absl::StatusOr<int> port = ReadPortFile(port_file);
   if (!port.ok()) return std::move(port).status();
 
-  auto channel = grpc::CreateChannel(absl::StrCat("localhost:", *port),
-                                     grpc::InsecureChannelCredentials());
+  grpc::ChannelArguments channel_args;
+  channel_args.SetInt("grpc.max_metadata_size", options.max_metadata_size);
+  channel_args.SetMaxReceiveMessageSize(options.max_receive_message_size);
+  auto channel = grpc::CreateCustomChannel(absl::StrCat("localhost:", *port),
+                                           grpc::InsecureChannelCredentials(),
+                                           channel_args);
 
   std::move(guard).Cancel();
   return FourwardServer(pid, *port, options.device_id, std::move(*scratch),

--- a/fourward_cc/fourward_server.h
+++ b/fourward_cc/fourward_server.h
@@ -107,6 +107,21 @@ struct FourwardServerOptions {
   // Skip @entry_restriction / @action_restriction checking on Write RPCs.
   bool disable_p4_constraints_checking = false;
 
+  // Maximum gRPC metadata (header) size in bytes. Large P4Runtime batch errors
+  // return per-entity status details that easily exceed the default 8KB limit,
+  // causing Netty to reset the HTTP/2 stream with PROTOCOL_ERROR.
+  int max_metadata_size = 10 * 1024 * 1024;  // 10MB
+
+  // Maximum inbound gRPC message size in bytes. -1 means unlimited. Prevents
+  // client failures under the default 4MB limit when reading large flow tables
+  // via P4Runtime Read.
+  int max_receive_message_size = -1;
+
+  // Server-side keepalive permissions. Permissive defaults allow aggressive
+  // SDN controller keepalive pings without triggering Netty ping strikes.
+  bool permit_keepalive_without_calls = true;
+  int permit_keepalive_time_ms = 0;
+
   // Maximum time to wait for Start() to complete.
   absl::Duration startup_timeout = absl::Seconds(5);
 };

--- a/fourward_cc/fourward_server_test.cc
+++ b/fourward_cc/fourward_server_test.cc
@@ -7,6 +7,11 @@
 #include <sys/types.h>
 
 #include <chrono>
+#include <cstddef>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <string>
 #include <thread>
 #include <utility>
 
@@ -19,9 +24,16 @@
 #include "gtest/gtest.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+#ifndef PASSTHROUGH_PIPELINE_RLOCATION
+#error "PASSTHROUGH_PIPELINE_RLOCATION must be set by the BUILD rule"
+#endif
 
 namespace fourward {
 namespace {
+
+using ::bazel::tools::cpp::runfiles::Runfiles;
 
 // Issues a Capabilities RPC and asserts it succeeds. This proves the server
 // is not just TCP-listening but actually serving gRPC. Capabilities is used
@@ -169,6 +181,194 @@ TEST(FourwardServerTest, StartupTimeoutYieldsDeadlineExceeded) {
   ASSERT_FALSE(server.ok());
   EXPECT_EQ(server.status().code(), absl::StatusCode::kDeadlineExceeded)
       << server.status();
+}
+
+TEST(FourwardServerTest, LargeMetadataSucceedsUnderDefaultLimits) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+  ASSERT_TRUE(server.ok()) << server.status();
+
+  auto stub = server->NewP4RuntimeStub();
+  p4::v1::CapabilitiesRequest req;
+  p4::v1::CapabilitiesResponse resp;
+  grpc::ClientContext ctx;
+
+  // 1MB header is well above the default gRPC 8KB limit but below our 10MB.
+  std::string large_value(1024 * 1024, 'a');
+  ctx.AddMetadata("large-header", large_value);
+
+  grpc::Status status = stub->Capabilities(&ctx, req, &resp);
+  EXPECT_TRUE(status.ok()) << "Capabilities failed: code=" << status.error_code()
+                           << " msg=" << status.error_message();
+}
+
+TEST(FourwardServerTest, TightMetadataLimitRejectsLargeHeader) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start({
+      .max_metadata_size = 8192,
+  });
+  ASSERT_TRUE(server.ok()) << server.status();
+
+  auto stub = server->NewP4RuntimeStub();
+  p4::v1::CapabilitiesRequest req;
+  p4::v1::CapabilitiesResponse resp;
+  grpc::ClientContext ctx;
+
+  // 16KB header exceeds the 8KB limit.
+  std::string large_value(16384, 'a');
+  ctx.AddMetadata("large-header", large_value);
+
+  grpc::Status status = stub->Capabilities(&ctx, req, &resp);
+  EXPECT_FALSE(status.ok());
+}
+
+TEST(FourwardServerTest, LargeMessageSucceedsUnderDefaultLimits) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+  ASSERT_TRUE(server.ok()) << server.status();
+
+  auto stub = server->NewP4RuntimeStub();
+  p4::v1::SetForwardingPipelineConfigRequest req;
+  p4::v1::SetForwardingPipelineConfigResponse resp;
+  grpc::ClientContext ctx;
+
+  req.set_device_id(server->DeviceId());
+  req.set_action(p4::v1::SetForwardingPipelineConfigRequest::VERIFY);
+  // 5MB payload exceeds the default 4MB gRPC limit. The RPC will fail for
+  // application-level reasons (garbage config), but it must not fail with
+  // RESOURCE_EXHAUSTED — that would mean the size gate rejected it.
+  req.mutable_config()->set_p4_device_config(
+      std::string(5 * 1024 * 1024, 'a'));
+
+  grpc::Status status =
+      stub->SetForwardingPipelineConfig(&ctx, req, &resp);
+  EXPECT_NE(status.error_code(), grpc::StatusCode::RESOURCE_EXHAUSTED)
+      << "SetForwardingPipelineConfig hit message size limit: "
+      << status.error_message();
+}
+
+TEST(FourwardServerTest, TightMessageLimitRejectsLargeMessage) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start({
+      .max_receive_message_size = 1024 * 1024,
+  });
+  ASSERT_TRUE(server.ok()) << server.status();
+
+  auto stub = server->NewP4RuntimeStub();
+  p4::v1::SetForwardingPipelineConfigRequest req;
+  p4::v1::SetForwardingPipelineConfigResponse resp;
+  grpc::ClientContext ctx;
+
+  req.set_device_id(server->DeviceId());
+  req.set_action(p4::v1::SetForwardingPipelineConfigRequest::VERIFY);
+  // 2MB payload exceeds the 1MB limit.
+  req.mutable_config()->set_p4_device_config(
+      std::string(2 * 1024 * 1024, 'a'));
+
+  grpc::Status status =
+      stub->SetForwardingPipelineConfig(&ctx, req, &resp);
+  // The server rejects the message with RESOURCE_EXHAUSTED, but Netty may
+  // close the stream before the error propagates to the client — so we only
+  // assert the RPC fails, not the specific code.
+  EXPECT_FALSE(status.ok())
+      << "Expected RPC failure due to message size limit";
+}
+
+TEST(FourwardServerTest, CustomGrpcOptionsAccepted) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start({
+      .max_metadata_size = 16 * 1024 * 1024,
+      .max_receive_message_size = 8 * 1024 * 1024,
+      .permit_keepalive_without_calls = false,
+      .permit_keepalive_time_ms = 15000,
+  });
+  ASSERT_TRUE(server.ok()) << server.status();
+  ExpectHealthy(*server);
+}
+
+// Appends a valid proto field to `proto` so the serialized message grows by
+// `size` bytes of payload. Uses field 15 (wire type 2 / length-delimited)
+// which is treated as an unknown field by any proto message type — the proto
+// parser preserves it, inflating the serialized size on round-trip.
+void AppendProtoPadding(std::string& proto, size_t size) {
+  proto.push_back(static_cast<char>(0x7A));  // tag: (15 << 3) | 2
+  size_t remaining = size;
+  while (remaining >= 0x80) {
+    proto.push_back(static_cast<char>((remaining & 0x7F) | 0x80));
+    remaining >>= 7;
+  }
+  proto.push_back(static_cast<char>(remaining));
+  proto.append(size, 'x');
+}
+
+// Pushes a ForwardingPipelineConfig to the server via the P4Runtime API.
+// Establishes master arbitration first.
+grpc::Status PushPipeline(
+    const FourwardServer& server,
+    const p4::v1::ForwardingPipelineConfig& config) {
+  auto stub = server.NewP4RuntimeStub();
+
+  grpc::ClientContext stream_ctx;
+  auto stream = stub->StreamChannel(&stream_ctx);
+  p4::v1::StreamMessageRequest arb_req;
+  arb_req.mutable_arbitration()->set_device_id(server.DeviceId());
+  arb_req.mutable_arbitration()->mutable_election_id()->set_low(1);
+  stream->Write(arb_req);
+  p4::v1::StreamMessageResponse arb_resp;
+  stream->Read(&arb_resp);
+
+  grpc::ClientContext set_ctx;
+  p4::v1::SetForwardingPipelineConfigRequest req;
+  req.set_device_id(server.DeviceId());
+  req.mutable_election_id()->set_low(1);
+  req.set_action(
+      p4::v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT);
+  *req.mutable_config() = config;
+  p4::v1::SetForwardingPipelineConfigResponse resp;
+  grpc::Status status =
+      stub->SetForwardingPipelineConfig(&set_ctx, req, &resp);
+
+  stream_ctx.TryCancel();
+  return status;
+}
+
+TEST(FourwardServerTest, LargeResponseSucceedsUnderDefaultLimits) {
+  // Load the passthrough pipeline from runfiles and inflate p4_device_config
+  // to >4MB with a valid proto unknown field. After pushing the padded config,
+  // GetForwardingPipelineConfig returns it — producing a response that exceeds
+  // gRPC's default 4MB receive limit. This verifies the client channel is
+  // correctly configured with an unlimited receive message size.
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", &error));
+  ASSERT_NE(runfiles, nullptr) << error;
+  std::string path =
+      runfiles->Rlocation(PASSTHROUGH_PIPELINE_RLOCATION);
+  std::ifstream file(path, std::ios::binary);
+  ASSERT_TRUE(file.good()) << "cannot open: " << path;
+  std::string bytes((std::istreambuf_iterator<char>(file)),
+                    std::istreambuf_iterator<char>());
+
+  p4::v1::ForwardingPipelineConfig config;
+  ASSERT_TRUE(config.ParseFromString(bytes));
+  std::string padded_device_config = config.p4_device_config();
+  AppendProtoPadding(padded_device_config, 5 * 1024 * 1024);
+  config.set_p4_device_config(padded_device_config);
+
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+  ASSERT_TRUE(server.ok()) << server.status();
+
+  grpc::Status push_status = PushPipeline(*server, config);
+  ASSERT_TRUE(push_status.ok())
+      << "Push failed: " << push_status.error_message();
+
+  auto stub = server->NewP4RuntimeStub();
+  grpc::ClientContext get_ctx;
+  p4::v1::GetForwardingPipelineConfigRequest get_req;
+  get_req.set_device_id(server->DeviceId());
+  get_req.set_response_type(
+      p4::v1::GetForwardingPipelineConfigRequest::ALL);
+  p4::v1::GetForwardingPipelineConfigResponse get_resp;
+  grpc::Status get_status =
+      stub->GetForwardingPipelineConfig(&get_ctx, get_req, &get_resp);
+  EXPECT_TRUE(get_status.ok())
+      << "GetForwardingPipelineConfig failed on >4MB response: code="
+      << get_status.error_code()
+      << " msg=" << get_status.error_message();
 }
 
 }  // namespace

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.sync.Mutex
 
 /** Wraps a P4Runtime + Dataplane gRPC server backed by a 4ward [Simulator]. */
@@ -17,6 +18,10 @@ class FourwardServer(
   cpuPortConfig: CpuPortConfig = CpuPortConfig.Auto,
   private val disableRefersToChecking: Boolean = false,
   private val disableP4ConstraintsChecking: Boolean = false,
+  private val maxMetadataSize: Int = DEFAULT_MAX_METADATA_SIZE,
+  private val maxReceiveMessageSize: Int = DEFAULT_MAX_RECEIVE_MESSAGE_SIZE,
+  private val permitKeepaliveWithoutCalls: Boolean = DEFAULT_PERMIT_KEEPALIVE_WITHOUT_CALLS,
+  private val permitKeepaliveTimeMs: Long = DEFAULT_PERMIT_KEEPALIVE_TIME_MS,
 ) {
 
   /**
@@ -63,6 +68,8 @@ class FourwardServer(
   private lateinit var server: Server
 
   fun start(): FourwardServer {
+    val inboundMessageSize =
+      if (maxReceiveMessageSize == -1) Int.MAX_VALUE else maxReceiveMessageSize
     server =
       NettyServerBuilder.forPort(port)
         // Without a dedicated executor, gRPC-Java runs RPC handlers on Netty's
@@ -70,6 +77,10 @@ class FourwardServer(
         // awaiting the next client message) can prevent other RPCs on the same
         // HTTP/2 connection from being dispatched.
         .executor(Executors.newCachedThreadPool())
+        .maxInboundMetadataSize(maxMetadataSize)
+        .maxInboundMessageSize(inboundMessageSize)
+        .permitKeepAliveWithoutCalls(permitKeepaliveWithoutCalls)
+        .permitKeepAliveTime(permitKeepaliveTimeMs, TimeUnit.MILLISECONDS)
         .addService(service)
         .addService(dataplaneService)
         .build()
@@ -92,18 +103,34 @@ class FourwardServer(
 
   companion object {
     const val DEFAULT_PORT = 9559
+    const val DEFAULT_MAX_METADATA_SIZE = 10 * 1024 * 1024 // 10MB
+    const val DEFAULT_MAX_RECEIVE_MESSAGE_SIZE = -1 // unlimited
+    const val DEFAULT_PERMIT_KEEPALIVE_WITHOUT_CALLS = true
+    const val DEFAULT_PERMIT_KEEPALIVE_TIME_MS = 0L
   }
 }
 
 fun main(args: Array<String>) {
-  val port = flagValue(args, "--port")?.toIntOrNull() ?: FourwardServer.DEFAULT_PORT
+  val port = requireFlag(args, "--port", String::toIntOrNull) ?: FourwardServer.DEFAULT_PORT
   val deviceId =
-    flagValue(args, "--device-id")?.toLongOrNull() ?: P4RuntimeService.DEFAULT_DEVICE_ID
+    requireFlag(args, "--device-id", String::toLongOrNull) ?: P4RuntimeService.DEFAULT_DEVICE_ID
   val dropPort = flagValue(args, "--drop-port")?.let(PortOverride::fromFlag)
   val cpuPortConfig = CpuPortConfig.fromFlag(flagValue(args, "--cpu-port"))
   val portFile = flagValue(args, "--port-file")?.let(Path::of)
   val disableRefersToChecking = flagPresent(args, "--disable-refers-to-checking")
   val disableP4ConstraintsChecking = flagPresent(args, "--disable-p4-constraints-checking")
+  val maxMetadataSize =
+    requireFlag(args, "--max-metadata-size", String::toIntOrNull)
+      ?: FourwardServer.DEFAULT_MAX_METADATA_SIZE
+  val maxReceiveMessageSize =
+    requireFlag(args, "--max-receive-message-size", String::toIntOrNull)
+      ?: FourwardServer.DEFAULT_MAX_RECEIVE_MESSAGE_SIZE
+  val permitKeepaliveWithoutCalls =
+    requireFlag(args, "--permit-keepalive-without-calls", String::toBooleanStrictOrNull)
+      ?: FourwardServer.DEFAULT_PERMIT_KEEPALIVE_WITHOUT_CALLS
+  val permitKeepaliveTimeMs =
+    requireFlag(args, "--permit-keepalive-time-ms", String::toLongOrNull)
+      ?: FourwardServer.DEFAULT_PERMIT_KEEPALIVE_TIME_MS
 
   val server =
     FourwardServer(
@@ -113,6 +140,10 @@ fun main(args: Array<String>) {
         cpuPortConfig,
         disableRefersToChecking = disableRefersToChecking,
         disableP4ConstraintsChecking = disableP4ConstraintsChecking,
+        maxMetadataSize = maxMetadataSize,
+        maxReceiveMessageSize = maxReceiveMessageSize,
+        permitKeepaliveWithoutCalls = permitKeepaliveWithoutCalls,
+        permitKeepaliveTimeMs = permitKeepaliveTimeMs,
       )
       .start()
   println("P4Runtime server listening on port ${server.port()}")
@@ -135,3 +166,8 @@ private fun flagValue(args: Array<String>, flag: String): String? =
   args.find { it.startsWith("$flag=") }?.substringAfter("=")
 
 private fun flagPresent(args: Array<String>, flag: String): Boolean = args.any { it == flag }
+
+private fun <T> requireFlag(args: Array<String>, flag: String, parse: (String) -> T?): T? {
+  val raw = flagValue(args, flag) ?: return null
+  return parse(raw) ?: error("invalid $flag value: $raw")
+}


### PR DESCRIPTION
Production SDN controllers routinely exceed gRPC's conservative defaults, causing three classes of failures when integrating with 4ward:

1. **Metadata overflow**: batch Write errors carry per-entity status details that blow past the 8KB metadata limit, causing Netty to reset the HTTP/2 stream with `PROTOCOL_ERROR`.
2. **Message size cap**: bulk Read responses and large pipeline configs exceed the 4MB message limit, crashing clients with `RESOURCE_EXHAUSTED`.
3. **Keepalive strikes**: aggressive controller keepalive pings trigger Netty ping strikes on idle connections.

This PR configures opinionated defaults that work out of the box — 10MB metadata, unlimited messages, fully permissive keepalive — while exposing all four knobs through `FourwardServerOptions` for the rare case someone needs to override them. Both the Kotlin server and the C++ client channel are configured consistently from the same options.

### Design choices

- **Plain `int`/`bool` fields, not `std::optional`**: these knobs always have a value. No confusing `nullopt` semantics — simpler API, fewer edge cases.
- **Fail loudly on invalid CLI flags**: the Kotlin `main()` uses a single generic `requireFlag<T>` helper that throws on malformed input instead of silently falling back to defaults. Existing `--port` and `--device-id` flags were migrated to the same strict parsing.
- **`-1` means unlimited** for `max_receive_message_size`, following gRPC C++ convention. The Kotlin server maps this to `Int.MAX_VALUE` since Netty requires a positive value. The C++ client passes `-1` directly to `SetMaxReceiveMessageSize`, which gRPC-core natively accepts.
- **Used `maxInboundMetadataSize`** instead of the deprecated `maxHeaderListSize`.

### Test plan

- [x] `LargeMetadataSucceedsUnderDefaultLimits` — 1MB header succeeds (proves we're above the 8KB default)
- [x] `TightMetadataLimitRejectsLargeHeader` — 8KB limit rejects 16KB header
- [x] `LargeMessageSucceedsUnderDefaultLimits` — 5MB message passes the size gate (not `RESOURCE_EXHAUSTED`)
- [x] `TightMessageLimitRejectsLargeMessage` — 1MB limit rejects 2MB message
- [x] `CustomGrpcOptionsAccepted` — non-default values for all four knobs, server boots and serves healthy
- [x] `LargeResponseSucceedsUnderDefaultLimits` — loads a >4MB pipeline config and reads it back via `GetForwardingPipelineConfig`, proving the client receive limit is correctly set to unlimited. Confirmed this test fails with the error `Received message larger than max (5244785 vs. 4194304)` when the client channel arg is not set.

Supersedes #735 and #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)