### PR TITLE
Document meter rate behavior as out of scope

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -32,7 +32,7 @@ Legend:
 | Recirculate | Supported | Supported | Supported | PNA recirculate tracks pass count. |
 | Registers | Supported | Supported | Supported | Reproducers seed the packet-start register values read by the trace. |
 | Counters | Supported | Supported | Supported | Direct counters increment on table hits; PSA/PNA `Counter.count()` updates P4Runtime-readable counter state. |
-| Meters | Stub | Stub | Stub | Meter externs always return GREEN. |
+| Meters | Stub | Stub | Stub | Stubbed by design: configs round-trip, but meter externs always return GREEN and rate behavior is out of scope. |
 | Checksums | Supported | Supported | Supported | v1model checksum externs and PSA/PNA `InternetChecksum` are implemented. |
 | Hash externs | Supported | Supported | Supported | PSA/PNA support documented hash forms and algorithms. |
 | Random externs | Unsupported | Supported | Supported | v1model free-function `random()` is not implemented. |
@@ -57,7 +57,7 @@ Legend:
 | Action profile members/groups | Supported | CRUD, max size, empty groups, and selector references are tested. |
 | One-shot action selector entries | Supported | Validated and covered by table-store/write-validation tests. |
 | Counter entries | Supported | Indirect and direct counter read/write are tested. |
-| Meter entries | Partial | Config read/write works; per-color meter behavior is out of scope and meters always return GREEN. |
+| Meter entries | Partial | Config read/write works; token-bucket/rate behavior is permanently out of scope and meters always return GREEN. |
 | Register entries | Supported | MODIFY/read semantics and bounds checks are tested. |
 | PRE clone sessions | Supported | CRUD and Read support are tested. |
 | PRE multicast groups | Supported | CRUD and Read support are tested. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -38,9 +38,11 @@ guilt — just write it down so someone can find it later.
   without a body (e.g. `extern void f(out bit<32> d, bit<32> s)`) cannot be
   executed — their semantics exist only in architecture-specific libraries.
   Blocks 1 corpus test (`extern-funcs-bmv2`).
-- **Meters always return GREEN.** `meter.execute_meter()` and
-  `direct_meter.read()` always return GREEN (0). Rate limiting is not
-  simulated — there are no real packet rates in STF tests.
+- **Meters always return GREEN by design.** `meter.execute_meter()` and
+  `direct_meter.read()` always return GREEN (0). P4Runtime meter configs can be
+  written and read back, but token buckets, refill timing, and rate-based color
+  transitions are permanently out of scope: 4ward is a deterministic packet
+  simulator with no wall-clock traffic-rate model.
 - **`digest` is a no-op stub.** PSA `Digest.pack()` is accepted but doesn't
   deliver messages to the control plane. v1model `digest()` is not
   implemented and will crash at runtime.
@@ -75,10 +77,9 @@ guilt — just write it down so someone can find it later.
   to forward-allocate mappings, and provide explicit `TypeTranslation` entries
   for architecture-defined ports (like the CPU port) that auto-allocation
   cannot assign correctly.
-- **Direct meters always return GREEN.** Direct meter configs can be
-  written and read via P4Runtime, but the simulator does not perform
-  real rate limiting — `direct_meter.read()` always returns the default
-  color (GREEN).
+- **Direct meters always return GREEN by design.** Direct meter configs can be
+  written and read via P4Runtime, but `direct_meter.read()` does not consume or
+  refill buckets. It always returns the default color (GREEN).
 - **No digests or idle timeouts (by design).** Both are inherently
   time-dependent features that have no meaningful semantics in a reference
   simulator: there are no real packet rates to trigger digests, and no

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -324,6 +324,7 @@ kt_jvm_test(
     deps = [
         ":interpreter_test_dsl",
         ":ir_java_proto",
+        ":p4info_java_proto",
         ":p4runtime_java_proto",
         ":simulator",
         ":simulator_java_proto",

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -33,6 +33,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import p4.config.v1.P4InfoOuterClass
 import p4.v1.P4RuntimeOuterClass
 
 /**
@@ -151,6 +152,29 @@ class V1ModelArchitectureTest {
                       )
                       .setType(bitType(width))
                   )
+                  .setRight(
+                    Expr.newBuilder()
+                      .setLiteral(Literal.newBuilder().setInteger(value))
+                      .setType(bitType(width))
+                  )
+              )
+              .setType(Type.newBuilder().setBoolean(true))
+          )
+          .setThenBlock(BlockStmt.newBuilder().addStmts(body))
+      )
+      .build()
+
+  /** Wraps [body] in `if (name == value) { body }`. */
+  private fun ifNameEquals(name: String, value: Long, width: Int, body: Stmt): Stmt =
+    Stmt.newBuilder()
+      .setIfStmt(
+        IfStmt.newBuilder()
+          .setCondition(
+            Expr.newBuilder()
+              .setBinaryOp(
+                BinaryOp.newBuilder()
+                  .setOp(BinaryOperator.EQ)
+                  .setLeft(nameRef(name, bitType(width)))
                   .setRight(
                     Expr.newBuilder()
                       .setLiteral(Literal.newBuilder().setInteger(value))
@@ -581,6 +605,66 @@ class V1ModelArchitectureTest {
           ),
       )
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].dataplaneEgressPort)
+  }
+
+  @Test
+  fun `execute_meter returns GREEN even when meter config is present`() {
+    val config =
+      v1modelConfig(
+        ingressLocalVars =
+          listOf(VarDecl.newBuilder().setName("color").setType(bitType(8)).build()),
+        ingressStmts =
+          listOf(
+            methodCallStmt(
+              "my_meter",
+              "execute_meter",
+              bit(0, 32),
+              nameRef("color", bitType(8)),
+              targetType = namedType("meter"),
+            ),
+            ifNameEquals(
+              "color",
+              0,
+              8,
+              assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
+            ),
+          ),
+      )
+    val tableStore = TableStore()
+    tableStore.loadMappings(
+      p4info =
+        P4InfoOuterClass.P4Info.newBuilder()
+          .addMeters(
+            P4InfoOuterClass.Meter.newBuilder()
+              .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(1).setName("my_meter"))
+              .setSize(1)
+          )
+          .build()
+    )
+    assertEquals(
+      WriteResult.Success,
+      tableStore.write(
+        P4RuntimeOuterClass.Update.newBuilder()
+          .setType(P4RuntimeOuterClass.Update.Type.MODIFY)
+          .setEntity(
+            P4RuntimeOuterClass.Entity.newBuilder()
+              .setMeterEntry(
+                P4RuntimeOuterClass.MeterEntry.newBuilder()
+                  .setMeterId(1)
+                  .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(0))
+                  .setConfig(P4RuntimeOuterClass.MeterConfig.newBuilder().setCir(1).setPir(1))
+              )
+          )
+          .build()
+      ),
+    )
+    tableStore.publishSnapshot()
+
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)


### PR DESCRIPTION
## Summary
- Mark meter rate/token-bucket behavior as permanently out of scope in compatibility and limitations docs
- Keep P4Runtime meter config round-trip support documented separately from data-plane color behavior
- Add a v1model regression test showing configured meters still return GREEN

## Tests
- ./tools/format.sh
- bazel test //simulator:V1ModelArchitectureTest //simulator:TableStoreTest --test_filter='execute_meter|meter'
- bazel test //simulator:V1ModelArchitectureTest //simulator:TableStoreTest
- ./tools/lint.sh