### PR TITLE
Fix direct resource instance name mismatch between p4info and IR

### DIFF
--- a/simulator/DirectResourceUsage.kt
+++ b/simulator/DirectResourceUsage.kt
@@ -193,13 +193,32 @@ private fun deriveExplicitDirectResourceActions(
 private fun ActionDecl.p4RuntimeNames(): List<String> =
   listOf(name, currentName).filter { it.isNotEmpty() }
 
-private fun directResourceInstanceNames(preamble: P4InfoOuterClass.Preamble): Set<String> =
-  buildSet {
-    for (name in listOf(preamble.name, preamble.alias)) {
-      if (name.isEmpty()) continue
-      add(name)
-      add(name.replace('.', '_'))
-      add(name.substringAfterLast('.'))
+// Generates all name variants under which an action body might reference this
+// direct resource. p4info uses dot-separated fully-qualified names
+// ("ingress.ctrl.counter"); the IR uses midend-qualified names that may not
+// match any simple normalization of the p4info name ("ctrl_ctrl_counter").
+// Including matching IR instance names closes the gap.
+private fun directResourceInstanceNames(
+  preamble: P4InfoOuterClass.Preamble,
+  irInstanceNames: List<String>?,
+): Set<String> = buildSet {
+  val p4infoNames = mutableSetOf<String>()
+  for (name in listOf(preamble.name, preamble.alias)) {
+    if (name.isEmpty()) continue
+    add(name)
+    p4infoNames.add(name)
+    add(name.replace('.', '_'))
+    p4infoNames.add(name.replace('.', '_'))
+    add(name.substringAfterLast('.'))
+    p4infoNames.add(name.substringAfterLast('.'))
+  }
+  // Match IR instance names whose suffix (after a '_' word boundary) matches
+  // a p4info-derived variant. This handles midend control-block qualification
+  // like "ctrl_ctrl_counter" where the p4info alias is "ctrl_counter".
+  irInstanceNames?.forEach { irName ->
+    if (irName in p4infoNames) return@forEach
+    if (p4infoNames.any { variant -> irName.endsWith("_$variant") }) {
+      add(irName)
     }
   }
 

--- a/simulator/DirectResourceUsage.kt
+++ b/simulator/DirectResourceUsage.kt
@@ -33,31 +33,32 @@ internal fun validateInlineDirectResourceActions(
   val actions = selectedActionNames(entry.action, tableName, context)
   if (actions.isEmpty()) return null
 
-  context.counterActionsByTable[tableName]?.let { allowedActions ->
-    if (entry.hasCounterData()) {
+  fun checkResource(
+    hasData: Boolean,
+    actionsByTable: Map<String, Set<String>>,
+    dataField: String,
+    resourceKind: String,
+  ): WriteResult? {
+    if (!hasData) return null
+    actionsByTable[tableName]?.let { allowedActions ->
       actions
         .firstOrNull { it !in allowedActions }
         ?.let { action ->
           return WriteResult.InvalidArgument(
-            "TableEntry contained counter_data, but action '$action' for table '$tableName' " +
-              "does not execute the table's direct counter"
+            "TableEntry contained $dataField, but action '$action' for table '$tableName' " +
+              "does not execute the table's direct $resourceKind"
           )
         }
     }
+    return null
   }
-  context.meterActionsByTable[tableName]?.let { allowedActions ->
-    if (entry.hasMeterConfig()) {
-      actions
-        .firstOrNull { it !in allowedActions }
-        ?.let { action ->
-          return WriteResult.InvalidArgument(
-            "TableEntry contained meter_config, but action '$action' for table '$tableName' " +
-              "does not execute the table's direct meter"
-          )
-        }
-    }
-  }
-  return null
+
+  return checkResource(
+    entry.hasCounterData(),
+    context.counterActionsByTable,
+    "counter_data",
+    "counter",
+  ) ?: checkResource(entry.hasMeterConfig(), context.meterActionsByTable, "meter_config", "meter")
 }
 
 private fun selectedActionNames(
@@ -118,7 +119,7 @@ internal fun deriveDirectResourceActions(
     )
   }
 
-  return deriveExplicitDirectResourceActions(p4info, tableNameById, actions)
+  return deriveExplicitDirectResourceActions(behavioral, p4info, tableNameById, actions)
 }
 
 private fun deriveV1ModelDirectResourceActions(
@@ -150,43 +151,53 @@ private fun deriveV1ModelDirectResourceActions(
 }
 
 private fun deriveExplicitDirectResourceActions(
+  behavioral: BehavioralConfig,
   p4info: P4InfoOuterClass.P4Info,
   tableNameById: Map<Int, String>,
   actions: List<ActionDecl>,
 ): DirectResourceActions {
-  val counterTableByInstance =
-    p4info.directCountersList.flatMap { counter ->
-      val tableName = tableNameById[counter.directTableId] ?: return@flatMap emptyList()
-      directResourceInstanceNames(counter.preamble).map { it to tableName }
-    }
-  val meterTableByInstance =
-    p4info.directMetersList.flatMap { meter ->
-      val tableName = tableNameById[meter.directTableId] ?: return@flatMap emptyList()
-      directResourceInstanceNames(meter.preamble).map { it to tableName }
-    }
-  val counterActionsByTable =
-    counterTableByInstance.map { it.second }.associateWith { mutableSetOf<String>() }
-  val meterActionsByTable =
-    meterTableByInstance.map { it.second }.associateWith { mutableSetOf<String>() }
-  val counterTableByInstanceName = counterTableByInstance.toMap()
-  val meterTableByInstanceName = meterTableByInstance.toMap()
+  // IR extern instance names (post-midend) may differ from p4info preamble
+  // names due to control-block qualification. Collect all IR names by extern
+  // type so we can match them to p4info entries below.
+  val irInstancesByType =
+    behavioral.controlsList.flatMap { it.externInstancesList }.groupBy({ it.typeName }, { it.name })
 
-  for (action in actions) {
-    val names = action.p4RuntimeNames()
-    for (instance in action.directResourceCalls("direct_counter", "count")) {
-      counterTableByInstanceName[instance]?.let { tableName ->
-        counterActionsByTable.getValue(tableName).addAll(names)
+  fun deriveForResource(
+    p4infoEntries: List<Pair<P4InfoOuterClass.Preamble, Int>>,
+    externType: String,
+    method: String,
+  ): Map<String, Set<String>> {
+    val tableByInstance =
+      p4infoEntries.flatMap { (preamble, directTableId) ->
+        val tableName = tableNameById[directTableId] ?: return@flatMap emptyList()
+        directResourceInstanceNames(preamble, irInstancesByType[externType]).map { it to tableName }
+      }
+    val actionsByTable = tableByInstance.map { it.second }.associateWith { mutableSetOf<String>() }
+    val tableByInstanceName = tableByInstance.toMap()
+    for (action in actions) {
+      val names = action.p4RuntimeNames()
+      for (instance in action.directResourceCalls(externType, method)) {
+        tableByInstanceName[instance]?.let { tableName ->
+          actionsByTable.getValue(tableName).addAll(names)
+        }
       }
     }
-    for (instance in action.directResourceCalls("direct_meter", "read")) {
-      meterTableByInstanceName[instance]?.let { tableName ->
-        meterActionsByTable.getValue(tableName).addAll(names)
-      }
-    }
+    return actionsByTable.mapValues { it.value.toSet() }
   }
+
   return DirectResourceActions(
-    counterActionsByTable.mapValues { it.value.toSet() },
-    meterActionsByTable.mapValues { it.value.toSet() },
+    counterActionsByTable =
+      deriveForResource(
+        p4info.directCountersList.map { it.preamble to it.directTableId },
+        "direct_counter",
+        "count",
+      ),
+    meterActionsByTable =
+      deriveForResource(
+        p4info.directMetersList.map { it.preamble to it.directTableId },
+        "direct_meter",
+        "read",
+      ),
   )
 }
 
@@ -220,6 +231,7 @@ private fun directResourceInstanceNames(
       add(irName)
     }
   }
+}
 
 private fun ActionDecl.directResourceCalls(externType: String, method: String): Set<String> =
   buildSet {

--- a/simulator/DirectResourceUsage.kt
+++ b/simulator/DirectResourceUsage.kt
@@ -202,16 +202,15 @@ private fun directResourceInstanceNames(
   preamble: P4InfoOuterClass.Preamble,
   irInstanceNames: List<String>?,
 ): Set<String> = buildSet {
-  val p4infoNames = mutableSetOf<String>()
-  for (name in listOf(preamble.name, preamble.alias)) {
-    if (name.isEmpty()) continue
-    add(name)
-    p4infoNames.add(name)
-    add(name.replace('.', '_'))
-    p4infoNames.add(name.replace('.', '_'))
-    add(name.substringAfterLast('.'))
-    p4infoNames.add(name.substringAfterLast('.'))
+  val p4infoNames = buildSet {
+    for (name in listOf(preamble.name, preamble.alias)) {
+      if (name.isEmpty()) continue
+      add(name)
+      add(name.replace('.', '_'))
+      add(name.substringAfterLast('.'))
+    }
   }
+  addAll(p4infoNames)
   // Match IR instance names whose suffix (after a '_' word boundary) matches
   // a p4info-derived variant. This handles midend control-block qualification
   // like "ctrl_ctrl_counter" where the p4info alias is "ctrl_counter".

--- a/simulator/DirectResourceUsageTest.kt
+++ b/simulator/DirectResourceUsageTest.kt
@@ -4,7 +4,9 @@ import com.google.protobuf.ByteString
 import fourward.ActionDecl
 import fourward.Architecture
 import fourward.BehavioralConfig
+import fourward.ControlDecl
 import fourward.DeviceConfig
+import fourward.ExternInstanceDecl
 import fourward.Expr
 import fourward.MethodCall
 import fourward.MethodCallStmt
@@ -244,6 +246,171 @@ class DirectResourceUsageTest {
     assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
   }
 
+  @Test
+  fun `explicit direct counter matches midend-qualified IR instance name`() {
+    // After p4c midend, a counter declared as "my_counter" inside control
+    // "my_ctrl" may appear in the IR as "my_ctrl_my_counter". The p4info
+    // preamble has name="ingress.my_ctrl.my_counter" and alias="my_counter".
+    // The action body references the IR name, not the p4info name.
+    val store = TableStore()
+    store.loadMappings(
+      p4info =
+        baseP4InfoBuilder()
+          .addDirectCounters(
+            P4InfoOuterClass.DirectCounter.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(DIRECT_COUNTER_ID)
+                  .setName("ingress.my_ctrl.my_counter")
+                  .setAlias("my_counter")
+              )
+              .setDirectTableId(TABLE_ID)
+          )
+          .build(),
+      device = deviceWithDirectCounterAction(counterInstanceName = "my_ctrl_my_counter"),
+    )
+    val entry = withCounterData(exactEntry(actionId = ACTION_10_ID))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+  }
+
+  @Test
+  fun `explicit direct counter rejects action without count even with qualified names`() {
+    val store = TableStore()
+    store.loadMappings(
+      p4info =
+        baseP4InfoBuilder()
+          .addDirectCounters(
+            P4InfoOuterClass.DirectCounter.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(DIRECT_COUNTER_ID)
+                  .setName("ingress.my_ctrl.my_counter")
+                  .setAlias("my_counter")
+              )
+              .setDirectTableId(TABLE_ID)
+          )
+          .build(),
+      device = deviceWithDirectCounterAction(counterInstanceName = "my_ctrl_my_counter"),
+    )
+    val entry = withCounterData(exactEntry(actionId = ACTION_20_ID))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertTrue("expected InvalidArgument, got $result", result is WriteResult.InvalidArgument)
+  }
+
+  @Test
+  fun `suffix match does not cross-contaminate counters on different tables`() {
+    val tableAId = 1
+    val tableBId = 2
+    val store = TableStore()
+    store.loadMappings(
+      p4info =
+        P4InfoOuterClass.P4Info.newBuilder()
+          .addTables(
+            P4InfoOuterClass.Table.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder().setId(tableAId).setAlias("tableA")
+              )
+              .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_10_ID))
+              .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_20_ID))
+          )
+          .addTables(
+            P4InfoOuterClass.Table.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder().setId(tableBId).setAlias("tableB")
+              )
+              .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_10_ID))
+              .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_20_ID))
+          )
+          .addActions(action(ACTION_10_ID, "action10"))
+          .addActions(action(ACTION_20_ID, "action20"))
+          .addDirectCounters(
+            P4InfoOuterClass.DirectCounter.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(801)
+                  .setName("ingress.ctrl.a_counter")
+                  .setAlias("a_counter")
+              )
+              .setDirectTableId(tableAId)
+          )
+          .addDirectCounters(
+            P4InfoOuterClass.DirectCounter.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(802)
+                  .setName("ingress.ctrl.b_counter")
+                  .setAlias("b_counter")
+              )
+              .setDirectTableId(tableBId)
+          )
+          .build(),
+      device =
+        DeviceConfig.newBuilder()
+          .setBehavioral(
+            BehavioralConfig.newBuilder()
+              .addTables(TableBehavior.newBuilder().setName("tableA"))
+              .addTables(TableBehavior.newBuilder().setName("tableB"))
+              .addActions(
+                ActionDecl.newBuilder()
+                  .setName("action10")
+                  .addBody(directResourceCall("ctrl_a_counter", "direct_counter", "count"))
+              )
+              .addActions(
+                ActionDecl.newBuilder()
+                  .setName("action20")
+                  .addBody(directResourceCall("ctrl_b_counter", "direct_counter", "count"))
+              )
+              .addControls(
+                ControlDecl.newBuilder()
+                  .setName("ctrl")
+                  .addExternInstances(
+                    ExternInstanceDecl.newBuilder()
+                      .setTypeName("direct_counter")
+                      .setName("ctrl_a_counter")
+                  )
+                  .addExternInstances(
+                    ExternInstanceDecl.newBuilder()
+                      .setTypeName("direct_counter")
+                      .setName("ctrl_b_counter")
+                  )
+              )
+          )
+          .build(),
+    )
+
+    val entryA =
+      TableEntry.newBuilder()
+        .setTableId(tableAId)
+        .addMatch(
+          FieldMatch.newBuilder()
+            .setFieldId(FIELD_ID)
+            .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(1))))
+        )
+        .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(ACTION_10_ID)))
+        .setCounterData(P4RuntimeOuterClass.CounterData.newBuilder().setPacketCount(1))
+        .build()
+    assertEquals(WriteResult.Success, store.writeAndPublish(insertUpdate(entryA)))
+
+    val entryA2 =
+      TableEntry.newBuilder()
+        .setTableId(tableAId)
+        .addMatch(
+          FieldMatch.newBuilder()
+            .setFieldId(FIELD_ID)
+            .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(2))))
+        )
+        .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(ACTION_20_ID)))
+        .setCounterData(P4RuntimeOuterClass.CounterData.newBuilder().setPacketCount(1))
+        .build()
+    val result = store.writeAndPublish(insertUpdate(entryA2))
+    assertTrue("expected InvalidArgument, got $result", result is WriteResult.InvalidArgument)
+  }
+
   private fun TableStore.writeAndPublish(update: Update): WriteResult =
     write(update).also { publishSnapshot() }
 
@@ -370,7 +537,9 @@ class DirectResourceUsageTest {
       )
       .build()
 
-  private fun deviceWithDirectCounterAction(): DeviceConfig =
+  private fun deviceWithDirectCounterAction(
+    counterInstanceName: String = "dc",
+  ): DeviceConfig =
     DeviceConfig.newBuilder()
       .setBehavioral(
         BehavioralConfig.newBuilder()
@@ -378,9 +547,18 @@ class DirectResourceUsageTest {
           .addActions(
             ActionDecl.newBuilder()
               .setName("action10")
-              .addBody(directResourceCall("dc", "direct_counter", "count"))
+              .addBody(directResourceCall(counterInstanceName, "direct_counter", "count"))
           )
           .addActions(ActionDecl.newBuilder().setName("action20"))
+          .addControls(
+            ControlDecl.newBuilder()
+              .setName("ctrl")
+              .addExternInstances(
+                ExternInstanceDecl.newBuilder()
+                  .setTypeName("direct_counter")
+                  .setName(counterInstanceName)
+              )
+          )
       )
       .build()
 


### PR DESCRIPTION
P4Runtime table writes with `counter_data` were rejected for actions
that explicitly call `counter.count()`, when the IR's midend-qualified
instance name didn't match any p4info preamble name variant.

Example: p4info says `ingress.my_ctrl.my_counter` (alias `my_counter`),
but the IR action body references `my_ctrl_my_counter` — a form the
lookup map didn't contain.

The fix collects `direct_counter` / `direct_meter` extern instance
names from the behavioral IR's control declarations and adds matching
ones to the lookup map, bridging the p4info↔IR naming gap. Only
affects the explicit-scan path (PSA/PNA); the v1model path was already
correct (it allows all actions unconditionally).

## Test plan

- New test: `explicit direct counter matches midend-qualified IR instance name` — verifies the fix
- New test: `explicit direct counter rejects action without count even with qualified names` — guards against over-matching
- Existing `DirectResourceUsageTest`, `TableStoreTest`, `P4RuntimeWriteErrorTest`, `P4RuntimeConformanceTest` all pass

Fixes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)