### PR TITLE
Trace trees: replace Fork with Continuations (AND) / Choice (OR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,17 +194,17 @@ One packet goes in, two come out
 ```protobuf
 events { parser_transition { from_state: "start"  to_state: "accept" } }
 events { clone { session_id: 100 } }
-fork_outcome {
-  reason: CLONE
-  branches {
-    label: "original"
+continuations {
+  continuations {
+    kind: ORIGINAL
     subtree {
       events { table_lookup { action_name: "tag_original" } }
       packet_outcome { output { egress_port: 2 } }
     }
   }
-  branches {
-    label: "clone"
+  continuations {
+    kind: CLONE
+    dataplane_egress_port: 3
     subtree {
       events { table_lookup { action_name: "tag_clone" } }
       packet_outcome { output { egress_port: 3 } }

--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -14,12 +14,18 @@ object TraceFormatter {
       appendEvent(event, indent)
     }
     when (tree.outcomeCase) {
-      TraceTree.OutcomeCase.FORK_OUTCOME -> {
-        val fork = tree.forkOutcome
-        appendLine("${pad(indent)}fork (${fork.reason.humanName()})")
-        for (branch in fork.branchesList) {
-          appendLine("${pad(indent + 1)}branch: ${branch.label}")
-          appendTree(branch.subtree, indent + 2)
+      TraceTree.OutcomeCase.CONTINUATIONS -> {
+        appendLine("${pad(indent)}continues as:")
+        for (continuation in tree.continuations.continuationsList) {
+          appendLine("${pad(indent + 1)}${continuation.humanName()}:")
+          appendTree(continuation.subtree, indent + 2)
+        }
+      }
+      TraceTree.OutcomeCase.CHOICE -> {
+        appendLine("${pad(indent)}one of (action selector):")
+        for (alternative in tree.choice.alternativesList) {
+          appendLine("${pad(indent + 1)}member ${alternative.memberId}:")
+          appendTree(alternative.subtree, indent + 2)
         }
       }
       TraceTree.OutcomeCase.PACKET_OUTCOME -> {
@@ -113,6 +119,21 @@ object TraceFormatter {
       else -> "unknown"
     }
 
-  private fun fourward.ForkReason.humanName(): String =
-    name.removePrefix("ACTION_").lowercase().replace('_', ' ')
+  /** e.g. "original", "recirculate", "clone port 5 instance 2", "replica port 6". */
+  private fun fourward.Continuation.humanName(): String = buildString {
+    append(
+      when (kind) {
+        fourward.ContinuationKind.ORIGINAL -> "original"
+        fourward.ContinuationKind.CLONE -> "clone"
+        fourward.ContinuationKind.MIRROR -> "mirror"
+        fourward.ContinuationKind.MULTICAST_REPLICA -> "replica"
+        fourward.ContinuationKind.RESUBMIT -> "resubmit"
+        fourward.ContinuationKind.RECIRCULATE -> "recirculate"
+        fourward.ContinuationKind.CONTINUATION_KIND_UNSPECIFIED,
+        fourward.ContinuationKind.UNRECOGNIZED -> "unknown"
+      }
+    )
+    if (hasDataplaneEgressPort()) append(" port $dataplaneEgressPort")
+    if (hasInstance()) append(" instance $instance")
+  }
 }

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -2,12 +2,14 @@ package fourward.cli
 
 import com.google.protobuf.ByteString
 import fourward.ActionExecutionEvent
+import fourward.Alternative
 import fourward.AssertionEvent
+import fourward.Choice
+import fourward.Continuation
+import fourward.ContinuationKind
+import fourward.Continuations
 import fourward.Drop
 import fourward.DropReason
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.LogMessageEvent
 import fourward.MarkToDropEvent
 import fourward.OutputPacket
@@ -126,7 +128,7 @@ class TraceFormatterTest {
   }
 
   @Test
-  fun forkTree() {
+  fun cloneContinuations() {
     val tree =
       TraceTree.newBuilder()
         .addEvents(
@@ -135,12 +137,11 @@ class TraceFormatterTest {
               ParserTransitionEvent.newBuilder().setFromState("start").setToState("accept")
             )
         )
-        .setForkOutcome(
-          Fork.newBuilder()
-            .setReason(ForkReason.CLONE)
-            .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("original")
+        .setContinuations(
+          Continuations.newBuilder()
+            .addContinuations(
+              Continuation.newBuilder()
+                .setKind(ContinuationKind.ORIGINAL)
                 .setSubtree(
                   TraceTree.newBuilder()
                     .setPacketOutcome(
@@ -153,9 +154,11 @@ class TraceFormatterTest {
                     )
                 )
             )
-            .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("clone")
+            .addContinuations(
+              Continuation.newBuilder()
+                .setKind(ContinuationKind.CLONE)
+                .setDataplaneEgressPort(2)
+                .setInstance(1)
                 .setSubtree(
                   TraceTree.newBuilder()
                     .setPacketOutcome(
@@ -175,10 +178,70 @@ class TraceFormatterTest {
     assertEquals(
       """
       |parse: start -> accept
-      |fork (clone)
-      |  branch: original
+      |continues as:
+      |  original:
       |    output port 1, 0 bytes
-      |  branch: clone
+      |  clone port 2 instance 1:
+      |    output port 2, 0 bytes
+      |"""
+        .trimMargin(),
+      output,
+    )
+  }
+
+  @Test
+  fun choiceTree() {
+    val tree =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setParserTransition(
+              ParserTransitionEvent.newBuilder().setFromState("start").setToState("accept")
+            )
+        )
+        .setChoice(
+          Choice.newBuilder()
+            .addAlternatives(
+              Alternative.newBuilder()
+                .setMemberId(7)
+                .setSubtree(
+                  TraceTree.newBuilder()
+                    .setPacketOutcome(
+                      PacketOutcome.newBuilder()
+                        .setOutput(
+                          OutputPacket.newBuilder()
+                            .setDataplaneEgressPort(1)
+                            .setPayload(ByteString.EMPTY)
+                        )
+                    )
+                )
+            )
+            .addAlternatives(
+              Alternative.newBuilder()
+                .setMemberId(8)
+                .setSubtree(
+                  TraceTree.newBuilder()
+                    .setPacketOutcome(
+                      PacketOutcome.newBuilder()
+                        .setOutput(
+                          OutputPacket.newBuilder()
+                            .setDataplaneEgressPort(2)
+                            .setPayload(ByteString.EMPTY)
+                        )
+                    )
+                )
+            )
+        )
+        .build()
+
+    val output = TraceFormatter.format(tree)
+    assertEquals(
+      """
+      |parse: start -> accept
+      |one of (action selector):
+      |  member 7:
+      |    output port 1, 0 bytes
+      |  member 8:
       |    output port 2, 0 bytes
       |"""
         .trimMargin(),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,8 +148,8 @@ where `InputPacket`, `OutputPacket`, and the trace tree types live.
 A Kotlin/JVM library that walks the proto IR and actually *runs* your P4
 program. Callers instantiate `Simulator` directly and use its typed API
 (`loadPipeline`, `processPacket`, `writeEntry`, `readEntries`). Packet
-processing is fully parallelized: fork branches within a single packet run
-concurrently, and `InjectPackets` sends many packets through the pipeline at
+processing is fully parallelized: trace tree branches within a single packet
+run concurrently, and `InjectPackets` sends many packets through the pipeline at
 once.
 
 ```
@@ -187,12 +187,13 @@ its own implementation.
 
 The interpreter (`Interpreter.kt`) is designed to be a pure IR tree-walker —
 evaluating expressions, walking control flow, performing table lookups, and
-managing variable scopes. Architecture-specific extern dispatch, fork
-semantics, and pipeline orchestration belong in the architecture layer.
+managing variable scopes. Architecture-specific extern dispatch, trace tree
+branching, and pipeline orchestration belong in the architecture layer.
 
 **Current status:** v1model, PSA, and PNA are all implemented. The interpreter is
 a pure IR tree-walker with no architecture-specific code — extern dispatch,
-fork semantics, and pipeline orchestration all live in the architecture layer
+trace tree branching, and pipeline orchestration all live in the architecture
+layer
 (`V1ModelArchitecture.kt`, `PSAArchitecture.kt`, `PNAArchitecture.kt`). See
 [ROADMAP.md](ROADMAP.md) Track 6 for the multi-architecture plan.
 
@@ -203,37 +204,46 @@ See [TESTING_STRATEGY.md](TESTING_STRATEGY.md).
 ## Trace trees
 
 4ward's output format is a **trace tree** (`TraceTree` in `simulator.proto`) —
-a recursive structure where each node contains a sequence of events and an
-optional fork. At non-deterministic choice points (action selectors, clone,
-multicast), execution forks into branches, one per possible outcome. A program
-with no non-determinism produces a zero-fork tree that is structurally
-equivalent to a flat trace — there is no separate "flat trace" format.
+a recursive structure where each node contains a sequence of events followed
+by an outcome: a final packet fate, a set of *continuations*, or a *choice*.
+A program that never multiplies, re-enters, or branches produces a single-node
+tree that is structurally equivalent to a flat trace — there is no separate
+"flat trace" format.
 
 The key insight: even when choices like action selector hashing are technically
 deterministic, it's often more useful to reason about them as
 non-deterministic — "what *could* happen to my packet?" rather than "what
 happens with this specific hash seed?"
 
-### Parallel vs alternative forks
+### Continuations vs choices
 
-Not all forks are created equal. The simulator distinguishes two kinds of
-nondeterminism (see `ForkMode` and `forkModeOf` in `TraceHelpers.kt`):
+The tree is an AND/OR tree, and the two node types mean very different things:
 
-- **Parallel forks** (clone, multicast, resubmit, recirculate) — all branches
-  execute simultaneously in a single real execution. The output packets are the
-  union of all branch outputs.
-- **Alternative forks** (action selector) — exactly one branch executes at
-  runtime (determined by a hash function). Each branch represents one *possible
-  world*; the trace tree explores all of them.
+- **Continuations** (AND — clone, multicast, resubmit, recirculate) — execution
+  continued in all of the listed ways within a single real execution. The
+  output packets are the union of the continuations' outputs. A single
+  continuation is common and meaningful: a recirculated packet simply
+  continues as one new pipeline pass.
+- **Choice** (OR — action selector) — exactly one alternative executes at
+  runtime (determined by a hash function). Each alternative represents one
+  *possible world*; the trace tree explores all of them.
+
+Each continuation carries a typed kind (`ORIGINAL`, `CLONE`, `MIRROR`,
+`MULTICAST_REPLICA`, `RESUBMIT`, `RECIRCULATE`) plus the replica's egress port
+and instance id where applicable; each choice alternative carries the selected
+member id. Because the node type itself encodes the AND/OR semantics, every
+consumer that walks the tree is forced by the exhaustive `when` over the
+outcome oneof to handle the two cases — there is no runtime mode lookup to
+forget.
 
 This distinction matters when collecting output packets from the tree:
 `collectPossibleOutcomes()` in `Simulator.kt` returns a `List<List<OutputPacket>>`
 where each inner list is one possible set of outputs from a single real execution.
-Parallel branches are combined (union), while alternative branches produce separate
-possible worlds (Cartesian product when nested inside parallel forks).
+Continuations are combined (union), while choice alternatives produce separate
+possible worlds (Cartesian product when nested inside continuations).
 
-**Status:** Complete. The simulator produces full trace trees with forking at
-all non-deterministic choice points: action selectors, clone (I2E/E2E),
+**Status:** Complete. The simulator produces full trace trees with branching at
+all multiplication and choice points: action selectors, clone (I2E/E2E),
 multicast replication, resubmit, and recirculate.
 
 **Why this matters:**

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -20,7 +20,7 @@ guilt — just write it down so someone can find it later.
   bare fields, 1-arg and 3-arg forms), `Meter.execute` (stub GREEN),
   `Random.read()`, `InternetChecksum` (clear/add/subtract/get/get_state/set_state),
   `Digest.pack` (stub no-op), counters (indirect + direct), action profiles,
-  action selectors (including fork-based trace trees for group hits), parser
+  action selectors (including choice-based trace trees for group hits), parser
   `value_set`, header stacks, and top-level assignments. 73 additional PSA
   programs (BMv2 + DPDK targets) are verified to compile. TNA is not
   implemented.
@@ -83,14 +83,15 @@ guilt — just write it down so someone can find it later.
   wall-clock time to expire idle entries. These are explicitly out of scope.
 ## Simulator
 
-- **Fork-point resume is v1model only.** When the trace tree forks (action
-  selectors, clone, multicast), v1model continues each branch from the fork
+- **Fork-point resume is v1model only.** When the trace tree branches (action
+  selectors, clone, multicast), v1model continues each subtree from the fork
   point instead of replaying the pipeline. PSA and PNA still use the
   replay-based approach (`handleActionSelectorFork` in `ArchitectureHelpers.kt`).
   Other v1model-specific optimizations (Long-backed `BitVector`, `CompactFieldMap`,
   proto builder pooling) benefit all architectures.
 - **Multicast: basic replication only.** Multicast group replication works
-  for the trace tree (forking per replica). PRE entries are installed via
+  for the trace tree (one continuation per replica). PRE entries are installed
+  via
   P4Runtime `PacketReplicationEngineEntry`.
 
 ## Web playground
@@ -106,10 +107,10 @@ guilt — just write it down so someone can find it later.
 - **Read API only returns table entries.** `GET /api/read` hard-codes a
   `TableEntry` filter. Clone sessions, counters, and other entity types
   cannot be read back through the REST API.
-- **Forking programs: output packets panel flattens possible worlds.** For
+- **Branching programs: output packets panel flattens possible worlds.** For
   programs with action selectors, the web playground's output panel shows
-  outputs from *all* possible worlds. The trace tab shows the full fork
-  structure. See [Trace Trees: Forks](../userdocs/concepts/traces.md#forks).
+  outputs from *all* possible worlds. The trace tab shows the full tree
+  structure. See [Trace Trees: Continuations and choices](../userdocs/concepts/traces.md#continuations-and-choices).
 - **No `StreamChannel`.** The web UI uses REST APIs, not the P4Runtime
   bidirectional stream. This means no PacketIO (`packet_in`/`packet_out`),
   no digest notifications, and no arbitration updates. Packets are injected

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -20,7 +20,7 @@ import org.junit.runners.Parameterized.Parameters
  * the trace tree.
  *
  * The possible outcomes should be consistent with the trace tree's leaf outcomes, whether the trace
- * forks (multicast, clone, action selectors) or not.
+ * branches (multicast, clone, action selectors) or not.
  */
 @RunWith(Parameterized::class)
 class TraceTreeConsistencyTest(private val testName: String) {
@@ -72,7 +72,7 @@ class TraceTreeConsistencyTest(private val testName: String) {
         .filter { it.hasOutput() }
         .map { it.output.dataplaneEgressPort to it.output.payload }
 
-    // For trees without nested alternative-inside-parallel forks, these match exactly.
+    // For trees without a choice nested inside continuations, these match exactly.
     // For trees with such nesting, possibleOutcomes may have duplicates from the Cartesian
     // product, so we compare as sets.
     assertEquals(
@@ -87,8 +87,10 @@ class TraceTreeConsistencyTest(private val testName: String) {
   private fun collectLeafOutcomes(tree: TraceTree): List<PacketOutcome> =
     when (tree.outcomeCase) {
       TraceTree.OutcomeCase.PACKET_OUTCOME -> listOf(tree.packetOutcome)
-      TraceTree.OutcomeCase.FORK_OUTCOME ->
-        tree.forkOutcome.branchesList.flatMap { collectLeafOutcomes(it.subtree) }
+      TraceTree.OutcomeCase.CONTINUATIONS ->
+        tree.continuations.continuationsList.flatMap { collectLeafOutcomes(it.subtree) }
+      TraceTree.OutcomeCase.CHOICE ->
+        tree.choice.alternativesList.flatMap { collectLeafOutcomes(it.subtree) }
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,
       null -> emptyList()
     }

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -82,10 +82,8 @@ events {
     value: "281474976710655 (0xffffffffffff)"
   }
 }
-fork_outcome {
-  reason: ACTION_SELECTOR
-  branches {
-    label: "member_0"
+choice {
+  alternatives {
     subtree {
       events {
         action_execution {
@@ -185,8 +183,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "member_1"
+  alternatives {
+    member_id: 1
     subtree {
       events {
         action_execution {
@@ -286,8 +284,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "member_2"
+  alternatives {
+    member_id: 2
     subtree {
       events {
         action_execution {

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -82,10 +82,8 @@ events {
     value: "281474976710655 (0xffffffffffff)"
   }
 }
-fork_outcome {
-  reason: ACTION_SELECTOR
-  branches {
-    label: "member_0"
+choice {
+  alternatives {
     subtree {
       events {
         action_execution {
@@ -147,10 +145,8 @@ fork_outcome {
           value: "2048 (0x800)"
         }
       }
-      fork_outcome {
-        reason: ACTION_SELECTOR
-        branches {
-          label: "member_0"
+      choice {
+        alternatives {
           subtree {
             events {
               action_execution {
@@ -250,8 +246,8 @@ fork_outcome {
             }
           }
         }
-        branches {
-          label: "member_1"
+        alternatives {
+          member_id: 1
           subtree {
             events {
               action_execution {
@@ -354,8 +350,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "member_1"
+  alternatives {
+    member_id: 1
     subtree {
       events {
         action_execution {
@@ -417,10 +413,8 @@ fork_outcome {
           value: "2048 (0x800)"
         }
       }
-      fork_outcome {
-        reason: ACTION_SELECTOR
-        branches {
-          label: "member_0"
+      choice {
+        alternatives {
           subtree {
             events {
               action_execution {
@@ -520,8 +514,8 @@ fork_outcome {
             }
           }
         }
-        branches {
-          label: "member_1"
+        alternatives {
+          member_id: 1
           subtree {
             events {
               action_execution {

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -92,10 +92,9 @@ events {
     replica_count: 1
   }
 }
-fork_outcome {
-  reason: CLONE
-  branches {
-    label: "original"
+continuations {
+  continuations {
+    kind: ORIGINAL
     subtree {
       events {
         multicast_group_lookup {
@@ -104,10 +103,9 @@ fork_outcome {
           replica_count: 2
         }
       }
-      fork_outcome {
-        reason: MULTICAST
-        branches {
-          label: "replica_0_port_1"
+      continuations {
+        continuations {
+          kind: MULTICAST_REPLICA
           subtree {
             events {
               pipeline_stage {
@@ -168,9 +166,11 @@ fork_outcome {
               }
             }
           }
+          dataplane_egress_port: 1
+          instance: 0
         }
-        branches {
-          label: "replica_0_port_2"
+        continuations {
+          kind: MULTICAST_REPLICA
           subtree {
             events {
               pipeline_stage {
@@ -231,12 +231,14 @@ fork_outcome {
               }
             }
           }
+          dataplane_egress_port: 2
+          instance: 0
         }
       }
     }
   }
-  branches {
-    label: "clone"
+  continuations {
+    kind: CLONE
     subtree {
       events {
         pipeline_stage {
@@ -297,5 +299,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 3
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -92,10 +92,9 @@ events {
     replica_count: 1
   }
 }
-fork_outcome {
-  reason: CLONE
-  branches {
-    label: "original"
+continuations {
+  continuations {
+    kind: ORIGINAL
     subtree {
       events {
         pipeline_stage {
@@ -157,8 +156,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "clone"
+  continuations {
+    kind: CLONE
     subtree {
       events {
         pipeline_stage {
@@ -219,5 +218,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 1
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -103,10 +103,9 @@ events {
     replica_count: 1
   }
 }
-fork_outcome {
-  reason: CLONE
-  branches {
-    label: "original"
+continuations {
+  continuations {
+    kind: ORIGINAL
     subtree {
       events {
         pipeline_stage {
@@ -168,8 +167,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "clone"
+  continuations {
+    kind: CLONE
     subtree {
       events {
         pipeline_stage {
@@ -230,5 +229,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 1
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -93,10 +93,8 @@ events {
     value: "281474976710655 (0xffffffffffff)"
   }
 }
-fork_outcome {
-  reason: ACTION_SELECTOR
-  branches {
-    label: "member_0"
+choice {
+  alternatives {
     subtree {
       events {
         action_execution {
@@ -144,10 +142,9 @@ fork_outcome {
           replica_count: 1
         }
       }
-      fork_outcome {
-        reason: CLONE
-        branches {
-          label: "original"
+      continuations {
+        continuations {
+          kind: ORIGINAL
           subtree {
             events {
               pipeline_stage {
@@ -209,8 +206,8 @@ fork_outcome {
             }
           }
         }
-        branches {
-          label: "clone"
+        continuations {
+          kind: CLONE
           subtree {
             events {
               pipeline_stage {
@@ -271,12 +268,14 @@ fork_outcome {
               }
             }
           }
+          dataplane_egress_port: 1
+          instance: 0
         }
       }
     }
   }
-  branches {
-    label: "member_1"
+  alternatives {
+    member_id: 1
     subtree {
       events {
         action_execution {
@@ -324,10 +323,9 @@ fork_outcome {
           replica_count: 1
         }
       }
-      fork_outcome {
-        reason: CLONE
-        branches {
-          label: "original"
+      continuations {
+        continuations {
+          kind: ORIGINAL
           subtree {
             events {
               pipeline_stage {
@@ -389,8 +387,8 @@ fork_outcome {
             }
           }
         }
-        branches {
-          label: "clone"
+        continuations {
+          kind: CLONE
           subtree {
             events {
               pipeline_stage {
@@ -451,6 +449,8 @@ fork_outcome {
               }
             }
           }
+          dataplane_egress_port: 1
+          instance: 0
         }
       }
     }

--- a/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
@@ -116,10 +116,9 @@ events {
     replica_count: 1
   }
 }
-fork_outcome {
-  reason: CLONE
-  branches {
-    label: "original"
+continuations {
+  continuations {
+    kind: ORIGINAL
     subtree {
       events {
         pipeline_stage {
@@ -198,8 +197,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "clone"
+  continuations {
+    kind: CLONE
     subtree {
       events {
         pipeline_stage {
@@ -293,5 +292,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 2
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -92,10 +92,9 @@ events {
     replica_count: 1
   }
 }
-fork_outcome {
-  reason: CLONE
-  branches {
-    label: "original"
+continuations {
+  continuations {
+    kind: ORIGINAL
     subtree {
       events {
         pipeline_stage {
@@ -212,8 +211,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "clone"
+  continuations {
+    kind: CLONE
     subtree {
       events {
         pipeline_stage {
@@ -329,5 +328,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 3
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/e2e_clone.golden.txtpb
+++ b/e2e_tests/trace_tree/e2e_clone.golden.txtpb
@@ -196,10 +196,9 @@ events {
     replica_count: 1
   }
 }
-fork_outcome {
-  reason: CLONE
-  branches {
-    label: "original"
+continuations {
+  continuations {
+    kind: ORIGINAL
     subtree {
       events {
         pipeline_stage {
@@ -229,8 +228,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "clone"
+  continuations {
+    kind: CLONE
     subtree {
       events {
         pipeline_stage {
@@ -363,5 +362,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 5
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -80,10 +80,9 @@ events {
     replica_count: 3
   }
 }
-fork_outcome {
-  reason: MULTICAST
-  branches {
-    label: "replica_0_port_1"
+continuations {
+  continuations {
+    kind: MULTICAST_REPLICA
     subtree {
       events {
         pipeline_stage {
@@ -144,9 +143,11 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 1
+    instance: 0
   }
-  branches {
-    label: "replica_0_port_2"
+  continuations {
+    kind: MULTICAST_REPLICA
     subtree {
       events {
         pipeline_stage {
@@ -207,9 +208,11 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 2
+    instance: 0
   }
-  branches {
-    label: "replica_0_port_3"
+  continuations {
+    kind: MULTICAST_REPLICA
     subtree {
       events {
         pipeline_stage {
@@ -270,5 +273,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 3
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -80,10 +80,9 @@ events {
     replica_count: 3
   }
 }
-fork_outcome {
-  reason: MULTICAST
-  branches {
-    label: "replica_0_port_1"
+continuations {
+  continuations {
+    kind: MULTICAST_REPLICA
     subtree {
       events {
         pipeline_stage {
@@ -161,9 +160,11 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 1
+    instance: 0
   }
-  branches {
-    label: "replica_0_port_2"
+  continuations {
+    kind: MULTICAST_REPLICA
     subtree {
       events {
         pipeline_stage {
@@ -231,9 +232,11 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 2
+    instance: 0
   }
-  branches {
-    label: "replica_0_port_3"
+  continuations {
+    kind: MULTICAST_REPLICA
     subtree {
       events {
         pipeline_stage {
@@ -311,5 +314,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 3
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -80,10 +80,9 @@ events {
     replica_count: 2
   }
 }
-fork_outcome {
-  reason: MULTICAST
-  branches {
-    label: "replica_0_port_1"
+continuations {
+  continuations {
+    kind: MULTICAST_REPLICA
     subtree {
       events {
         pipeline_stage {
@@ -122,10 +121,8 @@ fork_outcome {
           value: "281474976710655 (0xffffffffffff)"
         }
       }
-      fork_outcome {
-        reason: ACTION_SELECTOR
-        branches {
-          label: "member_0"
+      choice {
+        alternatives {
           subtree {
             events {
               action_execution {
@@ -199,8 +196,8 @@ fork_outcome {
             }
           }
         }
-        branches {
-          label: "member_1"
+        alternatives {
+          member_id: 1
           subtree {
             events {
               action_execution {
@@ -276,9 +273,11 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 1
+    instance: 0
   }
-  branches {
-    label: "replica_0_port_2"
+  continuations {
+    kind: MULTICAST_REPLICA
     subtree {
       events {
         pipeline_stage {
@@ -317,10 +316,8 @@ fork_outcome {
           value: "281474976710655 (0xffffffffffff)"
         }
       }
-      fork_outcome {
-        reason: ACTION_SELECTOR
-        branches {
-          label: "member_0"
+      choice {
+        alternatives {
           subtree {
             events {
               action_execution {
@@ -394,8 +391,8 @@ fork_outcome {
             }
           }
         }
-        branches {
-          label: "member_1"
+        alternatives {
+          member_id: 1
           subtree {
             events {
               action_execution {
@@ -471,5 +468,7 @@ fork_outcome {
         }
       }
     }
+    dataplane_egress_port: 2
+    instance: 0
   }
 }

--- a/e2e_tests/trace_tree/recirculate.golden.txtpb
+++ b/e2e_tests/trace_tree/recirculate.golden.txtpb
@@ -142,10 +142,9 @@ events {
     direction: EXIT
   }
 }
-fork_outcome {
-  reason: RECIRCULATE
-  branches {
-    label: "recirculate"
+continuations {
+  continuations {
+    kind: RECIRCULATE
     subtree {
       events {
         packet_ingress {

--- a/e2e_tests/trace_tree/resubmit.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit.golden.txtpb
@@ -90,10 +90,9 @@ events {
     dataplane_port: 0
   }
 }
-fork_outcome {
-  reason: RESUBMIT
-  branches {
-    label: "resubmit"
+continuations {
+  continuations {
+    kind: RESUBMIT
     subtree {
       events {
         packet_ingress {

--- a/e2e_tests/trace_tree/selector_exit.golden.txtpb
+++ b/e2e_tests/trace_tree/selector_exit.golden.txtpb
@@ -82,10 +82,8 @@ events {
     value: "281474976710655 (0xffffffffffff)"
   }
 }
-fork_outcome {
-  reason: ACTION_SELECTOR
-  branches {
-    label: "member_0"
+choice {
+  alternatives {
     subtree {
       events {
         action_execution {
@@ -240,8 +238,8 @@ fork_outcome {
       }
     }
   }
-  branches {
-    label: "member_1"
+  alternatives {
+    member_id: 1
     subtree {
       events {
         action_execution {

--- a/grpc/TraceEnricher.kt
+++ b/grpc/TraceEnricher.kt
@@ -46,15 +46,27 @@ object TraceEnricher {
     }
 
     when (tree.outcomeCase) {
-      TraceTree.OutcomeCase.FORK_OUTCOME -> {
-        val fork = tree.forkOutcome
-        for (i in 0 until fork.branchesCount) {
-          val branch = fork.getBranches(i)
-          val enrichedSubtree = enrichTree(branch.subtree, pt, translator)
-          if (enrichedSubtree !== branch.subtree) {
+      TraceTree.OutcomeCase.CONTINUATIONS -> {
+        val continuations = tree.continuations
+        for (i in 0 until continuations.continuationsCount) {
+          val cont = continuations.getContinuations(i)
+          val enrichedSubtree = enrichTree(cont.subtree, pt, translator)
+          if (enrichedSubtree !== cont.subtree) {
             lazyBuilder()
-              .forkOutcomeBuilder
-              .setBranches(i, branch.toBuilder().setSubtree(enrichedSubtree))
+              .continuationsBuilder
+              .setContinuations(i, cont.toBuilder().setSubtree(enrichedSubtree))
+          }
+        }
+      }
+      TraceTree.OutcomeCase.CHOICE -> {
+        val choice = tree.choice
+        for (i in 0 until choice.alternativesCount) {
+          val alternative = choice.getAlternatives(i)
+          val enrichedSubtree = enrichTree(alternative.subtree, pt, translator)
+          if (enrichedSubtree !== alternative.subtree) {
+            lazyBuilder()
+              .choiceBuilder
+              .setAlternatives(i, alternative.toBuilder().setSubtree(enrichedSubtree))
           }
         }
       }
@@ -91,7 +103,7 @@ object TraceEnricher {
     if (event.hasCloneSessionLookup() && pt != null) {
       val csl = event.cloneSessionLookup
       if (!csl.sessionFound) return null
-      // Enriches the first replica's port only; per-replica details are in fork branch labels.
+      // Enriches the first replica's port only; per-replica details are on the Continuations.
       val p4rtPort = pt.dataplaneToP4rt(csl.dataplaneEgressPort) ?: return null
       return event
         .toBuilder()

--- a/grpc/TraceEnricherTest.kt
+++ b/grpc/TraceEnricherTest.kt
@@ -1,12 +1,14 @@
 package fourward.grpc
 
 import com.google.protobuf.ByteString
+import fourward.Alternative
+import fourward.Choice
 import fourward.CloneSessionLookupEvent
+import fourward.Continuation
+import fourward.ContinuationKind
+import fourward.Continuations
 import fourward.Drop
 import fourward.DropReason
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.OutputPacket
 import fourward.PacketIngressEvent
 import fourward.PacketOutcome
@@ -195,23 +197,23 @@ class TraceEnricherTest {
   }
 
   // ===========================================================================
-  // Fork propagation
+  // Subtree recursion
   // ===========================================================================
 
   @Test
-  fun `enrichment propagates through fork branches`() {
+  fun `enrichment propagates through continuations`() {
     val translator = portTranslator()
     translator.p4rtToDataplane(PORT_TYPE, "Ethernet0")
     translator.p4rtToDataplane(PORT_TYPE, "Ethernet1")
 
-    val branch1 =
+    val replica0 =
       TraceTree.newBuilder()
         .setPacketOutcome(
           PacketOutcome.newBuilder()
             .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(0).setPayload(EMPTY))
         )
         .build()
-    val branch2 =
+    val replica1 =
       TraceTree.newBuilder()
         .setPacketOutcome(
           PacketOutcome.newBuilder()
@@ -221,20 +223,70 @@ class TraceEnricherTest {
 
     val trace =
       TraceTree.newBuilder()
-        .setForkOutcome(
-          Fork.newBuilder()
-            .setReason(ForkReason.MULTICAST)
-            .addBranches(ForkBranch.newBuilder().setLabel("replica_0").setSubtree(branch1))
-            .addBranches(ForkBranch.newBuilder().setLabel("replica_1").setSubtree(branch2))
+        .setContinuations(
+          Continuations.newBuilder()
+            .addContinuations(
+              Continuation.newBuilder()
+                .setKind(ContinuationKind.MULTICAST_REPLICA)
+                .setDataplaneEgressPort(0)
+                .setInstance(1)
+                .setSubtree(replica0)
+            )
+            .addContinuations(
+              Continuation.newBuilder()
+                .setKind(ContinuationKind.MULTICAST_REPLICA)
+                .setDataplaneEgressPort(1)
+                .setInstance(2)
+                .setSubtree(replica1)
+            )
         )
         .build()
 
     val enriched = TraceEnricher.enrich(trace, translator)
 
-    val out0 = enriched.forkOutcome.getBranches(0).subtree.packetOutcome.output
+    val out0 = enriched.continuations.getContinuations(0).subtree.packetOutcome.output
     assertEquals(ByteString.copyFromUtf8("Ethernet0"), out0.p4RtEgressPort)
 
-    val out1 = enriched.forkOutcome.getBranches(1).subtree.packetOutcome.output
+    val out1 = enriched.continuations.getContinuations(1).subtree.packetOutcome.output
+    assertEquals(ByteString.copyFromUtf8("Ethernet1"), out1.p4RtEgressPort)
+  }
+
+  @Test
+  fun `enrichment propagates through choice alternatives`() {
+    val translator = portTranslator()
+    translator.p4rtToDataplane(PORT_TYPE, "Ethernet0")
+    translator.p4rtToDataplane(PORT_TYPE, "Ethernet1")
+
+    val world0 =
+      TraceTree.newBuilder()
+        .setPacketOutcome(
+          PacketOutcome.newBuilder()
+            .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(0).setPayload(EMPTY))
+        )
+        .build()
+    val world1 =
+      TraceTree.newBuilder()
+        .setPacketOutcome(
+          PacketOutcome.newBuilder()
+            .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(EMPTY))
+        )
+        .build()
+
+    val trace =
+      TraceTree.newBuilder()
+        .setChoice(
+          Choice.newBuilder()
+            .addAlternatives(Alternative.newBuilder().setMemberId(7).setSubtree(world0))
+            .addAlternatives(Alternative.newBuilder().setMemberId(8).setSubtree(world1))
+        )
+        .build()
+
+    val enriched = TraceEnricher.enrich(trace, translator)
+
+    val out0 = enriched.choice.getAlternatives(0).subtree.packetOutcome.output
+    assertEquals(ByteString.copyFromUtf8("Ethernet0"), out0.p4RtEgressPort)
+
+    val out1 = enriched.choice.getAlternatives(1).subtree.packetOutcome.output
     assertEquals(ByteString.copyFromUtf8("Ethernet1"), out1.p4RtEgressPort)
   }
 

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -178,11 +178,11 @@ internal fun runControlStage(
  *
  * On the first encounter with an action selector group hit, the [Interpreter] throws
  * [ActionSelectorFork] with the list of group members and the trace events accumulated before the
- * fork. This method builds a fork [TraceTree] with one branch per member, re-executing via
- * [reExecute] with the forced member selection added to [currentSelectors].
+ * fork point. This method builds a [fourward.Choice] [TraceTree] with one alternative per member,
+ * re-executing via [reExecute] with the forced member selection added to [currentSelectors].
  *
  * The re-execution produces identical events up to the fork point (deterministic replay), so the
- * prefix is safely stripped from each branch's trace.
+ * prefix is safely stripped from each alternative's trace.
  */
 internal fun handleActionSelectorFork(
   fork: ActionSelectorFork,
@@ -190,19 +190,20 @@ internal fun handleActionSelectorFork(
   reExecute: (Map<String, Int>) -> TraceTree,
 ): TraceTree {
   val prefixLength = fork.eventsBeforeFork.size
-  val branches =
+  val alternatives =
     fork.members.map { member ->
       val newSelectors = currentSelectors + (fork.tableName to member.memberId)
       val subtree = reExecute(newSelectors)
-      val stripped = TraceTree.newBuilder().addAllEvents(subtree.eventsList.drop(prefixLength))
-      if (subtree.hasPacketOutcome()) stripped.setPacketOutcome(subtree.packetOutcome)
-      if (subtree.hasForkOutcome()) stripped.setForkOutcome(subtree.forkOutcome)
-      fourward.ForkBranch.newBuilder()
-        .setLabel("member_${member.memberId}")
+      val stripped =
+        TraceTree.newBuilder()
+          .addAllEvents(subtree.eventsList.drop(prefixLength))
+          .copyOutcome(subtree)
+      fourward.Alternative.newBuilder()
+        .setMemberId(member.memberId)
         .setSubtree(stripped.build())
         .build()
     }
-  return buildForkTree(fork.eventsBeforeFork, fourward.ForkReason.ACTION_SELECTOR, branches)
+  return buildChoiceTree(fork.eventsBeforeFork, alternatives)
 }
 
 /**

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -1,11 +1,10 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
+import fourward.Continuation
+import fourward.ContinuationKind
 import fourward.DropReason
 import fourward.ExternInstanceDecl
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.PipelineStage
 import fourward.TraceTree
 import fourward.TypeDecl
@@ -200,11 +199,11 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     runControlStage(interpreter, ctx, env, pipeline.mainDeparser)
     val deparsedBytes = ctx.deparsedPayload()
 
-    val mirrorBranches = buildMirrorBranches(pipeline, deparsedBytes, forwardingState)
+    val mirrors = buildMirrors(pipeline, deparsedBytes, forwardingState)
 
     if (forwardingState.dropped && !forwardingState.recirculate) {
-      // Dropped with mirror: emit only mirror branches.
-      return buildForkTree(ctx.getEvents(), ForkReason.CLONE, mirrorBranches)
+      // Dropped with mirror: only the mirror copies continue.
+      return buildContinuationsTree(ctx.getEvents(), mirrors)
     }
 
     if (forwardingState.recirculate) {
@@ -217,23 +216,20 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
           passNumber = passNumber + 1,
           depth = depth + 1,
         )
-      val recircBranch =
-        ForkBranch.newBuilder().setLabel("recirculate").setSubtree(recircTree).build()
       // Mirror is independent of recirculation — emit both if requested.
-      val branches = mirrorBranches + recircBranch
-      val reason = if (mirrorBranches.isNotEmpty()) ForkReason.CLONE else ForkReason.RECIRCULATE
-      return TraceTree.newBuilder()
-        .addAllEvents(ctx.getEvents())
-        .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
-        .build()
+      return buildContinuationsTree(
+        ctx.getEvents(),
+        mirrors + continuation(ContinuationKind.RECIRCULATE, recircTree),
+      )
     }
 
     val originalTree = buildOutputTrace(ctx.getEvents(), forwardingState.destPort, deparsedBytes)
 
-    if (mirrorBranches.isNotEmpty()) {
-      val originalBranch =
-        ForkBranch.newBuilder().setLabel("original").setSubtree(originalTree).build()
-      return buildForkTree(emptyList(), ForkReason.CLONE, listOf(originalBranch) + mirrorBranches)
+    if (mirrors.isNotEmpty()) {
+      return buildContinuationsTree(
+        emptyList(),
+        listOf(continuation(ContinuationKind.ORIGINAL, originalTree)) + mirrors,
+      )
     }
 
     return originalTree
@@ -406,28 +402,33 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       )
 
   // ---------------------------------------------------------------------------
-  // Mirror branch construction
+  // Mirror continuation construction
   // ---------------------------------------------------------------------------
 
   /**
-   * Builds mirror branches if `mirror_packet()` was called during main control.
+   * Builds mirror continuations if `mirror_packet()` was called during main control.
    *
    * PNA mirrors the deparsed packet (post-modification), matching DPDK SoftNIC behavior. Each
    * replica in the clone session outputs the deparsed bytes on the replica's egress port. Unlike
    * PSA clones (which run through a separate egress pipeline), PNA mirror replicas emit directly
    * because PNA has no separate egress stage for mirrored packets to traverse.
    */
-  private fun buildMirrorBranches(
+  private fun buildMirrors(
     pipeline: PipelineConfig,
     deparsedBytes: ByteArray,
     forwardingState: ForwardingState,
-  ): List<ForkBranch> {
+  ): List<Continuation> {
     val sessionId = forwardingState.mirrorSessionId ?: return emptyList()
     val session = pipeline.tableStore.getCloneSession(sessionId) ?: return emptyList()
     return session.replicasList.map { replica ->
       val port = replicaPort(replica)
       val subtree = buildOutputTrace(emptyList(), port, deparsedBytes)
-      ForkBranch.newBuilder().setLabel("mirror_port_$port").setSubtree(subtree).build()
+      continuation(
+        ContinuationKind.MIRROR,
+        subtree,
+        dataplaneEgressPort = port,
+        instance = replica.instance,
+      )
     }
   }
 

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -3,12 +3,12 @@ package fourward.simulator
 import com.google.protobuf.ByteString
 import fourward.Architecture
 import fourward.BehavioralConfig
+import fourward.ContinuationKind
 import fourward.ControlDecl
 import fourward.DropReason
 import fourward.EnumDecl
 import fourward.ExternInstanceDecl
 import fourward.FieldDecl
-import fourward.ForkReason
 import fourward.HeaderDecl
 import fourward.ParamDecl
 import fourward.ParserDecl
@@ -442,7 +442,7 @@ class PNAArchitectureTest {
     externCall("mirror_packet", bit(slotId, 8), bit(sessionId, 16))
 
   @Test
-  fun `mirror_packet creates fork with original and mirror branches`() {
+  fun `mirror_packet creates original and mirror outputs`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(2), mirrorPacket(0, 100)))
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
@@ -510,17 +510,21 @@ class PNAArchitectureTest {
   }
 
   @Test
-  fun `mirror_packet trace has CLONE fork reason`() {
+  fun `mirror_packet trace has ORIGINAL and MIRROR continuations`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(2), mirrorPacket(0, 100)))
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
     val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    assertEquals("original", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("mirror_port_5", result.trace.forkOutcome.branchesList[1].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(ContinuationKind.ORIGINAL, continuations[0].kind)
+    assertEquals(ContinuationKind.MIRROR, continuations[1].kind)
+    assertEquals(5, continuations[1].dataplaneEgressPort)
+    // instance defaults to 0 when unset, so check presence before value.
+    assertTrue(continuations[1].hasInstance())
+    assertEquals(0, continuations[1].instance)
   }
 
   @Test
@@ -554,7 +558,7 @@ class PNAArchitectureTest {
   fun `mirror_packet with recirculate emits both`() {
     // Mirror is independent of recirculate — both should take effect.
     // Every pass calls recirculate(), so this hits MAX_RECIRCULATIONS, but the first
-    // fork should contain both mirror and recirculate branches.
+    // Continuations node should contain both mirror and recirculate continuations.
     val config =
       pnaConfig(mainControlStmts = listOf(sendToPort(2), mirrorPacket(0, 100), recirculate()))
     val store = TableStore()

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -1,11 +1,10 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
+import fourward.Continuation
+import fourward.ContinuationKind
 import fourward.DropReason
 import fourward.ExternInstanceDecl
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.PipelineStage
 import fourward.TraceEvent
 import fourward.TraceTree
@@ -134,10 +133,9 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     // I2E clone is independent of drop but suppressed by resubmit.
 
     if (ingress.dropped) {
-      val i2eCloneBranches =
-        buildI2ECloneBranches(pipeline, packet, ingress.output, selectorMembers)
-      if (i2eCloneBranches.isNotEmpty()) {
-        return buildForkTree(ingress.events, ForkReason.CLONE, i2eCloneBranches)
+      val i2eClones = buildI2EClones(pipeline, packet, ingress.output, selectorMembers)
+      if (i2eClones.isNotEmpty()) {
+        return buildContinuationsTree(ingress.events, i2eClones)
       }
       return buildDropTrace(ingress.events, ingress.dropReason)
     }
@@ -153,24 +151,20 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           PACKET_PATH_RESUBMIT,
           depth = depth + 1,
         )
-      return buildForkTree(
+      return buildContinuationsTree(
         ingress.events,
-        ForkReason.RESUBMIT,
-        listOf(ForkBranch.newBuilder().setLabel("resubmit").setSubtree(resubmitTree).build()),
+        listOf(continuation(ContinuationKind.RESUBMIT, resubmitTree)),
       )
     }
 
     // === Traffic Manager: I2E clone + multicast/unicast ===
-    val i2eCloneBranches = buildI2ECloneBranches(pipeline, packet, ingress.output, selectorMembers)
+    val i2eClones = buildI2EClones(pipeline, packet, ingress.output, selectorMembers)
     val originalTree = buildOriginalEgressPath(pipeline, ingress, depth, selectorMembers)
 
-    if (i2eCloneBranches.isNotEmpty()) {
-      val originalBranch =
-        ForkBranch.newBuilder().setLabel("original").setSubtree(originalTree).build()
-      return buildForkTree(
+    if (i2eClones.isNotEmpty()) {
+      return buildContinuationsTree(
         ingress.events,
-        ForkReason.CLONE,
-        listOf(originalBranch) + i2eCloneBranches,
+        listOf(continuation(ContinuationKind.ORIGINAL, originalTree)) + i2eClones,
       )
     }
 
@@ -178,8 +172,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     return TraceTree.newBuilder()
       .addAllEvents(ingress.events)
       .addAllEvents(originalTree.eventsList)
-      .also { if (originalTree.hasPacketOutcome()) it.setPacketOutcome(originalTree.packetOutcome) }
-      .also { if (originalTree.hasForkOutcome()) it.setForkOutcome(originalTree.forkOutcome) }
+      .copyOutcome(originalTree)
       .build()
   }
 
@@ -304,7 +297,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     }
 
     val lookupEvent = multicastGroupLookupEvent(multicastGroup, group.replicasCount)
-    val branches =
+    val replicas =
       group.replicasList.map { replica ->
         val port = replicaPort(replica)
         val subtree =
@@ -317,15 +310,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
             depth,
             selectorMembers,
           )
-        ForkBranch.newBuilder()
-          .setLabel("replica_${replica.instance}_port_$port")
-          .setSubtree(subtree)
-          .build()
+        continuation(
+          ContinuationKind.MULTICAST_REPLICA,
+          subtree,
+          dataplaneEgressPort = port,
+          instance = replica.instance,
+        )
       }
-    return TraceTree.newBuilder()
-      .addEvents(lookupEvent)
-      .setForkOutcome(Fork.newBuilder().setReason(ForkReason.MULTICAST).addAllBranches(branches))
-      .build()
+    return buildContinuationsTree(listOf(lookupEvent), replicas)
   }
 
   // ---------------------------------------------------------------------------
@@ -385,11 +377,11 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     }
 
     // E2E clone: uses deparsed bytes from this egress pass. Independent of drop decision.
-    val e2eCloneBranches = buildE2ECloneBranches(state.pipeline, core, selectorMembers)
+    val e2eClones = buildE2EClones(state.pipeline, core, selectorMembers)
 
     if (core.dropped) {
-      if (e2eCloneBranches.isNotEmpty()) {
-        return buildForkTree(core.events, ForkReason.CLONE, e2eCloneBranches)
+      if (e2eClones.isNotEmpty()) {
+        return buildContinuationsTree(core.events, e2eClones)
       }
       return buildDropTrace(core.events, core.dropReason)
     }
@@ -406,22 +398,19 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
             PACKET_PATH_RECIRCULATE,
             depth = depth + 1,
           )
-        TraceTree.newBuilder()
-          .addAllEvents(core.events)
-          .setForkOutcome(
-            Fork.newBuilder()
-              .setReason(ForkReason.RECIRCULATE)
-              .addBranches(ForkBranch.newBuilder().setLabel("recirculate").setSubtree(recircTree))
-          )
-          .build()
+        buildContinuationsTree(
+          core.events,
+          listOf(continuation(ContinuationKind.RECIRCULATE, recircTree)),
+        )
       } else {
         buildOutputTrace(core.events, egressPort, core.deparsedBytes)
       }
 
-    if (e2eCloneBranches.isNotEmpty()) {
-      val originalBranch =
-        ForkBranch.newBuilder().setLabel("original").setSubtree(outputTree).build()
-      return buildForkTree(emptyList(), ForkReason.CLONE, listOf(originalBranch) + e2eCloneBranches)
+    if (e2eClones.isNotEmpty()) {
+      return buildContinuationsTree(
+        emptyList(),
+        listOf(continuation(ContinuationKind.ORIGINAL, outputTree)) + e2eClones,
+      )
     }
 
     return outputTree
@@ -489,41 +478,35 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   // ---------------------------------------------------------------------------
 
   /**
-   * Builds I2E clone branches if the ingress output metadata requests cloning.
+   * Builds I2E clone continuations if the ingress output metadata requests cloning.
    *
    * I2E clones use the ORIGINAL input bytes (pre-ingress) — not the ingress-deparsed output. Each
    * replica in the clone session's multicast group produces a separate egress execution with
    * `packet_path = CLONE_I2E`.
    */
-  private fun buildI2ECloneBranches(
+  private fun buildI2EClones(
     pipeline: PipelineConfig,
     originalPacket: PacketBits,
     ingressOutput: StructVal?,
     selectorMembers: Map<String, Int> = emptyMap(),
-  ): List<ForkBranch> =
+  ): List<Continuation> =
     // I2E clones don't carry ingress output metadata to egress — egress gets a fresh EgressState
     // with no ingressOutput. Clones do not produce further clones (no chained cloning in PSA).
-    buildCloneBranches(
-      pipeline,
-      ingressOutput,
-      originalPacket,
-      PACKET_PATH_CLONE_I2E,
-      selectorMembers,
-    )
+    buildClones(pipeline, ingressOutput, originalPacket, PACKET_PATH_CLONE_I2E, selectorMembers)
 
   /**
-   * Builds E2E clone branches if the egress output metadata requests cloning.
+   * Builds E2E clone continuations if the egress output metadata requests cloning.
    *
    * E2E clones use the deparsed bytes from the current egress pass. Each replica produces a fresh
    * egress execution with `packet_path = CLONE_E2E`. Chained E2E cloning is suppressed (PSA spec:
    * behavior is implementation-specific; BMv2 suppresses it).
    */
-  private fun buildE2ECloneBranches(
+  private fun buildE2EClones(
     pipeline: PipelineConfig,
     core: EgressCoreResult,
     selectorMembers: Map<String, Int> = emptyMap(),
-  ): List<ForkBranch> =
-    buildCloneBranches(
+  ): List<Continuation> =
+    buildClones(
       pipeline,
       core.output,
       PacketBits.ofBytes(core.deparsedBytes),
@@ -532,19 +515,19 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     )
 
   /**
-   * Shared clone branch builder for both I2E and E2E cloning.
+   * Shared clone continuation builder for both I2E and E2E cloning.
    *
    * Checks the clone flag in [cloneMetadata], looks up the clone session, and runs a fresh egress
    * for each replica. Clone egress runs via [runEgressCore] directly (no post-processing), which
    * prevents chained cloning.
    */
-  private fun buildCloneBranches(
+  private fun buildClones(
     pipeline: PipelineConfig,
     cloneMetadata: StructVal?,
     clonePacket: PacketBits,
     packetPath: String,
     selectorMembers: Map<String, Int> = emptyMap(),
-  ): List<ForkBranch> {
+  ): List<Continuation> {
     if ((cloneMetadata?.fields?.get("clone") as? BoolVal)?.value != true) return emptyList()
     val sessionId =
       (cloneMetadata.fields["clone_session_id"] as? BitVal)?.bits?.value?.toInt()
@@ -555,15 +538,21 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       val port = replicaPort(replica)
       val subtree =
         runCloneEgress(cloneState, clonePacket, port, replica.instance, packetPath, selectorMembers)
-      ForkBranch.newBuilder().setLabel("clone_port_$port").setSubtree(subtree).build()
+      continuation(
+        ContinuationKind.CLONE,
+        subtree,
+        dataplaneEgressPort = port,
+        instance = replica.instance,
+      )
     }
   }
 
   /**
    * Runs a single clone replica's egress pipeline, handling ActionSelectorFork.
    *
-   * Clone branches call [runEgressCore] directly (no post-processing) to prevent chained cloning.
-   * But egress tables can still hit action selector groups, so we must catch the fork here.
+   * Clone continuations call [runEgressCore] directly (no post-processing) to prevent chained
+   * cloning. But egress tables can still hit action selector groups, so we must catch the fork
+   * here.
    */
   private fun runCloneEgress(
     cloneState: EgressState,
@@ -706,7 +695,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
   // Hash helpers (evalGetHash, hashDataArg, sumWords) live in Hash.kt.
   // Action selector fork handling (handleActionSelectorFork) and trace helpers
-  // (buildForkTree) live in ArchitectureHelpers.kt and TraceHelpers.kt.
+  // (buildContinuationsTree, buildChoiceTree) live in ArchitectureHelpers.kt and TraceHelpers.kt.
 
   private companion object {
     // PSA_PacketPath_t enum values (PSA spec §6.1).

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -6,6 +6,7 @@ import fourward.AssignmentStmt
 import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
+import fourward.ContinuationKind
 import fourward.ControlDecl
 import fourward.DropReason
 import fourward.EnumDecl
@@ -13,7 +14,6 @@ import fourward.Expr
 import fourward.ExternInstanceDecl
 import fourward.FieldAccess
 import fourward.FieldDecl
-import fourward.ForkReason
 import fourward.Literal
 import fourward.MethodCall
 import fourward.MethodCallStmt
@@ -471,18 +471,24 @@ class PSAArchitectureTest {
   }
 
   @Test
-  fun `multicast trace has fork node with MULTICAST reason`() {
+  fun `multicast trace has MULTICAST_REPLICA continuations`() {
     val config = psaConfig(ingressStmts = listOf(multicast(1)))
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 1 to 3))
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
-    assertEquals("replica_0_port_2", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("replica_1_port_3", result.trace.forkOutcome.branchesList[1].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(2, continuations.size)
+    assertEquals(ContinuationKind.MULTICAST_REPLICA, continuations[0].kind)
+    // instance defaults to 0 when unset, so check presence before value.
+    assertTrue(continuations[0].hasInstance())
+    assertEquals(0, continuations[0].instance)
+    assertEquals(2, continuations[0].dataplaneEgressPort)
+    assertEquals(ContinuationKind.MULTICAST_REPLICA, continuations[1].kind)
+    assertEquals(1, continuations[1].instance)
+    assertEquals(3, continuations[1].dataplaneEgressPort)
   }
 
   @Test
@@ -891,7 +897,7 @@ class PSAArchitectureTest {
   }
 
   @Test
-  fun `I2E clone produces clone and original branches`() {
+  fun `I2E clone produces clone and original outputs`() {
     val config = psaConfig(ingressStmts = cloneStmts(100) + listOf(sendToPort(2)))
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
@@ -939,17 +945,21 @@ class PSAArchitectureTest {
   }
 
   @Test
-  fun `I2E clone trace has CLONE fork reason`() {
+  fun `I2E clone trace has ORIGINAL and CLONE continuations`() {
     val config = psaConfig(ingressStmts = cloneStmts(100) + listOf(sendToPort(2)))
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    assertEquals("original", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("clone_port_5", result.trace.forkOutcome.branchesList[1].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(ContinuationKind.ORIGINAL, continuations[0].kind)
+    assertEquals(ContinuationKind.CLONE, continuations[1].kind)
+    assertEquals(5, continuations[1].dataplaneEgressPort)
+    // instance defaults to 0 when unset, so check presence before value.
+    assertTrue(continuations[1].hasInstance())
+    assertEquals(0, continuations[1].instance)
   }
 
   @Test
@@ -970,7 +980,7 @@ class PSAArchitectureTest {
   }
 
   @Test
-  fun `E2E clone produces clone and original branches`() {
+  fun `E2E clone produces clone and original outputs`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(2)), egressStmts = cloneStmts(200))
     val store = TableStore()
     writeCloneSession(store, 200, listOf(0 to 8))
@@ -984,7 +994,7 @@ class PSAArchitectureTest {
   }
 
   @Test
-  fun `E2E clone with drop still creates clone fork`() {
+  fun `E2E clone with drop still creates clone continuation`() {
     // Egress unconditionally sets clone=true and drops. The E2E clone runs through a fresh
     // egress pipeline, but the same control code drops it too. This is correct PSA behavior —
     // in real programs, the egress control checks istd.packet_path to handle clones differently.
@@ -999,13 +1009,18 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xDD.toByte()), store)
 
-    // Clone fork exists even though original drops — E2E clone is processed independently.
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    assertEquals(1, result.trace.forkOutcome.branchesCount)
-    assertEquals("clone_port_9", result.trace.forkOutcome.branchesList[0].label)
+    // Clone continuation exists even though original drops — E2E clone is processed
+    // independently.
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(1, continuations.size)
+    assertEquals(ContinuationKind.CLONE, continuations[0].kind)
+    assertEquals(9, continuations[0].dataplaneEgressPort)
+    // instance defaults to 0 when unset, so check presence before value.
+    assertTrue(continuations[0].hasInstance())
+    assertEquals(0, continuations[0].instance)
     // Clone also dropped by the same egress control.
-    assertTrue(result.trace.forkOutcome.branchesList[0].subtree.packetOutcome.hasDrop())
+    assertTrue(continuations[0].subtree.packetOutcome.hasDrop())
   }
 
   @Test
@@ -1020,20 +1035,24 @@ class PSAArchitectureTest {
   }
 
   @Test
-  fun `E2E clone trace has CLONE fork reason`() {
+  fun `E2E clone trace has ORIGINAL and CLONE continuations`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(2)), egressStmts = cloneStmts(200))
     val store = TableStore()
     writeCloneSession(store, 200, listOf(0 to 8))
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
-    // E2E clone fork is in the egress subtree, flattened into the top-level trace since
-    // there's no I2E clone.
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
-    assertEquals("original", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("clone_port_8", result.trace.forkOutcome.branchesList[1].label)
+    // The E2E clone Continuations node is in the egress subtree, flattened into the top-level
+    // trace since there's no I2E clone.
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(2, continuations.size)
+    assertEquals(ContinuationKind.ORIGINAL, continuations[0].kind)
+    assertEquals(ContinuationKind.CLONE, continuations[1].kind)
+    assertEquals(8, continuations[1].dataplaneEgressPort)
+    // instance defaults to 0 when unset, so check presence before value.
+    assertTrue(continuations[1].hasInstance())
+    assertEquals(0, continuations[1].instance)
   }
 
   @Test
@@ -1100,10 +1119,11 @@ class PSAArchitectureTest {
     // Packet recirculates once, then forwards on port 5.
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
-    // Trace should show a RECIRCULATE fork.
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
-    assertEquals("recirculate", result.trace.forkOutcome.branchesList[0].label)
+    // Trace should show a single RECIRCULATE continuation.
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(1, continuations.size)
+    assertEquals(ContinuationKind.RECIRCULATE, continuations[0].kind)
   }
 
   @Test
@@ -1169,9 +1189,10 @@ class PSAArchitectureTest {
 
     assertEquals(1, outputs.size)
     assertEquals(7, outputs[0].dataplaneEgressPort)
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
-    assertEquals("resubmit", result.trace.forkOutcome.branchesList[0].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(1, continuations.size)
+    assertEquals(ContinuationKind.RESUBMIT, continuations[0].kind)
   }
 
   @Test
@@ -1233,7 +1254,10 @@ class PSAArchitectureTest {
     // Resubmit wins: packet loops back, then exits on port 5. No clone on port 9.
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
-    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
+    assertEquals(
+      ContinuationKind.RESUBMIT,
+      result.trace.continuations.continuationsList.single().kind,
+    )
   }
 
   @Test
@@ -1249,7 +1273,7 @@ class PSAArchitectureTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Action selector fork tests
+  // Action selector choice tests
   // ---------------------------------------------------------------------------
 
   private companion object {
@@ -1264,7 +1288,7 @@ class PSAArchitectureTest {
    * Builds a control block with a table apply and optional post-table statements.
    *
    * The table has one exact-match key reading from a local variable `k` (initializer `0x0A`), with
-   * empty `actionA`/`actionB` local actions. Tests care about fork structure, not action bodies.
+   * empty `actionA`/`actionB` local actions. Tests care about choice structure, not action bodies.
    */
   private fun controlWithTable(
     controlName: String,
@@ -1447,7 +1471,7 @@ class PSAArchitectureTest {
   }
 
   @Test
-  fun `action selector group hit produces fork with member branches`() {
+  fun `action selector group hit produces choice with member alternatives`() {
     val config = psaConfigWithTable()
     val store = storeWithActionProfile()
     writeActionProfileMember(store, memberId = 0, actionId = AS_ACTION_A_ID)
@@ -1457,35 +1481,35 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
-    // Should produce an ACTION_SELECTOR fork with 2 member branches.
-    assertTrue("expected fork outcome", result.trace.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
-    assertEquals("member_0", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("member_1", result.trace.forkOutcome.branchesList[1].label)
+    // Should produce a Choice with one alternative per group member.
+    assertTrue("expected choice outcome", result.trace.hasChoice())
+    val alternatives = result.trace.choice.alternativesList
+    assertEquals(2, alternatives.size)
+    assertEquals(0, alternatives[0].memberId)
+    assertEquals(1, alternatives[1].memberId)
 
-    // Alternative fork: 2 possible worlds, each with 1 output (send_to_port(1) post-table).
+    // Choice (OR-node): 2 possible worlds, each with 1 output (send_to_port(1) post-table).
     val outcomes = result.possibleOutcomes
     assertEquals(2, outcomes.size)
     assertTrue(outcomes.all { world -> world.size == 1 && world[0].dataplaneEgressPort == 1 })
   }
 
   @Test
-  fun `action selector table miss uses default action without fork`() {
+  fun `action selector table miss uses default action without choice`() {
     // Table miss: no entry for key 0x0A → falls through to NoAction default.
-    // No group resolution → no ActionSelectorFork → no fork, just drop (PSA default).
+    // No group resolution → no ActionSelectorFork → no choice, just drop (PSA default).
     val config = psaConfigWithTable(postTableStmts = emptyList())
     val store = storeWithActionProfile()
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
-    // No fork — table miss falls through to default action, packet dropped by PSA default.
-    assertTrue("expected drop (no fork)", result.trace.hasPacketOutcome())
+    // No choice — table miss falls through to default action, packet dropped by PSA default.
+    assertTrue("expected drop (no choice)", result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
   }
 
   @Test
-  fun `action selector single member produces single-branch fork`() {
+  fun `action selector single member produces single-alternative choice`() {
     val config = psaConfigWithTable()
     val store = storeWithActionProfile()
     writeActionProfileMember(store, memberId = 0, actionId = AS_ACTION_A_ID)
@@ -1494,19 +1518,18 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
-    assertTrue("expected fork outcome", result.trace.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, result.trace.forkOutcome.reason)
-    assertEquals(1, result.trace.forkOutcome.branchesCount)
-    assertEquals("member_0", result.trace.forkOutcome.branchesList[0].label)
+    assertTrue("expected choice outcome", result.trace.hasChoice())
+    assertEquals(1, result.trace.choice.alternativesCount)
+    assertEquals(0, result.trace.choice.alternativesList[0].memberId)
 
-    // Alternative fork: 1 possible world with 1 output.
+    // Choice (OR-node): 1 possible world with 1 output.
     val outcomes = result.possibleOutcomes
     assertEquals(1, outcomes.size)
     assertEquals(1, outcomes[0].size)
   }
 
   @Test
-  fun `action selector fork in egress produces fork`() {
+  fun `action selector in egress produces choice`() {
     // Table is in egress control. Ingress forwards via send_to_port(1), then egress hits the
     // action selector group — exercises the runEgressWithPostProcessing catch site.
     val config = psaConfigWithEgressTable()
@@ -1518,21 +1541,21 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
-    // Egress fork: ACTION_SELECTOR with 2 member branches.
-    assertTrue("expected fork outcome", result.trace.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
-    assertEquals("member_0", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("member_1", result.trace.forkOutcome.branchesList[1].label)
+    // Egress choice: one alternative per group member.
+    assertTrue("expected choice outcome", result.trace.hasChoice())
+    val alternatives = result.trace.choice.alternativesList
+    assertEquals(2, alternatives.size)
+    assertEquals(0, alternatives[0].memberId)
+    assertEquals(1, alternatives[1].memberId)
 
-    // Alternative fork: 2 possible worlds, each with 1 output.
+    // Choice (OR-node): 2 possible worlds, each with 1 output.
     val outcomes = result.possibleOutcomes
     assertEquals(2, outcomes.size)
     assertTrue(outcomes.all { world -> world.size == 1 && world[0].dataplaneEgressPort == 1 })
   }
 
   @Test
-  fun `action selector fork in clone branch egress`() {
+  fun `action selector choice in clone continuation egress`() {
     // I2E clone + egress table with action selector group. The clone's egress runs through
     // runCloneEgress, which must catch ActionSelectorFork — this is the third catch site.
     val config = psaConfigWithEgressTable(ingressStmts = cloneStmts(100) + listOf(sendToPort(2)))
@@ -1545,23 +1568,21 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
 
-    // Top-level fork is CLONE (I2E clone) — parallel.
-    assertTrue("expected clone fork", result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    // Top-level outcome is the I2E clone Continuations node (AND): original + clone.
+    assertTrue("expected continuations outcome", result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
 
-    // Original branch: egress action selector fork with 2 members.
-    val originalBranch = result.trace.forkOutcome.branchesList.first { it.label == "original" }
-    assertTrue("expected fork in original", originalBranch.subtree.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, originalBranch.subtree.forkOutcome.reason)
-    assertEquals(2, originalBranch.subtree.forkOutcome.branchesCount)
+    // Original continuation: egress action selector choice with 2 members.
+    val original = continuations.first { it.kind == ContinuationKind.ORIGINAL }
+    assertTrue("expected choice in original", original.subtree.hasChoice())
+    assertEquals(2, original.subtree.choice.alternativesCount)
 
-    // Clone branch: also hits the egress table, producing its own action selector fork.
-    val cloneBranch = result.trace.forkOutcome.branchesList.first { it.label.startsWith("clone_") }
-    assertTrue("expected fork in clone", cloneBranch.subtree.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, cloneBranch.subtree.forkOutcome.reason)
-    assertEquals(2, cloneBranch.subtree.forkOutcome.branchesCount)
+    // Clone continuation: also hits the egress table, producing its own action selector choice.
+    val clone = continuations.first { it.kind == ContinuationKind.CLONE }
+    assertTrue("expected choice in clone", clone.subtree.hasChoice())
+    assertEquals(2, clone.subtree.choice.alternativesCount)
 
-    // Parallel clone × alternative selector: 2 members × 2 members = 4 possible worlds,
+    // Continuations (AND) × choice (OR): 2 members × 2 members = 4 possible worlds,
     // each with 2 outputs (one from original, one from clone).
     val outcomes = result.possibleOutcomes
     assertEquals(4, outcomes.size)

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -44,9 +44,14 @@ private fun collectEntities(
     collectFromEvent(event, snapshot, tableStore, staticEntries, out)
   }
   when (trace.outcomeCase) {
-    TraceTree.OutcomeCase.FORK_OUTCOME -> {
-      for (branch in trace.forkOutcome.branchesList) {
-        collectEntities(branch.subtree, snapshot, tableStore, staticEntries, out)
+    TraceTree.OutcomeCase.CONTINUATIONS -> {
+      for (continuation in trace.continuations.continuationsList) {
+        collectEntities(continuation.subtree, snapshot, tableStore, staticEntries, out)
+      }
+    }
+    TraceTree.OutcomeCase.CHOICE -> {
+      for (alternative in trace.choice.alternativesList) {
+        collectEntities(alternative.subtree, snapshot, tableStore, staticEntries, out)
       }
     }
     TraceTree.OutcomeCase.PACKET_OUTCOME,

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -1,12 +1,14 @@
 package fourward.simulator
 
 import com.google.protobuf.ByteString
+import fourward.Alternative
+import fourward.Choice
 import fourward.CloneSessionLookupEvent
+import fourward.Continuation
+import fourward.ContinuationKind
+import fourward.Continuations
 import fourward.Drop
 import fourward.DropReason
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.PacketOutcome
 import fourward.TableLookupEvent
 import fourward.TraceEvent
@@ -234,27 +236,65 @@ class ReproducerExtractorTest {
   }
 
   @Test
-  fun `fork branches are traversed recursively`() {
+  fun `continuations are traversed recursively`() {
     val entry1 = tableEntry(tableId = 1, matchValue = byteArrayOf(0x01), actionId = 10)
     val entry2 = tableEntry(tableId = 2, matchValue = byteArrayOf(0x02), actionId = 20)
 
     val trace =
       TraceTree.newBuilder()
-        .setForkOutcome(
-          Fork.newBuilder()
-            .setReason(ForkReason.CLONE)
-            .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("original")
+        .setContinuations(
+          Continuations.newBuilder()
+            .addContinuations(
+              Continuation.newBuilder()
+                .setKind(ContinuationKind.ORIGINAL)
                 .setSubtree(
                   TraceTree.newBuilder()
                     .addEvents(tableLookupHit(entry1))
                     .setPacketOutcome(dropOutcome())
                 )
             )
-            .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("clone")
+            .addContinuations(
+              Continuation.newBuilder()
+                .setKind(ContinuationKind.CLONE)
+                .setDataplaneEgressPort(7)
+                .setInstance(1)
+                .setSubtree(
+                  TraceTree.newBuilder()
+                    .addEvents(tableLookupHit(entry2))
+                    .setPacketOutcome(dropOutcome())
+                )
+            )
+        )
+        .build()
+
+    val entities = extract(trace, emptyTableStore())
+
+    assertEquals(2, entities.size)
+    assertEquals(entry1, entities[0].tableEntry)
+    assertEquals(entry2, entities[1].tableEntry)
+  }
+
+  @Test
+  fun `choice alternatives are traversed recursively`() {
+    val entry1 = tableEntry(tableId = 1, matchValue = byteArrayOf(0x01), actionId = 10)
+    val entry2 = tableEntry(tableId = 2, matchValue = byteArrayOf(0x02), actionId = 20)
+
+    val trace =
+      TraceTree.newBuilder()
+        .setChoice(
+          Choice.newBuilder()
+            .addAlternatives(
+              Alternative.newBuilder()
+                .setMemberId(1)
+                .setSubtree(
+                  TraceTree.newBuilder()
+                    .addEvents(tableLookupHit(entry1))
+                    .setPacketOutcome(dropOutcome())
+                )
+            )
+            .addAlternatives(
+              Alternative.newBuilder()
+                .setMemberId(2)
                 .setSubtree(
                   TraceTree.newBuilder()
                     .addEvents(tableLookupHit(entry2))

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -8,15 +8,14 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * Result of processing a single packet through the pipeline.
  *
- * [possibleOutcomes] captures both kinds of nondeterminism in the trace tree:
- * - **Parallel forks** (clone, multicast, resubmit, recirculate): all branches execute
- *   simultaneously, so their outputs are combined within each possible outcome.
- * - **Alternative forks** (action selector): exactly one branch executes at runtime, so each branch
+ * [possibleOutcomes] captures both kinds of branching in the trace tree:
+ * - **Continuations** (clone, multicast, resubmit, recirculate): all happen within one real
+ *   execution, so their outputs are combined within each possible outcome.
+ * - **Choices** (action selector): exactly one alternative happens at runtime, so each alternative
  *   produces a separate possible outcome.
  *
- * Programs with no alternative forks have exactly one possible outcome. Programs with action
- * selectors have one possible outcome per alternative (Cartesian product when nested inside
- * parallel forks).
+ * Programs with no choices have exactly one possible outcome. Programs with action selectors have
+ * one possible outcome per alternative (Cartesian product when nested inside continuations).
  *
  * Decouples the simulator from the gRPC wire format ([fourward.InjectPacketResponse]). Each RPC
  * method builds its own wire proto from this data class.
@@ -140,8 +139,8 @@ class Simulator : TableDataReader {
     val result = captured.result
 
     // Output packets are extracted from trace tree leaves — the tree is the single source
-    // of truth for packet outcomes. Parallel forks (clone, multicast) combine outputs within
-    // each world; alternative forks (action selector) produce separate possible worlds.
+    // of truth for packet outcomes. Continuations (clone, multicast) combine outputs within
+    // each world; choices (action selector) produce separate possible worlds.
     val trace = result.trace
     return ProcessPacketResult(
       trace = trace,
@@ -272,40 +271,39 @@ class Simulator : TableDataReader {
 }
 
 /**
- * Collects all possible outcome sets from a trace tree, respecting fork semantics.
- * - **Parallel forks** (clone, multicast, resubmit, recirculate): outputs from all branches are
- *   combined within each possible world (Cartesian product of branch outcomes).
- * - **Alternative forks** (action selector): each branch is a separate possible world; outcomes are
- *   concatenated (union of branch outcomes).
+ * Collects all possible outcome sets from a trace tree.
+ * - **Continuations (AND):** all happen within one execution, so outputs are combined within each
+ *   possible world (Cartesian product across continuations).
+ * - **Choice (OR):** each alternative is a separate possible world; their worlds are concatenated.
  * - **Leaf (output):** one possible world with one packet.
  * - **Leaf (drop):** one possible world with no packets.
  *
  * Returns a non-empty list. Each inner list is one complete set of output packets that could result
  * from a single real execution.
  */
-fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
+fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> =
   when (tree.outcomeCase) {
     TraceTree.OutcomeCase.PACKET_OUTCOME ->
-      return if (tree.packetOutcome.hasOutput()) {
+      if (tree.packetOutcome.hasOutput()) {
         listOf(listOf(tree.packetOutcome.output))
       } else {
         listOf(emptyList())
       }
     TraceTree.OutcomeCase.OUTCOME_NOT_SET,
-    null -> return listOf(emptyList())
-    TraceTree.OutcomeCase.FORK_OUTCOME -> {} // fall through to fork handling below
+    null -> listOf(emptyList())
+    TraceTree.OutcomeCase.CHOICE ->
+      tree.choice.alternativesList
+        .flatMap { collectPossibleOutcomes(it.subtree) }
+        .ifEmpty { listOf(emptyList()) }
+    TraceTree.OutcomeCase.CONTINUATIONS -> {
+      val perContinuation =
+        tree.continuations.continuationsList.map { collectPossibleOutcomes(it.subtree) }
+      if (perContinuation.isEmpty()) listOf(emptyList())
+      // Cartesian product: for each combination of one world per continuation, concatenate
+      // the packets.
+      else
+        perContinuation.reduce { acc, next ->
+          acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
+        }
+    }
   }
-  val fork = tree.forkOutcome
-  val branchOutcomes = fork.branchesList.map { collectPossibleOutcomes(it.subtree) }
-  if (branchOutcomes.isEmpty()) return listOf(emptyList())
-  return when (forkModeOf(fork.reason)) {
-    // Alternative: each branch adds its worlds to the result.
-    ForkMode.ALTERNATIVE -> branchOutcomes.flatten()
-    // Parallel: Cartesian product across branches — for each combination of one world per
-    // branch, concatenate the packets.
-    ForkMode.PARALLEL ->
-      branchOutcomes.reduce { acc, next ->
-        acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
-      }
-  }
-}

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -378,7 +378,7 @@ class SimulatorTest {
   }
 }
 
-/** Unit tests for [collectPossibleOutcomes] — the parallel vs alternative fork semantics. */
+/** Unit tests for [collectPossibleOutcomes] — Continuations (AND) vs Choice (OR) semantics. */
 class CollectPossibleOutcomesTest {
 
   private fun output(port: Int): fourward.TraceTree =
@@ -401,25 +401,31 @@ class CollectPossibleOutcomesTest {
       )
       .build()
 
-  private fun fork(
-    reason: fourward.ForkReason,
-    vararg branches: Pair<String, fourward.TraceTree>,
+  private fun continuations(
+    vararg branches: Pair<fourward.ContinuationKind, fourward.TraceTree>
   ): fourward.TraceTree =
     fourward.TraceTree.newBuilder()
-      .setForkOutcome(
-        fourward.Fork.newBuilder()
-          .setReason(reason)
-          .addAllBranches(
+      .setContinuations(
+        fourward.Continuations.newBuilder()
+          .addAllContinuations(
             branches.map {
-              fourward.ForkBranch.newBuilder().setLabel(it.first).setSubtree(it.second).build()
+              fourward.Continuation.newBuilder().setKind(it.first).setSubtree(it.second).build()
             }
           )
       )
       .build()
 
-  private fun alternativeFork(
-    vararg branches: Pair<String, fourward.TraceTree>
-  ): fourward.TraceTree = fork(fourward.ForkReason.ACTION_SELECTOR, *branches)
+  private fun choice(vararg alternatives: Pair<Int, fourward.TraceTree>): fourward.TraceTree =
+    fourward.TraceTree.newBuilder()
+      .setChoice(
+        fourward.Choice.newBuilder()
+          .addAllAlternatives(
+            alternatives.map {
+              fourward.Alternative.newBuilder().setMemberId(it.first).setSubtree(it.second).build()
+            }
+          )
+      )
+      .build()
 
   @Test
   fun `linear trace produces one world with one output`() {
@@ -435,8 +441,12 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `parallel fork combines outputs within each world`() {
-    val tree = fork(fourward.ForkReason.CLONE, "original" to output(1), "clone" to output(2))
+  fun `continuations combine outputs within one world`() {
+    val tree =
+      continuations(
+        fourward.ContinuationKind.ORIGINAL to output(1),
+        fourward.ContinuationKind.CLONE to output(2),
+      )
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals("one world", 1, outcomes.size)
     assertEquals("two outputs", 2, outcomes[0].size)
@@ -445,9 +455,8 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `alternative fork produces one world per branch`() {
-    val tree =
-      alternativeFork("member_0" to output(1), "member_1" to output(2), "member_2" to output(3))
+  fun `choice produces one world per alternative`() {
+    val tree = choice(0 to output(1), 1 to output(2), 2 to output(3))
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals("three worlds", 3, outcomes.size)
     assertEquals(1, outcomes[0].single().dataplaneEgressPort)
@@ -456,13 +465,12 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `alternative inside parallel produces Cartesian product`() {
-    // Clone (parallel) with 2 branches, each containing a 2-member selector (alternative).
+  fun `choice inside continuations produces Cartesian product`() {
+    // A clone (AND) with 2 continuations, each containing a 2-member selector choice (OR).
     val tree =
-      fork(
-        fourward.ForkReason.CLONE,
-        "original" to alternativeFork("m0" to output(1), "m1" to output(2)),
-        "clone" to alternativeFork("m0" to output(3), "m1" to output(4)),
+      continuations(
+        fourward.ContinuationKind.ORIGINAL to choice(0 to output(1), 1 to output(2)),
+        fourward.ContinuationKind.CLONE to choice(0 to output(3), 1 to output(4)),
       )
     val outcomes = collectPossibleOutcomes(tree)
     // 2 × 2 = 4 possible worlds, each with 2 outputs (one from original, one from clone).
@@ -474,8 +482,8 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `alternative with drop produces world with empty output`() {
-    val tree = alternativeFork("m0" to output(1), "m1" to drop())
+  fun `choice with drop produces world with empty output`() {
+    val tree = choice(0 to output(1), 1 to drop())
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals(2, outcomes.size)
     assertEquals(1, outcomes[0].size)
@@ -483,9 +491,13 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `multicast fork is parallel`() {
+  fun `multicast replicas are combined into one world`() {
     val tree =
-      fork(fourward.ForkReason.MULTICAST, "r0" to output(1), "r1" to output(2), "r2" to output(3))
+      continuations(
+        fourward.ContinuationKind.MULTICAST_REPLICA to output(1),
+        fourward.ContinuationKind.MULTICAST_REPLICA to output(2),
+        fourward.ContinuationKind.MULTICAST_REPLICA to output(3),
+      )
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals("one world", 1, outcomes.size)
     assertEquals("three outputs", 3, outcomes[0].size)

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -1,10 +1,12 @@
 package fourward.simulator
 
+import fourward.Alternative
+import fourward.Choice
+import fourward.Continuation
+import fourward.ContinuationKind
+import fourward.Continuations
 import fourward.Drop
 import fourward.DropReason
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.MulticastGroupLookupEvent
 import fourward.PacketIngressEvent
 import fourward.PacketOutcome
@@ -12,34 +14,6 @@ import fourward.PipelineStage
 import fourward.PipelineStageEvent
 import fourward.TraceEvent
 import fourward.TraceTree
-
-/**
- * Whether a fork's branches all happen (parallel) or only one happens (alternative).
- * - **Parallel** (clone, multicast, resubmit, recirculate): all branches execute simultaneously.
- *   Output packets are the union of all branch outputs.
- * - **Alternative** (action selector): exactly one branch executes at runtime. Each branch is a
- *   "possible world" — a distinct possible outcome set.
- */
-enum class ForkMode {
-  PARALLEL,
-  ALTERNATIVE,
-}
-
-/**
- * Maps a [ForkReason] to its [ForkMode].
- *
- * Exhaustive — adding a new [ForkReason] without updating this function is a compile error.
- */
-fun forkModeOf(reason: ForkReason): ForkMode =
-  when (reason) {
-    ForkReason.ACTION_SELECTOR -> ForkMode.ALTERNATIVE
-    ForkReason.CLONE,
-    ForkReason.MULTICAST,
-    ForkReason.RESUBMIT,
-    ForkReason.RECIRCULATE -> ForkMode.PARALLEL
-    ForkReason.FORK_REASON_UNSPECIFIED,
-    ForkReason.UNRECOGNIZED -> error("unexpected fork reason: $reason")
-  }
 
 /** Builds a [TraceTree] representing a dropped packet with the given trace events and reason. */
 internal fun buildDropTrace(
@@ -102,13 +76,51 @@ internal fun multicastGroupMissEvent(groupId: Int): TraceEvent =
     )
     .build()
 
-/** Builds a [TraceTree] with a fork outcome from accumulated events and branches. */
-internal fun buildForkTree(
+/**
+ * Builds a [TraceTree] that ends a pipeline pass by continuing in all the given ways (AND-node).
+ */
+internal fun buildContinuationsTree(
   events: List<TraceEvent>,
-  reason: ForkReason,
-  branches: List<ForkBranch>,
+  continuations: List<Continuation>,
 ): TraceTree =
   TraceTree.newBuilder()
     .addAllEvents(events)
-    .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
+    .setContinuations(Continuations.newBuilder().addAllContinuations(continuations))
     .build()
+
+/** Builds a [TraceTree] that explores all alternatives of a non-deterministic choice (OR-node). */
+internal fun buildChoiceTree(events: List<TraceEvent>, alternatives: List<Alternative>): TraceTree =
+  TraceTree.newBuilder()
+    .addAllEvents(events)
+    .setChoice(Choice.newBuilder().addAllAlternatives(alternatives))
+    .build()
+
+/**
+ * Creates a [Continuation] of [kind]. For copy kinds (clone, mirror, multicast replica),
+ * [dataplaneEgressPort] and [instance] identify the replica.
+ */
+internal fun continuation(
+  kind: ContinuationKind,
+  subtree: TraceTree,
+  dataplaneEgressPort: Int? = null,
+  instance: Int? = null,
+): Continuation =
+  Continuation.newBuilder()
+    .setKind(kind)
+    .setSubtree(subtree)
+    .apply {
+      if (dataplaneEgressPort != null) setDataplaneEgressPort(dataplaneEgressPort)
+      if (instance != null) setInstance(instance)
+    }
+    .build()
+
+/** Copies the outcome of [from] into this builder; leaves it unset if [from] has none. */
+internal fun TraceTree.Builder.copyOutcome(from: TraceTree): TraceTree.Builder = apply {
+  when (from.outcomeCase) {
+    TraceTree.OutcomeCase.PACKET_OUTCOME -> setPacketOutcome(from.packetOutcome)
+    TraceTree.OutcomeCase.CONTINUATIONS -> setContinuations(from.continuations)
+    TraceTree.OutcomeCase.CHOICE -> setChoice(from.choice)
+    TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+    null -> {}
+  }
+}

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -1,11 +1,11 @@
 package fourward.simulator
 
+import fourward.Alternative
 import fourward.BehavioralConfig
 import fourward.CloneEvent
 import fourward.CloneSessionLookupEvent
+import fourward.ContinuationKind
 import fourward.DropReason
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.LogMessageEvent
 import fourward.MarkToDropEvent
 import fourward.PipelineStage
@@ -176,13 +176,11 @@ class V1ModelArchitecture(
         fork.members.map(buildBranch)
       }
 
-    val branches =
+    val alternatives =
       fork.members.zip(traces).map { (member, trace) ->
-        ForkBranch.newBuilder().setLabel("member_${member.memberId}").setSubtree(trace).build()
+        Alternative.newBuilder().setMemberId(member.memberId).setSubtree(trace).build()
       }
-    return PipelineResult(
-      buildForkTree(fork.eventsBeforeFork, ForkReason.ACTION_SELECTOR, branches)
-    )
+    return PipelineResult(buildChoiceTree(fork.eventsBeforeFork, alternatives))
   }
 
   // -------------------------------------------------------------------------
@@ -338,14 +336,16 @@ class V1ModelArchitecture(
       } else {
         fork.replicas.map(buildBranch)
       }
-    val branches =
+    val continuations =
       fork.replicas.zip(results).map { (replica, trace) ->
-        ForkBranch.newBuilder()
-          .setLabel("replica_${replica.rid}_port_${replica.port}")
-          .setSubtree(trace)
-          .build()
+        continuation(
+          ContinuationKind.MULTICAST_REPLICA,
+          trace,
+          dataplaneEgressPort = replica.port,
+          instance = replica.rid,
+        )
       }
-    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.MULTICAST, branches))
+    return PipelineResult(buildContinuationsTree(fork.eventsBeforeFork, continuations))
   }
 
   /**
@@ -467,26 +467,26 @@ class V1ModelArchitecture(
     }
   }
 
-  /** Assembles the "original" branch + clone branches into a CLONE fork result. */
+  /** Assembles the original continuation + clone continuations into one AND-node result. */
   private fun assembleCloneFork(
     eventsBeforeFork: List<TraceEvent>,
     original: TraceTree,
     replicas: List<Replica>,
     clones: List<TraceTree>,
   ): PipelineResult {
-    val branches =
+    val continuations =
       buildList(replicas.size + 1) {
-        add(ForkBranch.newBuilder().setLabel("original").setSubtree(original).build())
+        add(continuation(ContinuationKind.ORIGINAL, original))
         replicas.zip(clones).mapTo(this) { (replica, trace) ->
-          ForkBranch.newBuilder()
-            .setLabel(
-              if (replicas.size == 1) "clone" else "clone_${replica.rid}_port_${replica.port}"
-            )
-            .setSubtree(trace)
-            .build()
+          continuation(
+            ContinuationKind.CLONE,
+            trace,
+            dataplaneEgressPort = replica.port,
+            instance = replica.rid,
+          )
         }
       }
-    return PipelineResult(buildForkTree(eventsBeforeFork, ForkReason.CLONE, branches))
+    return PipelineResult(buildContinuationsTree(eventsBeforeFork, continuations))
   }
 
   /** Resubmit: restarts the pipeline with preserved metadata. */
@@ -501,12 +501,8 @@ class V1ModelArchitecture(
         instanceTypeOverride = RESUBMIT_INSTANCE_TYPE,
         preservedMetadata = fork.preservedMetadata,
       )
-    val branch =
-      ForkBranch.newBuilder()
-        .setLabel("resubmit")
-        .setSubtree(buildTraceTree(ctx, decisions).trace)
-        .build()
-    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.RESUBMIT, listOf(branch)))
+    val resubmitted = continuation(ContinuationKind.RESUBMIT, buildTraceTree(ctx, decisions).trace)
+    return PipelineResult(buildContinuationsTree(fork.eventsBeforeFork, listOf(resubmitted)))
   }
 
   /** Recirculate: restarts the pipeline with deparsed bytes. */
@@ -521,16 +517,12 @@ class V1ModelArchitecture(
         instanceTypeOverride = RECIRC_INSTANCE_TYPE,
         preservedMetadata = fork.preservedMetadata,
       )
-    val branch =
-      ForkBranch.newBuilder()
-        .setLabel("recirculate")
-        .setSubtree(
-          buildTraceTree(ctx.copy(packet = PacketBits.ofBytes(fork.deparsedBytes)), decisions).trace
-        )
-        .build()
-    return PipelineResult(
-      buildForkTree(fork.eventsBeforeFork, ForkReason.RECIRCULATE, listOf(branch))
-    )
+    val recirculated =
+      continuation(
+        ContinuationKind.RECIRCULATE,
+        buildTraceTree(ctx.copy(packet = PacketBits.ofBytes(fork.deparsedBytes)), decisions).trace,
+      )
+    return PipelineResult(buildContinuationsTree(fork.eventsBeforeFork, listOf(recirculated)))
   }
 
   /**

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -6,13 +6,13 @@ import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
 import fourward.BlockStmt
+import fourward.ContinuationKind
 import fourward.ControlDecl
 import fourward.DropReason
 import fourward.ExitStmt
 import fourward.Expr
 import fourward.FieldAccess
 import fourward.FieldDecl
-import fourward.ForkReason
 import fourward.IfStmt
 import fourward.Literal
 import fourward.ParamDecl
@@ -432,7 +432,7 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `multicast fork produces output packets for each replica`() {
+  fun `multicast produces output packets for each replica`() {
     val config = v1modelConfig(assignField("sm", "mcast_grp", 1, 16))
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))
@@ -696,20 +696,24 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `multicast fork trace tree has fork node`() {
+  fun `multicast trace tree has continuations node with one replica each`() {
     val config = v1modelConfig(assignField("sm", "mcast_grp", 1, 16))
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(2, continuations.size)
+    assertEquals(ContinuationKind.MULTICAST_REPLICA, continuations[0].kind)
+    assertEquals(2, continuations[0].dataplaneEgressPort)
+    assertEquals(ContinuationKind.MULTICAST_REPLICA, continuations[1].kind)
+    assertEquals(3, continuations[1].dataplaneEgressPort)
   }
 
   @Test
-  fun `I2E clone forks into original and clone branch`() {
+  fun `I2E clone continues as original and clone`() {
     // Ingress calls clone(I2E, session=1), sets egress_spec=2 for the original.
     val config =
       v1modelConfig(
@@ -722,18 +726,22 @@ class V1ModelArchitectureTest {
     val payload = byteArrayOf(0xAA.toByte())
     val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(2, branches.size)
-    assertEquals("original", branches[0].label)
-    assertEquals("clone", branches[1].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(2, continuations.size)
+    assertEquals(ContinuationKind.ORIGINAL, continuations[0].kind)
+    assertFalse(continuations[0].hasDataplaneEgressPort())
+    assertFalse(continuations[0].hasInstance())
+    assertEquals(ContinuationKind.CLONE, continuations[1].kind)
+    assertEquals(7, continuations[1].dataplaneEgressPort)
+    assertTrue(continuations[1].hasInstance())
+    assertEquals(0, continuations[1].instance)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
-    // Original branch uses egress_spec set by ingress.
+    // The original uses egress_spec set by ingress.
     assertEquals(2, outputs[0].dataplaneEgressPort)
-    // Clone branch uses the clone session's egress port.
+    // The clone uses the clone session's egress port.
     assertEquals(7, outputs[1].dataplaneEgressPort)
   }
 
@@ -760,7 +768,7 @@ class V1ModelArchitectureTest {
   fun `I2E clone sets egress_rid from clone session replica instance`() {
     // Egress copies egress_rid into a user metadata field, then uses it to
     // decide whether to drop. Verifies the replica's instance field flows
-    // through to standard_metadata.egress_rid in the clone branch.
+    // through to standard_metadata.egress_rid in the clone's pipeline pass.
     val config =
       v1modelConfig(
         ingressStmts =
@@ -770,7 +778,7 @@ class V1ModelArchitectureTest {
           ),
         egressStmts =
           listOf(
-            // In the clone branch, drop if egress_rid == 0 (the default / unfixed value).
+            // In the clone's pass, drop if egress_rid == 0 (the default / unfixed value).
             ifFieldEquals(
               "sm",
               "instance_type",
@@ -833,7 +841,7 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `E2E clone forks into original and clone branch`() {
+  fun `E2E clone continues as original and clone`() {
     // Egress calls clone(E2E, session=1); ingress sets egress_spec=3 for routing.
     val config =
       v1modelConfig(
@@ -846,12 +854,16 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(2, branches.size)
-    assertEquals("original", branches[0].label)
-    assertEquals("clone", branches[1].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(2, continuations.size)
+    assertEquals(ContinuationKind.ORIGINAL, continuations[0].kind)
+    assertFalse(continuations[0].hasDataplaneEgressPort())
+    assertFalse(continuations[0].hasInstance())
+    assertEquals(ContinuationKind.CLONE, continuations[1].kind)
+    assertEquals(8, continuations[1].dataplaneEgressPort)
+    assertTrue(continuations[1].hasInstance())
+    assertEquals(0, continuations[1].instance)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
@@ -910,13 +922,16 @@ class V1ModelArchitectureTest {
     val result =
       V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(3, branches.size)
-    assertEquals("original", branches[0].label)
-    assertEquals("clone_10_port_7", branches[1].label)
-    assertEquals("clone_20_port_8", branches[2].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(3, continuations.size)
+    assertEquals(ContinuationKind.ORIGINAL, continuations[0].kind)
+    assertEquals(ContinuationKind.CLONE, continuations[1].kind)
+    assertEquals(7, continuations[1].dataplaneEgressPort)
+    assertEquals(10, continuations[1].instance)
+    assertEquals(ContinuationKind.CLONE, continuations[2].kind)
+    assertEquals(8, continuations[2].dataplaneEgressPort)
+    assertEquals(20, continuations[2].instance)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(3, outputs.size)
@@ -947,11 +962,12 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(3, branches.size)
-    assertEquals("original", branches[0].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(3, continuations.size)
+    assertEquals(ContinuationKind.ORIGINAL, continuations[0].kind)
+    assertEquals(ContinuationKind.CLONE, continuations[1].kind)
+    assertEquals(ContinuationKind.CLONE, continuations[2].kind)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(3, outputs.size)
@@ -993,7 +1009,7 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `multi-replica clone preserves metadata on all clone branches`() {
+  fun `multi-replica clone preserves metadata on all clones`() {
     val config =
       v1modelConfig(
         ingressStmts =
@@ -1068,9 +1084,9 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `resubmit forks and re-enters ingress`() {
+  fun `resubmit continues into a new ingress pass`() {
     // Ingress calls resubmit() only on the first pass (instance_type == 0).
-    // The resubmit branch gets instance_type=6 (RESUBMIT), so it won't re-trigger.
+    // The resubmitted pass gets instance_type=6 (RESUBMIT), so it won't re-trigger.
     val config =
       v1modelConfig(
         ifFieldEquals("sm", "instance_type", 0, 32, externCall("resubmit", intArg(0, 8)))
@@ -1078,17 +1094,16 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(1, branches.size)
-    assertEquals("resubmit", branches[0].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(1, continuations.size)
+    assertEquals(ContinuationKind.RESUBMIT, continuations[0].kind)
   }
 
   @Test
-  fun `recirculate forks after deparser`() {
+  fun `recirculate continues after deparser`() {
     // Egress calls recirculate() only on the first pass (instance_type == 0).
-    // The recirculated branch gets instance_type=4, so it won't re-trigger.
+    // The recirculated pass gets instance_type=4, so it won't re-trigger.
     val config =
       v1modelConfig(
         ingressStmts =
@@ -1101,17 +1116,16 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(1, branches.size)
-    assertEquals("recirculate", branches[0].label)
+    assertTrue(result.trace.hasContinuations())
+    val continuations = result.trace.continuations.continuationsList
+    assertEquals(1, continuations.size)
+    assertEquals(ContinuationKind.RECIRCULATE, continuations[0].kind)
   }
 
   @Test
   fun `I2E clone with missing session is silently ignored`() {
     // Clone session 99 is never installed — BMv2 silently ignores the clone.
-    // No fork appears; the packet outputs normally.
+    // No continuations node appears; the packet outputs normally.
     val config =
       v1modelConfig(
         externCall("clone", enumArg("I2E"), intArg(99, 32)),
@@ -1120,7 +1134,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
-    assertFalse(result.trace.hasForkOutcome())
+    assertFalse(result.trace.hasContinuations())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(2, outputs[0].dataplaneEgressPort)
@@ -1138,7 +1152,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
-    assertFalse(result.trace.hasForkOutcome())
+    assertFalse(result.trace.hasContinuations())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
@@ -1158,7 +1172,7 @@ class V1ModelArchitectureTest {
       byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte())
     val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasContinuations())
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     assertEquals(5, outputs[0].payload.size())
@@ -1180,7 +1194,7 @@ class V1ModelArchitectureTest {
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte())
     val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasContinuations())
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     assertEquals(4, outputs[0].payload.size())
@@ -1235,7 +1249,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
-    // No fork — falls through to unicast path.
+    // No continuations node — falls through to unicast path.
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
@@ -1270,14 +1284,14 @@ class V1ModelArchitectureTest {
   @Test
   fun `I2E clone survives ingress mark_to_drop on original`() {
     // Ingress calls clone(I2E) then mark_to_drop(). The original should be dropped
-    // (egress_spec == drop port), but the clone branch should still forward.
+    // (egress_spec == drop port), but the clone should still forward.
     val config = v1modelConfig(externCall("clone", enumArg("I2E"), intArg(1, 32)), markToDrop)
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasContinuations())
     val outputs = result.possibleOutcomes.single()
     // Original is dropped (mark_to_drop set egress_spec to drop port).
     // Clone survives on port 7.
@@ -1311,7 +1325,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasContinuations())
     val outputs = result.possibleOutcomes.single()
     // Original is dropped (egress mark_to_drop). Clone survives on port 8.
     assertEquals(1, outputs.size)
@@ -1505,7 +1519,7 @@ class V1ModelArchitectureTest {
   @Test
   fun `clone_preserving_field_list preserves annotated metadata`() {
     // Ingress: set meta.preserved = 0xABCD, then clone with field_list 1.
-    // Egress (clone branch only): if meta.preserved == 0 → drop.
+    // Egress (clone only): if meta.preserved == 0 → drop.
     // With preservation working, meta.preserved is 0xABCD on the clone, so no drop → 2 outputs.
     // Without preservation, meta.preserved would be 0 (default), so clone drops → 1 output.
     val config =
@@ -1518,7 +1532,7 @@ class V1ModelArchitectureTest {
           ),
         egressStmts =
           listOf(
-            // On clone branch (instance_type == 1): drop if metadata was reset.
+            // On the clone (instance_type == 1): drop if metadata was reset.
             ifFieldEquals(
               "sm",
               "instance_type",
@@ -1534,8 +1548,11 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasContinuations())
+    assertEquals(
+      listOf(ContinuationKind.ORIGINAL, ContinuationKind.CLONE),
+      result.trace.continuations.continuationsList.map { it.kind },
+    )
     val outputs = result.possibleOutcomes.single()
     // Both original and clone produce output (metadata was preserved, so no drop).
     assertEquals(2, outputs.size)
@@ -1580,8 +1597,11 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasContinuations())
+    assertEquals(
+      listOf(ContinuationKind.ORIGINAL, ContinuationKind.CLONE),
+      result.trace.continuations.continuationsList.map { it.kind },
+    )
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
@@ -1668,10 +1688,13 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasContinuations())
+    assertEquals(
+      listOf(ContinuationKind.RESUBMIT),
+      result.trace.continuations.continuationsList.map { it.kind },
+    )
     val outputs = result.possibleOutcomes.single()
-    // Resubmit branch outputs (metadata was preserved, so no drop).
+    // The resubmitted pass outputs (metadata was preserved, so no drop).
     assertEquals(1, outputs.size)
     assertEquals(1, outputs[0].dataplaneEgressPort)
   }
@@ -1721,10 +1744,13 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasContinuations())
+    assertEquals(
+      listOf(ContinuationKind.RECIRCULATE),
+      result.trace.continuations.continuationsList.map { it.kind },
+    )
     val outputs = result.possibleOutcomes.single()
-    // Recirculate branch outputs (metadata was preserved, so no drop).
+    // The recirculated pass outputs (metadata was preserved, so no drop).
     assertEquals(1, outputs.size)
     assertEquals(1, outputs[0].dataplaneEgressPort)
   }
@@ -1732,7 +1758,7 @@ class V1ModelArchitectureTest {
   @Test
   fun `clone_preserving_field_list does not preserve non-annotated fields`() {
     // Same setup, but check that not_preserved (no @field_list annotation) resets to 0.
-    // Egress (clone branch): if meta.not_preserved == 0 → set egress_spec to 42 (distinctive).
+    // Egress (clone): if meta.not_preserved == 0 → set egress_spec to 42 (distinctive).
     // If not_preserved was correctly reset, the clone outputs on port 42.
     val config =
       v1modelConfig(
@@ -1744,7 +1770,7 @@ class V1ModelArchitectureTest {
           ),
         egressStmts =
           listOf(
-            // On clone branch: drop if not_preserved was NOT reset (still has ingress value).
+            // On the clone: drop if not_preserved was NOT reset (still has ingress value).
             ifFieldEquals(
               "sm",
               "instance_type",
@@ -1766,7 +1792,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasContinuations())
     val outputs = result.possibleOutcomes.single()
     // Clone should NOT drop: not_preserved was reset to 0, so 0x1234 check is false.
     assertEquals(2, outputs.size)

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -47,63 +47,89 @@ message OutputPacket {
 // Execution trace tree
 //
 // A complete record of every decision the simulator made while processing a
-// packet.  Events within a node are ordered chronologically.  At
-// non-deterministic choice points the tree forks: each branch represents one
-// possible outcome and contains its own subtree of events.
+// packet.  Events within a node are ordered chronologically.
 //
-// Every node terminates: either forking (fork_outcome) or reaching a final
-// packet fate (packet_outcome).  A zero-fork tree has a single
-// packet_outcome at the root.
+// The tree is an AND/OR tree over pipeline passes:
+//
+//  • A **Continuations** node (AND) says execution continued in ALL of the
+//    listed ways within a single real execution: copies (clone, mirror,
+//    multicast replica) and/or re-entries (resubmit, recirculate).  A single
+//    continuation is common and meaningful — a recirculated packet simply
+//    continues as one new pipeline pass.
+//
+//  • A **Choice** node (OR) is a non-deterministic decision the simulator
+//    explores exhaustively: exactly one alternative happens in a real
+//    execution.  Each alternative is a distinct possible world.
+//
+// A trace therefore denotes a *set* of possible executions.  Choice nodes
+// are the compression points: they share the common event prefix instead of
+// enumerating the (exponential) product of all selector decisions.
+//
+// Every node terminates: with continuations, a choice, or a final packet
+// fate.  Shared prefix events (e.g. the parser trace before a selector
+// choice) live in the parent node; per-branch events live in the subtrees.
 // =============================================================================
 
 // Recursive trace structure: a sequence of events followed by an outcome.
-// Shared prefix events (e.g. the parser trace before a selector fork) live in
-// the parent node; per-branch events live in the fork's subtrees.
 message TraceTree {
   repeated TraceEvent events = 1;
+
+  // Field 2 was `Fork fork_outcome` in the pre-Continuations/Choice schema;
+  // reserved so stale serialized traces can't be misread.
+  reserved 2;
+  reserved "fork_outcome";
+
   oneof outcome {
-    Fork fork_outcome = 2;
     PacketOutcome packet_outcome = 3;
+    Continuations continuations = 4;
+    Choice choice = 5;
   }
 }
 
-// A non-deterministic choice point where execution forks into multiple
-// possible paths.
-//
-// Forks come in two flavors (see ForkMode):
-//
-//  • **Parallel** (clone, multicast, resubmit, recirculate) — all branches
-//    execute simultaneously in a single real execution.  The packet outputs
-//    are the union of all branch outputs.
-//
-//  • **Alternative** (action selector) — exactly one branch executes at
-//    runtime (determined by a hash function).  Each branch represents one
-//    *possible world*; the trace tree explores all of them.
-//
-// This distinction matters when collecting output packets from the tree:
-// parallel branches are combined (union), while alternative branches are
-// kept separate (each is a distinct possible outcome set).
-message Fork {
-  ForkReason reason = 1;
-  repeated ForkBranch branches = 2;
+// AND-node: this pipeline pass ended, and execution continued in all of the
+// listed ways — within one real execution.  The packet outputs of this node
+// are the union of the continuations' outputs.
+message Continuations {
+  repeated Continuation continuations = 1;
 }
 
-// One branch of a fork.  The label describes this particular outcome (e.g. the
-// action selector member name or "clone"/"original").
-message ForkBranch {
-  string label = 1;
+// One way execution continued: the original packet's own processing, a copy
+// of it, or a re-entry into the pipeline.
+message Continuation {
+  ContinuationKind kind = 1;
   TraceTree subtree = 2;
+
+  // For copy kinds (CLONE, MIRROR, MULTICAST_REPLICA): the replica's egress
+  // port and instance id (PSA/PNA `instance`, v1model `rid`) as configured
+  // in the clone/mirror session or multicast group.
+  optional uint32 dataplane_egress_port = 3;
+  optional uint32 instance = 4;
 }
 
-// Whether a fork's branches all happen or only one happens is determined by
-// the ForkReason.  See ForkMode in the simulator Kotlin code.
-enum ForkReason {
-  FORK_REASON_UNSPECIFIED = 0;
-  ACTION_SELECTOR = 1;  // Alternative: one member is selected by hash.
-  CLONE = 2;            // Parallel: original + clone(s) all execute.
-  MULTICAST = 3;        // Parallel: one replica per multicast group member.
-  RESUBMIT = 4;         // Parallel: packet re-enters the pipeline.
-  RECIRCULATE = 5;      // Parallel: deparsed packet loops back.
+enum ContinuationKind {
+  CONTINUATION_KIND_UNSPECIFIED = 0;
+  ORIGINAL = 1;           // the packet's own processing continues
+  CLONE = 2;              // v1model/PSA clone-session copy
+  MIRROR = 3;             // PNA mirror-session copy
+  MULTICAST_REPLICA = 4;  // one copy per multicast group member
+  RESUBMIT = 5;           // original bytes re-enter ingress
+  RECIRCULATE = 6;        // deparsed bytes re-enter the pipeline
+}
+
+// OR-node: a non-deterministic decision point.  Exactly one alternative
+// happens in a real execution; the simulator explores all of them.  The only
+// source of choice today is an action selector — which group member the
+// (unmodeled) hash picks.
+message Choice {
+  repeated Alternative alternatives = 1;
+}
+
+// One possible world: the trace as it unfolds if the selector picks this
+// member.
+message Alternative {
+  // P4Runtime action-profile member id the selector resolved to.
+  uint32 member_id = 1;
+  TraceTree subtree = 2;
 }
 
 // The terminal fate of a packet: either output on a port or dropped.
@@ -304,6 +330,6 @@ enum DropReason {
   MARK_TO_DROP = 1;   // explicit mark_to_drop()
   PARSER_REJECT = 2;  // parser transitioned to reject state
   PIPELINE_EXECUTION_LIMIT_REACHED =
-      3;                  // too many fork branches (exponential blowup guard)
+      3;  // trace tree grew too large (exponential blowup guard)
   ASSERTION_FAILURE = 4;  // assert() or assume() failed
 }

--- a/userdocs/concepts/architecture-modifications.md
+++ b/userdocs/concepts/architecture-modifications.md
@@ -91,7 +91,8 @@ class PnaArchitecture : Architecture {
   ): PipelineResult {
     // Run pipeline stages in order.
     // Handle architecture-specific externs.
-    // Produce trace tree with forks for non-deterministic operations.
+    // Produce trace tree with continuations/choices for packet
+    // multiplication and non-deterministic operations.
   }
 }
 ```
@@ -136,9 +137,9 @@ architecture = when (archName) {
 
 ### Key patterns
 
-- **Forks at boundaries** — clone/resubmit/recirculate decisions are deferred
-  to pipeline boundaries, not executed inline. The extern sets a flag; the
-  boundary logic checks it and forks.
+- **Branch at boundaries** — clone/resubmit/recirculate decisions are
+  deferred to pipeline boundaries, not executed inline. The extern sets a
+  flag; the boundary logic checks it and emits the continuations.
 - **Drop port from port width** — `(1L shl portBits) - 1`. Never hardcoded.
 - **Never fail silently** — unknown externs should `error()`, not fall through.
 - **Trace everything** — log architecture-specific decisions (drops, clones,

--- a/userdocs/concepts/architectures.md
+++ b/userdocs/concepts/architectures.md
@@ -67,7 +67,7 @@ present). Both can be overridden via `--drop-port` and `--cpu-port` flags.
     for a thorough writeup.
 
 Multiple calls use last-writer-wins semantics. All of these produce
-[trace tree forks](traces.md#forks).
+[trace tree branching](traces.md#continuations-and-choices).
 
 **Checksums:**
 

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -8,9 +8,10 @@ Every packet 4ward processes produces a **trace tree**
 ([`TraceTree`](https://github.com/smolkaj/4ward/blob/main/simulator/simulator.proto)
 in `simulator.proto`) — a complete record of every decision the simulator
 made. Most packets take a single path through the
-pipeline and produce a linear trace. At non-deterministic choice points (action
-selectors, clone, multicast), the trace **forks** into branches, one per
-possible outcome.
+pipeline and produce a linear trace. When a packet multiplies (clone,
+multicast) or re-enters the pipeline (resubmit, recirculate), the trace
+**continues** as several subtrees; at non-deterministic choice points (action
+selectors), it branches into one subtree per possible outcome.
 
 No other P4 tool gives you this. [BMv2](https://github.com/p4lang/behavioral-model) picks one path. Hardware picks one path.
 4ward shows you *all* paths in a single pass.
@@ -24,12 +25,16 @@ TraceTree
 ├── events[]          — chronologically ordered
 └── outcome
     ├── PacketOutcome — terminal: output on a port, or drop
-    └── Fork          — non-terminal: branches into subtrees
+    ├── Continuations — non-terminal: ALL subtrees happen (clone, multicast,
+    │                   resubmit, recirculate)
+    └── Choice        — non-terminal: exactly ONE subtree happens
+                        (action selector)
 ```
 
-Events at the parent level are **shared** across all branches. Per-branch
-events live in the fork's subtrees. A program with no non-determinism produces
-a zero-fork tree — structurally equivalent to a flat trace.
+Events at the parent level are **shared** across all subtrees. Per-subtree
+events live below the branching point. A program that never multiplies,
+re-enters, or branches produces a single-node tree — structurally equivalent
+to a flat trace.
 
 ## A simple trace
 
@@ -71,37 +76,38 @@ packet_outcome {
 }
 ```
 
-## Forks
+## Continuations and choices
 
-When execution reaches a non-deterministic choice point, the trace forks.
-Each branch gets its own subtree with the remaining pipeline events.
+A trace tree branches for two very different reasons, and the distinction is
+important for understanding what the output packets mean:
 
-There are two kinds of forks, and the distinction is important for
-understanding what the output packets mean:
+- **Continuations** (clone, multicast, resubmit, recirculate) — execution
+  continued in *all* of the listed ways within a single real execution. A
+  clone creates both the original *and* the clone; multicast creates all
+  replicas at once; a recirculated packet continues as one new pipeline pass.
+  Each continuation is typed: `ORIGINAL`, `CLONE`, `MIRROR`,
+  `MULTICAST_REPLICA`, `RESUBMIT`, or `RECIRCULATE`, with the replica's egress
+  port and instance id where applicable.
+- **Choices** (action selector) — exactly *one* alternative happens at
+  runtime, determined by a hash function. Each alternative represents one
+  *possible world* — a forwarding outcome that *could* happen, depending on
+  the hash. 4ward explores all of them in a single pass.
 
-- **Parallel forks** (clone, multicast, resubmit, recirculate) — all branches
-  happen simultaneously in a single real execution. A clone creates both the
-  original *and* the clone; multicast creates all replicas at once.
-- **Alternative forks** (action selector) — exactly one branch happens at
-  runtime, determined by a hash function. Each branch represents one *possible
-  world* — a forwarding outcome that *could* happen, depending on the hash.
-
-For parallel forks, the output packets are the combined outputs from all
-branches. For alternative forks, each branch produces its own independent set
-of outputs — a "possible outcome." The `possible_outcomes` field in the gRPC
+For continuations, the output packets are the combined outputs from all
+subtrees. For choices, each alternative produces its own independent set of
+outputs — a "possible outcome." The `possible_outcomes` field in the gRPC
 response (and `possibleOutcomes` in the Kotlin API) gives you the full picture:
 each entry is one set of output packets that could result from a single real
 execution.
 
-Programs with only parallel forks have exactly one possible outcome. Programs
-with action selectors have one possible outcome per member — and when
-alternative forks are nested inside parallel forks (e.g., a clone where both
-original and clone hit an action selector), the outcomes multiply
-(Cartesian product).
+Programs with no action selectors have exactly one possible outcome. Programs
+with action selectors have one possible outcome per member — and when choices
+are nested inside continuations (e.g., a clone where both original and clone
+hit an action selector), the outcomes multiply (Cartesian product).
 
 ### Clone
 
-A clone creates two branches — the **original** packet continues on its
+A clone creates two continuations — the **original** packet continues on its
 normal path, and the **clone** goes to the clone session's egress port:
 
 ```
@@ -111,60 +117,62 @@ packet_ingress (port 0)
 ├─ action forward(port=2)
 ├─ clone session 1
 ├─ clone_session_lookup: session 1 → port 3
-└─ fork (clone)
-   ├─ branch: original
+└─ continues as:
+   ├─ original:
    │  ├─ egress pipeline...
    │  └─ output port 2
-   └─ branch: clone
+   └─ clone port 3:
       ├─ egress pipeline...
       └─ output port 3
 ```
 
 ### Multicast
 
-Multicast creates one branch per replica in the multicast group:
+Multicast creates one continuation per replica in the multicast group:
 
 ```
 ├─ table routing: hit → multicast_forward
 ├─ action multicast_forward(group=1)
-└─ fork (multicast)
-   ├─ branch: replica_0_port_1
+└─ continues as:
+   ├─ replica port 1 instance 0:
    │  └─ output port 1
-   ├─ branch: replica_0_port_2
+   ├─ replica port 2 instance 0:
    │  └─ output port 2
-   └─ branch: replica_0_port_3
+   └─ replica port 3 instance 0:
       └─ output port 3
 ```
 
 ### Action selector
 
-An action selector with multiple members forks into one branch per member —
-showing every possible forwarding decision. This is an **alternative fork**:
-real hardware picks exactly one member (via hashing), but 4ward shows all
+An action selector with multiple members produces a **choice** with one
+alternative per member — showing every possible forwarding decision. Real
+hardware picks exactly one member (via hashing), but 4ward shows all
 possibilities so you can verify that every path is correct.
 
 ```
 ├─ table ecmp: hit → set_port
-└─ fork (action selector)       ← alternative: one of these happens
-   ├─ branch: member_0
+└─ one of (action selector):    ← exactly one of these happens
+   ├─ member 0:
    │  ├─ action set_port(port=1)
    │  └─ output port 1
-   ├─ branch: member_1
+   ├─ member 1:
    │  ├─ action set_port(port=2)
    │  └─ output port 2
-   └─ branch: member_2
+   └─ member 2:
       ├─ action set_port(port=3)
       └─ output port 3
 ```
 
 This trace has three **possible outcomes**: `{port 1}`, `{port 2}`, or
-`{port 3}`. Compare this with a clone fork, which has one possible outcome
-containing *all* branch outputs.
+`{port 3}`. Compare this with the clone above, which has one possible outcome
+containing *all* its outputs.
 
 ### Resubmit and recirculate
 
-Both create a fork where one branch is the resubmitted/recirculated packet
-re-entering the pipeline. The branch label is `resubmit` or `recirculate`.
+Both end the current pipeline pass with a single continuation — the
+resubmitted/recirculated packet re-entering the pipeline as a new pass, with
+kind `RESUBMIT` or `RECIRCULATE`. A single continuation is the common case
+here: nothing is copied, the packet simply continues.
 
 ## Event catalog
 
@@ -195,7 +203,7 @@ Every trace path terminates with a **PacketOutcome**:
 - **Drop** — packet dropped, with a reason:
     - `MARK_TO_DROP` — explicit `mark_to_drop()` call.
     - `PARSER_REJECT` — parser transitioned to the reject state.
-    - `PIPELINE_EXECUTION_LIMIT_REACHED` — too many fork branches
+    - `PIPELINE_EXECUTION_LIMIT_REACHED` — the trace tree grew too large
       (exponential blowup guard).
     - `ASSERTION_FAILURE` — `assert()` or `assume()` failed.
 

--- a/userdocs/examples.md
+++ b/userdocs/examples.md
@@ -90,7 +90,7 @@ apply {
 The egress pipeline uses `instance_type` to distinguish originals from clones
 and tags cloned packets with a distinctive source MAC.
 
-**What to look for in the trace:** the trace tree **forks** at the clone
+**What to look for in the trace:** the trace tree **splits** at the clone
 point — one branch for the original packet (exits on the routed port) and
 one for the clone (exits on the mirror port with rewritten source MAC).
 
@@ -98,7 +98,7 @@ one for the clone (exits on the mirror port with rewritten source MAC).
 
 - Parser state transitions (`select` on `etherType`)
 - LPM table matching
-- Packet cloning and trace tree forking
+- Packet cloning and trace tree continuations
 - Egress branching on `instance_type`
 
 ## sai_middleblock

--- a/userdocs/getting-started/cli.md
+++ b/userdocs/getting-started/cli.md
@@ -113,6 +113,6 @@ programs, split the work:
   CI-verified so it's always up to date.
 - **STF format** — full syntax for [table entries, match types, and
   clone/multicast setup](../reference/stf.md).
-- **Trace trees** — understand the [event types and fork
+- **Trace trees** — understand the [event types and branching
   semantics](../concepts/traces.md) behind the trace output.
 - **Reference** — complete [CLI reference](../reference/cli.md) with all flags.

--- a/userdocs/getting-started/playground.md
+++ b/userdocs/getting-started/playground.md
@@ -95,7 +95,7 @@ entry. The trace shows `port_table: miss → drop` and the packet is dropped.
 
 ## What's next
 
-- **Trace trees** — understand the [event types and fork
+- **Trace trees** — understand the [event types and branching
   semantics](../concepts/traces.md) behind the trace visualization.
 - **CLI** — run the same tests [from the terminal](cli.md) with STF files.
 - **Reference** — full [playground feature reference](../reference/playground.md).

--- a/userdocs/index.md
+++ b/userdocs/index.md
@@ -13,7 +13,7 @@ description: "4ward is a glass-box P4 simulator that traces every decision your 
 4ward is a spec-compliant [P4₁₆](https://p4.org/wp-content/uploads/sites/53/p4-spec/docs/P4-16-v1.2.4.html) reference simulator that produces **trace
 trees**: a complete record of every parser transition, table lookup, action
 execution, and branch decision a packet encounters. At non-deterministic
-choice points (action selectors, clone, multicast), the trace forks — showing
+choice points (action selectors, clone, multicast), the trace branches — showing
 all possible outcomes in a single pass.
 
 !!! tip "Prefer to get your hands dirty?"
@@ -41,7 +41,7 @@ all possible outcomes in a single pass.
 ## Key features
 
 - **Trace trees** record every parser transition, table lookup, action, and
-  branch — and fork at non-deterministic choice points to show all possible
+  branch — and split at non-deterministic choice points to show all possible
   outcomes. [Learn more](concepts/traces.md).
 - **v1model, PSA, and PNA** are fully implemented, with support for
   architecture modifications like translated port types.

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -86,9 +86,9 @@ message PacketSet {
 ```
 
 The `possible_outcomes` field captures the distinction between
-[parallel and alternative forks](../concepts/traces.md#forks).
+[continuations and choices](../concepts/traces.md#continuations-and-choices).
 Each `PacketSet` is one possible set of output packets from a single real
-execution. Programs with only parallel forks (clone, multicast) have exactly
+execution. Programs with only continuations (clone, multicast) have exactly
 one entry. Programs with action selectors have one entry per alternative.
 
 ### `InjectPackets`
@@ -111,7 +111,7 @@ message InjectPacketsResponse {}  // empty — results via SubscribeResults
 4. Collect results from the subscription (exactly one per injected
    packet).
 
-Packets process concurrently across available cores, with trace tree fork
+Packets process concurrently across available cores, with trace tree
 branches (WCMP groups, multicast, clones) also parallelized within each
 packet.
 
@@ -209,13 +209,13 @@ cores, 128 MB L3) running OpenJDK 21.
 wait for the result, repeat. "Batch" uses the `InjectPackets` streaming
 RPC to send 1,000 packets concurrently. The "16 cores" columns show the
 effect of parallelism: even sequential calls benefit from multi-core
-because fork branches (WCMP members, clones) within a single packet are
+because trace tree branches (WCMP members, clones) within a single packet are
 processed in parallel. Batch mode adds a second level of parallelism by
 processing multiple packets at once.
 
 The three workloads exercise increasingly complex trace trees. **L3
 forwarding** is a straight-line pipeline (VRF, LPM, nexthop, MAC
-rewrite) with no forks. **WCMP ×16** adds a 16-member action selector,
+rewrite) with no branching. **WCMP ×16** adds a 16-member action selector,
 producing 16 trace tree branches per packet. **WCMP ×16 + mirror** adds
 an ingress clone on top, doubling to 32 branches.
 

--- a/userdocs/reference/playground.md
+++ b/userdocs/reference/playground.md
@@ -68,7 +68,7 @@ numbers).
 
 The default **visual view** shows an interactive trace tree with events
 grouped by pipeline stage. Table hits include matched entry details, and
-forks display their branches.
+branching trees display their subtrees.
 
 Use the **← →** arrow keys to step through events. Each step highlights:
 

--- a/web/frontend/js/dissect.js
+++ b/web/frontend/js/dissect.js
@@ -22,21 +22,28 @@ function collectEmitEvents(trace, targetPayload) {
     return { emits, match: trace.packet_outcome.output.payload === targetPayload };
   }
 
-  // No fork — this is either a drop or has no outcome.
-  if (!trace.fork_outcome?.branches?.length) {
+  // Continuations and choice alternatives are walked the same way here: we
+  // only need the path leading to the matching output packet.
+  const subtrees = [
+    ...(trace.continuations?.continuations || []),
+    ...(trace.choice?.alternatives || []),
+  ].map((branch) => branch.subtree);
+
+  // No subtrees — this is either a drop or has no outcome.
+  if (subtrees.length === 0) {
     return { emits, match: false };
   }
 
-  // Walk fork branches. If targetPayload is provided, look for matching branch.
-  for (const branch of trace.fork_outcome.branches) {
-    const sub = collectEmitEvents(branch.subtree, targetPayload);
+  // If targetPayload is provided, look for the matching subtree.
+  for (const subtree of subtrees) {
+    const sub = collectEmitEvents(subtree, targetPayload);
     if (sub.match) {
       return { emits: [...emits, ...sub.emits], match: true };
     }
   }
 
-  // No match found — fall back to first branch.
-  const fallback = collectEmitEvents(trace.fork_outcome.branches[0].subtree, null);
+  // No match found — fall back to the first subtree.
+  const fallback = collectEmitEvents(subtrees[0], null);
   return { emits: [...emits, ...fallback.emits], match: false };
 }
 
@@ -47,7 +54,7 @@ function collectEmitEvents(trace, targetPayload) {
  *
  * @param {Uint8Array} payload - output packet bytes
  * @param {object} trace - trace tree node (must have `events` array)
- * @param {string} [targetPayload] - base64 payload to match a specific fork branch
+ * @param {string} [targetPayload] - base64 payload to match a specific subtree
  */
 export function dissectPacket(payload, trace, targetPayload) {
   if (!payload || !trace || !state.headerTypes) return null;

--- a/web/frontend/js/trace-render.js
+++ b/web/frontend/js/trace-render.js
@@ -75,8 +75,10 @@ export function renderTraceNode(node, isRoot) {
   // Outcome
   if (node.packet_outcome) {
     html += renderPacketOutcome(node.packet_outcome, node);
-  } else if (node.fork_outcome) {
-    html += renderFork(node.fork_outcome);
+  } else if (node.continuations) {
+    html += renderContinuations(node.continuations);
+  } else if (node.choice) {
+    html += renderChoice(node.choice);
   }
 
   html += '</div>';
@@ -292,18 +294,32 @@ function renderPacketOutcome(outcome, traceNode) {
   return '';
 }
 
-function renderFork(fork) {
-  const reason = formatForkReason(fork.reason);
-  let html = `<div class="trace-fork-label">\u2442 fork (${reason})</div>`;
-  for (const branch of fork.branches || []) {
-    html += `<div class="trace-branch-label">branch: ${branch.label}</div>`;
-    html += renderTraceNode(branch.subtree, false);
+// All continuations happen within one real execution (AND-node).
+function renderContinuations(continuations) {
+  let html = `<div class="trace-fork-label">\u2442 continues as</div>`;
+  for (const c of continuations.continuations || []) {
+    html += `<div class="trace-branch-label">${formatContinuation(c)}</div>`;
+    html += renderTraceNode(c.subtree, false);
   }
   return html;
 }
 
-function formatForkReason(reason) {
-  return (reason || 'fork').toLowerCase().replace(/_/g, ' ');
+// Exactly one alternative happens; the simulator explores all of them (OR-node).
+function renderChoice(choice) {
+  let html = `<div class="trace-fork-label">\u2442 one of (action selector)</div>`;
+  for (const alt of choice.alternatives || []) {
+    html += `<div class="trace-branch-label">member ${alt.member_id}</div>`;
+    html += renderTraceNode(alt.subtree, false);
+  }
+  return html;
+}
+
+function formatContinuation(c) {
+  const kind = (c.kind || 'unknown').toLowerCase().replace(/_/g, ' ');
+  let label = kind;
+  if (c.dataplane_egress_port !== undefined) label += ` port ${c.dataplane_egress_port}`;
+  if (c.instance !== undefined) label += ` instance ${c.instance}`;
+  return label;
 }
 
 function formatDropReason(reason) {


### PR DESCRIPTION
## The win

The trace tree is now an honest AND/OR tree. The two fundamentally different kinds of branching — *everything below happens* (clone, multicast, resubmit, recirculate) vs. *exactly one of these happens* (action selector) — are now distinct node types in the schema, instead of one `Fork` node with the semantics hidden behind a `ForkReason → ForkMode` runtime lookup.

```protobuf
oneof outcome {
  PacketOutcome packet_outcome = 3;
  Continuations continuations = 4;  // AND: all happen in one real execution
  Choice choice = 5;                // OR: one happens; we explore all
}
```

## Why

The old `ForkReason` enum conflated two independent axes: **combination semantics** (parallel/alternative — what every consumer must dispatch on) and **cause** (clone/multicast/selector — descriptive). That conflation produced real warts:

- A recirculating packet became a single-branch "fork" — confusing, since nothing forks.
- The fork-level `reason` couldn't describe PNA's mixed mirror+recirculate instant; the code guessed `CLONE` and the recirculation survived only as a label string (`PNAArchitecture.kt` line 224, now deleted).
- Replica and member identity was smuggled through display labels (`"replica_2_port_6"`, `"member_1"`) that tests and tools had to string-match.

The redesign puts each axis where it belongs: semantics in the type system (the oneof — every tree walker is now forced by the exhaustive `when` to handle AND and OR explicitly, per design invariant #2), cause in per-branch data (`ContinuationKind` + structured `dataplane_egress_port` / `instance`; `member_id` on choice alternatives). `ForkMode` / `forkModeOf` are gone entirely.

## Notes for review

- **Wire break, by design**: field 2 (`fork_outcome`) is `reserved`; traces aren't persisted anywhere in-repo (goldens regenerated via `--update`), and all consumers live in this repo and are migrated (simulator, CLI formatter, gRPC enricher, reproducer extractor, web renderer/dissector, docs).
- Test assertions got **stronger**, not just renamed: label string-matching became typed kind/port/instance/member assertions, and previously untested paths (Choice formatting, Choice recursion in the enricher/extractor) gained coverage.
- The internal fork-on-write exception machinery (`ActionSelectorFork`, `CloneFork`, …) keeps its names — it describes interpreter control flow, not the schema; happy to rename in a follow-up if desired.
- CLI human format changed: `fork (clone)` / `branch: original` → `continues as:` / `original:` / `clone port 5 instance 2:`, and `one of (action selector):` / `member 1:`.

`bazel test //... --test_tag_filters=-heavy`: 77/77 pass. `format.sh` + `lint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)