### PR TITLE
Capture subprocess stdout/stderr in FourwardServer

### DIFF
--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -134,6 +134,7 @@ cc_test(
     srcs = ["output_capture_test.cc"],
     deps = [
         ":output_capture",
+        "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -7,6 +7,17 @@ package(
 )
 
 cc_library(
+    name = "output_capture",
+    srcs = ["output_capture.cc"],
+    hdrs = ["output_capture.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/base:core_headers",
+        "@abseil-cpp//absl/synchronization",
+    ],
+)
+
+cc_library(
     name = "fourward_server",
     srcs = ["fourward_server.cc"],
     hdrs = ["fourward_server.h"],
@@ -18,6 +29,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":output_capture",
         "//grpc:dataplane_cc_grpc",
         "//grpc:dataplane_cc_proto",
         "@abseil-cpp//absl/cleanup",
@@ -114,6 +126,17 @@ cc_test(
         "@grpc//:grpc++",
         "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
         "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+    ],
+)
+
+cc_test(
+    name = "output_capture_test",
+    srcs = ["output_capture_test.cc"],
+    deps = [
+        ":output_capture",
+        "@abseil-cpp//absl/time",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -341,9 +341,11 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
 
   int stdout_tee_fd = options.tee ? STDOUT_FILENO : -1;
   int stderr_tee_fd = options.tee ? STDERR_FILENO : -1;
-  stdout_capture = OutputCapture::Start(stdout_pipe[0], stdout_tee_fd);
+  stdout_capture = OutputCapture::Start(stdout_pipe[0], stdout_tee_fd,
+                                        "[4ward stdout] ");
   stdout_pipe[0] = -1;  // Ownership transferred to OutputCapture.
-  stderr_capture = OutputCapture::Start(stderr_pipe[0], stderr_tee_fd);
+  stderr_capture = OutputCapture::Start(stderr_pipe[0], stderr_tee_fd,
+                                        "[4ward stderr] ");
   stderr_pipe[0] = -1;  // Ownership transferred to OutputCapture.
 
   absl::Time deadline = absl::Now() + options.startup_timeout;

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -358,10 +358,20 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
 
   absl::Time deadline = absl::Now() + options.startup_timeout;
   if (absl::Status s = WaitForPortFile(port_file, pid, deadline); !s.ok()) {
+    // Kill the child and drain the reader threads so the enriched status
+    // contains all server output, not just what was consumed so far.
+    KillAndReap(pid);
+    pid = -1;
+    stdout_capture->Join();
+    stderr_capture->Join();
     return EnrichWithCapturedOutput(s, stdout_capture, stderr_capture);
   }
   absl::StatusOr<int> port = ReadPortFile(port_file);
   if (!port.ok()) {
+    KillAndReap(pid);
+    pid = -1;
+    stdout_capture->Join();
+    stderr_capture->Join();
     return EnrichWithCapturedOutput(port.status(), stdout_capture,
                                     stderr_capture);
   }

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -187,13 +187,41 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   if (!scratch.ok()) return std::move(scratch).status();
   std::string port_file = absl::StrCat(*scratch, "/port");
 
-  // One guard owns every in-flight resource until Start() commits. On any
-  // early return (spawn failure, port-file timeout, malformed port, …) the
-  // guard kills the child and removes the scratch dir. On success we cancel
-  // it and transfer ownership of scratch to the FourwardServer instance.
+  // Pipes for capturing the child's stdout and stderr. Sentinels of -1
+  // mean "not yet created"; the cleanup guard closes any that are still open
+  // on early return.
+  int stdout_pipe[2] = {-1, -1};
+  int stderr_pipe[2] = {-1, -1};
+  if (::pipe(stdout_pipe) != 0) {
+    return absl::ErrnoToStatus(errno, "pipe (stdout)");
+  }
+  if (::pipe(stderr_pipe) != 0) {
+    ::close(stdout_pipe[0]);
+    ::close(stdout_pipe[1]);
+    return absl::ErrnoToStatus(errno, "pipe (stderr)");
+  }
+
+  // Captures must be declared before the guard so the guard (which runs
+  // first in destruction order) kills the child — unblocking the reader
+  // threads — before the captures' destructors join them.
   pid_t pid = -1;
+  std::unique_ptr<OutputCapture> stdout_capture;
+  std::unique_ptr<OutputCapture> stderr_capture;
+
+  // One guard owns every in-flight resource until Start() commits. On any
+  // early return (spawn failure, port-file timeout, malformed port, ...) the
+  // guard kills the child, closes pipe fds, joins reader threads, and removes
+  // the scratch dir. On success we cancel it and transfer ownership to the
+  // FourwardServer instance.
   absl::Cleanup guard = [&] {
     KillAndReap(pid);
+    // Kill first so the pipe write-ends close, then join reader threads.
+    stdout_capture.reset();
+    stderr_capture.reset();
+    if (stdout_pipe[0] >= 0) ::close(stdout_pipe[0]);
+    if (stdout_pipe[1] >= 0) ::close(stdout_pipe[1]);
+    if (stderr_pipe[0] >= 0) ::close(stderr_pipe[0]);
+    if (stderr_pipe[1] >= 0) ::close(stderr_pipe[1]);
     RemoveScratchDir(*scratch);
   };
 
@@ -255,11 +283,45 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
     return absl::ErrnoToStatus(rc, "posix_spawnattr_setpgroup");
   }
 
-  if (int rc = posix_spawn(&pid, server_path.c_str(), /*file_actions=*/nullptr,
-                           &attr, argv.data(), environ);
+  // Redirect the child's stdout/stderr to our pipes.
+  posix_spawn_file_actions_t file_actions;
+  if (int rc = posix_spawn_file_actions_init(&file_actions); rc != 0) {
+    return absl::ErrnoToStatus(rc, "posix_spawn_file_actions_init");
+  }
+  absl::Cleanup file_actions_destroy = [&] {
+    posix_spawn_file_actions_destroy(&file_actions);
+  };
+  // Child closes read-ends, dups write-ends onto stdout/stderr, then closes
+  // the original write-end fds (dup2 doesn't close the source).
+  posix_spawn_file_actions_addclose(&file_actions, stdout_pipe[0]);
+  posix_spawn_file_actions_addclose(&file_actions, stderr_pipe[0]);
+  posix_spawn_file_actions_adddup2(&file_actions, stdout_pipe[1],
+                                   STDOUT_FILENO);
+  posix_spawn_file_actions_adddup2(&file_actions, stderr_pipe[1],
+                                   STDERR_FILENO);
+  posix_spawn_file_actions_addclose(&file_actions, stdout_pipe[1]);
+  posix_spawn_file_actions_addclose(&file_actions, stderr_pipe[1]);
+
+  if (int rc = posix_spawn(&pid, server_path.c_str(), &file_actions, &attr,
+                           argv.data(), environ);
       rc != 0) {
     return absl::ErrnoToStatus(rc, "posix_spawn");
   }
+
+  // Parent closes write-ends (the child owns them now) and starts capturing
+  // from the read-ends. Mark write-end sentinels so the cleanup guard
+  // doesn't double-close.
+  ::close(stdout_pipe[1]);
+  stdout_pipe[1] = -1;
+  ::close(stderr_pipe[1]);
+  stderr_pipe[1] = -1;
+
+  int stdout_tee_fd = options.quiet ? -1 : STDOUT_FILENO;
+  int stderr_tee_fd = options.quiet ? -1 : STDERR_FILENO;
+  stdout_capture = OutputCapture::Start(stdout_pipe[0], stdout_tee_fd);
+  stdout_pipe[0] = -1;  // Ownership transferred to OutputCapture.
+  stderr_capture = OutputCapture::Start(stderr_pipe[0], stderr_tee_fd);
+  stderr_pipe[0] = -1;  // Ownership transferred to OutputCapture.
 
   absl::Time deadline = absl::Now() + options.startup_timeout;
   if (absl::Status s = WaitForPortFile(port_file, pid, deadline); !s.ok()) {
@@ -277,24 +339,31 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
 
   std::move(guard).Cancel();
   return FourwardServer(pid, *port, options.device_id, std::move(*scratch),
-                        std::move(channel));
+                        std::move(channel), std::move(stdout_capture),
+                        std::move(stderr_capture));
 }
 
 FourwardServer::FourwardServer(pid_t pid, int port, uint64_t device_id,
                                std::string scratch_dir,
-                               std::shared_ptr<grpc::Channel> channel)
+                               std::shared_ptr<grpc::Channel> channel,
+                               std::unique_ptr<OutputCapture> stdout_capture,
+                               std::unique_ptr<OutputCapture> stderr_capture)
     : pid_(pid),
       port_(port),
       device_id_(device_id),
       scratch_dir_(std::move(scratch_dir)),
-      channel_(std::move(channel)) {}
+      channel_(std::move(channel)),
+      stdout_capture_(std::move(stdout_capture)),
+      stderr_capture_(std::move(stderr_capture)) {}
 
 FourwardServer::FourwardServer(FourwardServer&& other) noexcept
     : pid_(std::exchange(other.pid_, -1)),
       port_(other.port_),
       device_id_(other.device_id_),
       scratch_dir_(std::move(other.scratch_dir_)),
-      channel_(std::move(other.channel_)) {}
+      channel_(std::move(other.channel_)),
+      stdout_capture_(std::move(other.stdout_capture_)),
+      stderr_capture_(std::move(other.stderr_capture_)) {}
 
 FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
   if (this != &other) {
@@ -304,6 +373,8 @@ FourwardServer& FourwardServer::operator=(FourwardServer&& other) noexcept {
     device_id_ = other.device_id_;
     scratch_dir_ = std::move(other.scratch_dir_);
     channel_ = std::move(other.channel_);
+    stdout_capture_ = std::move(other.stdout_capture_);
+    stderr_capture_ = std::move(other.stderr_capture_);
   }
   return *this;
 }
@@ -317,8 +388,22 @@ void FourwardServer::Shutdown() {
   channel_.reset();
   KillAndReap(pid_);
   pid_ = -1;
+  // Join reader threads (they see EOF once the child is dead) before removing
+  // the scratch dir, so all captured output is finalized.
+  stdout_capture_.reset();
+  stderr_capture_.reset();
   RemoveScratchDir(scratch_dir_);
   scratch_dir_.clear();
+}
+
+std::string FourwardServer::Stdout() const {
+  if (stdout_capture_ == nullptr) return "";
+  return stdout_capture_->CapturedOutput();
+}
+
+std::string FourwardServer::Stderr() const {
+  if (stderr_capture_ == nullptr) return "";
+  return stderr_capture_->CapturedOutput();
 }
 
 }  // namespace fourward

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -339,8 +339,8 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   ::close(stderr_pipe[1]);
   stderr_pipe[1] = -1;
 
-  int stdout_tee_fd = options.quiet ? -1 : STDOUT_FILENO;
-  int stderr_tee_fd = options.quiet ? -1 : STDERR_FILENO;
+  int stdout_tee_fd = options.tee ? STDOUT_FILENO : -1;
+  int stderr_tee_fd = options.tee ? STDERR_FILENO : -1;
   stdout_capture = OutputCapture::Start(stdout_pipe[0], stdout_tee_fd);
   stdout_pipe[0] = -1;  // Ownership transferred to OutputCapture.
   stderr_capture = OutputCapture::Start(stderr_pipe[0], stderr_tee_fd);

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -161,6 +161,29 @@ void KillAndReap(pid_t pid) {
   }
 }
 
+// Appends any captured stdout/stderr to the error message so the caller sees
+// server output inline with the failure reason — the key diagnostic when the
+// server crashes or misbehaves during startup.
+absl::Status EnrichWithCapturedOutput(
+    absl::Status status,
+    const std::unique_ptr<OutputCapture>& stdout_capture,
+    const std::unique_ptr<OutputCapture>& stderr_capture) {
+  std::string enriched = std::string(status.message());
+  if (stdout_capture != nullptr) {
+    std::string out = stdout_capture->CapturedOutput();
+    if (!out.empty()) {
+      absl::StrAppend(&enriched, "\n--- server stdout ---\n", out);
+    }
+  }
+  if (stderr_capture != nullptr) {
+    std::string err = stderr_capture->CapturedOutput();
+    if (!err.empty()) {
+      absl::StrAppend(&enriched, "\n--- server stderr ---\n", err);
+    }
+  }
+  return absl::Status(status.code(), enriched);
+}
+
 }  // namespace
 
 absl::StatusOr<FourwardServer> FourwardServer::Start(
@@ -325,10 +348,13 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
 
   absl::Time deadline = absl::Now() + options.startup_timeout;
   if (absl::Status s = WaitForPortFile(port_file, pid, deadline); !s.ok()) {
-    return s;
+    return EnrichWithCapturedOutput(s, stdout_capture, stderr_capture);
   }
   absl::StatusOr<int> port = ReadPortFile(port_file);
-  if (!port.ok()) return std::move(port).status();
+  if (!port.ok()) {
+    return EnrichWithCapturedOutput(port.status(), stdout_capture,
+                                    stderr_capture);
+  }
 
   grpc::ChannelArguments channel_args;
   channel_args.SetInt("grpc.max_metadata_size", options.max_metadata_size);

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -23,6 +23,8 @@
 #include <utility>
 #include <vector>
 
+#include "fourward_cc/output_capture.h"
+
 #include "absl/cleanup/cleanup.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -216,11 +218,13 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   int stdout_pipe[2] = {-1, -1};
   int stderr_pipe[2] = {-1, -1};
   if (::pipe(stdout_pipe) != 0) {
+    RemoveScratchDir(*scratch);
     return absl::ErrnoToStatus(errno, "pipe (stdout)");
   }
   if (::pipe(stderr_pipe) != 0) {
     ::close(stdout_pipe[0]);
     ::close(stdout_pipe[1]);
+    RemoveScratchDir(*scratch);
     return absl::ErrnoToStatus(errno, "pipe (stderr)");
   }
 
@@ -316,14 +320,18 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   };
   // Child closes read-ends, dups write-ends onto stdout/stderr, then closes
   // the original write-end fds (dup2 doesn't close the source).
-  posix_spawn_file_actions_addclose(&file_actions, stdout_pipe[0]);
-  posix_spawn_file_actions_addclose(&file_actions, stderr_pipe[0]);
-  posix_spawn_file_actions_adddup2(&file_actions, stdout_pipe[1],
-                                   STDOUT_FILENO);
-  posix_spawn_file_actions_adddup2(&file_actions, stderr_pipe[1],
-                                   STDERR_FILENO);
-  posix_spawn_file_actions_addclose(&file_actions, stdout_pipe[1]);
-  posix_spawn_file_actions_addclose(&file_actions, stderr_pipe[1]);
+  for (int rc : {
+           posix_spawn_file_actions_addclose(&file_actions, stdout_pipe[0]),
+           posix_spawn_file_actions_addclose(&file_actions, stderr_pipe[0]),
+           posix_spawn_file_actions_adddup2(&file_actions, stdout_pipe[1],
+                                            STDOUT_FILENO),
+           posix_spawn_file_actions_adddup2(&file_actions, stderr_pipe[1],
+                                            STDERR_FILENO),
+           posix_spawn_file_actions_addclose(&file_actions, stdout_pipe[1]),
+           posix_spawn_file_actions_addclose(&file_actions, stderr_pipe[1]),
+       }) {
+    if (rc != 0) return absl::ErrnoToStatus(rc, "posix_spawn_file_actions");
+  }
 
   if (int rc = posix_spawn(&pid, server_path.c_str(), &file_actions, &attr,
                            argv.data(), environ);

--- a/fourward_cc/fourward_server.h
+++ b/fourward_cc/fourward_server.h
@@ -39,12 +39,13 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
-#include "fourward_cc/output_capture.h"
 #include "grpc/dataplane.grpc.pb.h"
 #include "grpcpp/channel.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 
 namespace fourward {
+
+class OutputCapture;
 
 // A port override: either a raw dataplane port number or a P4Runtime port
 // name that gets resolved at pipeline load time.

--- a/fourward_cc/fourward_server.h
+++ b/fourward_cc/fourward_server.h
@@ -123,9 +123,9 @@ struct FourwardServerOptions {
   bool permit_keepalive_without_calls = true;
   int permit_keepalive_time_ms = 0;
 
-  // When true, captured stdout/stderr is not tee'd to the parent's original
-  // fds. The output is still captured and available via Stdout()/Stderr().
-  bool quiet = false;
+  // Tee captured stdout/stderr to the parent's original fds so server output
+  // appears in the test log. Disable to capture without console noise.
+  bool tee = true;
 
   // Maximum time to wait for Start() to complete.
   absl::Duration startup_timeout = absl::Seconds(5);

--- a/fourward_cc/fourward_server.h
+++ b/fourward_cc/fourward_server.h
@@ -39,6 +39,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
+#include "fourward_cc/output_capture.h"
 #include "grpc/dataplane.grpc.pb.h"
 #include "grpcpp/channel.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
@@ -122,6 +123,10 @@ struct FourwardServerOptions {
   bool permit_keepalive_without_calls = true;
   int permit_keepalive_time_ms = 0;
 
+  // When true, captured stdout/stderr is not tee'd to the parent's original
+  // fds. The output is still captured and available via Stdout()/Stderr().
+  bool quiet = false;
+
   // Maximum time to wait for Start() to complete.
   absl::Duration startup_timeout = absl::Seconds(5);
 };
@@ -169,10 +174,17 @@ class FourwardServer {
   const std::shared_ptr<grpc::Channel>& Channel() const { return channel_; }
   pid_t Pid() const { return pid_; }
 
+  // Subprocess stdout/stderr captured since Start(). Thread-safe; may be
+  // called while the server is still running to observe partial output.
+  std::string Stdout() const;
+  std::string Stderr() const;
+
  private:
   FourwardServer(pid_t pid, int port, uint64_t device_id,
                  std::string scratch_dir,
-                 std::shared_ptr<grpc::Channel> channel);
+                 std::shared_ptr<grpc::Channel> channel,
+                 std::unique_ptr<OutputCapture> stdout_capture,
+                 std::unique_ptr<OutputCapture> stderr_capture);
 
   // Kills the subprocess (SIGTERM → SIGKILL) and removes the scratch dir.
   void Shutdown();
@@ -183,6 +195,8 @@ class FourwardServer {
   // Scratch directory holding the `--port-file`. Removed on Shutdown.
   std::string scratch_dir_;
   std::shared_ptr<grpc::Channel> channel_;
+  std::unique_ptr<OutputCapture> stdout_capture_;
+  std::unique_ptr<OutputCapture> stderr_capture_;
 };
 
 }  // namespace fourward

--- a/fourward_cc/fourward_server_test.cc
+++ b/fourward_cc/fourward_server_test.cc
@@ -392,9 +392,9 @@ TEST(FourwardServerTest, StderrInitiallyEmptyForHealthyServer) {
       << "unexpected stderr: " << server->Stderr();
 }
 
-TEST(FourwardServerTest, QuietModeSuppressesTeeButStillCaptures) {
+TEST(FourwardServerTest, TeeDisabledStillCaptures) {
   absl::StatusOr<FourwardServer> server =
-      FourwardServer::Start({.quiet = true});
+      FourwardServer::Start({.tee = false});
   ASSERT_TRUE(server.ok()) << server.status();
   absl::SleepFor(absl::Milliseconds(100));
   EXPECT_THAT(server->Stdout(),

--- a/fourward_cc/fourward_server_test.cc
+++ b/fourward_cc/fourward_server_test.cc
@@ -18,7 +18,9 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "gmock/gmock.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/support/status.h"
 #include "gtest/gtest.h"
@@ -369,6 +371,44 @@ TEST(FourwardServerTest, LargeResponseSucceedsUnderDefaultLimits) {
       << "GetForwardingPipelineConfig failed on >4MB response: code="
       << get_status.error_code()
       << " msg=" << get_status.error_message();
+}
+
+TEST(FourwardServerTest, StdoutCapturesStartupMessage) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+  ASSERT_TRUE(server.ok()) << server.status();
+  absl::SleepFor(absl::Milliseconds(100));
+  std::string stdout_output = server->Stdout();
+  EXPECT_THAT(stdout_output,
+              ::testing::HasSubstr("P4Runtime server listening on port"));
+  EXPECT_THAT(stdout_output,
+              ::testing::HasSubstr(absl::StrCat(server->Port())));
+}
+
+TEST(FourwardServerTest, StderrInitiallyEmptyForHealthyServer) {
+  absl::StatusOr<FourwardServer> server = FourwardServer::Start();
+  ASSERT_TRUE(server.ok()) << server.status();
+  absl::SleepFor(absl::Milliseconds(100));
+  EXPECT_TRUE(server->Stderr().empty())
+      << "unexpected stderr: " << server->Stderr();
+}
+
+TEST(FourwardServerTest, QuietModeSuppressesTeeButStillCaptures) {
+  absl::StatusOr<FourwardServer> server =
+      FourwardServer::Start({.quiet = true});
+  ASSERT_TRUE(server.ok()) << server.status();
+  absl::SleepFor(absl::Milliseconds(100));
+  EXPECT_THAT(server->Stdout(),
+              ::testing::HasSubstr("P4Runtime server listening on port"));
+}
+
+TEST(FourwardServerTest, CapturedOutputSurvivesMove) {
+  absl::StatusOr<FourwardServer> original = FourwardServer::Start();
+  ASSERT_TRUE(original.ok()) << original.status();
+  absl::SleepFor(absl::Milliseconds(100));
+
+  FourwardServer moved = *std::move(original);
+  EXPECT_THAT(moved.Stdout(),
+              ::testing::HasSubstr("P4Runtime server listening on port"));
 }
 
 }  // namespace

--- a/fourward_cc/output_capture.cc
+++ b/fourward_cc/output_capture.cc
@@ -1,0 +1,78 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fourward_cc/output_capture.h"
+
+#include <unistd.h>
+
+#include <memory>
+#include <string>
+#include <thread>  // NOLINT(build/c++11)
+#include <utility>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+
+namespace fourward {
+
+class OutputCapture::Impl {
+ public:
+  Impl(int pipe_read_fd, int tee_fd)
+      : pipe_read_fd_(pipe_read_fd), tee_fd_(tee_fd) {}
+
+  void StartThread() {
+    thread_ = std::thread(&Impl::ReadLoop, this);
+  }
+
+  ~Impl() {
+    if (thread_.joinable()) thread_.join();
+  }
+
+  std::string CapturedOutput() const {
+    absl::MutexLock lock(mu_);
+    return buffer_;
+  }
+
+ private:
+  void ReadLoop() {
+    char buf[4096];
+    while (true) {
+      ssize_t n = ::read(pipe_read_fd_, buf, sizeof(buf));
+      if (n <= 0) break;  // EOF or error.
+      if (tee_fd_ >= 0) {
+        // Best-effort tee — partial writes are acceptable for diagnostic
+        // output; we don't retry on EINTR because the tee target (typically
+        // the parent's stdout/stderr) is not critical.
+        (void)::write(tee_fd_, buf, n);
+      }
+      absl::MutexLock lock(mu_);
+      buffer_.append(buf, n);
+    }
+    ::close(pipe_read_fd_);
+  }
+
+  const int pipe_read_fd_;
+  const int tee_fd_;
+  std::thread thread_;
+  mutable absl::Mutex mu_;
+  std::string buffer_ ABSL_GUARDED_BY(mu_);
+};
+
+std::unique_ptr<OutputCapture> OutputCapture::Start(int pipe_read_fd,
+                                                    int tee_fd) {
+  auto impl = std::make_unique<Impl>(pipe_read_fd, tee_fd);
+  impl->StartThread();
+  return std::unique_ptr<OutputCapture>(
+      new OutputCapture(std::move(impl)));
+}
+
+OutputCapture::OutputCapture(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
+
+OutputCapture::~OutputCapture() = default;
+
+std::string OutputCapture::CapturedOutput() const {
+  return impl_->CapturedOutput();
+}
+
+}  // namespace fourward

--- a/fourward_cc/output_capture.cc
+++ b/fourward_cc/output_capture.cc
@@ -6,21 +6,27 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstring>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace fourward {
 
 std::unique_ptr<OutputCapture> OutputCapture::Start(int pipe_read_fd,
-                                                    int tee_fd) {
+                                                    int tee_fd,
+                                                    std::string tee_prefix) {
   auto capture = std::unique_ptr<OutputCapture>(
-      new OutputCapture(pipe_read_fd, tee_fd));
+      new OutputCapture(pipe_read_fd, tee_fd, std::move(tee_prefix)));
   capture->thread_ = std::thread(&OutputCapture::ReadLoop, capture.get());
   return capture;
 }
 
-OutputCapture::OutputCapture(int pipe_read_fd, int tee_fd)
-    : pipe_read_fd_(pipe_read_fd), tee_fd_(tee_fd) {}
+OutputCapture::OutputCapture(int pipe_read_fd, int tee_fd,
+                             std::string tee_prefix)
+    : pipe_read_fd_(pipe_read_fd),
+      tee_fd_(tee_fd),
+      tee_prefix_(std::move(tee_prefix)) {}
 
 OutputCapture::~OutputCapture() {
   if (thread_.joinable()) thread_.join();
@@ -31,16 +37,42 @@ std::string OutputCapture::CapturedOutput() const {
   return buffer_;
 }
 
+// Best-effort write — partial writes are acceptable for diagnostic output.
+static void WriteAll(int fd, const char* data, size_t len) {
+  (void)::write(fd, data, len);
+}
+
 void OutputCapture::ReadLoop() {
   char buf[4096];
   while (true) {
     ssize_t n = ::read(pipe_read_fd_, buf, sizeof(buf));
     if (n > 0) {
       if (tee_fd_ >= 0) {
-        // Best-effort tee — partial writes are acceptable for diagnostic
-        // output; we don't retry on EINTR because the tee target (typically
-        // the parent's stdout/stderr) is not critical.
-        (void)::write(tee_fd_, buf, n);
+        if (tee_prefix_.empty()) {
+          WriteAll(tee_fd_, buf, n);
+        } else {
+          // Prepend the prefix at the start of each line so tee'd output is
+          // clearly attributed. Scan for newlines and insert the prefix after
+          // each one (and at the very start if we're at a line boundary).
+          const char* p = buf;
+          const char* end = buf + n;
+          while (p < end) {
+            if (tee_at_line_start_) {
+              WriteAll(tee_fd_, tee_prefix_.data(), tee_prefix_.size());
+              tee_at_line_start_ = false;
+            }
+            const char* nl = static_cast<const char*>(
+                std::memchr(p, '\n', end - p));
+            if (nl != nullptr) {
+              WriteAll(tee_fd_, p, nl - p + 1);
+              tee_at_line_start_ = true;
+              p = nl + 1;
+            } else {
+              WriteAll(tee_fd_, p, end - p);
+              p = end;
+            }
+          }
+        }
       }
       absl::MutexLock lock(mu_);
       buffer_.append(buf, n);

--- a/fourward_cc/output_capture.cc
+++ b/fourward_cc/output_capture.cc
@@ -28,7 +28,9 @@ OutputCapture::OutputCapture(int pipe_read_fd, int tee_fd,
       tee_fd_(tee_fd),
       tee_prefix_(std::move(tee_prefix)) {}
 
-OutputCapture::~OutputCapture() {
+OutputCapture::~OutputCapture() { Join(); }
+
+void OutputCapture::Join() {
   if (thread_.joinable()) thread_.join();
 }
 

--- a/fourward_cc/output_capture.cc
+++ b/fourward_cc/output_capture.cc
@@ -5,40 +5,37 @@
 
 #include <unistd.h>
 
+#include <cerrno>
 #include <memory>
 #include <string>
-#include <thread>  // NOLINT(build/c++11)
-#include <utility>
-
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
 
 namespace fourward {
 
-class OutputCapture::Impl {
- public:
-  Impl(int pipe_read_fd, int tee_fd)
-      : pipe_read_fd_(pipe_read_fd), tee_fd_(tee_fd) {}
+std::unique_ptr<OutputCapture> OutputCapture::Start(int pipe_read_fd,
+                                                    int tee_fd) {
+  auto capture = std::unique_ptr<OutputCapture>(
+      new OutputCapture(pipe_read_fd, tee_fd));
+  capture->thread_ = std::thread(&OutputCapture::ReadLoop, capture.get());
+  return capture;
+}
 
-  void StartThread() {
-    thread_ = std::thread(&Impl::ReadLoop, this);
-  }
+OutputCapture::OutputCapture(int pipe_read_fd, int tee_fd)
+    : pipe_read_fd_(pipe_read_fd), tee_fd_(tee_fd) {}
 
-  ~Impl() {
-    if (thread_.joinable()) thread_.join();
-  }
+OutputCapture::~OutputCapture() {
+  if (thread_.joinable()) thread_.join();
+}
 
-  std::string CapturedOutput() const {
-    absl::MutexLock lock(mu_);
-    return buffer_;
-  }
+std::string OutputCapture::CapturedOutput() const {
+  absl::MutexLock lock(mu_);
+  return buffer_;
+}
 
- private:
-  void ReadLoop() {
-    char buf[4096];
-    while (true) {
-      ssize_t n = ::read(pipe_read_fd_, buf, sizeof(buf));
-      if (n <= 0) break;  // EOF or error.
+void OutputCapture::ReadLoop() {
+  char buf[4096];
+  while (true) {
+    ssize_t n = ::read(pipe_read_fd_, buf, sizeof(buf));
+    if (n > 0) {
       if (tee_fd_ >= 0) {
         // Best-effort tee — partial writes are acceptable for diagnostic
         // output; we don't retry on EINTR because the tee target (typically
@@ -47,32 +44,14 @@ class OutputCapture::Impl {
       }
       absl::MutexLock lock(mu_);
       buffer_.append(buf, n);
+    } else if (n == 0) {
+      break;  // EOF.
+    } else if (errno != EINTR) {
+      break;  // Real error.
     }
-    ::close(pipe_read_fd_);
+    // EINTR: a signal interrupted the read — retry.
   }
-
-  const int pipe_read_fd_;
-  const int tee_fd_;
-  std::thread thread_;
-  mutable absl::Mutex mu_;
-  std::string buffer_ ABSL_GUARDED_BY(mu_);
-};
-
-std::unique_ptr<OutputCapture> OutputCapture::Start(int pipe_read_fd,
-                                                    int tee_fd) {
-  auto impl = std::make_unique<Impl>(pipe_read_fd, tee_fd);
-  impl->StartThread();
-  return std::unique_ptr<OutputCapture>(
-      new OutputCapture(std::move(impl)));
-}
-
-OutputCapture::OutputCapture(std::unique_ptr<Impl> impl)
-    : impl_(std::move(impl)) {}
-
-OutputCapture::~OutputCapture() = default;
-
-std::string OutputCapture::CapturedOutput() const {
-  return impl_->CapturedOutput();
+  ::close(pipe_read_fd_);
 }
 
 }  // namespace fourward

--- a/fourward_cc/output_capture.cc
+++ b/fourward_cc/output_capture.cc
@@ -37,19 +37,19 @@ std::string OutputCapture::CapturedOutput() const {
   return buffer_;
 }
 
-// Best-effort write — partial writes are acceptable for diagnostic output.
-static void WriteAll(int fd, const char* data, size_t len) {
+static void TeeWrite(int fd, const char* data, size_t len) {
   (void)::write(fd, data, len);
 }
 
 void OutputCapture::ReadLoop() {
+  bool at_line_start = true;
   char buf[4096];
   while (true) {
     ssize_t n = ::read(pipe_read_fd_, buf, sizeof(buf));
     if (n > 0) {
       if (tee_fd_ >= 0) {
         if (tee_prefix_.empty()) {
-          WriteAll(tee_fd_, buf, n);
+          TeeWrite(tee_fd_, buf, n);
         } else {
           // Prepend the prefix at the start of each line so tee'd output is
           // clearly attributed. Scan for newlines and insert the prefix after
@@ -57,18 +57,18 @@ void OutputCapture::ReadLoop() {
           const char* p = buf;
           const char* end = buf + n;
           while (p < end) {
-            if (tee_at_line_start_) {
-              WriteAll(tee_fd_, tee_prefix_.data(), tee_prefix_.size());
-              tee_at_line_start_ = false;
+            if (at_line_start) {
+              TeeWrite(tee_fd_, tee_prefix_.data(), tee_prefix_.size());
+              at_line_start = false;
             }
             const char* nl = static_cast<const char*>(
                 std::memchr(p, '\n', end - p));
             if (nl != nullptr) {
-              WriteAll(tee_fd_, p, nl - p + 1);
-              tee_at_line_start_ = true;
+              TeeWrite(tee_fd_, p, nl - p + 1);
+              at_line_start = true;
               p = nl + 1;
             } else {
-              WriteAll(tee_fd_, p, end - p);
+              TeeWrite(tee_fd_, p, end - p);
               p = end;
             }
           }

--- a/fourward_cc/output_capture.h
+++ b/fourward_cc/output_capture.h
@@ -48,9 +48,6 @@ class OutputCapture {
   std::thread thread_;
   mutable absl::Mutex mu_;
   std::string buffer_ ABSL_GUARDED_BY(mu_);
-  // Whether the last tee'd byte was a newline (or start-of-stream), meaning
-  // the next tee'd byte starts a new line that needs the prefix.
-  bool tee_at_line_start_ = true;
 };
 
 }  // namespace fourward

--- a/fourward_cc/output_capture.h
+++ b/fourward_cc/output_capture.h
@@ -34,6 +34,10 @@ class OutputCapture {
   OutputCapture(OutputCapture&&) = delete;
   OutputCapture& operator=(OutputCapture&&) = delete;
 
+  // Blocks until the reader thread has finished (the pipe write-end must be
+  // closed first, or this blocks forever). Safe to call multiple times.
+  void Join();
+
   // Returns a snapshot of captured output so far. Thread-safe.
   std::string CapturedOutput() const;
 

--- a/fourward_cc/output_capture.h
+++ b/fourward_cc/output_capture.h
@@ -6,6 +6,10 @@
 
 #include <memory>
 #include <string>
+#include <thread>  // NOLINT(build/c++11)
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 
 namespace fourward {
 
@@ -30,9 +34,15 @@ class OutputCapture {
   std::string CapturedOutput() const;
 
  private:
-  class Impl;
-  std::unique_ptr<Impl> impl_;
-  explicit OutputCapture(std::unique_ptr<Impl> impl);
+  OutputCapture(int pipe_read_fd, int tee_fd);
+
+  void ReadLoop();
+
+  const int pipe_read_fd_;
+  const int tee_fd_;
+  std::thread thread_;
+  mutable absl::Mutex mu_;
+  std::string buffer_ ABSL_GUARDED_BY(mu_);
 };
 
 }  // namespace fourward

--- a/fourward_cc/output_capture.h
+++ b/fourward_cc/output_capture.h
@@ -1,0 +1,40 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FOURWARD_CC_OUTPUT_CAPTURE_H_
+#define FOURWARD_CC_OUTPUT_CAPTURE_H_
+
+#include <memory>
+#include <string>
+
+namespace fourward {
+
+// Reads from a pipe fd in a background thread, appending to an in-memory
+// buffer and optionally teeing to a target fd. Not movable or copyable —
+// own via unique_ptr.
+class OutputCapture {
+ public:
+  // Creates an OutputCapture that reads from `pipe_read_fd` (takes ownership,
+  // closes on destruction) and optionally tees to `tee_fd` (-1 to suppress).
+  // Starts the reader thread immediately.
+  static std::unique_ptr<OutputCapture> Start(int pipe_read_fd, int tee_fd);
+
+  ~OutputCapture();
+
+  OutputCapture(const OutputCapture&) = delete;
+  OutputCapture& operator=(const OutputCapture&) = delete;
+  OutputCapture(OutputCapture&&) = delete;
+  OutputCapture& operator=(OutputCapture&&) = delete;
+
+  // Returns a snapshot of captured output so far. Thread-safe.
+  std::string CapturedOutput() const;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+  explicit OutputCapture(std::unique_ptr<Impl> impl);
+};
+
+}  // namespace fourward
+
+#endif  // FOURWARD_CC_OUTPUT_CAPTURE_H_

--- a/fourward_cc/output_capture.h
+++ b/fourward_cc/output_capture.h
@@ -20,8 +20,12 @@ class OutputCapture {
  public:
   // Creates an OutputCapture that reads from `pipe_read_fd` (takes ownership,
   // closes on destruction) and optionally tees to `tee_fd` (-1 to suppress).
+  // When teeing, `tee_prefix` is prepended to each line so tee'd output is
+  // clearly attributed (e.g. "[4ward stdout] "). The prefix only affects the
+  // tee target — the captured buffer always contains the raw output.
   // Starts the reader thread immediately.
-  static std::unique_ptr<OutputCapture> Start(int pipe_read_fd, int tee_fd);
+  static std::unique_ptr<OutputCapture> Start(int pipe_read_fd, int tee_fd,
+                                              std::string tee_prefix = "");
 
   ~OutputCapture();
 
@@ -34,15 +38,19 @@ class OutputCapture {
   std::string CapturedOutput() const;
 
  private:
-  OutputCapture(int pipe_read_fd, int tee_fd);
+  OutputCapture(int pipe_read_fd, int tee_fd, std::string tee_prefix);
 
   void ReadLoop();
 
   const int pipe_read_fd_;
   const int tee_fd_;
+  const std::string tee_prefix_;
   std::thread thread_;
   mutable absl::Mutex mu_;
   std::string buffer_ ABSL_GUARDED_BY(mu_);
+  // Whether the last tee'd byte was a newline (or start-of-stream), meaning
+  // the next tee'd byte starts a new line that needs the prefix.
+  bool tee_at_line_start_ = true;
 };
 
 }  // namespace fourward

--- a/fourward_cc/output_capture_test.cc
+++ b/fourward_cc/output_capture_test.cc
@@ -61,6 +61,35 @@ TEST(OutputCaptureTest, TeesDataToTargetFd) {
   ::close(tee_pipe[0]);
 }
 
+TEST(OutputCaptureTest, TeePrefixPrependedToEachLine) {
+  int capture_pipe[2];
+  ASSERT_EQ(::pipe(capture_pipe), 0);
+
+  int tee_pipe[2];
+  ASSERT_EQ(::pipe(tee_pipe), 0);
+
+  auto capture = OutputCapture::Start(capture_pipe[0], /*tee_fd=*/tee_pipe[1],
+                                      "[srv] ");
+
+  const std::string data = "line one\nline two\n";
+  ASSERT_EQ(::write(capture_pipe[1], data.data(), data.size()),
+            static_cast<ssize_t>(data.size()));
+  ::close(capture_pipe[1]);
+
+  absl::SleepFor(absl::Milliseconds(50));
+
+  // Captured buffer is raw — no prefix.
+  EXPECT_EQ(capture->CapturedOutput(), data);
+
+  // Tee target has the prefix on each line.
+  ::close(tee_pipe[1]);
+  char buf[256];
+  ssize_t n = ::read(tee_pipe[0], buf, sizeof(buf));
+  ASSERT_GT(n, 0);
+  EXPECT_EQ(std::string(buf, n), "[srv] line one\n[srv] line two\n");
+  ::close(tee_pipe[0]);
+}
+
 TEST(OutputCaptureTest, EmptyPipeReturnsEmptyString) {
   int fds[2];
   ASSERT_EQ(::pipe(fds), 0);

--- a/fourward_cc/output_capture_test.cc
+++ b/fourward_cc/output_capture_test.cc
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "absl/strings/str_cat.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "gtest/gtest.h"
@@ -68,6 +69,32 @@ TEST(OutputCaptureTest, EmptyPipeReturnsEmptyString) {
 
   absl::SleepFor(absl::Milliseconds(50));
   EXPECT_TRUE(capture->CapturedOutput().empty());
+}
+
+TEST(OutputCaptureTest, IncrementalCaptureWhileWriteEndOpen) {
+  int fds[2];
+  ASSERT_EQ(::pipe(fds), 0);
+  auto capture = OutputCapture::Start(fds[0], /*tee_fd=*/-1);
+
+  // First chunk: write and verify CapturedOutput() returns it while the
+  // write-end is still open (data still flowing).
+  const std::string chunk1 = "chunk one\n";
+  ASSERT_EQ(::write(fds[1], chunk1.data(), chunk1.size()),
+            static_cast<ssize_t>(chunk1.size()));
+  absl::SleepFor(absl::Milliseconds(50));
+  EXPECT_EQ(capture->CapturedOutput(), chunk1);
+
+  // Second chunk: verify CapturedOutput() now returns both chunks.
+  const std::string chunk2 = "chunk two\n";
+  ASSERT_EQ(::write(fds[1], chunk2.data(), chunk2.size()),
+            static_cast<ssize_t>(chunk2.size()));
+  absl::SleepFor(absl::Milliseconds(50));
+  EXPECT_EQ(capture->CapturedOutput(), absl::StrCat(chunk1, chunk2));
+
+  // Close the write-end and verify the final output matches.
+  ::close(fds[1]);
+  absl::SleepFor(absl::Milliseconds(50));
+  EXPECT_EQ(capture->CapturedOutput(), absl::StrCat(chunk1, chunk2));
 }
 
 TEST(OutputCaptureTest, LargeDataCapturedCorrectly) {

--- a/fourward_cc/output_capture_test.cc
+++ b/fourward_cc/output_capture_test.cc
@@ -1,0 +1,100 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fourward_cc/output_capture.h"
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "gtest/gtest.h"
+
+namespace fourward {
+namespace {
+
+TEST(OutputCaptureTest, CapturesWrittenData) {
+  int fds[2];
+  ASSERT_EQ(::pipe(fds), 0);
+  auto capture = OutputCapture::Start(fds[0], /*tee_fd=*/-1);
+
+  const std::string data = "hello, world\n";
+  ASSERT_EQ(::write(fds[1], data.data(), data.size()),
+            static_cast<ssize_t>(data.size()));
+  ::close(fds[1]);
+
+  // The reader thread exits once the write-end is closed. Give it a moment.
+  absl::SleepFor(absl::Milliseconds(50));
+  EXPECT_EQ(capture->CapturedOutput(), data);
+}
+
+TEST(OutputCaptureTest, TeesDataToTargetFd) {
+  int capture_pipe[2];
+  ASSERT_EQ(::pipe(capture_pipe), 0);
+
+  int tee_pipe[2];
+  ASSERT_EQ(::pipe(tee_pipe), 0);
+
+  auto capture =
+      OutputCapture::Start(capture_pipe[0], /*tee_fd=*/tee_pipe[1]);
+
+  const std::string data = "tee test\n";
+  ASSERT_EQ(::write(capture_pipe[1], data.data(), data.size()),
+            static_cast<ssize_t>(data.size()));
+  ::close(capture_pipe[1]);
+
+  absl::SleepFor(absl::Milliseconds(50));
+  EXPECT_EQ(capture->CapturedOutput(), data);
+
+  // Read from the tee target and verify the same data arrived.
+  ::close(tee_pipe[1]);  // Close write-end so read sees EOF after data.
+  // OutputCapture does not own the tee fd, but we need to close our copy
+  // of the write-end to unblock the read below.
+  char buf[64];
+  ssize_t n = ::read(tee_pipe[0], buf, sizeof(buf));
+  ASSERT_GT(n, 0);
+  EXPECT_EQ(std::string(buf, n), data);
+  ::close(tee_pipe[0]);
+}
+
+TEST(OutputCaptureTest, EmptyPipeReturnsEmptyString) {
+  int fds[2];
+  ASSERT_EQ(::pipe(fds), 0);
+  auto capture = OutputCapture::Start(fds[0], /*tee_fd=*/-1);
+  ::close(fds[1]);
+
+  absl::SleepFor(absl::Milliseconds(50));
+  EXPECT_TRUE(capture->CapturedOutput().empty());
+}
+
+TEST(OutputCaptureTest, LargeDataCapturedCorrectly) {
+  int fds[2];
+  ASSERT_EQ(::pipe(fds), 0);
+  auto capture = OutputCapture::Start(fds[0], /*tee_fd=*/-1);
+
+  // 1 MB of data, written in chunks to avoid filling the pipe buffer and
+  // blocking the writer (the reader thread drains concurrently).
+  constexpr int kTotalBytes = 1 << 20;
+  constexpr int kChunkSize = 4096;
+  std::string chunk(kChunkSize, 'x');
+  int written = 0;
+  while (written < kTotalBytes) {
+    int to_write =
+        std::min(kChunkSize, kTotalBytes - written);
+    ssize_t n = ::write(fds[1], chunk.data(), to_write);
+    ASSERT_GT(n, 0) << "write failed at offset " << written;
+    written += n;
+  }
+  ::close(fds[1]);
+
+  absl::SleepFor(absl::Milliseconds(100));
+  std::string captured = capture->CapturedOutput();
+  EXPECT_EQ(static_cast<int>(captured.size()), kTotalBytes);
+  EXPECT_EQ(captured, std::string(kTotalBytes, 'x'));
+}
+
+}  // namespace
+}  // namespace fourward


### PR DESCRIPTION
## Summary

`FourwardServer` now captures its child process's stdout and stderr via
pipes, making the output available programmatically through `Stdout()` and
`Stderr()` accessors. A `quiet` option suppresses teeing to the parent's
terminal while still capturing.

When `Start()` fails after the subprocess has been spawned (timeout, crash,
malformed port file), the error status includes whatever stdout/stderr the
server managed to produce -- the key diagnostic for understanding why a
server crashed.

- New `OutputCapture` helper: background reader thread drains a pipe fd
  into a thread-safe in-memory buffer, optionally teeing to a target fd.
- `FourwardServer::Start()` sets up `posix_spawn` file actions to redirect
  child stdout/stderr into pipes, then hands the read-ends to
  `OutputCapture` instances.
- Careful destruction ordering ensures the child is killed before reader
  threads are joined, avoiding deadlocks on early-return paths (e.g.
  startup timeout).
- Startup-failure error statuses are enriched with captured stdout/stderr
  so callers see server output inline with the failure reason.

### Follow-up cleanup

- **EINTR fix:** The `ReadLoop` previously broke on any `read() <= 0`,
  treating EINTR the same as EOF. A signal during read would silently stop
  capturing. Now retries on EINTR.
- **Pimpl removal:** `OutputCapture` had a pimpl (`unique_ptr<Impl>`) for
  ~20 lines of state with a single consumer. Fields now live directly in
  the class, cutting a layer of indirection.
- **Deprecated API cleanup:** `absl::MutexLock` pointer constructor
  replaced with the reference constructor.

## Test plan

- [x] `output_capture_test`: basic capture, tee, empty pipe, 1 MB data,
  incremental capture while write-end is still open
- [x] `fourward_server_test`: stdout contains startup message with port,
  stderr is empty for healthy server, quiet mode still captures, captured
  output survives move construction, startup timeout yields DEADLINE_EXCEEDED