### PR TITLE
InjectPackets: drop the stream deadline that broke lossless delivery

### DIFF
--- a/fourward_cc/dataplane_client.cc
+++ b/fourward_cc/dataplane_client.cc
@@ -170,9 +170,14 @@ class PacketWriter::Impl {
   absl::Status finished_status_;
 };
 
-PacketWriter DataplaneClient::InjectPackets() {
+PacketWriter DataplaneClient::InjectPackets(
+    std::optional<absl::Duration> total_timeout) {
+  // No deadline unless the caller opted in — see the header for the
+  // rationale (#760).
   auto context = std::make_unique<grpc::ClientContext>();
-  context->set_deadline(AbsoluteDeadline(default_timeout_));
+  if (total_timeout.has_value()) {
+    context->set_deadline(AbsoluteDeadline(*total_timeout));
+  }
   return PacketWriter(
       PacketWriter::Impl::Create(stub_.get(), std::move(context)));
 }

--- a/fourward_cc/dataplane_client.h
+++ b/fourward_cc/dataplane_client.h
@@ -53,7 +53,9 @@ struct Tag {
 };
 
 // RAII handle for a client-streaming InjectPackets RPC. Destructor calls
-// Finish() if not already called.
+// Finish() if not already called — so like Finish(), it blocks until the
+// server has processed every injected packet, unless a `total_timeout` was
+// passed to InjectPackets().
 //
 // Not thread-safe: callers must serialize Inject/Finish calls.
 class PacketWriter {
@@ -69,7 +71,8 @@ class PacketWriter {
   absl::Status Inject(P4RuntimePort ingress_port, std::string_view payload,
                       Tag tag = {});
 
-  // Signals end-of-stream and returns the number of packets injected.
+  // Signals end-of-stream, blocks until the server has processed every
+  // injected packet, and returns the number of packets injected.
   absl::StatusOr<int> Finish();
 
  private:
@@ -131,7 +134,14 @@ class DataplaneClient {
 
   // Returns a writer for streaming packet injection. Results are delivered
   // via SubscribeResults, not inline.
-  PacketWriter InjectPackets();
+  //
+  // By default the stream has no deadline (see PacketWriter); it is
+  // deliberately exempt from `default_timeout`, which cannot know the burst
+  // size (#760). Callers who can bound their burst may pass `total_timeout`
+  // to bound the entire stream — every Inject(), server-side processing,
+  // and Finish().
+  PacketWriter InjectPackets(
+      std::optional<absl::Duration> total_timeout = std::nullopt);
 
   // Blocks until the server confirms the subscription is active. The
   // ResultStream is then long-lived; cancel via destruction.

--- a/fourward_cc/dataplane_client_test.cc
+++ b/fourward_cc/dataplane_client_test.cc
@@ -78,24 +78,27 @@ TEST_F(DataplaneClientTest, InjectPacketP4RuntimePortRespectsDefaultTimeout) {
       << resp.status();
 }
 
-TEST_F(DataplaneClientTest, InjectPacketsWriterFinishesCleanly) {
+TEST_F(DataplaneClientTest, InjectPacketsExplicitTimeoutBoundsTheStream) {
   DataplaneClient client(*server_);
+
+  PacketWriter writer = client.InjectPackets(absl::Nanoseconds(1));
+  absl::Status inject = writer.Inject(DataplanePort{0}, "a");
+  // Either the inject or the finish surfaces the deadline error.
+  absl::StatusOr<int> finish = writer.Finish();
+  EXPECT_TRUE(!inject.ok() || !finish.ok())
+      << "inject: " << inject << ", finish: " << finish.status();
+}
+
+TEST_F(DataplaneClientTest, InjectPacketsIsExemptFromDefaultTimeout) {
+  // Even with an absurdly short default_timeout, a streaming injection must
+  // complete: the stream carries no deadline unless one is passed explicitly
+  // (#760).
+  DataplaneClient client(*server_, absl::Nanoseconds(1));
 
   PacketWriter writer = client.InjectPackets();
   absl::StatusOr<int> count = writer.Finish();
   ASSERT_TRUE(count.ok()) << count.status();
   EXPECT_EQ(*count, 0);
-}
-
-TEST_F(DataplaneClientTest, InjectPacketsRespectsDefaultTimeout) {
-  DataplaneClient client(*server_, absl::Nanoseconds(1));
-
-  PacketWriter writer = client.InjectPackets();
-  absl::Status inject = writer.Inject(DataplanePort{0}, "a");
-  // Either the inject or finish will surface the deadline error.
-  absl::StatusOr<int> finish = writer.Finish();
-  EXPECT_TRUE(!inject.ok() || !finish.ok())
-      << "inject: " << inject << ", finish: " << finish.status();
 }
 
 TEST_F(DataplaneClientTest, MoveConstructionPreservesStub) {


### PR DESCRIPTION
Fixes #760.

`InjectPacketsBurstCanBeDrainedAfterInjection` flaked with `DEADLINE_EXCEEDED` about half the time in google3. The test was the canary, not the bug: `DataplaneClient` stamped its 10s default deadline onto the `InjectPackets` streaming RPC, whose duration is proportional to how many packets the *caller* writes. The 10'000-packet burst takes ~3s on a fast dev machine, so slower runners land right at the edge — and any real `PacketWriter` user with a large burst hits the same wall.

Worse than flakiness: a deadline expiring mid-burst cancels packets already written, silently breaking the lossless delivery this RPC exists to guarantee (the very property the test was added to prove in b04d6ff70).

**The fix:** no deadline on the `InjectPackets` stream by default, mirroring `SubscribeResults`, whose long-lived stream already runs without one for the same reason — no constant chosen up front can bound caller-controlled work. `Finish()` now blocks until the server has processed every written packet; a wedged server hangs loudly (backstopped by test timeouts) instead of dropping packets, per the never-fail-silently invariant. Unary RPCs keep their deadline — their work is bounded.

Bounding the stream is still possible, but as an explicit opt-in: `InjectPackets(total_timeout)` sets a deadline over the entire stream — every `Inject()`, server-side processing, and `Finish()`. Only the caller knows the burst size, so it is deliberately a per-call parameter rather than the client-wide `default_timeout` — the client-wide default was the bug.

Unit tests pin both sides of the new contract: a client with a 1ns `default_timeout` must still complete a streaming injection, and an explicit 1ns `total_timeout` must bound the stream.

Verified with `bazel test //fourward_cc:all --runs_per_test=3`: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)