### PR TITLE
test: reproduce submit_to_ingress=0 egress port issue

### DIFF
--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -1,10 +1,18 @@
 package fourward.grpc
 
 import com.google.protobuf.ByteString
+import fourward.DataplaneGrpcKt.DataplaneCoroutineStub
 import fourward.PipelineConfig
+import fourward.SubscribeResultsRequest
+import fourward.SubscribeResultsResponse
 import fourward.TranslationEntry
 import fourward.TypeTranslation
 import io.grpc.Status
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -596,6 +604,54 @@ class SaiP4E2ETest {
       assertNull("data-plane output should not become PacketIn", response)
     }
   }
+
+  @Test
+  fun `PacketOut with submit_to_ingress=0 bypasses ingress and exits on egress_port`() =
+    runBlocking {
+      // Install routing entries that forward to Ethernet1. If ingress is truly bypassed,
+      // the packet still exits on Ethernet1 (from the PacketOut header), but via a
+      // different code path — the routing chain sets egress_spec via table lookup, while
+      // bypass sets it directly from packet_out_header.egress_port.
+      //
+      // To distinguish: also install an ACL drop rule. If ingress runs, the ACL drops
+      // the packet. If ingress is bypassed, the packet exits on egress_port.
+      installRoutingChain()
+      installAclEntry(findAction("acl_drop"))
+
+      val stub = DataplaneCoroutineStub(harness.channel)
+      val results = Channel<SubscribeResultsResponse>(UNLIMITED)
+      val job = launch {
+        stub.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
+          results.send(it)
+        }
+      }
+      val first = withTimeout(5000) { results.receive() }
+      assertTrue("first message should be SubscriptionActive", first.hasActive())
+
+      harness.openStream().use { session ->
+        session.arbitrate()
+        session.sendPacketOut(
+          buildCpuPacketOut(submitToIngress = false),
+          timeoutMs = FourwardTestHarness.NO_RESPONSE_TIMEOUT_MS,
+        )
+      }
+
+      val msg = withTimeout(5000) { results.receive() }
+      assertTrue("should be a result", msg.hasResult())
+      val outputs = msg.result.possibleOutcomesList.single().packetsList
+      assertEquals(
+        "submit_to_ingress=0 should bypass ingress (ACL drop) and exit on egress_port",
+        1,
+        outputs.size,
+      )
+      assertEquals(
+        "should exit on the PacketOut's egress_port",
+        "Ethernet1",
+        outputs[0].p4RtEgressPort.toStringUtf8(),
+      )
+
+      job.cancel()
+    }
 
   @Test
   fun `PacketOut with invalid translated metadata returns StreamError and keeps stream open`() {


### PR DESCRIPTION
## Summary

Adds a stronger test for PacketOut with `submit_to_ingress=0` (#734). The existing test only verifies absence of PacketIn; this one installs an ACL drop rule and checks the packet actually exits on the PacketOut's `egress_port` — proving ingress was bypassed.

**Expected outcome:** If ingress bypass works correctly, the packet exits on `Ethernet1` despite the ACL drop rule. If ingress runs (the bug from #734), the packet is dropped.

## Test plan

- [ ] CI confirms whether the test passes or fails (reproducing #734).

🤖 Generated with [Claude Code](https://claude.com/claude-code)