### PR TITLE
Fix toDualEncoded crash for unmapped egress ports

### DIFF
--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -687,6 +687,7 @@ kt_jvm_test(
         "//simulator:p4data_java_proto",
         "//simulator:p4info_java_proto",
         "//simulator:p4runtime_java_proto",
+        "//simulator:p4types_java_proto",
         "//simulator:simulator_java_proto",
         "@fourward_maven//:com_google_protobuf_protobuf_java",
         "@fourward_maven//:io_grpc_grpc_api",

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -324,16 +324,10 @@ private fun OutputPacket.toDualEncoded(
     .setDataplaneEgressPort(dataplaneEgressPort)
     .setPayload(rawPayload)
     .apply {
-      if (pt != null) {
-        val p4rtPort =
-          pt.dataplaneToP4rt(dataplaneEgressPort)
-            ?: error(
-              "No P4Runtime port name for dataplane egress port $dataplaneEgressPort. " +
-                "Ensure the port has a @p4runtime_translation_mappings entry or was " +
-                "auto-allocated via a prior P4Runtime Write."
-            )
-        setP4RtEgressPort(p4rtPort)
-      }
+      // Egress ports may come from P4 pipeline logic (e.g. the CPU port, hardcoded
+      // by the architecture) that was never forward-allocated via a P4Runtime Write,
+      // so a missing reverse mapping is expected — same as for ingress ports above.
+      pt?.dataplaneToP4rt(dataplaneEgressPort)?.let { setP4RtEgressPort(it) }
       if (codec != null && dataplaneEgressPort == codec.cpuPort) {
         val rawPacketIn =
           p4.v1.P4RuntimeOuterClass.PacketIn.newBuilder()

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -437,7 +437,7 @@ class DataplaneServiceTest {
 
   @Test
   @Suppress("MagicNumber")
-  fun `toDualEncoded crashes when egress port has no P4RT mapping`() {
+  fun `unmapped egress port omits P4RT port but preserves PacketIn enrichment`() {
     val baseConfig =
       compileInlineP4(
         """

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -466,7 +466,7 @@ class DataplaneServiceTest {
         apply {
           h.pkt_in.setValid();
           h.pkt_in.ingress_port = sm.ingress_port;
-          h.pkt_in.target_egress_port = sm.egress_spec;
+          h.pkt_in.target_egress_port = sm.egress_port;
         }
       }
       control D(packet_out pkt, in headers_t h) {
@@ -477,8 +477,8 @@ class DataplaneServiceTest {
       )
 
     // Inject port translation: pretend the port type has @p4runtime_translation.
-    // This creates a PortTranslator with an empty translation table —
-    // dataplaneToP4rt(510) returns null, and toDualEncoded throws IllegalStateException.
+    // This creates a PortTranslator with an empty translation table, so
+    // dataplaneToP4rt(510) returns null and p4rt_egress_port is omitted.
     val config =
       baseConfig
         .toBuilder()
@@ -512,20 +512,17 @@ class DataplaneServiceTest {
         )
         .build()
 
-    val testHarness = FourwardTestHarness()
-    testHarness.use {
-      it.loadPipeline(config)
-      val payload = buildEthernetFrame(etherType = 0x0800)
-      val response = it.injectPacket(ingressPort = 0, payload = payload)
+    harness.loadPipeline(config)
+    val payload = buildEthernetFrame(etherType = 0x0800)
+    val response = harness.injectPacket(ingressPort = 0, payload = payload)
 
-      val output = response.possibleOutcomesList.single().getPackets(0)
-      assertEquals("should egress on CPU port", 510, output.dataplaneEgressPort)
-      assertTrue(
-        "p4rt_egress_port should be empty (no mapping for CPU port)",
-        output.p4RtEgressPort.isEmpty,
-      )
-      assertTrue("should have packet_in enrichment", output.hasPacketIn())
-    }
+    val output = response.possibleOutcomesList.single().getPackets(0)
+    assertEquals("should egress on CPU port", 510, output.dataplaneEgressPort)
+    assertTrue(
+      "p4rt_egress_port should be empty (no mapping for CPU port)",
+      output.p4RtEgressPort.isEmpty,
+    )
+    assertTrue("should have packet_in enrichment", output.hasPacketIn())
   }
 
   @Test
@@ -559,7 +556,7 @@ class DataplaneServiceTest {
         apply {
           h.pkt_in.setValid();
           h.pkt_in.ingress_port = sm.ingress_port;
-          h.pkt_in.target_egress_port = sm.egress_spec;
+          h.pkt_in.target_egress_port = sm.egress_port;
         }
       }
       control D(packet_out pkt, in headers_t h) {
@@ -606,23 +603,20 @@ class DataplaneServiceTest {
         )
         .build()
 
-    val testHarness = FourwardTestHarness()
-    testHarness.use {
-      it.loadPipeline(config)
-      val stub = DataplaneCoroutineStub(it.channel)
-      val (job, results) = subscribeAndAwaitActive(stub)
+    harness.loadPipeline(config)
+    val stub = DataplaneCoroutineStub(harness.channel)
+    val (job, results) = subscribeAndAwaitActive(stub)
 
-      it.injectPacket(ingressPort = 0, payload = buildEthernetFrame(etherType = 0x0800))
+    harness.injectPacket(ingressPort = 0, payload = buildEthernetFrame(etherType = 0x0800))
 
-      val msg = withTimeout(5000) { results.receive() }
-      assertTrue("should be a result", msg.hasResult())
-      val output = msg.result.possibleOutcomesList.single().getPackets(0)
-      assertEquals("should egress on CPU port", 510, output.dataplaneEgressPort)
-      assertTrue("p4rt_egress_port should be empty", output.p4RtEgressPort.isEmpty)
-      assertTrue("should have packet_in enrichment", output.hasPacketIn())
+    val msg = withTimeout(5000) { results.receive() }
+    assertTrue("should be a result", msg.hasResult())
+    val output = msg.result.possibleOutcomesList.single().getPackets(0)
+    assertEquals("should egress on CPU port", 510, output.dataplaneEgressPort)
+    assertTrue("p4rt_egress_port should be empty", output.p4RtEgressPort.isEmpty)
+    assertTrue("should have packet_in enrichment", output.hasPacketIn())
 
-      job.cancel()
-    }
+    job.cancel()
   }
 
   // =========================================================================

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -528,6 +528,103 @@ class DataplaneServiceTest {
     }
   }
 
+  @Test
+  @Suppress("MagicNumber")
+  fun `SubscribeResults survives unmapped egress port`() = runBlocking {
+    val baseConfig =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      @controller_header("packet_out")
+      header packet_out_t { bit<9> egress_port; }
+
+      @controller_header("packet_in")
+      header packet_in_t { bit<9> ingress_port; bit<9> target_egress_port; }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { packet_out_t pkt_out; packet_in_t pkt_in; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 510; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          h.pkt_in.setValid();
+          h.pkt_in.ingress_port = sm.ingress_port;
+          h.pkt_in.target_egress_port = sm.egress_spec;
+        }
+      }
+      control D(packet_out pkt, in headers_t h) {
+        apply { pkt.emit(h.pkt_in); pkt.emit(h.eth); }
+      }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val config =
+      baseConfig
+        .toBuilder()
+        .setDevice(
+          baseConfig.device
+            .toBuilder()
+            .setBehavioral(
+              baseConfig.device.behavioral
+                .toBuilder()
+                .setArchitecture(
+                  baseConfig.device.behavioral.architecture
+                    .toBuilder()
+                    .setPortTypeName("port_id_t")
+                )
+            )
+        )
+        .setP4Info(
+          baseConfig.p4Info
+            .toBuilder()
+            .setTypeInfo(
+              P4Types.P4TypeInfo.newBuilder()
+                .putNewTypes(
+                  "port_id_t",
+                  P4Types.P4NewTypeSpec.newBuilder()
+                    .setTranslatedType(
+                      P4Types.P4NewTypeTranslation.newBuilder()
+                        .setUri("")
+                        .setSdnString(
+                          P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance()
+                        )
+                    )
+                    .build(),
+                )
+            )
+        )
+        .build()
+
+    val testHarness = FourwardTestHarness()
+    testHarness.use {
+      it.loadPipeline(config)
+      val stub = DataplaneCoroutineStub(it.channel)
+      val (job, results) = subscribeAndAwaitActive(stub)
+
+      it.injectPacket(ingressPort = 0, payload = buildEthernetFrame(etherType = 0x0800))
+
+      val msg = withTimeout(5000) { results.receive() }
+      assertTrue("should be a result", msg.hasResult())
+      val output = msg.result.possibleOutcomesList.single().getPackets(0)
+      assertEquals("should egress on CPU port", 510, output.dataplaneEgressPort)
+      assertTrue("p4rt_egress_port should be empty", output.p4RtEgressPort.isEmpty)
+      assertTrue("should have packet_in enrichment", output.hasPacketIn())
+
+      job.cancel()
+    }
+  }
+
   // =========================================================================
   // PacketIn enrichment
   // =========================================================================

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -576,9 +576,7 @@ class DataplaneServiceTest {
               baseConfig.device.behavioral
                 .toBuilder()
                 .setArchitecture(
-                  baseConfig.device.behavioral.architecture
-                    .toBuilder()
-                    .setPortTypeName("port_id_t")
+                  baseConfig.device.behavioral.architecture.toBuilder().setPortTypeName("port_id_t")
                 )
             )
         )
@@ -593,9 +591,7 @@ class DataplaneServiceTest {
                     .setTranslatedType(
                       P4Types.P4NewTypeTranslation.newBuilder()
                         .setUri("")
-                        .setSdnString(
-                          P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance()
-                        )
+                        .setSdnString(P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance())
                     )
                     .build(),
                 )

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -34,6 +34,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
+import p4.config.v1.P4Types
 
 class DataplaneServiceTest {
 
@@ -433,6 +434,99 @@ class DataplaneServiceTest {
 
   // Positive dual-encoding tests (P4RT port injection and response population) are in
   // SaiP4E2ETest, which uses a program with @controller_header and @p4runtime_translation.
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `toDualEncoded crashes when egress port has no P4RT mapping`() {
+    val baseConfig =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      @controller_header("packet_out")
+      header packet_out_t { bit<9> egress_port; }
+
+      @controller_header("packet_in")
+      header packet_in_t { bit<9> ingress_port; bit<9> target_egress_port; }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t { packet_out_t pkt_out; packet_in_t pkt_in; ethernet_t eth; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start { pkt.extract(hdr.eth); transition accept; }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = 510; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          h.pkt_in.setValid();
+          h.pkt_in.ingress_port = sm.ingress_port;
+          h.pkt_in.target_egress_port = sm.egress_spec;
+        }
+      }
+      control D(packet_out pkt, in headers_t h) {
+        apply { pkt.emit(h.pkt_in); pkt.emit(h.eth); }
+      }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    // Inject port translation: pretend the port type has @p4runtime_translation.
+    // This creates a PortTranslator with an empty translation table —
+    // dataplaneToP4rt(510) returns null, and toDualEncoded throws IllegalStateException.
+    val config =
+      baseConfig
+        .toBuilder()
+        .setDevice(
+          baseConfig.device
+            .toBuilder()
+            .setBehavioral(
+              baseConfig.device.behavioral
+                .toBuilder()
+                .setArchitecture(
+                  baseConfig.device.behavioral.architecture.toBuilder().setPortTypeName("port_id_t")
+                )
+            )
+        )
+        .setP4Info(
+          baseConfig.p4Info
+            .toBuilder()
+            .setTypeInfo(
+              P4Types.P4TypeInfo.newBuilder()
+                .putNewTypes(
+                  "port_id_t",
+                  P4Types.P4NewTypeSpec.newBuilder()
+                    .setTranslatedType(
+                      P4Types.P4NewTypeTranslation.newBuilder()
+                        .setUri("")
+                        .setSdnString(P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance())
+                    )
+                    .build(),
+                )
+            )
+        )
+        .build()
+
+    val testHarness = FourwardTestHarness()
+    testHarness.use {
+      it.loadPipeline(config)
+      val payload = buildEthernetFrame(etherType = 0x0800)
+      val response = it.injectPacket(ingressPort = 0, payload = payload)
+
+      val output = response.possibleOutcomesList.single().getPackets(0)
+      assertEquals("should egress on CPU port", 510, output.dataplaneEgressPort)
+      assertTrue(
+        "p4rt_egress_port should be empty (no mapping for CPU port)",
+        output.p4RtEgressPort.isEmpty,
+      )
+      assertTrue("should have packet_in enrichment", output.hasPacketIn())
+    }
+  }
 
   // =========================================================================
   // PacketIn enrichment


### PR DESCRIPTION
## Summary

- `toDualEncoded` crashed with `IllegalStateException` when an output packet egressed on a port without a P4RT mapping (e.g. the CPU port, which is set by the architecture and never forward-allocated via P4Runtime).
- On the `InjectPacket` path this surfaced as a gRPC `INTERNAL` error. On the `SubscribeResults` path — which DVaaS uses — the crash in the subscriber callback killed the entire subscription stream.
- The fix skips setting `p4rt_egress_port` when no mapping exists, matching the existing behavior for ingress ports (line 193).

## Test plan

- [x] New test: `toDualEncoded crashes when egress port has no P4RT mapping` — injects port translation into a compiled config to create an empty `PortTranslator`, verifies the output packet has no `p4rt_egress_port` but still gets `PacketIn` enrichment.
- [x] `DataplaneServiceTest` passes (29 tests).
- [x] `SaiP4E2ETest` passes (existing tests with pre-populated CPU port mappings still work).

Fixes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)