### PR TITLE
Increase FourwardServer startup timeout from 5s to 15s

### DIFF
--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
         "//grpc:dataplane_cc_grpc",
         "//grpc:dataplane_cc_proto",
         "@abseil-cpp//absl/cleanup",
+        "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -26,6 +26,7 @@
 #include "fourward_cc/output_capture.h"
 
 #include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -356,7 +357,8 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
                                         "[4ward stderr] ");
   stderr_pipe[0] = -1;  // Ownership transferred to OutputCapture.
 
-  absl::Time deadline = absl::Now() + options.startup_timeout;
+  absl::Time start_time = absl::Now();
+  absl::Time deadline = start_time + options.startup_timeout;
   if (absl::Status s = WaitForPortFile(port_file, pid, deadline); !s.ok()) {
     // Kill the child and drain the reader threads so the enriched status
     // contains all server output, not just what was consumed so far.
@@ -367,6 +369,8 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
     return EnrichWithCapturedOutput(s, stdout_capture, stderr_capture);
   }
   absl::StatusOr<int> port = ReadPortFile(port_file);
+  VLOG(1) << "FourwardServer started in "
+          << absl::FormatDuration(absl::Now() - start_time);
   if (!port.ok()) {
     KillAndReap(pid);
     pid = -1;

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -373,11 +373,11 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   }
   absl::StatusOr<int> port = ReadPortFile(port_file);
   absl::Duration elapsed = absl::Now() - start_time;
-  VLOG(1) << "FourwardServer started in " << absl::FormatDuration(elapsed);
   if (elapsed > options.startup_timeout / 2) {
     LOG(WARNING) << "FourwardServer startup took "
-                 << absl::FormatDuration(elapsed) << " (timeout is "
-                 << absl::FormatDuration(options.startup_timeout) << ")";
+                 << absl::FormatDuration(elapsed) << ", more than half the "
+                 << absl::FormatDuration(options.startup_timeout)
+                 << " timeout — may flake under heavier load";
   }
   if (!port.ok()) {
     KillAndReap(pid);

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -115,8 +115,9 @@ absl::StatusOr<int> ReadPortFile(const std::string& path) {
 // The child's exit is checked on each poll so we don't hang forever if the
 // server crashed before writing the file.
 absl::Status WaitForPortFile(const std::string& path, pid_t child_pid,
-                             absl::Time deadline) {
+                             absl::Duration timeout) {
   constexpr absl::Duration kPoll = absl::Milliseconds(25);
+  absl::Time deadline = absl::Now() + timeout;
   while (absl::Now() < deadline) {
     struct stat st;
     if (::stat(path.c_str(), &st) == 0 && st.st_size > 0) {
@@ -134,8 +135,9 @@ absl::Status WaitForPortFile(const std::string& path, pid_t child_pid,
 
     absl::SleepFor(kPoll);
   }
-  return absl::DeadlineExceededError(absl::StrCat(
-      "server did not publish its port to ", path, " before the timeout"));
+  return absl::DeadlineExceededError(absl::StrFormat(
+      "server did not publish its port to %s within %s", path,
+      absl::FormatDuration(timeout)));
 }
 
 // Reaps `pid` with a bounded wait; returns true if the process is gone.
@@ -358,8 +360,9 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
   stderr_pipe[0] = -1;  // Ownership transferred to OutputCapture.
 
   absl::Time start_time = absl::Now();
-  absl::Time deadline = start_time + options.startup_timeout;
-  if (absl::Status s = WaitForPortFile(port_file, pid, deadline); !s.ok()) {
+  if (absl::Status s =
+          WaitForPortFile(port_file, pid, options.startup_timeout);
+      !s.ok()) {
     // Kill the child and drain the reader threads so the enriched status
     // contains all server output, not just what was consumed so far.
     KillAndReap(pid);
@@ -369,8 +372,13 @@ absl::StatusOr<FourwardServer> FourwardServer::Start(
     return EnrichWithCapturedOutput(s, stdout_capture, stderr_capture);
   }
   absl::StatusOr<int> port = ReadPortFile(port_file);
-  VLOG(1) << "FourwardServer started in "
-          << absl::FormatDuration(absl::Now() - start_time);
+  absl::Duration elapsed = absl::Now() - start_time;
+  VLOG(1) << "FourwardServer started in " << absl::FormatDuration(elapsed);
+  if (elapsed > options.startup_timeout / 2) {
+    LOG(WARNING) << "FourwardServer startup took "
+                 << absl::FormatDuration(elapsed) << " (timeout is "
+                 << absl::FormatDuration(options.startup_timeout) << ")";
+  }
   if (!port.ok()) {
     KillAndReap(pid);
     pid = -1;

--- a/fourward_cc/fourward_server.h
+++ b/fourward_cc/fourward_server.h
@@ -128,8 +128,9 @@ struct FourwardServerOptions {
   // appears in the test log. Disable to capture without console noise.
   bool tee = true;
 
-  // Maximum time to wait for Start() to complete.
-  absl::Duration startup_timeout = absl::Seconds(5);
+  // Maximum time to wait for Start() to complete. JVM cold starts can
+  // exceed 5s under CI load, so the default is generous.
+  absl::Duration startup_timeout = absl::Seconds(15);
 };
 
 class FourwardServer {

--- a/fourward_cc/fourward_server_test.cc
+++ b/fourward_cc/fourward_server_test.cc
@@ -23,7 +23,6 @@
 #include "gmock/gmock.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/support/status.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -184,7 +183,6 @@ TEST(FourwardServerTest, StartupTimeoutYieldsDeadlineExceeded) {
   ASSERT_FALSE(server.ok());
   EXPECT_EQ(server.status().code(), absl::StatusCode::kDeadlineExceeded)
       << server.status();
-  EXPECT_THAT(server.status().message(), ::testing::HasSubstr("within 1ns"));
 }
 
 TEST(FourwardServerTest, LargeMetadataSucceedsUnderDefaultLimits) {

--- a/fourward_cc/fourward_server_test.cc
+++ b/fourward_cc/fourward_server_test.cc
@@ -23,6 +23,7 @@
 #include "gmock/gmock.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/support/status.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -183,6 +184,7 @@ TEST(FourwardServerTest, StartupTimeoutYieldsDeadlineExceeded) {
   ASSERT_FALSE(server.ok());
   EXPECT_EQ(server.status().code(), absl::StatusCode::kDeadlineExceeded)
       << server.status();
+  EXPECT_THAT(server.status().message(), ::testing::HasSubstr("within 1ns"));
 }
 
 TEST(FourwardServerTest, LargeMetadataSucceedsUnderDefaultLimits) {


### PR DESCRIPTION
Fixes occasional flakes where `FourwardServer::Start()` returns `DEADLINE_EXCEEDED` because the JVM didn't boot within 5 seconds.

JVM cold starts can exceed 5s under CI load or on machines running parallel test shards. Three changes:

1. **Bump default timeout from 5s to 15s** — generous enough to absorb cold-start variance, still fast enough to catch genuinely broken startups. Callers that override `startup_timeout` explicitly are unaffected.

2. **`LOG(WARNING)` when startup takes >50% of the timeout** — surfaces "almost flaky" runs without opt-in, e.g. `FourwardServer startup took 8.2s, more than half the 15s timeout — may flake under heavier load`.

3. **Include timeout in `DEADLINE_EXCEEDED` message** — failures are self-documenting, e.g. `server did not publish its port to /tmp/.../port within 15s`.