### PR TITLE
docs: clarify why resubmit/recirculate is a single-branch fork

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,10 +217,11 @@ happens with this specific hash seed?"
 ### Parallel vs alternative forks
 
 Not all forks are created equal. The simulator distinguishes two kinds of
-nondeterminism (see `ForkMode` and `forkModeOf` in `TraceHelpers.kt`):
+nondeterminism (see the `Fork` message in `simulator.proto` and `ForkMode` in
+`TraceHelpers.kt`):
 
 - **Parallel forks** (clone, multicast, resubmit, recirculate) — all branches
-  execute simultaneously in a single real execution. The output packets are the
+  occur in a single real execution. The output packets are the
   union of all branch outputs.
 - **Alternative forks** (action selector) — exactly one branch executes at
   runtime (determined by a hash function). Each branch represents one *possible

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -9,8 +9,8 @@ import java.util.concurrent.atomic.AtomicReference
  * Result of processing a single packet through the pipeline.
  *
  * [possibleOutcomes] captures both kinds of nondeterminism in the trace tree:
- * - **Parallel forks** (clone, multicast, resubmit, recirculate): all branches execute
- *   simultaneously, so their outputs are combined within each possible outcome.
+ * - **Parallel forks** (clone, multicast, resubmit, recirculate): all branches occur in a single
+ *   real execution, so their outputs are combined within each possible outcome.
  * - **Alternative forks** (action selector): exactly one branch executes at runtime, so each branch
  *   produces a separate possible outcome.
  *

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -15,8 +15,9 @@ import fourward.TraceTree
 
 /**
  * Whether a fork's branches all happen (parallel) or only one happens (alternative).
- * - **Parallel** (clone, multicast, resubmit, recirculate): all branches execute simultaneously.
- *   Output packets are the union of all branch outputs.
+ * - **Parallel** (clone, multicast, resubmit, recirculate): all branches occur in a single real
+ *   execution. Output packets are the union of all branch outputs. Resubmit/recirculate forks have
+ *   a single branch — the packet's re-entry into the pipeline is the sole continuation.
  * - **Alternative** (action selector): exactly one branch executes at runtime. Each branch is a
  *   "possible world" — a distinct possible outcome set.
  */

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -68,20 +68,19 @@ message TraceTree {
   }
 }
 
-// A pipeline-pass boundary: the point where one pipeline pass ends and
-// spawns labeled continuations, each a subtree of further execution.
+// A point where execution splits into labeled subtrees — either because one
+// pipeline pass spawns others (clone, multicast, resubmit, recirculate) or
+// because a non-deterministic choice is explored (action selector).
 //
-// What matters about a fork is not simultaneity but how branch outcomes
-// combine (see ForkMode):
+// Forks come in two flavors (see ForkMode):
 //
 //  • **Parallel** (clone, multicast, resubmit, recirculate) — all branches
 //    occur in a single real execution.  The packet outputs are the union of
-//    all branch outputs.  Resubmit and recirculate are the single-branch
-//    case: the packet's re-entry into the pipeline is the sole continuation.
-//    A one-branch fork is deliberate, not a degenerate encoding — it marks
-//    where the new pass begins (fresh instance_type, preserved metadata) and
-//    keeps one uniform shape for re-entry whether it occurs alone or
-//    alongside clones (e.g. PNA mirror + recirculate).
+//    all branch outputs.  Resubmit and recirculate are single-branch forks:
+//    the packet's re-entry into the pipeline is the sole continuation.  The
+//    fork node marks where the new pass begins, and gives re-entry the same
+//    shape whether it occurs alone or alongside clones (e.g. PNA mirror +
+//    recirculate).
 //
 //  • **Alternative** (action selector) — exactly one branch executes at
 //    runtime (determined by a hash function).  Each branch represents one
@@ -109,8 +108,8 @@ enum ForkReason {
   ACTION_SELECTOR = 1;  // Alternative: one member is selected by hash.
   CLONE = 2;            // Parallel: original + clone(s) all execute.
   MULTICAST = 3;        // Parallel: one replica per multicast group member.
-  RESUBMIT = 4;         // Parallel: packet re-enters the pipeline.
-  RECIRCULATE = 5;      // Parallel: deparsed packet loops back.
+  RESUBMIT = 4;     // Parallel, single branch: packet re-enters the pipeline.
+  RECIRCULATE = 5;  // Parallel, single branch: deparsed packet loops back.
 }
 
 // The terminal fate of a packet: either output on a port or dropped.

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -47,9 +47,10 @@ message OutputPacket {
 // Execution trace tree
 //
 // A complete record of every decision the simulator made while processing a
-// packet.  Events within a node are ordered chronologically.  At
-// non-deterministic choice points the tree forks: each branch represents one
-// possible outcome and contains its own subtree of events.
+// packet.  Events within a node are ordered chronologically.  The tree forks
+// where one pipeline pass spawns others (clone, multicast, resubmit,
+// recirculate) and at non-deterministic choice points (action selector);
+// each branch contains its own subtree of events.
 //
 // Every node terminates: either forking (fork_outcome) or reaching a final
 // packet fate (packet_outcome).  A zero-fork tree has a single
@@ -67,14 +68,20 @@ message TraceTree {
   }
 }
 
-// A non-deterministic choice point where execution forks into multiple
-// possible paths.
+// A pipeline-pass boundary: the point where one pipeline pass ends and
+// spawns labeled continuations, each a subtree of further execution.
 //
-// Forks come in two flavors (see ForkMode):
+// What matters about a fork is not simultaneity but how branch outcomes
+// combine (see ForkMode):
 //
 //  • **Parallel** (clone, multicast, resubmit, recirculate) — all branches
-//    execute simultaneously in a single real execution.  The packet outputs
-//    are the union of all branch outputs.
+//    occur in a single real execution.  The packet outputs are the union of
+//    all branch outputs.  Resubmit and recirculate are the single-branch
+//    case: the packet's re-entry into the pipeline is the sole continuation.
+//    A one-branch fork is deliberate, not a degenerate encoding — it marks
+//    where the new pass begins (fresh instance_type, preserved metadata) and
+//    keeps one uniform shape for re-entry whether it occurs alone or
+//    alongside clones (e.g. PNA mirror + recirculate).
 //
 //  • **Alternative** (action selector) — exactly one branch executes at
 //    runtime (determined by a hash function).  Each branch represents one

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -73,15 +73,18 @@ packet_outcome {
 
 ## Forks
 
-When execution reaches a non-deterministic choice point, the trace forks.
-Each branch gets its own subtree with the remaining pipeline events.
+The trace forks where the packet is replicated or re-enters the pipeline
+(clone, multicast, resubmit, recirculate) and at non-deterministic choice
+points (action selector). Each branch gets its own subtree with the
+remaining pipeline events.
 
 There are two kinds of forks, and the distinction is important for
 understanding what the output packets mean:
 
 - **Parallel forks** (clone, multicast, resubmit, recirculate) — all branches
-  happen simultaneously in a single real execution. A clone creates both the
-  original *and* the clone; multicast creates all replicas at once.
+  happen in a single real execution. A clone creates both the original *and*
+  the clone; multicast creates all replicas at once; a resubmitted or
+  recirculated packet has a single branch: its re-entry into the pipeline.
 - **Alternative forks** (action selector) — exactly one branch happens at
   runtime, determined by a hash function. Each branch represents one *possible
   world* — a forwarding outcome that *could* happen, depending on the hash.


### PR DESCRIPTION
A fresh reader of `simulator.proto` hits a natural question: resubmit/recirculate is *sequential* — one packet re-entering the pipeline — so why is it modeled as a `Fork`? The old comment made this worse by describing parallel branches as "executing simultaneously," which makes a one-branch fork read like a modeling error.

This PR answers the question where it arises, in the comments themselves:

- The `Fork` comment now explains that resubmit/recirculate are single-branch forks: the fork node marks where the new pipeline pass begins and gives re-entry the same shape whether it occurs alone or alongside clones (e.g. PNA mirror + recirculate, where the recirculated pass is one branch among mirrors).
- The `Fork` opening no longer attributes all forks to "non-deterministic choice points" — re-entry is deterministic, and action-selector forks are the only non-deterministic kind.
- The RESUBMIT/RECIRCULATE enum values say "single branch" inline, so readers scanning `ForkReason` don't have to find the `Fork` comment.
- The same stale "execute simultaneously" framing is synced everywhere it appeared: `docs/ARCHITECTURE.md`, `userdocs/concepts/traces.md`, and the `ProcessPacketResult` KDoc in `Simulator.kt`, plus the matching `ForkMode` KDoc in `TraceHelpers.kt`.

Comment/docs-only change; no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)