### PR TITLE
Test v1model direct counter validation with action profiles

### DIFF
--- a/simulator/DirectResourceUsageTest.kt
+++ b/simulator/DirectResourceUsageTest.kt
@@ -102,7 +102,7 @@ class DirectResourceUsageTest {
   // -------------------------------------------------------------------------
   // v1model + action profile/selector: counters fire implicitly on every hit,
   // so counter_data must be accepted even for actions that don't call count().
-  // Regression tests for https://github.com/4ward/issues/737.
+  // Regression tests for https://github.com/smolkaj/4ward/issues/737.
   // -------------------------------------------------------------------------
 
   @Test
@@ -121,8 +121,11 @@ class DirectResourceUsageTest {
   @Test
   fun `v1model action selector one-shot accepts counter data for action without explicit count`() {
     val store = TableStore()
-    store.loadMappings(p4info = p4infoWithActionSelectorDirectCounter(), device = v1modelDevice())
-    val entry = withCounterData(exactOneShotEntry(ACTION_10_ID, ACTION_20_ID))
+    store.loadMappings(
+      p4info = p4infoWithActionProfileDirectCounter(withSelector = true),
+      device = v1modelDevice(),
+    )
+    val entry = withCounterData(exactOneShotEntry(ACTION_20_ID))
 
     val result = store.writeAndPublish(insertUpdate(entry))
 
@@ -149,13 +152,7 @@ class DirectResourceUsageTest {
     write(update).also { publishSnapshot() }
 
   private fun exactEntry(actionId: Int): TableEntry =
-    TableEntry.newBuilder()
-      .setTableId(TABLE_ID)
-      .addMatch(
-        FieldMatch.newBuilder()
-          .setFieldId(FIELD_ID)
-          .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(10))))
-      )
+    exactEntryBuilder()
       .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId)))
       .build()
 
@@ -324,30 +321,14 @@ class DirectResourceUsageTest {
       )
       .build()
 
-  private fun p4infoWithActionProfileDirectCounter(): P4InfoOuterClass.P4Info =
+  private fun p4infoWithActionProfileDirectCounter(
+    withSelector: Boolean = false
+  ): P4InfoOuterClass.P4Info =
     baseP4InfoBuilder(implementationId = PROFILE_ID)
       .addActionProfiles(
         P4InfoOuterClass.ActionProfile.newBuilder()
           .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_ID))
-      )
-      .addDirectCounters(
-        P4InfoOuterClass.DirectCounter.newBuilder()
-          .setPreamble(
-            P4InfoOuterClass.Preamble.newBuilder()
-              .setId(DIRECT_COUNTER_ID)
-              .setName("dc")
-              .setAlias("dc")
-          )
-          .setDirectTableId(TABLE_ID)
-      )
-      .build()
-
-  private fun p4infoWithActionSelectorDirectCounter(): P4InfoOuterClass.P4Info =
-    baseP4InfoBuilder(implementationId = PROFILE_ID)
-      .addActionProfiles(
-        P4InfoOuterClass.ActionProfile.newBuilder()
-          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_ID))
-          .setWithSelector(true)
+          .setWithSelector(withSelector)
       )
       .addDirectCounters(
         P4InfoOuterClass.DirectCounter.newBuilder()

--- a/simulator/DirectResourceUsageTest.kt
+++ b/simulator/DirectResourceUsageTest.kt
@@ -99,6 +99,52 @@ class DirectResourceUsageTest {
     assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
   }
 
+  // -------------------------------------------------------------------------
+  // v1model + action profile/selector: counters fire implicitly on every hit,
+  // so counter_data must be accepted even for actions that don't call count().
+  // Regression tests for https://github.com/4ward/issues/737.
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun `v1model action profile member accepts counter data for action without explicit count`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithActionProfileDirectCounter(), device = v1modelDevice())
+    writeMember(store, memberId = 1, actionId = ACTION_20_ID)
+    val entry = withCounterData(exactMemberEntry(memberId = 1))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+  }
+
+  @Test
+  fun `v1model action selector one-shot accepts counter data for action without explicit count`() {
+    val store = TableStore()
+    store.loadMappings(p4info = p4infoWithActionSelectorDirectCounter(), device = v1modelDevice())
+    val entry = withCounterData(exactOneShotEntry(ACTION_10_ID, ACTION_20_ID))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertEquals(WriteResult.Success, result)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+  }
+
+  @Test
+  fun `non-v1model rejects counter data for action without explicit count`() {
+    val store = TableStore()
+    store.loadMappings(
+      p4info = p4infoWithNamedDirectCounter(),
+      device = deviceWithDirectCounterAction(),
+    )
+    val entry = withCounterData(exactEntry(actionId = ACTION_20_ID))
+
+    val result = store.writeAndPublish(insertUpdate(entry))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+  }
+
   private fun TableStore.writeAndPublish(update: Update): WriteResult =
     write(update).also { publishSnapshot() }
 
@@ -120,6 +166,24 @@ class DirectResourceUsageTest {
 
   private fun exactGroupEntry(groupId: Int): TableEntry =
     exactEntryBuilder().setAction(TableAction.newBuilder().setActionProfileGroupId(groupId)).build()
+
+  private fun exactOneShotEntry(vararg actionIds: Int): TableEntry =
+    exactEntryBuilder()
+      .setAction(
+        TableAction.newBuilder()
+          .setActionProfileActionSet(
+            P4RuntimeOuterClass.ActionProfileActionSet.newBuilder()
+              .addAllActionProfileActions(
+                actionIds.map { actionId ->
+                  P4RuntimeOuterClass.ActionProfileAction.newBuilder()
+                    .setAction(Action.newBuilder().setActionId(actionId))
+                    .setWeight(1)
+                    .build()
+                }
+              )
+          )
+      )
+      .build()
 
   private fun exactEntryBuilder(): TableEntry.Builder =
     TableEntry.newBuilder()
@@ -242,11 +306,48 @@ class DirectResourceUsageTest {
       )
       .build()
 
+  /**
+   * Like [p4infoWithDirectCounter], but with a name on the counter preamble so the explicit
+   * (non-v1model) path can match it against `directResourceCalls` in the action body.
+   */
+  private fun p4infoWithNamedDirectCounter(): P4InfoOuterClass.P4Info =
+    baseP4InfoBuilder()
+      .addDirectCounters(
+        P4InfoOuterClass.DirectCounter.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder()
+              .setId(DIRECT_COUNTER_ID)
+              .setName("dc")
+              .setAlias("dc")
+          )
+          .setDirectTableId(TABLE_ID)
+      )
+      .build()
+
   private fun p4infoWithActionProfileDirectCounter(): P4InfoOuterClass.P4Info =
     baseP4InfoBuilder(implementationId = PROFILE_ID)
       .addActionProfiles(
         P4InfoOuterClass.ActionProfile.newBuilder()
           .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_ID))
+      )
+      .addDirectCounters(
+        P4InfoOuterClass.DirectCounter.newBuilder()
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder()
+              .setId(DIRECT_COUNTER_ID)
+              .setName("dc")
+              .setAlias("dc")
+          )
+          .setDirectTableId(TABLE_ID)
+      )
+      .build()
+
+  private fun p4infoWithActionSelectorDirectCounter(): P4InfoOuterClass.P4Info =
+    baseP4InfoBuilder(implementationId = PROFILE_ID)
+      .addActionProfiles(
+        P4InfoOuterClass.ActionProfile.newBuilder()
+          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(PROFILE_ID))
+          .setWithSelector(true)
       )
       .addDirectCounters(
         P4InfoOuterClass.DirectCounter.newBuilder()


### PR DESCRIPTION
Adds regression tests for #737: v1model direct counters should be
accepted for action profile members and action selector one-shots even
when the action doesn't explicitly call `count()`, because v1model fires
direct counters implicitly on every table hit.

## Tests added

- **v1model + action profile member**: installs a profile member with an
  action that doesn't call `count()`, writes a table entry referencing
  it with `counter_data` -- asserts success.
- **v1model + action selector one-shot**: writes a one-shot
  `ActionProfileActionSet` entry with `counter_data` where one action
  doesn't call `count()` -- asserts success.
- **non-v1model rejects**: confirms the explicit (non-v1model) path
  still rejects `counter_data` when the action doesn't call `count()`.

All three tests pass on the current codebase, confirming the v1model
special-casing in `deriveV1ModelDirectResourceActions` already handles
these cases correctly. The tests lock in the behavior to prevent
regressions.

## Test plan
- [x] `bazel test //simulator:DirectResourceUsageTest` -- 8/8 pass
- [x] `./tools/format.sh` -- clean
- [x] `./tools/lint.sh` -- clean