### PR TITLE
Implement v1model random extern

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -35,7 +35,7 @@ Legend:
 | Meters | Stub | Stub | Stub | Stubbed by design: configs round-trip, but meter externs always return GREEN and rate behavior is out of scope. |
 | Checksums | Supported | Supported | Supported | v1model checksum externs and PSA/PNA `InternetChecksum` are implemented. |
 | Hash externs | Supported | Supported | Supported | PSA/PNA support documented hash forms and algorithms. |
-| Random externs | Unsupported | Supported | Supported | v1model free-function `random()` is not implemented. |
+| Random externs | Supported | Supported | Supported | v1model `random()` and PSA/PNA `Random.read()` are implemented. |
 | Digest externs | Unsupported | Stub | Stub | PSA/PNA `Digest.pack` is a no-op; v1model `digest()` is not implemented. |
 | v1model `truncate()` | Supported | N/A | N/A | Caps the emitted packet length after deparser; repeated calls keep the shortest requested length. |
 | PNA add-on-miss externs | N/A | N/A | Stub | `add_entry`, `allocate_flow_id`, and timer externs are simplified stubs. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -49,9 +49,6 @@ guilt — just write it down so someone can find it later.
 
 ## v1model gaps
 
-- **`random()` not implemented.** The v1model free-function form
-  `random(out bit<32> result, in bit<32> lo, in bit<32> hi)` is not
-  handled and will crash at runtime. (PSA/PNA `Random.read()` works.)
 - **`standard_metadata` queue depth fields are always zero.**
   `enq_qdepth`, `deq_qdepth`, and `deq_timedelta` are never populated.
   The simulator has no traffic manager queue model, so these fields stay

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -8,10 +8,21 @@ import fourward.PipelineStageEvent
 import fourward.TraceTree
 import fourward.TypeDecl
 import java.math.BigInteger
+import java.util.concurrent.ThreadLocalRandom
 import p4.v1.P4RuntimeOuterClass
 
 /** Simplified parameter descriptor: just name and type. */
 internal data class BlockParam(val name: String, val typeName: String)
+
+internal fun randomInInclusiveRange(lo: BigInteger, hi: BigInteger): BigInteger {
+  if (hi <= lo) return lo
+  val rangeSize = hi - lo + BigInteger.ONE
+  var offset: BigInteger
+  do {
+    offset = BigInteger(rangeSize.bitLength(), ThreadLocalRandom.current())
+  } while (offset >= rangeSize)
+  return lo + offset
+}
 
 /**
  * Reads the egress port from a [P4RuntimeOuterClass.Replica], supporting both `port` (bytes,
@@ -221,8 +232,12 @@ internal fun handleCommonExternMethod(
           val instance = externInstances[call.instanceName]
           val lo = instance?.constructorArgsList?.getOrNull(0)?.literal?.integer ?: 0L
           val hi = instance?.constructorArgsList?.getOrNull(1)?.literal?.integer ?: 0L
-          val value = if (hi > lo) kotlin.random.Random.nextLong(lo, hi + 1) else lo
-          BitVal(BitVector(BigInteger.valueOf(value), eval.returnType().bit.width))
+          BitVal(
+            BitVector(
+              randomInInclusiveRange(BigInteger.valueOf(lo), BigInteger.valueOf(hi)),
+              eval.returnType().bit.width,
+            )
+          )
         }
         else -> null
       }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -41,23 +41,20 @@ import java.math.BigInteger
  * Evaluates an extern argument as an Int, handling both sized (BitVal) and unsized (InfIntVal)
  * integer literals. p4c sometimes emits unsized literals for field list IDs.
  */
-private fun evalIntArg(eval: ExternEvaluator, index: Int): Int =
-  when (val arg = eval.evalArg(index)) {
-    is BitVal -> arg.bits.value.toInt()
-    is InfIntVal -> arg.value.toInt()
-    else -> error("expected integer argument at index $index, got: $arg")
-  }
+private fun evalIntArg(eval: ExternEvaluator, index: Int): Int = evalIntegerArg(eval, index).toInt()
 
 private fun evalPacketLengthArg(eval: ExternEvaluator, index: Int): Int {
-  val value =
-    when (val arg = eval.evalArg(index)) {
-      is BitVal -> arg.bits.value
-      is InfIntVal -> arg.value
-      else -> error("expected integer argument at index $index, got: $arg")
-    }
+  val value = evalIntegerArg(eval, index)
   require(value >= BigInteger.ZERO) { "packet length must be non-negative, got: $value" }
   return if (value > BigInteger.valueOf(Int.MAX_VALUE.toLong())) Int.MAX_VALUE else value.toInt()
 }
+
+private fun evalIntegerArg(eval: ExternEvaluator, index: Int): BigInteger =
+  when (val arg = eval.evalArg(index)) {
+    is BitVal -> arg.bits.value
+    is InfIntVal -> arg.value
+    else -> error("expected integer argument at index $index, got: $arg")
+  }
 
 /**
  * Benchmark-only knob for measuring the scaling impact of intra-packet parallelism. Not a public
@@ -1159,6 +1156,14 @@ class V1ModelArchitecture(
         val result = if (max > BigInteger.ZERO) base + hashVal.mod(max) else base
         val resultWidth = eval.argType(0).bit.width
         eval.writeOutArg(0, BitVal(BitVector(result, resultWidth)))
+        UnitVal
+      }
+      // random(out result, in lo, in hi): inclusive uniform random value in [lo, hi].
+      "random" -> {
+        val lo = evalIntegerArg(eval, 1)
+        val hi = evalIntegerArg(eval, 2)
+        val resultWidth = eval.argType(0).bit.width
+        eval.writeOutArg(0, BitVal(BitVector(randomInInclusiveRange(lo, hi), resultWidth)))
         UnitVal
       }
       // log_msg(msg) / log_msg(msg, data): debug output with {} placeholders.

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -672,6 +672,30 @@ class V1ModelArchitectureTest {
   }
 
   @Test
+  fun `random writes inclusive random value to out parameter`() {
+    val config =
+      v1modelConfig(
+        ingressLocalVars =
+          listOf(VarDecl.newBuilder().setName("value").setType(bitType(8)).build()),
+        ingressStmts =
+          listOf(
+            externCall("random", nameRef("value", bitType(8)), bit(7, 8), bit(7, 8)),
+            ifNameEquals(
+              "value",
+              7,
+              8,
+              assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
+            ),
+          ),
+      )
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].dataplaneEgressPort)
+  }
+
+  @Test
   fun `multicast fork trace tree has fork node`() {
     val config = v1modelConfig(assignField("sm", "mcast_grp", 1, 16))
     val tableStore = TableStore()


### PR DESCRIPTION
## Summary
- Implement v1model free-function `random(out result, lo, hi)` with inclusive bounds
- Share the inclusive random range helper with PSA/PNA `Random.read()`
- Add a v1model regression test proving the out parameter is written
- Mark random externs supported in the compatibility docs and remove the stale limitation
- Apply formatter cleanup required by detekt in `DirectResourceUsageTest`

Fixes #748

## Tests
- bazel test //simulator:V1ModelArchitectureTest --test_filter='random writes inclusive'
- bazel test //simulator:V1ModelArchitectureTest
- bazel test //simulator:V1ModelArchitectureTest //simulator:DirectResourceUsageTest
- bazel test //simulator:V1ModelArchitectureTest //simulator:PSAArchitectureTest //simulator:PNAArchitectureTest
- ./tools/format.sh
- ./tools/lint.sh