### PR TITLE
[codex] Preserve dataplane results under backpressure

### DIFF
--- a/fourward_cc/dataplane_client_e2e_test.cc
+++ b/fourward_cc/dataplane_client_e2e_test.cc
@@ -177,6 +177,29 @@ TEST_F(DataplaneClientE2ETest, InjectPacketsResultsDeliveredViaSubscribe) {
   }
 }
 
+TEST_F(DataplaneClientE2ETest, InjectPacketsBurstCanBeDrainedAfterInjection) {
+  DataplaneClient client(*server_);
+
+  absl::StatusOr<ResultStream> stream = client.SubscribeResults();
+  ASSERT_TRUE(stream.ok()) << stream.status();
+
+  constexpr int kPackets = 10'000;
+  PacketWriter writer = client.InjectPackets();
+  for (int i = 0; i < kPackets; ++i) {
+    ASSERT_TRUE(writer.Inject(DataplanePort{0}, MakeEthernetFrame()).ok())
+        << "packet " << i;
+  }
+  absl::StatusOr<int> count = writer.Finish();
+  ASSERT_TRUE(count.ok()) << count.status();
+  ASSERT_EQ(*count, kPackets);
+
+  for (int i = 0; i < kPackets; ++i) {
+    absl::StatusOr<ProcessPacketResult> result = stream->Next();
+    ASSERT_TRUE(result.ok()) << "result " << i << ": " << result.status();
+    EXPECT_THAT(*result, ForwardsTo(1));
+  }
+}
+
 TEST_F(DataplaneClientE2ETest,
        InjectPacketWithP4RuntimePortFailsWithoutTranslation) {
   DataplaneClient client(*server_);

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -108,7 +109,7 @@ class DataplaneService(
         .build()
   }
 
-  private fun processAndEnrich(
+  private suspend fun processAndEnrich(
     request: InjectPacketRequest,
     rpcName: String,
   ): Pair<EnrichedResult, PipelineSnapshot?> {
@@ -153,26 +154,18 @@ class DataplaneService(
   override suspend fun injectPackets(requests: Flow<InjectPacketRequest>): InjectPacketsResponse {
     val translator = pipelineSnapshot()?.typeTranslator
     broker.withHookOnce { processPacket ->
-      val futures = mutableListOf<java.util.concurrent.ForkJoinTask<*>>()
-      kotlinx.coroutines.runBlocking {
-        requests.collect { request ->
-          val port = resolveIngressPort(request, translator)
-          val payload = request.payload.toByteArray()
-          val tag = request.tag
-          futures.add(
-            java.util.concurrent.ForkJoinPool.commonPool().submit {
-              processPacket(port, payload, tag)
-            }
-          )
-        }
+      requests.collect { request ->
+        val port = resolveIngressPort(request, translator)
+        val payload = request.payload.toByteArray()
+        val tag = request.tag
+        processPacket(port, payload, tag)
       }
-      futures.forEach { it.join() }
     }
     return InjectPacketsResponse.getDefaultInstance()
   }
 
   override fun subscribeResults(request: SubscribeResultsRequest): Flow<SubscribeResultsResponse> =
-    callbackFlow {
+    channelFlow {
       send(
         SubscribeResultsResponse.newBuilder()
           .setActive(SubscriptionActive.getDefaultInstance())
@@ -210,11 +203,10 @@ class DataplaneService(
                 )
                 .setTrace(enrichTrace(subResult.trace, translator))
                 .build()
-            // Close the stream if the channel is full or closed — silently dropping a packet
-            // result would violate the SubscribeResults contract.
-            val sendResult =
-              trySend(SubscribeResultsResponse.newBuilder().setResult(result).build())
-            if (sendResult.isFailure) close(sendResult.exceptionOrNull())
+            val response = SubscribeResultsResponse.newBuilder().setResult(result).build()
+            // Packet processing waits here when the gRPC subscriber is slow: SubscribeResults is
+            // the lossless result channel for batch InjectPackets callers.
+            send(response)
           } catch (
             @Suppress("TooGenericExceptionCaught") // Any translation/encoding failure should
             e: Exception // terminate this subscription stream, not crash the packet sender.

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -361,11 +361,11 @@ class DataplaneServiceTest {
   }
 
   // =========================================================================
-  // Subscriber-falls-behind close (regression for the silent-drop bug)
+  // Subscriber backpressure
   // =========================================================================
 
   @Test
-  fun `SubscribeResults flow closes when subscriber falls behind`() = runBlocking {
+  fun `SubscribeResults preserves results when subscriber falls behind`() = runBlocking {
     harness.loadPipeline(loadPassthroughConfig())
     val stub = DataplaneCoroutineStub(harness.channel)
 
@@ -373,18 +373,14 @@ class DataplaneServiceTest {
     val ready = CompletableDeferred<Unit>()
     val collectJob =
       launch(Dispatchers.IO) {
-        // Any exception is expected here — the stream closes abruptly on overflow.
-        @Suppress("TooGenericExceptionCaught")
-        try {
-          stub.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
-            if (it.hasActive()) {
-              ready.complete(Unit)
-            } else {
-              collected.incrementAndGet()
-              delay(50) // slow consumer: forces the buffer to fill on bursty input
-            }
+        stub.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
+          if (it.hasActive()) {
+            ready.complete(Unit)
+          } else {
+            collected.incrementAndGet()
+            delay(50) // slow consumer: forces backpressure on bursty input
           }
-        } catch (_: Exception) {}
+        }
       }
 
     withTimeout(5000) { ready.await() }
@@ -392,14 +388,10 @@ class DataplaneServiceTest {
     // 200 packets is well above the typical callbackFlow buffer (~64).
     repeat(200) { i -> harness.injectPacket(ingressPort = 0, payload = byteArrayOf(i.toByte())) }
 
-    withTimeout(20_000) { collectJob.join() }
+    withTimeout(20_000) { while (collected.get() < 200) delay(50) }
+    collectJob.cancel()
 
-    assertTrue("collector should have received at least some items", collected.get() > 0)
-    assertTrue(
-      "flow should close before all 200 items delivered " +
-        "(overflow surfaced); got ${collected.get()}",
-      collected.get() < 200,
-    )
+    assertEquals("all results should be preserved", 200, collected.get())
   }
 
   // =========================================================================

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -701,7 +701,9 @@ class P4RuntimeService(
    * Returns a [StreamError] response on failure (P4Runtime spec §16.6), or null on success. A
    * single bad PacketOut must not terminate arbitration or PacketIn delivery on the stream.
    */
-  private fun handlePacketOut(packet: p4.v1.P4RuntimeOuterClass.PacketOut): StreamMessageResponse? {
+  private suspend fun handlePacketOut(
+    packet: p4.v1.P4RuntimeOuterClass.PacketOut
+  ): StreamMessageResponse? {
     val state = pipeline ?: return null
 
     fun packetOutError(code: Int, message: String?): StreamMessageResponse =

--- a/grpc/PacketBroker.kt
+++ b/grpc/PacketBroker.kt
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import p4.v1.P4RuntimeOuterClass
@@ -75,22 +74,20 @@ class PacketBroker(
    * The hook may apply P4Runtime updates (via [applyUpdates]) which mutate forwarding state and
    * publish a new snapshot — all under the mutex.
    */
-  private fun fireHookIfRegistered() {
+  private suspend fun fireHookIfRegistered() {
     val h = hook.get() ?: return
-    runBlocking {
-      val invocation =
-        PrePacketHookInvocation.newBuilder()
-          .setPacket(
-            PrePacketHookInvocation.PacketEvent.newBuilder()
-              .addAllEntities(readAllEntities())
-              .apply { readP4Info()?.let { setP4Info(it) } }
-          )
-          .build()
-      h.invocations.send(invocation)
-      val response = h.responses.receive()
-      if (response.updatesList.isNotEmpty()) {
-        applyUpdates(response.updatesList)
-      }
+    val invocation =
+      PrePacketHookInvocation.newBuilder()
+        .setPacket(
+          PrePacketHookInvocation.PacketEvent.newBuilder().addAllEntities(readAllEntities()).apply {
+            readP4Info()?.let { setP4Info(it) }
+          }
+        )
+        .build()
+    h.invocations.send(invocation)
+    val response = h.responses.receive()
+    if (response.updatesList.isNotEmpty()) {
+      applyUpdates(response.updatesList)
     }
   }
 
@@ -113,20 +110,23 @@ class PacketBroker(
   }
 
   private val subscribers =
-    java.util.concurrent.CopyOnWriteArrayList<(SubscriptionResult) -> Unit>()
+    java.util.concurrent.CopyOnWriteArrayList<suspend (SubscriptionResult) -> Unit>()
 
   /**
    * If a hook is registered, acquires the [writeMutex] and fires it. The hook may apply P4Runtime
    * updates that publish a new forwarding snapshot. No-op if no hook is registered.
    */
-  private fun fireHookUnderMutex() {
+  private suspend fun fireHookUnderMutex() {
     if (hook.get() != null) {
-      runBlocking { writeMutex.withLock { fireHookIfRegistered() } }
+      writeMutex.withLock { fireHookIfRegistered() }
     }
   }
 
-  fun processPacket(ingressPort: Int, payload: ByteArray, tag: Long = 0): ProcessPacketResult =
-    processPacket(ingressPort, PacketBits.ofBytes(payload), tag)
+  suspend fun processPacket(
+    ingressPort: Int,
+    payload: ByteArray,
+    tag: Long = 0,
+  ): ProcessPacketResult = processPacket(ingressPort, PacketBits.ofBytes(payload), tag)
 
   /**
    * Processes a packet: fires the hook (if registered), runs the simulator, and dispatches results
@@ -134,7 +134,11 @@ class PacketBroker(
    * snapshot. Only acquires the [writeMutex] when a hook is registered (to fire the hook and apply
    * its updates atomically).
    */
-  fun processPacket(ingressPort: Int, packet: PacketBits, tag: Long = 0): ProcessPacketResult {
+  suspend fun processPacket(
+    ingressPort: Int,
+    packet: PacketBits,
+    tag: Long = 0,
+  ): ProcessPacketResult {
     fireHookUnderMutex()
     val result = simulatorFn(ingressPort, packet)
     dispatchToSubscribers(ingressPort, packet, result, tag)
@@ -146,7 +150,9 @@ class PacketBroker(
    *
    * Used by [DataplaneService.injectPackets] to stream packets without buffering the entire batch.
    */
-  fun <T> withHookOnce(block: (processor: (Int, ByteArray, Long) -> Unit) -> T): T {
+  suspend fun <T> withHookOnce(
+    block: suspend (processor: suspend (Int, ByteArray, Long) -> Unit) -> T
+  ): T {
     fireHookUnderMutex()
     return block { port, payload, tag ->
       val packet = PacketBits.ofBytes(payload)
@@ -155,13 +161,19 @@ class PacketBroker(
     }
   }
 
-  /** Registers a subscriber that receives results for every processed packet. */
-  fun subscribe(callback: (SubscriptionResult) -> Unit): SubscriptionHandle {
+  /**
+   * Registers a subscriber that receives results for every processed packet.
+   *
+   * Subscriber delivery is lossless and backpressured: packet processing waits for each subscriber
+   * callback to return. Keep subscriber callbacks lightweight or hand work off to a bounded queue
+   * if they need to do slow I/O.
+   */
+  fun subscribe(callback: suspend (SubscriptionResult) -> Unit): SubscriptionHandle {
     subscribers.add(callback)
     return SubscriptionHandle { subscribers.remove(callback) }
   }
 
-  private fun dispatchToSubscribers(
+  private suspend fun dispatchToSubscribers(
     ingressPort: Int,
     packet: PacketBits,
     result: ProcessPacketResult,

--- a/grpc/PacketBrokerTest.kt
+++ b/grpc/PacketBrokerTest.kt
@@ -40,7 +40,7 @@ class PacketBrokerTest {
     PacketBroker(fakeProcessor(*results), kotlinx.coroutines.sync.Mutex())
 
   @Test
-  fun `processPacket returns outputs and trace`() {
+  fun `processPacket returns outputs and trace`(): Unit = runBlocking {
     val expected = result(outputPacket(1, byteArrayOf(0xAB.toByte())))
     val broker = broker(0 to expected)
 
@@ -49,7 +49,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `processPacket forwards packet bit length`() {
+  fun `processPacket forwards packet bit length`(): Unit = runBlocking {
     var capturedBitLength = -1
     val broker =
       PacketBroker(
@@ -66,7 +66,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `subscriber receives result with input and outputs`() {
+  fun `subscriber receives result with input and outputs`(): Unit = runBlocking {
     val outputs = listOf(outputPacket(1))
     val broker = broker(0 to result(outputPacket(1)))
 
@@ -81,7 +81,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `subscriber receives PacketBits for padded packet`() {
+  fun `subscriber receives PacketBits for padded packet`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
     val received = mutableListOf<PacketBroker.SubscriptionResult>()
     broker.subscribe { received.add(it) }
@@ -99,7 +99,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `multiple subscribers each receive results`() {
+  fun `multiple subscribers each receive results`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
 
     val received1 = mutableListOf<PacketBroker.SubscriptionResult>()
@@ -114,13 +114,13 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `no subscribers does not cause errors`() {
+  fun `no subscribers does not cause errors`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
     broker.processPacket(0, byteArrayOf())
   }
 
   @Test
-  fun `unsubscribe stops delivery`() {
+  fun `unsubscribe stops delivery`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
 
     val received = mutableListOf<PacketBroker.SubscriptionResult>()
@@ -135,7 +135,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `subscriber receives tag from processPacket`() {
+  fun `subscriber receives tag from processPacket`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
     val received = mutableListOf<PacketBroker.SubscriptionResult>()
     broker.subscribe { received.add(it) }
@@ -147,7 +147,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `throwing subscriber does not crash caller or block other subscribers`() {
+  fun `throwing subscriber does not crash caller or block other subscribers`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
 
     val received = mutableListOf<PacketBroker.SubscriptionResult>()
@@ -197,7 +197,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `processPacket fires hook when registered`() {
+  fun `processPacket fires hook when registered`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
     val hookCount = registerAutoRespondHook(broker)
 
@@ -207,7 +207,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `processPacket fires hook on every call`() {
+  fun `processPacket fires hook on every call`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
     val hookCount = registerAutoRespondHook(broker)
 
@@ -219,7 +219,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `processPacket works without hook`() {
+  fun `processPacket works without hook`(): Unit = runBlocking {
     val expected = result(outputPacket(1))
     val broker = broker(0 to expected)
 
@@ -229,7 +229,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `withHookOnce fires hook exactly once for multiple packets`() {
+  fun `withHookOnce fires hook exactly once for multiple packets`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
     val hookCount = registerAutoRespondHook(broker)
 
@@ -243,7 +243,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `withHookOnce without hook does not fire hook`() {
+  fun `withHookOnce without hook does not fire hook`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
     // No hook registered.
     val processed = AtomicInteger(0)
@@ -257,7 +257,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `registerHook fails if hook already registered`() {
+  fun `registerHook fails if hook already registered`(): Unit = runBlocking {
     val broker = broker(0 to result())
     val hook1 = PacketBroker.Hook(Channel(Channel.UNLIMITED), Channel(Channel.UNLIMITED))
     val hook2 = PacketBroker.Hook(Channel(Channel.UNLIMITED), Channel(Channel.UNLIMITED))
@@ -267,7 +267,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `deregisterHook allows re-registration`() {
+  fun `deregisterHook allows re-registration`(): Unit = runBlocking {
     val broker = broker(0 to result())
     val hook1 = PacketBroker.Hook(Channel(Channel.UNLIMITED), Channel(Channel.UNLIMITED))
     val hook2 = PacketBroker.Hook(Channel(Channel.UNLIMITED), Channel(Channel.UNLIMITED))
@@ -278,7 +278,7 @@ class PacketBrokerTest {
   }
 
   @Test
-  fun `hook applyUpdates is called when response has updates`() {
+  fun `hook applyUpdates is called when response has updates`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
     val appliedUpdates = mutableListOf<p4.v1.P4RuntimeOuterClass.Update>()
     broker.applyUpdates = { updates -> appliedUpdates.addAll(updates) }


### PR DESCRIPTION
## Summary

Fixes the dataplane result subscription path so a slow `SubscribeResults` consumer applies coroutine backpressure instead of closing the stream when the flow buffer fills. This preserves the lossless result contract used by batch `InjectPackets` callers.

The broker dispatch path is now suspend-aware end to end, so `SubscribeResults` can call `send()` directly instead of bridging from synchronous dispatch with `runBlocking`. Batch injection also processes packets through that suspend-aware path without buffering the whole request stream.

Adds regression coverage for the observed C++ client failure by injecting 10,000 packets before draining results, and updates the Kotlin service test to assert that delayed subscribers still receive every result.

## Review follow-up

Documented the `PacketBroker.subscribe` backpressure contract and switched `subscribeResults` to `channelFlow`, since result delivery is now coroutine-native rather than callback-bridged.

## Root cause

`DataplaneService.subscribeResults` used `trySend()` and closed the stream whenever it failed. When the callbackFlow buffer filled, `trySend()` failed without an exception, so the server closed the result stream cleanly and the C++ client surfaced it as `CANCELLED: ResultStream::Next: server closed the stream`.

## Follow-up

Opened #741 to consider a cleaner long-term API where batch injection owns its result stream explicitly.

## Validation

- `./tools/format.sh`
- `bazel test //grpc:PacketBrokerTest --test_output=errors`
- `bazel test //grpc:DataplaneServiceTest --test_output=errors`
- `bazel test //fourward_cc:dataplane_client_e2e_test --test_output=errors`
- `./tools/lint.sh`