### PR TITLE
Remove dead DropReason values and the redundant MarkToDropEvent.reason

### DIFF
--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -107,10 +107,9 @@ object TraceFormatter {
   private fun DropReason.humanName(): String =
     when (this) {
       DropReason.MARK_TO_DROP -> "mark_to_drop"
-      DropReason.PARSER_REJECT -> "parser reject"
-      DropReason.PIPELINE_EXECUTION_LIMIT_REACHED -> "execution limit"
       DropReason.ASSERTION_FAILURE -> "assertion failure"
-      else -> "unknown"
+      DropReason.DROP_REASON_UNSPECIFIED,
+      DropReason.UNRECOGNIZED -> "unknown"
     }
 
   private fun fourward.ForkReason.humanName(): String =

--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -106,7 +106,7 @@ object TraceFormatter {
 
   private fun DropReason.humanName(): String =
     when (this) {
-      DropReason.MARK_TO_DROP -> "mark_to_drop"
+      DropReason.EGRESS_DROP -> "egress drop"
       DropReason.ASSERTION_FAILURE -> "assertion failure"
       DropReason.DROP_REASON_UNSPECIFIED,
       DropReason.UNRECOGNIZED -> "unknown"

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -107,7 +107,7 @@ class TraceFormatterTest {
       TraceTree.newBuilder()
         .addEvents(TraceEvent.newBuilder().setMarkToDrop(MarkToDropEvent.getDefaultInstance()))
         .setPacketOutcome(
-          PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
+          PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.EGRESS_DROP))
         )
         .build()
 
@@ -115,7 +115,7 @@ class TraceFormatterTest {
     assertEquals(
       """
       |mark_to_drop()
-      |drop (reason: mark_to_drop)
+      |drop (reason: egress drop)
       |"""
         .trimMargin(),
       output,

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -105,10 +105,7 @@ class TraceFormatterTest {
   fun dropWithMarkToDrop() {
     val tree =
       TraceTree.newBuilder()
-        .addEvents(
-          TraceEvent.newBuilder()
-            .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
-        )
+        .addEvents(TraceEvent.newBuilder().setMarkToDrop(MarkToDropEvent.getDefaultInstance()))
         .setPacketOutcome(
           PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
         )

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -101,6 +101,6 @@ events {
 }
 packet_outcome {
   drop {
-    reason: MARK_TO_DROP
+    reason: EGRESS_DROP
   }
 }

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -83,7 +83,6 @@ events {
 }
 events {
   mark_to_drop {
-    reason: MARK_TO_DROP
   }
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -192,7 +192,6 @@ fork_outcome {
       }
       events {
         mark_to_drop {
-          reason: MARK_TO_DROP
         }
         source_info {
           file: "e2e_tests/trace_tree/multicast_drop_replica.p4"

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -226,7 +226,7 @@ fork_outcome {
       }
       packet_outcome {
         drop {
-          reason: MARK_TO_DROP
+          reason: EGRESS_DROP
         }
       }
     }

--- a/fourward_cc/dataplane_client.h
+++ b/fourward_cc/dataplane_client.h
@@ -112,6 +112,10 @@ class ResultStream {
 // intentionally not wrapped — use the raw stub for advanced use cases.
 //
 // Thread-safe: each method uses its own ClientContext.
+//
+// `default_timeout` applies to unary RPCs (InjectPacket, GetReproducer).
+// Streaming RPCs (InjectPackets, SubscribeResults) carry no deadline by
+// default, since their duration is caller-controlled.
 class DataplaneClient {
  public:
   explicit DataplaneClient(const FourwardServer &server,

--- a/grpc/TraceEnricherTest.kt
+++ b/grpc/TraceEnricherTest.kt
@@ -246,7 +246,7 @@ class TraceEnricherTest {
     val trace =
       TraceTree.newBuilder()
         .setPacketOutcome(
-          PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
+          PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.EGRESS_DROP))
         )
         .build()
 

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -15,7 +15,8 @@ import p4.v1.P4RuntimeOuterClass
 internal data class BlockParam(val name: String, val typeName: String)
 
 internal fun randomInInclusiveRange(lo: BigInteger, hi: BigInteger): BigInteger {
-  if (hi <= lo) return lo
+  require(hi >= lo) { "lo ($lo) must be <= hi ($hi)" }
+  if (hi == lo) return lo
   val rangeSize = hi - lo + BigInteger.ONE
   var offset: BigInteger
   do {

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -144,7 +144,14 @@ class Interpreter internal constructor(config: BehavioralConfig) {
 
     fun runParser(parserName: String, env: Environment) {
       val parser = parsers[parserName] ?: error("unknown parser: $parserName")
-      withLocalScope(parser.localVarsList, env) { runParserState(parser, "start", env) }
+      try {
+        withLocalScope(parser.localVarsList, env) { runParserState(parser, "start", env) }
+      } catch (_: ExitException) {
+        // P4₁₆ allows exit statements only in actions and controls; p4c rejects
+        // them in parsers, so this IR is invalid. Fail loudly rather than guess
+        // a packet fate.
+        error("exit statement in parser $parserName — invalid IR")
+      }
     }
 
     private fun runParserState(parser: ParserDecl, startState: String, env: Environment) {

--- a/simulator/InterpreterTraceEventTest.kt
+++ b/simulator/InterpreterTraceEventTest.kt
@@ -1,7 +1,6 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
-import fourward.DropReason
 import fourward.Expr
 import fourward.MarkToDropEvent
 import fourward.MethodCall
@@ -50,10 +49,7 @@ class InterpreterTraceEventTest {
       "unexpected extern: $call"
     }
     eval.addTraceEvent(
-      eval
-        .traceEventBuilder()
-        .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
-        .build()
+      eval.traceEventBuilder().setMarkToDrop(MarkToDropEvent.getDefaultInstance()).build()
     )
     val smeta = eval.evalArg(0) as StructVal
     val portBits = smeta.bitWidth("egress_spec")
@@ -93,7 +89,7 @@ class InterpreterTraceEventTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  fun `mark_to_drop emits MarkToDropEvent with MARK_TO_DROP reason`() {
+  fun `mark_to_drop emits MarkToDropEvent`() {
     val config = controlConfig("MyIngress", markToDropStmt())
     val env = standardMetadataEnv()
     val pktCtx = PacketContext(byteArrayOf())
@@ -102,7 +98,6 @@ class InterpreterTraceEventTest {
 
     val markToDropEvents = pktCtx.getEvents().filter { it.hasMarkToDrop() }
     assertEquals("expected exactly one MarkToDropEvent", 1, markToDropEvents.size)
-    assertEquals(DropReason.MARK_TO_DROP, markToDropEvents[0].markToDrop.reason)
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -222,7 +222,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val output: StructVal?,
     val deparsedBytes: ByteArray,
     val dropped: Boolean,
-    val dropReason: DropReason = DropReason.MARK_TO_DROP,
+    val dropReason: DropReason = DropReason.EGRESS_DROP,
   )
 
   private fun runIngressPipeline(
@@ -343,7 +343,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val dropped: Boolean,
     val deparsedBytes: ByteArray,
     val output: StructVal?,
-    val dropReason: DropReason = DropReason.MARK_TO_DROP,
+    val dropReason: DropReason = DropReason.EGRESS_DROP,
   )
 
   /**

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -350,7 +350,7 @@ class PSAArchitectureTest {
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
+    assertEquals(DropReason.EGRESS_DROP, result.trace.packetOutcome.drop.reason)
   }
 
   @Test
@@ -493,7 +493,7 @@ class PSAArchitectureTest {
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
+    assertEquals(DropReason.EGRESS_DROP, result.trace.packetOutcome.drop.reason)
   }
 
   // ---------------------------------------------------------------------------
@@ -1114,7 +1114,7 @@ class PSAArchitectureTest {
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
+    assertEquals(DropReason.EGRESS_DROP, result.trace.packetOutcome.drop.reason)
   }
 
   @Test

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -69,7 +69,7 @@ class ReproducerExtractorTest {
       .build()
 
   private fun dropOutcome(): PacketOutcome =
-    PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP)).build()
+    PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.EGRESS_DROP)).build()
 
   private fun emptyTableStore(): TableStore = TableStore()
 

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -397,7 +397,7 @@ class CollectPossibleOutcomesTest {
     fourward.TraceTree.newBuilder()
       .setPacketOutcome(
         fourward.PacketOutcome.newBuilder()
-          .setDrop(fourward.Drop.newBuilder().setReason(fourward.DropReason.MARK_TO_DROP))
+          .setDrop(fourward.Drop.newBuilder().setReason(fourward.DropReason.EGRESS_DROP))
       )
       .build()
 

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -44,7 +44,7 @@ fun forkModeOf(reason: ForkReason): ForkMode =
 /** Builds a [TraceTree] representing a dropped packet with the given trace events and reason. */
 internal fun buildDropTrace(
   events: List<TraceEvent>,
-  reason: DropReason = DropReason.MARK_TO_DROP,
+  reason: DropReason = DropReason.EGRESS_DROP,
 ): TraceTree {
   val outcome = PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(reason)).build()
   return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -306,7 +306,7 @@ class V1ModelArchitecture(
       if (selectorFork.duringIngress) {
         ingressEgressBoundary(ctx, s)
         if (egressPortIsDropPort(s)) {
-          return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+          return buildDropTrace(s.packetCtx.getEvents(), DropReason.EGRESS_DROP)
         }
         return runEgressAndDeparser(ctx, s)
       }
@@ -363,7 +363,7 @@ class V1ModelArchitecture(
         pipelineTail = { c, s ->
           ingressEgressBoundary(c, s)
           if (egressPortIsDropPort(s))
-            buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+            buildDropTrace(s.packetCtx.getEvents(), DropReason.EGRESS_DROP)
           else runEgressAndDeparser(c, s)
         },
       )
@@ -403,7 +403,7 @@ class V1ModelArchitecture(
         configure = { s -> s.pendingOps.egressCloneSessionId = null },
         pipelineTail = { _, s ->
           if (egressSpecIsDropPort(s))
-            buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+            buildDropTrace(s.packetCtx.getEvents(), DropReason.EGRESS_DROP)
           else runDeparser(s)
         },
       )
@@ -424,7 +424,7 @@ class V1ModelArchitecture(
         resetEgressSpec(s)
         runControlStages(s, s.egressControls, dataplanePort = readEgressPort(s))
         if (egressSpecIsDropPort(s))
-          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+          buildDropTrace(s.packetCtx.getEvents(), DropReason.EGRESS_DROP)
         else runDeparser(s)
       },
     )
@@ -680,7 +680,7 @@ class V1ModelArchitecture(
       // --- Ingress→egress boundary (traffic manager) ---
       ingressEgressBoundary(ctx, s)
       if (egressPortIsDropPort(s)) {
-        return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        return buildDropTrace(s.packetCtx.getEvents(), DropReason.EGRESS_DROP)
       }
 
       // --- Egress + deparser ---
@@ -701,7 +701,7 @@ class V1ModelArchitecture(
     postEgressBoundary(ctx, s)
 
     if (egressSpecIsDropPort(s)) {
-      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+      return buildDropTrace(s.packetCtx.getEvents(), DropReason.EGRESS_DROP)
     }
 
     return runDeparser(s)
@@ -715,7 +715,7 @@ class V1ModelArchitecture(
     postEgressBoundary(ctx, s)
 
     if (egressSpecIsDropPort(s)) {
-      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+      return buildDropTrace(s.packetCtx.getEvents(), DropReason.EGRESS_DROP)
     }
 
     return runDeparser(s)

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -664,9 +664,8 @@ class V1ModelArchitecture(
     // --- Init + Parser ---
     val s = initPipelineState(ctx, decisions)
     s.packetCtx.addTraceEvent(packetIngressEvent(ctx.ingressPort))
-    val parserExitDrop = runParser(s)
+    runParser(s)
     s.postParserEnv = s.env.deepCopy()
-    if (parserExitDrop) return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
 
     // An assert()/assume() failure anywhere in the pipeline drops the packet.
     try {
@@ -755,21 +754,20 @@ class V1ModelArchitecture(
   private fun readEgressPort(s: PipelineState): Int =
     (s.standardMetadata.fields["egress_port"] as? BitVal)?.bits?.value?.toInt() ?: 0
 
-  /** Runs the parser stage, returning true if the parser called exit (drop). */
-  private fun runParser(s: PipelineState): Boolean {
-    if (s.parserStage == null) return false
+  /**
+   * Runs the parser stage. A parser error does not drop the packet: it continues to ingress with
+   * standard_metadata.parser_error set (BMv2 semantics).
+   */
+  private fun runParser(s: PipelineState) {
+    if (s.parserStage == null) return
     s.packetCtx.addTraceEvent(stageEvent(s.parserStage, PipelineStageEvent.Direction.ENTER))
-    var exitDrop = false
     try {
       s.interpreter.runParser(s.parserStage.blockName, s.env)
-    } catch (_: ExitException) {
-      exitDrop = true
     } catch (e: ParserErrorException) {
       s.standardMetadata.fields["parser_error"] = ErrorVal(e.errorName)
     } finally {
       s.packetCtx.addTraceEvent(stageEvent(s.parserStage, PipelineStageEvent.Direction.EXIT))
     }
-    return exitDrop
   }
 
   /** Runs a list of control stages, emitting enter/exit events for each. */
@@ -1046,10 +1044,7 @@ class V1ModelArchitecture(
       // mark_to_drop(standard_metadata): sets egress_spec to the drop port.
       "mark_to_drop" -> {
         eval.addTraceEvent(
-          eval
-            .traceEventBuilder()
-            .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
-            .build()
+          eval.traceEventBuilder().setMarkToDrop(MarkToDropEvent.getDefaultInstance()).build()
         )
         val smeta = eval.evalArg(0) as StructVal
         smeta.fields["egress_spec"] = BitVal(dropPort, smeta.bitWidth("egress_spec"))

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -31,6 +31,7 @@ import fourward.TypeDecl
 import fourward.VarDecl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import p4.config.v1.P4InfoOuterClass
@@ -1367,8 +1368,10 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `parser exit emits EXIT event before drop`() {
-    // Parser with an exit statement — triggers ExitException in the parser.
+  fun `exit in parser is rejected as invalid IR`() {
+    // P4₁₆ allows exit statements only in actions and controls, and p4c
+    // rejects them in parsers — so this IR can only be hand-written. The
+    // simulator must fail loudly rather than guess a packet fate.
     val exitParser =
       ParserDecl.newBuilder()
         .setName("MyParser")
@@ -1382,20 +1385,11 @@ class V1ModelArchitectureTest {
         .build()
 
     val config = v1modelConfig(parser = exitParser)
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
-
-    // Should be a drop.
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
-
-    // Parser EXIT event must be present even though the parser exited early.
-    val events = stageEvents(result.trace)
-    val stages = events.drop(1).map { it.pipelineStage }
-    assertEquals(
-      listOf(StageKind.PARSER to Direction.ENTER, StageKind.PARSER to Direction.EXIT),
-      stages.map { it.stageKind to it.direction },
-    )
+    val e =
+      assertThrows(IllegalStateException::class.java) {
+        V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+      }
+    assertTrue("unexpected message: ${e.message}", e.message!!.contains("exit statement in parser"))
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -216,7 +216,7 @@ message ExternCallEvent {
 // Fired when mark_to_drop() is called. Records the call site, not the packet
 // fate — the actual drop is represented by Drop in PacketOutcome.
 message MarkToDropEvent {
-  reserved 1;  // was `DropReason reason`, redundant: always MARK_TO_DROP
+  reserved 1;  // was `DropReason reason`, redundant: always EGRESS_DROP
   reserved "reason";
 }
 
@@ -312,6 +312,6 @@ enum DropReason {
   DROP_REASON_UNSPECIFIED = 0;
   // The egress spec points at the drop port — set by mark_to_drop() or by
   // direct assignment.
-  MARK_TO_DROP = 1;
+  EGRESS_DROP = 1;
   ASSERTION_FAILURE = 4;  // assert() or assume() failed
 }

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -216,7 +216,8 @@ message ExternCallEvent {
 // Fired when mark_to_drop() is called. Records the call site, not the packet
 // fate — the actual drop is represented by Drop in PacketOutcome.
 message MarkToDropEvent {
-  DropReason reason = 1;
+  reserved 1;  // was `DropReason reason`, redundant: always MARK_TO_DROP
+  reserved "reason";
 }
 
 // Fired when the P4 program calls clone().
@@ -300,10 +301,17 @@ message AssignmentEvent {
 }
 
 enum DropReason {
+  // Was PARSER_REJECT (2) and PIPELINE_EXECUTION_LIMIT_REACHED (3) — never
+  // produced. Parser errors don't drop in v1model (the packet proceeds to
+  // ingress with standard_metadata.parser_error set), and exceeding the
+  // pipeline depth limit fails the request loudly instead of reporting a
+  // quiet drop.
+  reserved 2, 3;
+  reserved "PARSER_REJECT", "PIPELINE_EXECUTION_LIMIT_REACHED";
+
   DROP_REASON_UNSPECIFIED = 0;
-  MARK_TO_DROP = 1;   // explicit mark_to_drop()
-  PARSER_REJECT = 2;  // parser transitioned to reject state
-  PIPELINE_EXECUTION_LIMIT_REACHED =
-      3;                  // too many fork branches (exponential blowup guard)
+  // The egress spec points at the drop port — set by mark_to_drop() or by
+  // direct assignment.
+  MARK_TO_DROP = 1;
   ASSERTION_FAILURE = 4;  // assert() or assume() failed
 }

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -193,10 +193,8 @@ Every trace path terminates with a **PacketOutcome**:
 
 - **Output** — packet transmitted: `dataplane_egress_port` + `payload`.
 - **Drop** — packet dropped, with a reason:
-    - `MARK_TO_DROP` — explicit `mark_to_drop()` call.
-    - `PARSER_REJECT` — parser transitioned to the reject state.
-    - `PIPELINE_EXECUTION_LIMIT_REACHED` — too many fork branches
-      (exponential blowup guard).
+    - `MARK_TO_DROP` — the egress spec points at the drop port, set by
+      `mark_to_drop()` or by direct assignment.
     - `ASSERTION_FAILURE` — `assert()` or `assume()` failed.
 
 ## P4RT enrichment

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -193,7 +193,7 @@ Every trace path terminates with a **PacketOutcome**:
 
 - **Output** — packet transmitted: `dataplane_egress_port` + `payload`.
 - **Drop** — packet dropped, with a reason:
-    - `MARK_TO_DROP` — the egress spec points at the drop port, set by
+    - `EGRESS_DROP` — the egress spec points at the drop port, set by
       `mark_to_drop()` or by direct assignment.
     - `ASSERTION_FAILURE` — `assert()` or `assume()` failed.
 

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -180,7 +180,7 @@ source fragment) linking back to the P4 source.
 | **ActionExecution** | `action_name`, `params` (name → bytes) | When an action begins executing |
 | **Branch** | `control_name`, `taken` (true=then, false=else) | Every if/else branch |
 | **ExternCall** | `extern_instance_name`, `method` | Every extern method call |
-| **MarkToDrop** | `reason` | `mark_to_drop()` called |
+| **MarkToDrop** | — | `mark_to_drop()` called |
 | **Clone** | `session_id` | `clone()` / `clone3()` called |
 | **CloneSessionLookup** | `session_id`, `session_found`, `dataplane_egress_port` | Traffic manager resolves a clone session |
 | **LogMessage** | `message` | `log_msg()` called |

--- a/web/frontend/js/trace-render.js
+++ b/web/frontend/js/trace-render.js
@@ -308,7 +308,7 @@ function formatForkReason(reason) {
 
 function formatDropReason(reason) {
   switch (reason) {
-    case 'MARK_TO_DROP': return 'mark_to_drop';
+    case 'EGRESS_DROP': return 'egress drop';
     case 'ASSERTION_FAILURE': return 'assertion failure';
     default: return reason || 'unknown';
   }

--- a/web/frontend/js/trace-render.js
+++ b/web/frontend/js/trace-render.js
@@ -309,6 +309,7 @@ function formatForkReason(reason) {
 function formatDropReason(reason) {
   switch (reason) {
     case 'MARK_TO_DROP': return 'mark_to_drop';
+    case 'ASSERTION_FAILURE': return 'assertion failure';
     default: return reason || 'unknown';
   }
 }

--- a/web/frontend/js/trace-render.js
+++ b/web/frontend/js/trace-render.js
@@ -309,8 +309,6 @@ function formatForkReason(reason) {
 function formatDropReason(reason) {
   switch (reason) {
     case 'MARK_TO_DROP': return 'mark_to_drop';
-    case 'PARSER_REJECT': return 'parser reject';
-    case 'PIPELINE_EXECUTION_LIMIT_REACHED': return 'execution limit';
     default: return reason || 'unknown';
   }
 }


### PR DESCRIPTION
An audit of `DropReason` (prompted by "is `PARSER_REJECT` ever used?") found dead enum values, a redundant field, a silent-drop path, and a misnomer — all cleaned up here. Breaking proto changes are deliberate; field/value numbers and names are reserved.

**Dead enum values removed.** `PARSER_REJECT` and `PIPELINE_EXECUTION_LIMIT_REACHED` date back to the initial project skeleton and are unreachable by design:

- Parser errors don't drop in v1model: the packet proceeds to ingress with `standard_metadata.parser_error` set (BMv2 semantics). No code path can produce a parser-reject drop.
- The pipeline depth guard uses `require()` (throws `INTERNAL`), never a quiet drop. The enum value was never populated.

Field numbers and names are reserved so proto binary compatibility is maintained.

**Redundant `MarkToDropEvent.reason` removed.** The field was always hardcoded `MARK_TO_DROP` — having it on the event (which records the call site) rather than on `Drop` (which records the outcome) was architecturally confused. It's been reserved.

**Silent-drop path in v1model fixed.** The parser stage caught `ExitException` and silently dropped with `MARK_TO_DROP`. This was wrong: `exit` in a parser is a p4c compile-time error (invalid IR), and the label was misleading since no `mark_to_drop()` was called. Changed to `error()` in `Interpreter.runParser`, making the constraint explicit and killing the special case in `V1ModelArchitecture`.

**`DropReason::MARK_TO_DROP` renamed to `EGRESS_DROP`.** The old name implies only explicit `mark_to_drop()` calls, but the value covers any path that sets `egress_spec` to the drop port — including direct assignment. `EGRESS_DROP` names the mechanism. The `MarkToDropEvent` type is unchanged; it still records the `mark_to_drop()` call site accurately.