### PR TITLE
Fix direct resource validation gaps

### DIFF
--- a/grpc/P4RuntimeConformanceTest.kt
+++ b/grpc/P4RuntimeConformanceTest.kt
@@ -1137,6 +1137,39 @@ class P4RuntimeConformanceTest {
     assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.installEntry(directCounterEntity) }
   }
 
+  /** P4Runtime spec §9.3.1: DirectCounterEntry can modify the default entry's counter. */
+  @Test
+  fun `54a - write default direct counter entry and read it back`() {
+    val config = loadConfigWithDirectCounter()
+    harness.loadPipeline(config)
+    val tableId = config.p4Info.tablesList.first().preamble.id
+    val dropActionId =
+      config.p4Info.actionsList.first { it.preamble.name.contains("drop") }.preamble.id
+    harness.modifyEntry(FourwardTestHarness.buildDefaultActionEntity(tableId, dropActionId))
+
+    val directCounterEntity =
+      Entity.newBuilder()
+        .setDirectCounterEntry(
+          P4RuntimeOuterClass.DirectCounterEntry.newBuilder()
+            .setTableEntry(defaultDirectExternTableEntry(tableId, dropActionId))
+            .setData(
+              P4RuntimeOuterClass.CounterData.newBuilder().setPacketCount(42).setByteCount(1000)
+            )
+        )
+        .build()
+    harness.modifyEntry(directCounterEntity)
+
+    val directRead = readDefaultDirectCounterEntry(tableId)
+    assertEquals(1, directRead.size)
+    assertEquals(42, directRead[0].directCounterEntry.data.packetCount)
+    assertEquals(1000, directRead[0].directCounterEntry.data.byteCount)
+
+    val tableRead = harness.readDefaultEntries(tableId)
+    assertEquals(1, tableRead.size)
+    assertEquals(42, tableRead[0].tableEntry.counterData.packetCount)
+    assertEquals(1000, tableRead[0].tableEntry.counterData.byteCount)
+  }
+
   // =========================================================================
   // Direct meter entries (scenarios 55-57)
   // =========================================================================
@@ -1219,6 +1252,47 @@ class P4RuntimeConformanceTest {
         )
         .build()
     assertGrpcError(Status.Code.INVALID_ARGUMENT) { harness.installEntry(directMeterEntity) }
+  }
+
+  /** P4Runtime spec §9.4.1: DirectMeterEntry can modify the default entry's meter config. */
+  @Test
+  fun `57a - write default direct meter entry and read it back`() {
+    val config = loadConfigWithDirectMeter()
+    harness.loadPipeline(config)
+    val tableId = config.p4Info.tablesList.first().preamble.id
+    val dropActionId =
+      config.p4Info.actionsList.first { it.preamble.name.contains("drop") }.preamble.id
+    harness.modifyEntry(FourwardTestHarness.buildDefaultActionEntity(tableId, dropActionId))
+
+    val directMeterEntity =
+      Entity.newBuilder()
+        .setDirectMeterEntry(
+          P4RuntimeOuterClass.DirectMeterEntry.newBuilder()
+            .setTableEntry(defaultDirectExternTableEntry(tableId, dropActionId))
+            .setConfig(
+              P4RuntimeOuterClass.MeterConfig.newBuilder()
+                .setCir(1000)
+                .setCburst(500)
+                .setPir(2000)
+                .setPburst(1000)
+            )
+        )
+        .build()
+    harness.modifyEntry(directMeterEntity)
+
+    val directRead = readDefaultDirectMeterEntry(tableId)
+    assertEquals(1, directRead.size)
+    assertEquals(1000, directRead[0].directMeterEntry.config.cir)
+    assertEquals(500, directRead[0].directMeterEntry.config.cburst)
+    assertEquals(2000, directRead[0].directMeterEntry.config.pir)
+    assertEquals(1000, directRead[0].directMeterEntry.config.pburst)
+
+    val tableRead = harness.readDefaultEntries(tableId)
+    assertEquals(1, tableRead.size)
+    assertEquals(1000, tableRead[0].tableEntry.meterConfig.cir)
+    assertEquals(500, tableRead[0].tableEntry.meterConfig.cburst)
+    assertEquals(2000, tableRead[0].tableEntry.meterConfig.pir)
+    assertEquals(1000, tableRead[0].tableEntry.meterConfig.pburst)
   }
 
   // =========================================================================
@@ -2741,6 +2815,55 @@ class P4RuntimeConformanceTest {
 
   private fun buildReadFilter(config: PipelineConfig, matchValue: Long): Entity =
     FourwardTestHarness.buildMatchFilter(config, matchValue)
+
+  private fun defaultDirectExternTableEntry(
+    tableId: Int,
+    actionId: Int,
+  ): P4RuntimeOuterClass.TableEntry =
+    P4RuntimeOuterClass.TableEntry.newBuilder()
+      .setTableId(tableId)
+      .setIsDefaultAction(true)
+      .setAction(
+        P4RuntimeOuterClass.TableAction.newBuilder()
+          .setAction(P4RuntimeOuterClass.Action.newBuilder().setActionId(actionId))
+      )
+      .build()
+
+  private fun readDefaultDirectCounterEntry(tableId: Int): List<Entity> =
+    harness.readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setDirectCounterEntry(
+              P4RuntimeOuterClass.DirectCounterEntry.newBuilder()
+                .setTableEntry(
+                  P4RuntimeOuterClass.TableEntry.newBuilder()
+                    .setTableId(tableId)
+                    .setIsDefaultAction(true)
+                )
+            )
+        )
+        .build()
+    )
+
+  private fun readDefaultDirectMeterEntry(tableId: Int): List<Entity> =
+    harness.readEntries(
+      ReadRequest.newBuilder()
+        .setDeviceId(1)
+        .addEntities(
+          Entity.newBuilder()
+            .setDirectMeterEntry(
+              P4RuntimeOuterClass.DirectMeterEntry.newBuilder()
+                .setTableEntry(
+                  P4RuntimeOuterClass.TableEntry.newBuilder()
+                    .setTableId(tableId)
+                    .setIsDefaultAction(true)
+                )
+            )
+        )
+        .build()
+    )
 
   /** Sends a raw SetForwardingPipelineConfig — bypasses the harness to test validation paths. */
   private fun loadRawPipeline(config: ForwardingPipelineConfig.Builder) = runBlocking {

--- a/grpc/P4RuntimeWriteErrorTest.kt
+++ b/grpc/P4RuntimeWriteErrorTest.kt
@@ -7,6 +7,7 @@ import fourward.grpc.FourwardTestHarness.Companion.assertGrpcError
 import fourward.grpc.FourwardTestHarness.Companion.buildExactEntry
 import io.grpc.Status
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import p4.v1.P4RuntimeOuterClass.CounterData
@@ -104,9 +105,9 @@ class P4RuntimeWriteErrorTest {
     assertGrpcError(Status.Code.NOT_FOUND) { harness.deleteEntry(entry) }
   }
 
-  // P4Runtime spec §12: DELETE ignores non-key fields, including counter_data.
+  // P4Runtime spec §9.1: counter_data is only valid for tables with a direct counter.
   @Test
-  fun `delete with counter data on table without direct counter succeeds`() {
+  fun `delete with counter data on table without direct counter returns INVALID_ARGUMENT`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
@@ -121,12 +122,15 @@ class P4RuntimeWriteErrorTest {
         )
         .build()
 
-    harness.deleteEntry(deleteEntry)
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "has no direct counter") {
+      harness.deleteEntry(deleteEntry)
+    }
+    assertEquals(1, harness.readEntry(entry).size)
   }
 
-  // P4Runtime spec §12: DELETE ignores non-key fields, including meter_config.
+  // P4Runtime spec §9.1: meter_config is only valid for tables with a direct meter.
   @Test
-  fun `delete with meter config on table without direct meter succeeds`() {
+  fun `delete with meter config on table without direct meter returns INVALID_ARGUMENT`() {
     val config = loadBasicTableConfig()
     harness.loadPipeline(config)
     val entry = buildExactEntry(config, matchValue = 0x0800, port = 1)
@@ -141,7 +145,10 @@ class P4RuntimeWriteErrorTest {
         )
         .build()
 
-    harness.deleteEntry(deleteEntry)
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "has no direct meter") {
+      harness.deleteEntry(deleteEntry)
+    }
+    assertEquals(1, harness.readEntry(entry).size)
   }
 
   // =========================================================================

--- a/simulator/DirectResourceUsageTest.kt
+++ b/simulator/DirectResourceUsageTest.kt
@@ -6,8 +6,8 @@ import fourward.Architecture
 import fourward.BehavioralConfig
 import fourward.ControlDecl
 import fourward.DeviceConfig
-import fourward.ExternInstanceDecl
 import fourward.Expr
+import fourward.ExternInstanceDecl
 import fourward.MethodCall
 import fourward.MethodCallStmt
 import fourward.NameRef
@@ -163,19 +163,37 @@ class DirectResourceUsageTest {
   }
 
   @Test
-  fun `DELETE ignores counter data on table without direct counter`() {
+  fun `DELETE rejects counter data on table without direct counter`() {
     val store = TableStore()
     store.loadMappings(
       p4info = p4infoWithoutDirectResources(),
       device = deviceWithDirectCounterAction(),
     )
-    assertEquals(WriteResult.Success, store.writeAndPublish(insertUpdate(exactEntry(ACTION_20_ID))))
+    val inserted = insertUpdate(exactEntry(ACTION_20_ID))
+    assertEquals(WriteResult.Success, store.writeAndPublish(inserted))
     val delete = withCounterData(exactEntryBuilder().build())
 
     val result = store.writeAndPublish(deleteUpdate(delete))
 
-    assertEquals(WriteResult.Success, result)
-    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
+  }
+
+  @Test
+  fun `DELETE rejects meter config on table without direct meter`() {
+    val store = TableStore()
+    store.loadMappings(
+      p4info = p4infoWithoutDirectResources(),
+      device = deviceWithDirectMeterAction(),
+    )
+    val inserted = insertUpdate(exactEntry(ACTION_20_ID))
+    assertEquals(WriteResult.Success, store.writeAndPublish(inserted))
+    val delete = withMeterConfig(exactEntryBuilder().build())
+
+    val result = store.writeAndPublish(deleteUpdate(delete))
+
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
   }
 
   @Test
@@ -391,7 +409,7 @@ class DirectResourceUsageTest {
             .setFieldId(FIELD_ID)
             .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(1))))
         )
-        .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(ACTION_10_ID)))
+        .setAction(tableAction(ACTION_10_ID))
         .setCounterData(P4RuntimeOuterClass.CounterData.newBuilder().setPacketCount(1))
         .build()
     assertEquals(WriteResult.Success, store.writeAndPublish(insertUpdate(entryA)))
@@ -404,7 +422,7 @@ class DirectResourceUsageTest {
             .setFieldId(FIELD_ID)
             .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(byteArrayOf(2))))
         )
-        .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(ACTION_20_ID)))
+        .setAction(tableAction(ACTION_20_ID))
         .setCounterData(P4RuntimeOuterClass.CounterData.newBuilder().setPacketCount(1))
         .build()
     val result = store.writeAndPublish(insertUpdate(entryA2))
@@ -415,9 +433,7 @@ class DirectResourceUsageTest {
     write(update).also { publishSnapshot() }
 
   private fun exactEntry(actionId: Int): TableEntry =
-    exactEntryBuilder()
-      .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId)))
-      .build()
+    exactEntryBuilder().setAction(tableAction(actionId)).build()
 
   private fun exactMemberEntry(memberId: Int): TableEntry =
     exactEntryBuilder()
@@ -426,6 +442,9 @@ class DirectResourceUsageTest {
 
   private fun exactGroupEntry(groupId: Int): TableEntry =
     exactEntryBuilder().setAction(TableAction.newBuilder().setActionProfileGroupId(groupId)).build()
+
+  private fun tableAction(actionId: Int): TableAction.Builder =
+    TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId))
 
   private fun exactOneShotEntry(vararg actionIds: Int): TableEntry =
     exactEntryBuilder()
@@ -448,9 +467,7 @@ class DirectResourceUsageTest {
   private fun defaultEntry(actionId: Int? = null): TableEntry {
     val builder = TableEntry.newBuilder().setTableId(TABLE_ID).setIsDefaultAction(true)
     if (actionId != null) {
-      builder.setAction(
-        TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId))
-      )
+      builder.setAction(tableAction(actionId))
     }
     return builder.build()
   }
@@ -537,9 +554,7 @@ class DirectResourceUsageTest {
       )
       .build()
 
-  private fun deviceWithDirectCounterAction(
-    counterInstanceName: String = "dc",
-  ): DeviceConfig =
+  private fun deviceWithDirectCounterAction(counterInstanceName: String = "dc"): DeviceConfig =
     DeviceConfig.newBuilder()
       .setBehavioral(
         BehavioralConfig.newBuilder()

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -162,7 +162,6 @@ private fun validateInlineDirectResourceWrite(
   directMeterTables: Set<String>,
   context: DirectResourceActionValidationContext,
 ): WriteResult? {
-  if (updateType == Update.Type.DELETE) return null
   val rawEntry = write.rawEntry
   if (rawEntry.hasCounterData() && tableName !in directCounterTables) {
     return WriteResult.InvalidArgument(
@@ -174,6 +173,8 @@ private fun validateInlineDirectResourceWrite(
       "table '$tableName' has no direct meter, but TableEntry contained meter_config"
     )
   }
+  // DELETE matches by key, but inline direct-resource fields still have to be valid for the table.
+  if (updateType == Update.Type.DELETE) return null
   if (
     (rawEntry.hasCounterData() || rawEntry.hasMeterConfig()) &&
       write.effectiveEntryForValidation?.action?.typeCase ==

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -1924,25 +1924,25 @@ class TableStoreTest {
   }
 
   @Test
-  fun `delete ignores counter data for table without direct counter`() {
+  fun `delete rejects counter data for table without direct counter`() {
     val entry = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
     store.writeAndPublish(insertUpdate(entry))
 
     val result = store.writeAndPublish(deleteUpdate(withCounterData(entry)))
 
-    assertEquals(WriteResult.Success, result)
-    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
   }
 
   @Test
-  fun `delete ignores meter config for table without direct meter`() {
+  fun `delete rejects meter config for table without direct meter`() {
     val entry = exactEntry(fieldId = 1, value = byteArrayOf(100), actionId = 10)
     store.writeAndPublish(insertUpdate(entry))
 
     val result = store.writeAndPublish(deleteUpdate(withMeterConfig(entry)))
 
-    assertEquals(WriteResult.Success, result)
-    assertTrue(store.getTableEntries(TABLE_NAME).isEmpty())
+    assertTrue("expected InvalidArgument", result is WriteResult.InvalidArgument)
+    assertEquals(1, store.getTableEntries(TABLE_NAME).size)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- reject inline counter_data / meter_config on DELETE when the table lacks the matching direct resource
- update simulator and gRPC tests that previously encoded the invalid DELETE behavior
- add P4Runtime conformance coverage for default DirectCounterEntry and DirectMeterEntry MODIFY round-trips

## Notes
P4Runtime TableEntry direct-resource fields are only valid for tables with the corresponding direct resource. DELETE still ignores normal non-key entry content for matching, but it must not accept direct-resource fields that are invalid for the table.

For DirectCounterEntry / DirectMeterEntry writes to default entries, the direct extern write targets the resource attached to the embedded table entry. DirectMeterEntry explicitly ignores the embedded TableEntry action field, so the PR documents that behavior with tests rather than applying inline TableEntry action validation there.

## Validation
- ./tools/format.sh
- bazel test //grpc:P4RuntimeConformanceTest --test_output=errors
- bazel test //simulator:DirectResourceUsageTest --test_output=errors
- bazel test //grpc:EntityReaderTest //simulator:DirectResourceUsageTest //simulator:TableStoreTest //grpc:P4RuntimeWriteErrorTest //grpc:P4RuntimeConformanceTest --test_output=errors
- ./tools/lint.sh