### PR TITLE
Suppress Netty MAC address warning in sandboxed environments

### DIFF
--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -111,6 +111,11 @@ class FourwardServer(
 }
 
 fun main(args: Array<String>) {
+  // Netty's MacAddressUtil logs a WARNING to stderr when it can't find a usable
+  // hardware address (common in sandboxed test environments). Providing a fixed
+  // machine ID suppresses the lookup entirely.
+  System.setProperty("io.netty.machineId", "00:00:00:00:00:00:00:00")
+
   val port = requireFlag(args, "--port", String::toIntOrNull) ?: FourwardServer.DEFAULT_PORT
   val deviceId =
     requireFlag(args, "--device-id", String::toLongOrNull) ?: P4RuntimeService.DEFAULT_DEVICE_ID

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -112,8 +112,9 @@ class FourwardServer(
 
 fun main(args: Array<String>) {
   // Netty's MacAddressUtil logs a WARNING to stderr when it can't find a usable
-  // hardware address (common in sandboxed test environments). Providing a fixed
-  // machine ID suppresses the lookup entirely.
+  // hardware address (common in sandboxed test environments). The machine ID is
+  // only used for Netty-internal channel ID generation, not for any networking
+  // purpose, so a fixed all-zeros value is safe.
   System.setProperty("io.netty.machineId", "00:00:00:00:00:00:00:00")
 
   val port = requireFlag(args, "--port", String::toIntOrNull) ?: FourwardServer.DEFAULT_PORT


### PR DESCRIPTION
Fixes #755.

Netty's `MacAddressUtil` logs a WARNING to stderr when it can't find a usable hardware address — common in sandboxed test environments like google3. This causes `StderrInitiallyEmptyForHealthyServer` to fail.

Sets `io.netty.machineId` at the top of `main()` before Netty initializes, providing a fixed machine ID so the network interface lookup is skipped entirely.