### PR TITLE
Implement typed trace tree outcomes

### DIFF
--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -32,7 +32,9 @@ object TraceFormatter {
           when (cont.kind) {
             Continuation.Kind.RESUBMIT -> "resubmit"
             Continuation.Kind.RECIRCULATE -> "recirculate"
-            else -> "continuation"
+            Continuation.Kind.KIND_UNSPECIFIED,
+            Continuation.Kind.UNRECOGNIZED,
+            null -> error("unexpected continuation kind: ${cont.kind}")
           }
         if (cont.preservedFieldsCount > 0) {
           val fields =

--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -1,5 +1,6 @@
 package fourward.cli
 
+import fourward.Continuation
 import fourward.TraceEvent
 import fourward.TraceTree
 
@@ -26,8 +27,21 @@ object TraceFormatter {
         }
       }
       TraceTree.OutcomeCase.CONTINUATION -> {
-        appendLine("${pad(indent)}continuation")
-        appendTree(tree.continuation.next, indent + 1)
+        val cont = tree.continuation
+        val label =
+          when (cont.kind) {
+            Continuation.Kind.RESUBMIT -> "resubmit"
+            Continuation.Kind.RECIRCULATE -> "recirculate"
+            else -> "continuation"
+          }
+        if (cont.preservedFieldsCount > 0) {
+          val fields =
+            cont.preservedFieldsMap.entries.joinToString(", ") { "${it.key}=${it.value}" }
+          appendLine("${pad(indent)}$label (preserved: $fields)")
+        } else {
+          appendLine("${pad(indent)}$label")
+        }
+        appendTree(cont.next, indent + 1)
       }
       TraceTree.OutcomeCase.OUTPUT -> {
         val out = tree.output
@@ -87,16 +101,6 @@ object TraceFormatter {
         val ml = event.multicastGroupLookup
         val result = if (ml.groupFound) "${ml.replicaCount} replicas" else "not found"
         appendLine("${prefix}multicast group ${ml.multicastGroupId}: $result")
-      }
-      TraceEvent.EventCase.CONTINUATION_TRIGGER -> {
-        val ct = event.continuationTrigger
-        val kind = ct.kind.name.lowercase()
-        if (ct.preservedFieldsCount > 0) {
-          val fields = ct.preservedFieldsMap.entries.joinToString(", ") { "${it.key}=${it.value}" }
-          appendLine("${prefix}$kind (preserved: $fields)")
-        } else {
-          appendLine("${prefix}$kind")
-        }
       }
       TraceEvent.EventCase.PACKET_INGRESS,
       TraceEvent.EventCase.PIPELINE_STAGE,

--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -88,6 +88,16 @@ object TraceFormatter {
         val result = if (ml.groupFound) "${ml.replicaCount} replicas" else "not found"
         appendLine("${prefix}multicast group ${ml.multicastGroupId}: $result")
       }
+      TraceEvent.EventCase.CONTINUATION_TRIGGER -> {
+        val ct = event.continuationTrigger
+        val kind = ct.kind.name.lowercase()
+        if (ct.preservedFieldsCount > 0) {
+          val fields = ct.preservedFieldsMap.entries.joinToString(", ") { "${it.key}=${it.value}" }
+          appendLine("${prefix}$kind (preserved: $fields)")
+        } else {
+          appendLine("${prefix}$kind")
+        }
+      }
       TraceEvent.EventCase.PACKET_INGRESS,
       TraceEvent.EventCase.PIPELINE_STAGE,
       TraceEvent.EventCase.CLONE_SESSION_LOOKUP,

--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -1,6 +1,5 @@
 package fourward.cli
 
-import fourward.DropReason
 import fourward.TraceEvent
 import fourward.TraceTree
 
@@ -14,30 +13,29 @@ object TraceFormatter {
       appendEvent(event, indent)
     }
     when (tree.outcomeCase) {
-      TraceTree.OutcomeCase.FORK_OUTCOME -> {
-        val fork = tree.forkOutcome
-        appendLine("${pad(indent)}fork (${fork.reason.humanName()})")
-        for (branch in fork.branchesList) {
-          appendLine("${pad(indent + 1)}branch: ${branch.label}")
-          appendTree(branch.subtree, indent + 2)
+      TraceTree.OutcomeCase.REPLICATION -> {
+        appendLine("${pad(indent)}replication")
+        for (branch in tree.replication.branchesList) {
+          appendTree(branch, indent + 1)
         }
       }
-      TraceTree.OutcomeCase.PACKET_OUTCOME -> {
-        val outcome = tree.packetOutcome
-        when (outcome.outcomeCase) {
-          fourward.PacketOutcome.OutcomeCase.OUTPUT -> {
-            val out = outcome.output
-            appendLine(
-              "${pad(indent)}output port ${out.dataplaneEgressPort}, ${out.payload.size()} bytes"
-            )
-          }
-          fourward.PacketOutcome.OutcomeCase.DROP -> {
-            appendLine("${pad(indent)}drop (reason: ${outcome.drop.reason.humanName()})")
-          }
-          fourward.PacketOutcome.OutcomeCase.OUTCOME_NOT_SET,
-          null -> {}
+      TraceTree.OutcomeCase.CHOICE -> {
+        appendLine("${pad(indent)}choice")
+        for (branch in tree.choice.branchesList) {
+          appendTree(branch, indent + 1)
         }
       }
+      TraceTree.OutcomeCase.CONTINUATION -> {
+        appendLine("${pad(indent)}continuation")
+        appendTree(tree.continuation.next, indent + 1)
+      }
+      TraceTree.OutcomeCase.OUTPUT -> {
+        val out = tree.output
+        appendLine(
+          "${pad(indent)}output port ${out.dataplaneEgressPort}, ${out.payload.size()} bytes"
+        )
+      }
+      TraceTree.OutcomeCase.DROP -> appendLine("${pad(indent)}drop")
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,
       null -> {}
     }
@@ -103,16 +101,4 @@ object TraceFormatter {
 
   private fun com.google.protobuf.ByteString.decimal(): String =
     java.math.BigInteger(1, toByteArray()).toString()
-
-  private fun DropReason.humanName(): String =
-    when (this) {
-      DropReason.MARK_TO_DROP -> "mark_to_drop"
-      DropReason.PARSER_REJECT -> "parser reject"
-      DropReason.PIPELINE_EXECUTION_LIMIT_REACHED -> "execution limit"
-      DropReason.ASSERTION_FAILURE -> "assertion failure"
-      else -> "unknown"
-    }
-
-  private fun fourward.ForkReason.humanName(): String =
-    name.removePrefix("ACTION_").lowercase().replace('_', ' ')
 }

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -9,6 +9,8 @@ import fourward.LogMessageEvent
 import fourward.MarkToDropEvent
 import fourward.OutputPacket
 import fourward.ParserTransitionEvent
+import fourward.Continuation
+import fourward.ContinuationEvent
 import fourward.Replication
 import fourward.TableLookupEvent
 import fourward.TraceEvent
@@ -207,6 +209,68 @@ class TraceFormatterTest {
       """
       |assert: FAILED
       |drop
+      |"""
+        .trimMargin(),
+      TraceFormatter.format(tree),
+    )
+  }
+
+  @Test
+  fun continuationTriggerResubmit() {
+    val tree =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setContinuationTrigger(
+              ContinuationEvent.newBuilder().setKind(ContinuationEvent.Kind.RESUBMIT)
+            )
+        )
+        .setContinuation(
+          Continuation.newBuilder()
+            .setNext(
+              TraceTree.newBuilder()
+                .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY))
+            )
+        )
+        .build()
+
+    assertEquals(
+      """
+      |resubmit
+      |continuation
+      |  output port 1, 0 bytes
+      |"""
+        .trimMargin(),
+      TraceFormatter.format(tree),
+    )
+  }
+
+  @Test
+  fun continuationTriggerWithPreservedFields() {
+    val tree =
+      TraceTree.newBuilder()
+        .addEvents(
+          TraceEvent.newBuilder()
+            .setContinuationTrigger(
+              ContinuationEvent.newBuilder()
+                .setKind(ContinuationEvent.Kind.RESUBMIT)
+                .putPreservedFields("tag", "48879")
+            )
+        )
+        .setContinuation(
+          Continuation.newBuilder()
+            .setNext(
+              TraceTree.newBuilder()
+                .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY))
+            )
+        )
+        .build()
+
+    assertEquals(
+      """
+      |resubmit (preserved: tag=48879)
+      |continuation
+      |  output port 1, 0 bytes
       |"""
         .trimMargin(),
       TraceFormatter.format(tree),

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -5,14 +5,11 @@ import fourward.ActionExecutionEvent
 import fourward.AssertionEvent
 import fourward.Drop
 import fourward.DropReason
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.LogMessageEvent
 import fourward.MarkToDropEvent
 import fourward.OutputPacket
-import fourward.PacketOutcome
 import fourward.ParserTransitionEvent
+import fourward.Replication
 import fourward.TableLookupEvent
 import fourward.TraceEvent
 import fourward.TraceTree
@@ -38,13 +35,10 @@ class TraceFormatterTest {
           TraceEvent.newBuilder()
             .setActionExecution(ActionExecutionEvent.newBuilder().setActionName("NoAction"))
         )
-        .setPacketOutcome(
-          PacketOutcome.newBuilder()
-            .setOutput(
-              OutputPacket.newBuilder()
-                .setDataplaneEgressPort(1)
-                .setPayload(ByteString.copyFrom(byteArrayOf(0xDE.toByte(), 0xAD.toByte())))
-            )
+        .setOutput(
+          OutputPacket.newBuilder()
+            .setDataplaneEgressPort(1)
+            .setPayload(ByteString.copyFrom(byteArrayOf(0xDE.toByte(), 0xAD.toByte())))
         )
         .build()
 
@@ -81,12 +75,7 @@ class TraceFormatterTest {
                 .putParams("port", ByteString.copyFrom(byteArrayOf(0x01)))
             )
         )
-        .setPacketOutcome(
-          PacketOutcome.newBuilder()
-            .setOutput(
-              OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY)
-            )
-        )
+        .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY))
         .build()
 
     val output = TraceFormatter.format(tree)
@@ -109,16 +98,14 @@ class TraceFormatterTest {
           TraceEvent.newBuilder()
             .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
         )
-        .setPacketOutcome(
-          PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
-        )
+        .setDrop(Drop.getDefaultInstance())
         .build()
 
     val output = TraceFormatter.format(tree)
     assertEquals(
       """
       |mark_to_drop()
-      |drop (reason: mark_to_drop)
+      |drop
       |"""
         .trimMargin(),
       output,
@@ -135,37 +122,18 @@ class TraceFormatterTest {
               ParserTransitionEvent.newBuilder().setFromState("start").setToState("accept")
             )
         )
-        .setForkOutcome(
-          Fork.newBuilder()
-            .setReason(ForkReason.CLONE)
+        .setReplication(
+          Replication.newBuilder()
             .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("original")
-                .setSubtree(
-                  TraceTree.newBuilder()
-                    .setPacketOutcome(
-                      PacketOutcome.newBuilder()
-                        .setOutput(
-                          OutputPacket.newBuilder()
-                            .setDataplaneEgressPort(1)
-                            .setPayload(ByteString.EMPTY)
-                        )
-                    )
+              TraceTree.newBuilder()
+                .setOutput(
+                  OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY)
                 )
             )
             .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("clone")
-                .setSubtree(
-                  TraceTree.newBuilder()
-                    .setPacketOutcome(
-                      PacketOutcome.newBuilder()
-                        .setOutput(
-                          OutputPacket.newBuilder()
-                            .setDataplaneEgressPort(2)
-                            .setPayload(ByteString.EMPTY)
-                        )
-                    )
+              TraceTree.newBuilder()
+                .setOutput(
+                  OutputPacket.newBuilder().setDataplaneEgressPort(2).setPayload(ByteString.EMPTY)
                 )
             )
         )
@@ -175,11 +143,9 @@ class TraceFormatterTest {
     assertEquals(
       """
       |parse: start -> accept
-      |fork (clone)
-      |  branch: original
-      |    output port 1, 0 bytes
-      |  branch: clone
-      |    output port 2, 0 bytes
+      |replication
+      |  output port 1, 0 bytes
+      |  output port 2, 0 bytes
       |"""
         .trimMargin(),
       output,
@@ -194,12 +160,7 @@ class TraceFormatterTest {
           TraceEvent.newBuilder()
             .setLogMessage(LogMessageEvent.newBuilder().setMessage("TTL = 64, port = 1"))
         )
-        .setPacketOutcome(
-          PacketOutcome.newBuilder()
-            .setOutput(
-              OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY)
-            )
-        )
+        .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY))
         .build()
 
     assertEquals(
@@ -219,12 +180,7 @@ class TraceFormatterTest {
         .addEvents(
           TraceEvent.newBuilder().setAssertion(AssertionEvent.newBuilder().setPassed(true))
         )
-        .setPacketOutcome(
-          PacketOutcome.newBuilder()
-            .setOutput(
-              OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY)
-            )
-        )
+        .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY))
         .build()
 
     assertEquals(
@@ -244,16 +200,13 @@ class TraceFormatterTest {
         .addEvents(
           TraceEvent.newBuilder().setAssertion(AssertionEvent.newBuilder().setPassed(false))
         )
-        .setPacketOutcome(
-          PacketOutcome.newBuilder()
-            .setDrop(Drop.newBuilder().setReason(DropReason.ASSERTION_FAILURE))
-        )
+        .setDrop(Drop.getDefaultInstance())
         .build()
 
     assertEquals(
       """
       |assert: FAILED
-      |drop (reason: assertion failure)
+      |drop
       |"""
         .trimMargin(),
       TraceFormatter.format(tree),

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -3,14 +3,12 @@ package fourward.cli
 import com.google.protobuf.ByteString
 import fourward.ActionExecutionEvent
 import fourward.AssertionEvent
+import fourward.Continuation
 import fourward.Drop
-import fourward.DropReason
 import fourward.LogMessageEvent
 import fourward.MarkToDropEvent
 import fourward.OutputPacket
 import fourward.ParserTransitionEvent
-import fourward.Continuation
-import fourward.ContinuationEvent
 import fourward.Replication
 import fourward.TableLookupEvent
 import fourward.TraceEvent
@@ -96,10 +94,7 @@ class TraceFormatterTest {
   fun dropWithMarkToDrop() {
     val tree =
       TraceTree.newBuilder()
-        .addEvents(
-          TraceEvent.newBuilder()
-            .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
-        )
+        .addEvents(TraceEvent.newBuilder().setMarkToDrop(MarkToDropEvent.newBuilder()))
         .setDrop(Drop.getDefaultInstance())
         .build()
 
@@ -219,17 +214,14 @@ class TraceFormatterTest {
   fun continuationTriggerResubmit() {
     val tree =
       TraceTree.newBuilder()
-        .addEvents(
-          TraceEvent.newBuilder()
-            .setContinuationTrigger(
-              ContinuationEvent.newBuilder().setKind(ContinuationEvent.Kind.RESUBMIT)
-            )
-        )
         .setContinuation(
           Continuation.newBuilder()
+            .setKind(Continuation.Kind.RESUBMIT)
             .setNext(
               TraceTree.newBuilder()
-                .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY))
+                .setOutput(
+                  OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY)
+                )
             )
         )
         .build()
@@ -237,7 +229,6 @@ class TraceFormatterTest {
     assertEquals(
       """
       |resubmit
-      |continuation
       |  output port 1, 0 bytes
       |"""
         .trimMargin(),
@@ -249,19 +240,15 @@ class TraceFormatterTest {
   fun continuationTriggerWithPreservedFields() {
     val tree =
       TraceTree.newBuilder()
-        .addEvents(
-          TraceEvent.newBuilder()
-            .setContinuationTrigger(
-              ContinuationEvent.newBuilder()
-                .setKind(ContinuationEvent.Kind.RESUBMIT)
-                .putPreservedFields("tag", "48879")
-            )
-        )
         .setContinuation(
           Continuation.newBuilder()
+            .setKind(Continuation.Kind.RESUBMIT)
+            .putPreservedFields("tag", "48879")
             .setNext(
               TraceTree.newBuilder()
-                .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY))
+                .setOutput(
+                  OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(ByteString.EMPTY)
+                )
             )
         )
         .build()
@@ -269,7 +256,6 @@ class TraceFormatterTest {
     assertEquals(
       """
       |resubmit (preserved: tag=48879)
-      |continuation
       |  output port 1, 0 bytes
       |"""
         .trimMargin(),

--- a/detekt.yml
+++ b/detekt.yml
@@ -57,7 +57,7 @@ complexity:
   # case without introducing opaque intermediate objects.
   # writeIndexedExtern() has 7 params (generic validation: type, name, id, index, info, storage, value).
   LongParameterList:
-    functionThreshold: 8
+    functionThreshold: 9
     constructorThreshold: 12
     excludes: ['**/test/**', '**/*Test.kt']
 

--- a/e2e_tests/trace_tree/BUILD.bazel
+++ b/e2e_tests/trace_tree/BUILD.bazel
@@ -40,6 +40,7 @@ _GOLDEN = [
     "selector_exit",
     "e2e_clone",
     "resubmit",
+    "resubmit_preserve_meta",
     "recirculate",
 ]
 

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -1,7 +1,6 @@
 package fourward.e2e.tracetree
 
 import com.google.protobuf.TextFormat
-import fourward.PacketOutcome
 import fourward.TraceTree
 import fourward.simulator.ProcessPacketResult
 import fourward.simulator.Simulator
@@ -58,9 +57,9 @@ class TraceTreeConsistencyTest(private val testName: String) {
 
   private fun verifyConsistency(result: ProcessPacketResult) {
     val trace = result.trace
-    val leafOutcomes = collectLeafOutcomes(trace)
+    val leafTrees = collectLeafOutcomes(trace)
 
-    assertTrue("Trace tree for $testName has no leaf outcomes", leafOutcomes.isNotEmpty())
+    assertTrue("Trace tree for $testName has no leaf outcomes", leafTrees.isNotEmpty())
 
     // Verify possibleOutcomes is consistent with the trace tree: flattening all worlds
     // should produce the same outputs as collecting all leaf outputs from the tree.
@@ -68,9 +67,7 @@ class TraceTreeConsistencyTest(private val testName: String) {
       result.possibleOutcomes.flatten().map { it.dataplaneEgressPort to it.payload }
 
     val outputsFromTree =
-      leafOutcomes
-        .filter { it.hasOutput() }
-        .map { it.output.dataplaneEgressPort to it.output.payload }
+      leafTrees.filter { it.hasOutput() }.map { it.output.dataplaneEgressPort to it.output.payload }
 
     // For trees without nested alternative-inside-parallel forks, these match exactly.
     // For trees with such nesting, possibleOutcomes may have duplicates from the Cartesian
@@ -83,12 +80,17 @@ class TraceTreeConsistencyTest(private val testName: String) {
     )
   }
 
-  /** Recursively collects all leaf [PacketOutcome]s from a trace tree. */
-  private fun collectLeafOutcomes(tree: TraceTree): List<PacketOutcome> =
+  /**
+   * Recursively collects all leaf [TraceTree]s (nodes with terminal outcomes) from a trace tree.
+   */
+  private fun collectLeafOutcomes(tree: TraceTree): List<TraceTree> =
     when (tree.outcomeCase) {
-      TraceTree.OutcomeCase.PACKET_OUTCOME -> listOf(tree.packetOutcome)
-      TraceTree.OutcomeCase.FORK_OUTCOME ->
-        tree.forkOutcome.branchesList.flatMap { collectLeafOutcomes(it.subtree) }
+      TraceTree.OutcomeCase.OUTPUT,
+      TraceTree.OutcomeCase.DROP -> listOf(tree)
+      TraceTree.OutcomeCase.REPLICATION ->
+        tree.replication.branchesList.flatMap { collectLeafOutcomes(it) }
+      TraceTree.OutcomeCase.CHOICE -> tree.choice.branchesList.flatMap { collectLeafOutcomes(it) }
+      TraceTree.OutcomeCase.CONTINUATION -> collectLeafOutcomes(tree.continuation.next)
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,
       null -> emptyList()
     }

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/action_selector_3.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,6 +58,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   table_lookup {
@@ -71,6 +78,7 @@ events {
     }
     action_name: "set_port"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/action_selector_3.p4"
     line: 49
@@ -82,309 +90,324 @@ events {
     value: "281474976710655 (0xffffffffffff)"
   }
 }
-fork_outcome {
-  reason: ACTION_SELECTOR
+choice {
+  cause: 8
   branches {
-    label: "member_0"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_port"
-          params {
-            key: "port"
-            value: "\000\001"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 49
-          column: 12
-          source_fragment: "ecmp.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 34
-          column: 53
-          source_fragment: "smeta.egress_spec = port"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_port"
+        params {
           key: "port"
-          value: "1"
-        }
-        result_value: "1"
-      }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
+          value: "\000\001"
         }
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_3.p4"
+        line: 49
+        column: 12
+        source_fragment: "ecmp.apply()"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_3.p4"
+        line: 34
+        column: 53
+        source_fragment: "smeta.egress_spec = port"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      variable_values {
+        key: "port"
+        value: "1"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      result_value: "1"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
+      }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 8
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 9
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 10
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "member_1"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_port"
-          params {
-            key: "port"
-            value: "\000\002"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 49
-          column: 12
-          source_fragment: "ecmp.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 34
-          column: 53
-          source_fragment: "smeta.egress_spec = port"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_port"
+        params {
           key: "port"
-          value: "2"
-        }
-        result_value: "2"
-      }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
+          value: "\000\002"
         }
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_3.p4"
+        line: 49
+        column: 12
+        source_fragment: "ecmp.apply()"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_3.p4"
+        line: 34
+        column: 53
+        source_fragment: "smeta.egress_spec = port"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+      variable_values {
+        key: "port"
+        value: "2"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      result_value: "2"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 2
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
+      }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 8
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 9
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 10
+    }
+    output {
+      dataplane_egress_port: 2
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "member_2"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_port"
-          params {
-            key: "port"
-            value: "\000\003"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 49
-          column: 12
-          source_fragment: "ecmp.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_3.p4"
-          line: 34
-          column: 53
-          source_fragment: "smeta.egress_spec = port"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_port"
+        params {
           key: "port"
-          value: "3"
-        }
-        result_value: "3"
-      }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
+          value: "\000\003"
         }
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_3.p4"
+        line: 49
+        column: 12
+        source_fragment: "ecmp.apply()"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_3.p4"
+        line: 34
+        column: 53
+        source_fragment: "smeta.egress_spec = port"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      variable_values {
+        key: "port"
+        value: "3"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      result_value: "3"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 3
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
+      }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 8
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 9
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 10
+    }
+    output {
+      dataplane_egress_port: 3
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,6 +58,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   table_lookup {
@@ -59,6 +66,7 @@ events {
     hit: false
     action_name: "drop"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"
     line: 49
@@ -74,6 +82,7 @@ events {
   action_execution {
     action_name: "drop"
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"
     line: 49
@@ -85,6 +94,7 @@ events {
   mark_to_drop {
     reason: MARK_TO_DROP
   }
+  id: 10
   source_info {
     file: "e2e_tests/trace_tree/action_selector_miss.p4"
     line: 35
@@ -99,9 +109,8 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 11
 }
-packet_outcome {
-  drop {
-    reason: MARK_TO_DROP
-  }
+drop {
+  trigger: 10
 }

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -92,7 +92,6 @@ events {
 }
 events {
   mark_to_drop {
-    reason: MARK_TO_DROP
   }
   id: 10
   source_info {

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -111,5 +111,5 @@ events {
   id: 11
 }
 drop {
-  trigger: 10
+  cause: 10
 }

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/action_selector_nested.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,6 +58,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   table_lookup {
@@ -71,6 +78,7 @@ events {
     }
     action_name: "set_tag"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/action_selector_nested.p4"
     line: 62
@@ -82,544 +90,564 @@ events {
     value: "281474976710655 (0xffffffffffff)"
   }
 }
-fork_outcome {
-  reason: ACTION_SELECTOR
+choice {
+  cause: 8
   branches {
-    label: "member_0"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_tag"
-          params {
-            key: "tag_1"
-            value: "\001"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 62
-          column: 8
-          source_fragment: "stage1.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "meta.tag"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 35
-          column: 42
-          source_fragment: "meta.tag = tag"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_tag"
+        params {
           key: "tag_1"
-          value: "1"
-        }
-        result_value: "1"
-      }
-      events {
-        table_lookup {
-          table_name: "stage2"
-          hit: true
-          matched_entry {
-            table_id: 35100795
-            match {
-              field_id: 1
-              exact {
-                value: "\b\000"
-              }
-            }
-            action {
-              action_profile_group_id: 1
-            }
-          }
-          action_name: "set_port"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 63
-          column: 8
-          source_fragment: "stage2.apply()"
-        }
-        variable_values {
-          key: "1"
-          value: "2048 (0x800)"
+          value: "\001"
         }
       }
-      fork_outcome {
-        reason: ACTION_SELECTOR
-        branches {
-          label: "member_0"
-          subtree {
-            events {
-              action_execution {
-                action_name: "set_port"
-                params {
-                  key: "port"
-                  value: "\000\001"
-                }
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 63
-                column: 8
-                source_fragment: "stage2.apply()"
-              }
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_nested.p4"
+        line: 62
+        column: 8
+        source_fragment: "stage1.apply()"
+      }
+    }
+    events {
+      assignment {
+        target: "meta.tag"
+      }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_nested.p4"
+        line: 35
+        column: 42
+        source_fragment: "meta.tag = tag"
+      }
+      variable_values {
+        key: "tag_1"
+        value: "1"
+      }
+      result_value: "1"
+    }
+    events {
+      table_lookup {
+        table_name: "stage2"
+        hit: true
+        matched_entry {
+          table_id: 35100795
+          match {
+            field_id: 1
+            exact {
+              value: "\b\000"
             }
-            events {
-              assignment {
-                target: "smeta.egress_spec"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 34
-                column: 53
-                source_fragment: "smeta.egress_spec = port"
-              }
-              variable_values {
-                key: "port"
-                value: "1"
-              }
-              result_value: "1"
-            }
-            events {
-              pipeline_stage {
-                stage_name: "ingress"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 1
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
-            }
+          }
+          action {
+            action_profile_group_id: 1
           }
         }
-        branches {
-          label: "member_1"
-          subtree {
-            events {
-              action_execution {
-                action_name: "set_port"
-                params {
-                  key: "port"
-                  value: "\000\002"
-                }
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 63
-                column: 8
-                source_fragment: "stage2.apply()"
-              }
-            }
-            events {
-              assignment {
-                target: "smeta.egress_spec"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 34
-                column: 53
-                source_fragment: "smeta.egress_spec = port"
-              }
-              variable_values {
-                key: "port"
-                value: "2"
-              }
-              result_value: "2"
-            }
-            events {
-              pipeline_stage {
-                stage_name: "ingress"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 2
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
+        action_name: "set_port"
+      }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_nested.p4"
+        line: 63
+        column: 8
+        source_fragment: "stage2.apply()"
+      }
+      variable_values {
+        key: "1"
+        value: "2048 (0x800)"
+      }
+    }
+    choice {
+      cause: 3
+      branches {
+        events {
+          action_execution {
+            action_name: "set_port"
+            params {
+              key: "port"
+              value: "\000\001"
             }
           }
+          id: 1
+          source_info {
+            file: "e2e_tests/trace_tree/action_selector_nested.p4"
+            line: 63
+            column: 8
+            source_fragment: "stage2.apply()"
+          }
+        }
+        events {
+          assignment {
+            target: "smeta.egress_spec"
+          }
+          id: 2
+          source_info {
+            file: "e2e_tests/trace_tree/action_selector_nested.p4"
+            line: 34
+            column: 53
+            source_fragment: "smeta.egress_spec = port"
+          }
+          variable_values {
+            key: "port"
+            value: "1"
+          }
+          result_value: "1"
+        }
+        events {
+          pipeline_stage {
+            stage_name: "ingress"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 5
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 7
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 8
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 9
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 10
+        }
+        output {
+          dataplane_egress_port: 1
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
+        }
+      }
+      branches {
+        events {
+          action_execution {
+            action_name: "set_port"
+            params {
+              key: "port"
+              value: "\000\002"
+            }
+          }
+          id: 1
+          source_info {
+            file: "e2e_tests/trace_tree/action_selector_nested.p4"
+            line: 63
+            column: 8
+            source_fragment: "stage2.apply()"
+          }
+        }
+        events {
+          assignment {
+            target: "smeta.egress_spec"
+          }
+          id: 2
+          source_info {
+            file: "e2e_tests/trace_tree/action_selector_nested.p4"
+            line: 34
+            column: 53
+            source_fragment: "smeta.egress_spec = port"
+          }
+          variable_values {
+            key: "port"
+            value: "2"
+          }
+          result_value: "2"
+        }
+        events {
+          pipeline_stage {
+            stage_name: "ingress"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 2
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 2
+          }
+          id: 5
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 2
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 2
+          }
+          id: 7
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 8
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 9
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 10
+        }
+        output {
+          dataplane_egress_port: 2
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
         }
       }
     }
   }
   branches {
-    label: "member_1"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_tag"
-          params {
-            key: "tag_1"
-            value: "\002"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 62
-          column: 8
-          source_fragment: "stage1.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "meta.tag"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 35
-          column: 42
-          source_fragment: "meta.tag = tag"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_tag"
+        params {
           key: "tag_1"
-          value: "2"
-        }
-        result_value: "2"
-      }
-      events {
-        table_lookup {
-          table_name: "stage2"
-          hit: true
-          matched_entry {
-            table_id: 35100795
-            match {
-              field_id: 1
-              exact {
-                value: "\b\000"
-              }
-            }
-            action {
-              action_profile_group_id: 1
-            }
-          }
-          action_name: "set_port"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/action_selector_nested.p4"
-          line: 63
-          column: 8
-          source_fragment: "stage2.apply()"
-        }
-        variable_values {
-          key: "1"
-          value: "2048 (0x800)"
+          value: "\002"
         }
       }
-      fork_outcome {
-        reason: ACTION_SELECTOR
-        branches {
-          label: "member_0"
-          subtree {
-            events {
-              action_execution {
-                action_name: "set_port"
-                params {
-                  key: "port"
-                  value: "\000\001"
-                }
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 63
-                column: 8
-                source_fragment: "stage2.apply()"
-              }
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_nested.p4"
+        line: 62
+        column: 8
+        source_fragment: "stage1.apply()"
+      }
+    }
+    events {
+      assignment {
+        target: "meta.tag"
+      }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_nested.p4"
+        line: 35
+        column: 42
+        source_fragment: "meta.tag = tag"
+      }
+      variable_values {
+        key: "tag_1"
+        value: "2"
+      }
+      result_value: "2"
+    }
+    events {
+      table_lookup {
+        table_name: "stage2"
+        hit: true
+        matched_entry {
+          table_id: 35100795
+          match {
+            field_id: 1
+            exact {
+              value: "\b\000"
             }
-            events {
-              assignment {
-                target: "smeta.egress_spec"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 34
-                column: 53
-                source_fragment: "smeta.egress_spec = port"
-              }
-              variable_values {
-                key: "port"
-                value: "1"
-              }
-              result_value: "1"
-            }
-            events {
-              pipeline_stage {
-                stage_name: "ingress"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 1
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
-            }
+          }
+          action {
+            action_profile_group_id: 1
           }
         }
-        branches {
-          label: "member_1"
-          subtree {
-            events {
-              action_execution {
-                action_name: "set_port"
-                params {
-                  key: "port"
-                  value: "\000\002"
-                }
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 63
-                column: 8
-                source_fragment: "stage2.apply()"
-              }
-            }
-            events {
-              assignment {
-                target: "smeta.egress_spec"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/action_selector_nested.p4"
-                line: 34
-                column: 53
-                source_fragment: "smeta.egress_spec = port"
-              }
-              variable_values {
-                key: "port"
-                value: "2"
-              }
-              result_value: "2"
-            }
-            events {
-              pipeline_stage {
-                stage_name: "ingress"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 2
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
+        action_name: "set_port"
+      }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/action_selector_nested.p4"
+        line: 63
+        column: 8
+        source_fragment: "stage2.apply()"
+      }
+      variable_values {
+        key: "1"
+        value: "2048 (0x800)"
+      }
+    }
+    choice {
+      cause: 3
+      branches {
+        events {
+          action_execution {
+            action_name: "set_port"
+            params {
+              key: "port"
+              value: "\000\001"
             }
           }
+          id: 1
+          source_info {
+            file: "e2e_tests/trace_tree/action_selector_nested.p4"
+            line: 63
+            column: 8
+            source_fragment: "stage2.apply()"
+          }
+        }
+        events {
+          assignment {
+            target: "smeta.egress_spec"
+          }
+          id: 2
+          source_info {
+            file: "e2e_tests/trace_tree/action_selector_nested.p4"
+            line: 34
+            column: 53
+            source_fragment: "smeta.egress_spec = port"
+          }
+          variable_values {
+            key: "port"
+            value: "1"
+          }
+          result_value: "1"
+        }
+        events {
+          pipeline_stage {
+            stage_name: "ingress"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 5
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 7
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 8
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 9
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 10
+        }
+        output {
+          dataplane_egress_port: 1
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
+        }
+      }
+      branches {
+        events {
+          action_execution {
+            action_name: "set_port"
+            params {
+              key: "port"
+              value: "\000\002"
+            }
+          }
+          id: 1
+          source_info {
+            file: "e2e_tests/trace_tree/action_selector_nested.p4"
+            line: 63
+            column: 8
+            source_fragment: "stage2.apply()"
+          }
+        }
+        events {
+          assignment {
+            target: "smeta.egress_spec"
+          }
+          id: 2
+          source_info {
+            file: "e2e_tests/trace_tree/action_selector_nested.p4"
+            line: 34
+            column: 53
+            source_fragment: "smeta.egress_spec = port"
+          }
+          variable_values {
+            key: "port"
+            value: "2"
+          }
+          result_value: "2"
+        }
+        events {
+          pipeline_stage {
+            stage_name: "ingress"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 2
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 2
+          }
+          id: 5
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 2
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 2
+          }
+          id: 7
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 8
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 9
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 10
+        }
+        output {
+          dataplane_egress_port: 2
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
         }
       }
     }

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/clone_and_multicast.p4"
     line: 23
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   clone {
     session_id: 100
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/clone_and_multicast.p4"
     line: 35
@@ -68,6 +76,7 @@ events {
   assignment {
     target: "smeta.mcast_grp"
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/clone_and_multicast.p4"
     line: 36
@@ -83,6 +92,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 10
 }
 events {
   clone_session_lookup {
@@ -91,211 +101,216 @@ events {
     dataplane_egress_port: 3
     replica_count: 1
   }
+  id: 11
 }
-fork_outcome {
-  reason: CLONE
+replication {
+  cause: 11
   branches {
-    label: "original"
-    subtree {
-      events {
-        multicast_group_lookup {
-          multicast_group_id: 1
-          group_found: true
-          replica_count: 2
+    events {
+      multicast_group_lookup {
+        multicast_group_id: 1
+        group_found: true
+        replica_count: 2
+      }
+      id: 1
+    }
+    replication {
+      cause: 1
+      branches {
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 1
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 2
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 5
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 7
+        }
+        output {
+          dataplane_egress_port: 1
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
         }
       }
-      fork_outcome {
-        reason: MULTICAST
-        branches {
-          label: "replica_0_port_1"
-          subtree {
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 1
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
-            }
+      branches {
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 2
           }
+          id: 1
         }
-        branches {
-          label: "replica_0_port_2"
-          subtree {
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 2
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
-            }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 2
           }
+          id: 2
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 2
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 2
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 5
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 7
+        }
+        output {
+          dataplane_egress_port: 2
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
         }
       }
     }
   }
   branches {
-    label: "clone"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 5
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 3
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 7
+    }
+    output {
+      dataplane_egress_port: 3
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/clone_ingress_egress.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/clone_ingress_egress.p4"
     line: 34
@@ -69,6 +77,7 @@ events {
   clone {
     session_id: 100
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/clone_ingress_egress.p4"
     line: 35
@@ -83,6 +92,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 10
 }
 events {
   clone_session_lookup {
@@ -91,133 +101,138 @@ events {
     dataplane_egress_port: 1
     replica_count: 1
   }
+  id: 11
 }
-fork_outcome {
-  reason: CLONE
+replication {
+  cause: 11
   branches {
-    label: "original"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 5
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 7
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "clone"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 5
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 7
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/clone_last_wins.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/clone_last_wins.p4"
     line: 34
@@ -69,6 +77,7 @@ events {
   clone {
     session_id: 200
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/clone_last_wins.p4"
     line: 35
@@ -80,6 +89,7 @@ events {
   clone {
     session_id: 100
   }
+  id: 10
   source_info {
     file: "e2e_tests/trace_tree/clone_last_wins.p4"
     line: 36
@@ -94,6 +104,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 11
 }
 events {
   clone_session_lookup {
@@ -102,133 +113,138 @@ events {
     dataplane_egress_port: 1
     replica_count: 1
   }
+  id: 12
 }
-fork_outcome {
-  reason: CLONE
+replication {
+  cause: 12
   branches {
-    label: "original"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 5
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 3
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 7
+    }
+    output {
+      dataplane_egress_port: 3
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "clone"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 5
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 7
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/clone_plus_selector.p4"
     line: 23
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   clone {
     session_id: 100
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/clone_plus_selector.p4"
     line: 51
@@ -82,6 +90,7 @@ events {
     }
     action_name: "set_port"
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/clone_plus_selector.p4"
     line: 52
@@ -93,364 +102,374 @@ events {
     value: "281474976710655 (0xffffffffffff)"
   }
 }
-fork_outcome {
-  reason: ACTION_SELECTOR
+choice {
+  cause: 9
   branches {
-    label: "member_0"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_port"
-          params {
-            key: "port"
-            value: "\000\001"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-          line: 52
-          column: 8
-          source_fragment: "ecmp.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-          line: 35
-          column: 53
-          source_fragment: "smeta.egress_spec = port"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_port"
+        params {
           key: "port"
-          value: "1"
-        }
-        result_value: "1"
-      }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
+          value: "\000\001"
         }
       }
-      events {
-        clone_session_lookup {
-          session_id: 100
-          session_found: true
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+        line: 52
+        column: 8
+        source_fragment: "ecmp.apply()"
+      }
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
+      }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+        line: 35
+        column: 53
+        source_fragment: "smeta.egress_spec = port"
+      }
+      variable_values {
+        key: "port"
+        value: "1"
+      }
+      result_value: "1"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
+      }
+      id: 3
+    }
+    events {
+      clone_session_lookup {
+        session_id: 100
+        session_found: true
+        dataplane_egress_port: 1
+        replica_count: 1
+      }
+      id: 4
+    }
+    replication {
+      cause: 4
+      branches {
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 1
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 2
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 5
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 7
+        }
+        output {
           dataplane_egress_port: 1
-          replica_count: 1
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
         }
       }
-      fork_outcome {
-        reason: CLONE
-        branches {
-          label: "original"
-          subtree {
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 1
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
-            }
+      branches {
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
           }
+          id: 1
         }
-        branches {
-          label: "clone"
-          subtree {
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 1
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
-            }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
           }
+          id: 2
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 5
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 7
+        }
+        output {
+          dataplane_egress_port: 1
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
         }
       }
     }
   }
   branches {
-    label: "member_1"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_port"
-          params {
-            key: "port"
-            value: "\000\002"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-          line: 52
-          column: 8
-          source_fragment: "ecmp.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_plus_selector.p4"
-          line: 35
-          column: 53
-          source_fragment: "smeta.egress_spec = port"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_port"
+        params {
           key: "port"
-          value: "2"
-        }
-        result_value: "2"
-      }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
+          value: "\000\002"
         }
       }
-      events {
-        clone_session_lookup {
-          session_id: 100
-          session_found: true
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+        line: 52
+        column: 8
+        source_fragment: "ecmp.apply()"
+      }
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
+      }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/clone_plus_selector.p4"
+        line: 35
+        column: 53
+        source_fragment: "smeta.egress_spec = port"
+      }
+      variable_values {
+        key: "port"
+        value: "2"
+      }
+      result_value: "2"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
+      }
+      id: 3
+    }
+    events {
+      clone_session_lookup {
+        session_id: 100
+        session_found: true
+        dataplane_egress_port: 1
+        replica_count: 1
+      }
+      id: 4
+    }
+    replication {
+      cause: 4
+      branches {
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 2
+          }
+          id: 1
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 2
+          }
+          id: 2
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 2
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 2
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 5
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 7
+        }
+        output {
+          dataplane_egress_port: 2
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
+        }
+      }
+      branches {
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 1
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 2
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+            dataplane_port: 1
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+            dataplane_port: 1
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 5
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 6
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 7
+        }
+        output {
           dataplane_egress_port: 1
-          replica_count: 1
-        }
-      }
-      fork_outcome {
-        reason: CLONE
-        branches {
-          label: "original"
-          subtree {
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 2
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 2
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
-            }
-          }
-        }
-        branches {
-          label: "clone"
-          subtree {
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-                dataplane_port: 1
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 1
-                payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-              }
-            }
-          }
+          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
         }
       }
     }

--- a/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
     line: 31
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
     line: 43
@@ -69,6 +77,7 @@ events {
   assignment {
     target: "meta.preserved_value"
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
     line: 44
@@ -81,6 +90,7 @@ events {
   assignment {
     target: "meta.not_preserved_value"
   }
+  id: 10
   source_info {
     file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
     line: 45
@@ -93,6 +103,7 @@ events {
   clone {
     session_id: 100
   }
+  id: 11
   source_info {
     file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
     line: 46
@@ -107,6 +118,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 12
 }
 events {
   clone_session_lookup {
@@ -115,183 +127,191 @@ events {
     dataplane_egress_port: 2
     replica_count: 1
   }
+  id: 13
 }
-fork_outcome {
-  reason: CLONE
+replication {
+  cause: 13
   branches {
-    label: "original"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        branch {
-          control_name: "MyEgress"
-          taken: false
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
-          line: 55
-          column: 12
-          source_fragment: "smeta.instance_type == 1"
-        }
-        variable_values {
-          key: "smeta.instance_type"
-          value: "0"
-        }
-        result_value: "false"
+      id: 1
+    }
+    events {
+      branch {
+        control_name: "MyEgress"
+        taken: false
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
+        line: 55
+        column: 12
+        source_fragment: "smeta.instance_type == 1"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      variable_values {
+        key: "smeta.instance_type"
+        value: "0"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      result_value: "false"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 6
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 8
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "clone"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
-      events {
-        branch {
-          control_name: "MyEgress"
-          taken: true
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
-          line: 55
-          column: 12
-          source_fragment: "smeta.instance_type == 1"
-        }
-        variable_values {
-          key: "smeta.instance_type"
-          value: "1"
-        }
-        result_value: "true"
+      id: 1
+    }
+    events {
+      branch {
+        control_name: "MyEgress"
+        taken: true
       }
-      events {
-        assignment {
-          target: "hdr.ethernet.etherType"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
-          line: 57
-          column: 35
-          source_fragment: "hdr.ethernet.etherType = meta.preserved_value"
-        }
-        variable_values {
-          key: "meta.preserved_value"
-          value: "43981 (0xabcd)"
-        }
-        result_value: "43981 (0xabcd)"
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
+        line: 55
+        column: 12
+        source_fragment: "smeta.instance_type == 1"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+      variable_values {
+        key: "smeta.instance_type"
+        value: "1"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+      result_value: "true"
+    }
+    events {
+      assignment {
+        target: "hdr.ethernet.etherType"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
+        line: 57
+        column: 35
+        source_fragment: "hdr.ethernet.etherType = meta.preserved_value"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      variable_values {
+        key: "meta.preserved_value"
+        value: "43981 (0xabcd)"
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      result_value: "43981 (0xabcd)"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 2
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\000\253\315"
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
       }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 7
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 8
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 9
+    }
+    output {
+      dataplane_egress_port: 2
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\000\253\315"
     }
   }
 }

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/clone_with_egress.p4"
     line: 24
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/clone_with_egress.p4"
     line: 36
@@ -69,6 +77,7 @@ events {
   clone {
     session_id: 100
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/clone_with_egress.p4"
     line: 37
@@ -83,6 +92,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 10
 }
 events {
   clone_session_lookup {
@@ -91,243 +101,254 @@ events {
     dataplane_egress_port: 3
     replica_count: 1
   }
+  id: 11
 }
-fork_outcome {
-  reason: CLONE
+replication {
+  cause: 11
   branches {
-    label: "original"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
-      events {
-        table_lookup {
-          table_name: "egress_classify"
-          hit: true
-          matched_entry {
-            table_id: 43808281
-            match {
-              field_id: 1
-              exact {
-                value: "\000\000\000\000"
-              }
+      id: 1
+    }
+    events {
+      table_lookup {
+        table_name: "egress_classify"
+        hit: true
+        matched_entry {
+          table_id: 43808281
+          match {
+            field_id: 1
+            exact {
+              value: "\000\000\000\000"
             }
-            action {
-              action {
-                action_id: 23337001
-              }
-            }
-            is_const: true
           }
-          action_name: "tag_original"
+          action {
+            action {
+              action_id: 23337001
+            }
+          }
+          is_const: true
         }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 55
-          column: 12
-          source_fragment: "egress_classify.apply()"
-        }
-        variable_values {
-          key: "1"
-          value: "0"
-        }
+        action_name: "tag_original"
       }
-      events {
-        action_execution {
-          action_name: "tag_original"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 55
-          column: 12
-          source_fragment: "egress_classify.apply()"
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/clone_with_egress.p4"
+        line: 55
+        column: 12
+        source_fragment: "egress_classify.apply()"
       }
-      events {
-        assignment {
-          target: "hdr.ethernet.dstAddr"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 43
-          column: 49
-          source_fragment: "hdr.ethernet.dstAddr = 48w0xaaaaaaaaaaaa"
-        }
-        result_value: "187649984473770 (0xaaaaaaaaaaaa)"
+      variable_values {
+        key: "1"
+        value: "0"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+    }
+    events {
+      action_execution {
+        action_name: "tag_original"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/clone_with_egress.p4"
+        line: 55
+        column: 12
+        source_fragment: "egress_classify.apply()"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+    }
+    events {
+      assignment {
+        target: "hdr.ethernet.dstAddr"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+      source_info {
+        file: "e2e_tests/trace_tree/clone_with_egress.p4"
+        line: 43
+        column: 49
+        source_fragment: "hdr.ethernet.dstAddr = 48w0xaaaaaaaaaaaa"
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      result_value: "187649984473770 (0xaaaaaaaaaaaa)"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 2
-          payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
       }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 8
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 9
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 10
+    }
+    output {
+      dataplane_egress_port: 2
+      payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "clone"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        table_lookup {
-          table_name: "egress_classify"
-          hit: true
-          matched_entry {
-            table_id: 43808281
-            match {
-              field_id: 1
-              exact {
-                value: "\000\000\000\001"
-              }
+      id: 1
+    }
+    events {
+      table_lookup {
+        table_name: "egress_classify"
+        hit: true
+        matched_entry {
+          table_id: 43808281
+          match {
+            field_id: 1
+            exact {
+              value: "\000\000\000\001"
             }
-            action {
-              action {
-                action_id: 20863306
-              }
-            }
-            is_const: true
           }
-          action_name: "tag_clone"
+          action {
+            action {
+              action_id: 20863306
+            }
+          }
+          is_const: true
         }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 55
-          column: 12
-          source_fragment: "egress_classify.apply()"
-        }
-        variable_values {
-          key: "1"
-          value: "1"
-        }
+        action_name: "tag_clone"
       }
-      events {
-        action_execution {
-          action_name: "tag_clone"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 55
-          column: 12
-          source_fragment: "egress_classify.apply()"
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/clone_with_egress.p4"
+        line: 55
+        column: 12
+        source_fragment: "egress_classify.apply()"
       }
-      events {
-        assignment {
-          target: "hdr.ethernet.srcAddr"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/clone_with_egress.p4"
-          line: 44
-          column: 46
-          source_fragment: "hdr.ethernet.srcAddr = 48w0xbbbbbbbbbbbb"
-        }
-        result_value: "206414982921147 (0xbbbbbbbbbbbb)"
+      variable_values {
+        key: "1"
+        value: "1"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+    }
+    events {
+      action_execution {
+        action_name: "tag_clone"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/clone_with_egress.p4"
+        line: 55
+        column: 12
+        source_fragment: "egress_classify.apply()"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+    }
+    events {
+      assignment {
+        target: "hdr.ethernet.srcAddr"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+      source_info {
+        file: "e2e_tests/trace_tree/clone_with_egress.p4"
+        line: 44
+        column: 46
+        source_fragment: "hdr.ethernet.srcAddr = 48w0xbbbbbbbbbbbb"
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      result_value: "206414982921147 (0xbbbbbbbbbbbb)"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 3
-          payload: "\377\377\377\377\377\377\273\273\273\273\273\273\b\000"
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 8
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 9
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 10
+    }
+    output {
+      dataplane_egress_port: 3
+      payload: "\377\377\377\377\377\377\273\273\273\273\273\273\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/e2e_clone.golden.txtpb
+++ b/e2e_tests/trace_tree/e2e_clone.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/e2e_clone.p4"
     line: 23
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/e2e_clone.p4"
     line: 34
@@ -72,6 +80,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 9
 }
 events {
   pipeline_stage {
@@ -80,12 +89,14 @@ events {
     direction: ENTER
     dataplane_port: 2
   }
+  id: 10
 }
 events {
   branch {
     control_name: "MyEgress"
     taken: true
   }
+  id: 11
   source_info {
     file: "e2e_tests/trace_tree/e2e_clone.p4"
     line: 53
@@ -102,6 +113,7 @@ events {
   clone {
     session_id: 100
   }
+  id: 12
   source_info {
     file: "e2e_tests/trace_tree/e2e_clone.p4"
     line: 54
@@ -130,6 +142,7 @@ events {
     }
     action_name: "tag_original"
   }
+  id: 13
   source_info {
     file: "e2e_tests/trace_tree/e2e_clone.p4"
     line: 56
@@ -145,6 +158,7 @@ events {
   action_execution {
     action_name: "tag_original"
   }
+  id: 14
   source_info {
     file: "e2e_tests/trace_tree/e2e_clone.p4"
     line: 56
@@ -156,6 +170,7 @@ events {
   assignment {
     target: "hdr.ethernet.dstAddr"
   }
+  id: 15
   source_info {
     file: "e2e_tests/trace_tree/e2e_clone.p4"
     line: 39
@@ -171,6 +186,7 @@ events {
     direction: EXIT
     dataplane_port: 2
   }
+  id: 16
 }
 events {
   pipeline_stage {
@@ -179,6 +195,7 @@ events {
     direction: ENTER
     dataplane_port: 2
   }
+  id: 17
 }
 events {
   pipeline_stage {
@@ -187,6 +204,7 @@ events {
     direction: EXIT
     dataplane_port: 2
   }
+  id: 18
 }
 events {
   clone_session_lookup {
@@ -195,173 +213,178 @@ events {
     dataplane_egress_port: 5
     replica_count: 1
   }
+  id: 19
 }
-fork_outcome {
-  reason: CLONE
+replication {
+  cause: 19
   branches {
-    label: "original"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 1
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 2
-          payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 3
+    }
+    output {
+      dataplane_egress_port: 2
+      payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "clone"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 5
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 5
       }
-      events {
-        branch {
-          control_name: "MyEgress"
-          taken: false
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/e2e_clone.p4"
-          line: 53
-          column: 12
-          source_fragment: "smeta.instance_type == 0"
-        }
-        variable_values {
-          key: "smeta.instance_type"
-          value: "2"
-        }
-        result_value: "false"
+      id: 1
+    }
+    events {
+      branch {
+        control_name: "MyEgress"
+        taken: false
       }
-      events {
-        table_lookup {
-          table_name: "egress_classify"
-          hit: true
-          matched_entry {
-            table_id: 43808281
-            match {
-              field_id: 1
-              exact {
-                value: "\000\000\000\002"
-              }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/e2e_clone.p4"
+        line: 53
+        column: 12
+        source_fragment: "smeta.instance_type == 0"
+      }
+      variable_values {
+        key: "smeta.instance_type"
+        value: "2"
+      }
+      result_value: "false"
+    }
+    events {
+      table_lookup {
+        table_name: "egress_classify"
+        hit: true
+        matched_entry {
+          table_id: 43808281
+          match {
+            field_id: 1
+            exact {
+              value: "\000\000\000\002"
             }
-            action {
-              action {
-                action_id: 20863306
-              }
-            }
-            is_const: true
           }
-          action_name: "tag_clone"
+          action {
+            action {
+              action_id: 20863306
+            }
+          }
+          is_const: true
         }
-        source_info {
-          file: "e2e_tests/trace_tree/e2e_clone.p4"
-          line: 56
-          column: 8
-          source_fragment: "egress_classify.apply()"
-        }
-        variable_values {
-          key: "1"
-          value: "2"
-        }
+        action_name: "tag_clone"
       }
-      events {
-        action_execution {
-          action_name: "tag_clone"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/e2e_clone.p4"
-          line: 56
-          column: 8
-          source_fragment: "egress_classify.apply()"
-        }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/e2e_clone.p4"
+        line: 56
+        column: 8
+        source_fragment: "egress_classify.apply()"
       }
-      events {
-        assignment {
-          target: "hdr.ethernet.srcAddr"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/e2e_clone.p4"
-          line: 40
-          column: 46
-          source_fragment: "hdr.ethernet.srcAddr = 48w0xbbbbbbbbbbbb"
-        }
-        result_value: "206414982921147 (0xbbbbbbbbbbbb)"
+      variable_values {
+        key: "1"
+        value: "2"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 5
-        }
+    }
+    events {
+      action_execution {
+        action_name: "tag_clone"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 5
-        }
+      id: 4
+      source_info {
+        file: "e2e_tests/trace_tree/e2e_clone.p4"
+        line: 56
+        column: 8
+        source_fragment: "egress_classify.apply()"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 5
-        }
+    }
+    events {
+      assignment {
+        target: "hdr.ethernet.srcAddr"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 5
+      source_info {
+        file: "e2e_tests/trace_tree/e2e_clone.p4"
+        line: 40
+        column: 46
+        source_fragment: "hdr.ethernet.srcAddr = 48w0xbbbbbbbbbbbb"
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      result_value: "206414982921147 (0xbbbbbbbbbbbb)"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 5
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 5
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 5
-          payload: "\252\252\252\252\252\252\273\273\273\273\273\273\b\000"
-        }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 5
       }
+      id: 8
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 9
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 10
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 11
+    }
+    output {
+      dataplane_egress_port: 5
+      payload: "\252\252\252\252\252\252\273\273\273\273\273\273\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/multicast.p4"
     line: 21
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.mcast_grp"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/multicast.p4"
     line: 33
@@ -72,6 +80,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 9
 }
 events {
   multicast_group_lookup {
@@ -79,196 +88,203 @@ events {
     group_found: true
     replica_count: 3
   }
+  id: 10
 }
-fork_outcome {
-  reason: MULTICAST
+replication {
+  cause: 10
   branches {
-    label: "replica_0_port_1"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 5
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 7
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "replica_0_port_2"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 5
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 2
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 7
+    }
+    output {
+      dataplane_egress_port: 2
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "replica_0_port_3"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+      id: 2
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 5
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 3
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
-      }
+      id: 7
+    }
+    output {
+      dataplane_egress_port: 3
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -205,7 +205,6 @@ replication {
     }
     events {
       mark_to_drop {
-        reason: MARK_TO_DROP
       }
       id: 3
       source_info {

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.mcast_grp"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
     line: 34
@@ -72,6 +80,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 9
 }
 events {
   multicast_group_lookup {
@@ -79,237 +88,245 @@ events {
     group_found: true
     replica_count: 3
   }
+  id: 10
 }
-fork_outcome {
-  reason: MULTICAST
+replication {
+  cause: 10
   branches {
-    label: "replica_0_port_1"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        branch {
-          control_name: "MyEgress"
-          taken: false
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-          line: 41
-          column: 12
-          source_fragment: "smeta.egress_port == 2"
-        }
-        variable_values {
-          key: "smeta.egress_port"
-          value: "1"
-        }
-        result_value: "false"
+      id: 1
+    }
+    events {
+      branch {
+        control_name: "MyEgress"
+        taken: false
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+        line: 41
+        column: 12
+        source_fragment: "smeta.egress_port == 2"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      variable_values {
+        key: "smeta.egress_port"
+        value: "1"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      result_value: "false"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 6
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 8
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "replica_0_port_2"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
       }
-      events {
-        branch {
-          control_name: "MyEgress"
-          taken: true
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-          line: 41
-          column: 12
-          source_fragment: "smeta.egress_port == 2"
-        }
-        variable_values {
-          key: "smeta.egress_port"
-          value: "2"
-        }
-        result_value: "true"
+      id: 1
+    }
+    events {
+      branch {
+        control_name: "MyEgress"
+        taken: true
       }
-      events {
-        mark_to_drop {
-          reason: MARK_TO_DROP
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-          line: 42
-          column: 12
-          source_fragment: "mark_to_drop(smeta)"
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+        line: 41
+        column: 12
+        source_fragment: "smeta.egress_port == 2"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+      variable_values {
+        key: "smeta.egress_port"
+        value: "2"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
-        }
+      result_value: "true"
+    }
+    events {
+      mark_to_drop {
+        reason: MARK_TO_DROP
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 2
-        }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+        line: 42
+        column: 12
+        source_fragment: "mark_to_drop(smeta)"
       }
-      packet_outcome {
-        drop {
-          reason: MARK_TO_DROP
-        }
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
       }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
+      }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 2
+      }
+      id: 6
+    }
+    drop {
+      trigger: 3
     }
   }
   branches {
-    label: "replica_0_port_3"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        branch {
-          control_name: "MyEgress"
-          taken: false
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
-          line: 41
-          column: 12
-          source_fragment: "smeta.egress_port == 2"
-        }
-        variable_values {
-          key: "smeta.egress_port"
-          value: "3"
-        }
-        result_value: "false"
+      id: 1
+    }
+    events {
+      branch {
+        control_name: "MyEgress"
+        taken: false
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
+        line: 41
+        column: 12
+        source_fragment: "smeta.egress_port == 2"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 3
-        }
+      variable_values {
+        key: "smeta.egress_port"
+        value: "3"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 3
-        }
+      result_value: "false"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 3
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 3
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 3
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 6
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
       }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 8
+    }
+    output {
+      dataplane_egress_port: 3
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -242,7 +242,7 @@ replication {
       id: 6
     }
     drop {
-      trigger: 3
+      cause: 3
     }
   }
   branches {

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/multicast_selector.p4"
     line: 23
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.mcast_grp"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/multicast_selector.p4"
     line: 35
@@ -72,6 +80,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 9
 }
 events {
   multicast_group_lookup {
@@ -79,395 +88,406 @@ events {
     group_found: true
     replica_count: 2
   }
+  id: 10
 }
-fork_outcome {
-  reason: MULTICAST
+replication {
+  cause: 10
   branches {
-    label: "replica_0_port_1"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
+      }
+      id: 1
+    }
+    events {
+      table_lookup {
+        table_name: "egress_selector"
+        hit: true
+        matched_entry {
+          table_id: 43223807
+          match {
+            field_id: 1
+            exact {
+              value: "\377\377\377\377\377\377"
+            }
+          }
+          action {
+            action_profile_group_id: 1
+          }
+        }
+        action_name: "tag_a"
+      }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/multicast_selector.p4"
+        line: 58
+        column: 12
+        source_fragment: "egress_selector.apply()"
+      }
+      variable_values {
+        key: "1"
+        value: "281474976710655 (0xffffffffffff)"
+      }
+    }
+    choice {
+      cause: 2
+      branches {
+        events {
+          action_execution {
+            action_name: "tag_a"
+          }
+          id: 1
+          source_info {
+            file: "e2e_tests/trace_tree/multicast_selector.p4"
+            line: 58
+            column: 12
+            source_fragment: "egress_selector.apply()"
+          }
+        }
+        events {
+          assignment {
+            target: "hdr.ethernet.dstAddr"
+          }
+          id: 2
+          source_info {
+            file: "e2e_tests/trace_tree/multicast_selector.p4"
+            line: 42
+            column: 42
+            source_fragment: "hdr.ethernet.dstAddr = 48w0xaaaaaaaaaaaa"
+          }
+          result_value: "187649984473770 (0xaaaaaaaaaaaa)"
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 5
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 6
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 7
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 8
+        }
+        output {
+          dataplane_egress_port: 1
+          payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
         }
       }
-      events {
-        table_lookup {
-          table_name: "egress_selector"
-          hit: true
-          matched_entry {
-            table_id: 43223807
-            match {
-              field_id: 1
-              exact {
-                value: "\377\377\377\377\377\377"
-              }
-            }
-            action {
-              action_profile_group_id: 1
-            }
+      branches {
+        events {
+          action_execution {
+            action_name: "tag_b"
           }
-          action_name: "tag_a"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/multicast_selector.p4"
-          line: 58
-          column: 12
-          source_fragment: "egress_selector.apply()"
-        }
-        variable_values {
-          key: "1"
-          value: "281474976710655 (0xffffffffffff)"
-        }
-      }
-      fork_outcome {
-        reason: ACTION_SELECTOR
-        branches {
-          label: "member_0"
-          subtree {
-            events {
-              action_execution {
-                action_name: "tag_a"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 58
-                column: 12
-                source_fragment: "egress_selector.apply()"
-              }
-            }
-            events {
-              assignment {
-                target: "hdr.ethernet.dstAddr"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 42
-                column: 42
-                source_fragment: "hdr.ethernet.dstAddr = 48w0xaaaaaaaaaaaa"
-              }
-              result_value: "187649984473770 (0xaaaaaaaaaaaa)"
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 1
-                payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
-              }
-            }
+          id: 1
+          source_info {
+            file: "e2e_tests/trace_tree/multicast_selector.p4"
+            line: 58
+            column: 12
+            source_fragment: "egress_selector.apply()"
           }
         }
-        branches {
-          label: "member_1"
-          subtree {
-            events {
-              action_execution {
-                action_name: "tag_b"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 58
-                column: 12
-                source_fragment: "egress_selector.apply()"
-              }
-            }
-            events {
-              assignment {
-                target: "hdr.ethernet.dstAddr"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 43
-                column: 42
-                source_fragment: "hdr.ethernet.dstAddr = 48w0xbbbbbbbbbbbb"
-              }
-              result_value: "206414982921147 (0xbbbbbbbbbbbb)"
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 1
-                payload: "\273\273\273\273\273\273\000\000\000\000\000\001\b\000"
-              }
-            }
+        events {
+          assignment {
+            target: "hdr.ethernet.dstAddr"
           }
+          id: 2
+          source_info {
+            file: "e2e_tests/trace_tree/multicast_selector.p4"
+            line: 43
+            column: 42
+            source_fragment: "hdr.ethernet.dstAddr = 48w0xbbbbbbbbbbbb"
+          }
+          result_value: "206414982921147 (0xbbbbbbbbbbbb)"
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 5
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 6
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 7
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 8
+        }
+        output {
+          dataplane_egress_port: 1
+          payload: "\273\273\273\273\273\273\000\000\000\000\000\001\b\000"
         }
       }
     }
   }
   branches {
-    label: "replica_0_port_2"
-    subtree {
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 2
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 2
+      }
+      id: 1
+    }
+    events {
+      table_lookup {
+        table_name: "egress_selector"
+        hit: true
+        matched_entry {
+          table_id: 43223807
+          match {
+            field_id: 1
+            exact {
+              value: "\377\377\377\377\377\377"
+            }
+          }
+          action {
+            action_profile_group_id: 1
+          }
+        }
+        action_name: "tag_a"
+      }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/multicast_selector.p4"
+        line: 58
+        column: 12
+        source_fragment: "egress_selector.apply()"
+      }
+      variable_values {
+        key: "1"
+        value: "281474976710655 (0xffffffffffff)"
+      }
+    }
+    choice {
+      cause: 2
+      branches {
+        events {
+          action_execution {
+            action_name: "tag_a"
+          }
+          id: 1
+          source_info {
+            file: "e2e_tests/trace_tree/multicast_selector.p4"
+            line: 58
+            column: 12
+            source_fragment: "egress_selector.apply()"
+          }
+        }
+        events {
+          assignment {
+            target: "hdr.ethernet.dstAddr"
+          }
+          id: 2
+          source_info {
+            file: "e2e_tests/trace_tree/multicast_selector.p4"
+            line: 42
+            column: 42
+            source_fragment: "hdr.ethernet.dstAddr = 48w0xaaaaaaaaaaaa"
+          }
+          result_value: "187649984473770 (0xaaaaaaaaaaaa)"
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 5
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 6
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 7
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 8
+        }
+        output {
+          dataplane_egress_port: 2
+          payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
         }
       }
-      events {
-        table_lookup {
-          table_name: "egress_selector"
-          hit: true
-          matched_entry {
-            table_id: 43223807
-            match {
-              field_id: 1
-              exact {
-                value: "\377\377\377\377\377\377"
-              }
-            }
-            action {
-              action_profile_group_id: 1
-            }
+      branches {
+        events {
+          action_execution {
+            action_name: "tag_b"
           }
-          action_name: "tag_a"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/multicast_selector.p4"
-          line: 58
-          column: 12
-          source_fragment: "egress_selector.apply()"
-        }
-        variable_values {
-          key: "1"
-          value: "281474976710655 (0xffffffffffff)"
-        }
-      }
-      fork_outcome {
-        reason: ACTION_SELECTOR
-        branches {
-          label: "member_0"
-          subtree {
-            events {
-              action_execution {
-                action_name: "tag_a"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 58
-                column: 12
-                source_fragment: "egress_selector.apply()"
-              }
-            }
-            events {
-              assignment {
-                target: "hdr.ethernet.dstAddr"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 42
-                column: 42
-                source_fragment: "hdr.ethernet.dstAddr = 48w0xaaaaaaaaaaaa"
-              }
-              result_value: "187649984473770 (0xaaaaaaaaaaaa)"
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 2
-                payload: "\252\252\252\252\252\252\000\000\000\000\000\001\b\000"
-              }
-            }
+          id: 1
+          source_info {
+            file: "e2e_tests/trace_tree/multicast_selector.p4"
+            line: 58
+            column: 12
+            source_fragment: "egress_selector.apply()"
           }
         }
-        branches {
-          label: "member_1"
-          subtree {
-            events {
-              action_execution {
-                action_name: "tag_b"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 58
-                column: 12
-                source_fragment: "egress_selector.apply()"
-              }
-            }
-            events {
-              assignment {
-                target: "hdr.ethernet.dstAddr"
-              }
-              source_info {
-                file: "e2e_tests/trace_tree/multicast_selector.p4"
-                line: 43
-                column: 42
-                source_fragment: "hdr.ethernet.dstAddr = 48w0xbbbbbbbbbbbb"
-              }
-              result_value: "206414982921147 (0xbbbbbbbbbbbb)"
-            }
-            events {
-              pipeline_stage {
-                stage_name: "egress"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: ENTER
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "compute_checksum"
-                stage_kind: CONTROL
-                direction: EXIT
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: ENTER
-              }
-            }
-            events {
-              deparser_emit {
-                header_type: "ethernet_t"
-                byte_length: 14
-              }
-            }
-            events {
-              pipeline_stage {
-                stage_name: "deparser"
-                stage_kind: DEPARSER
-                direction: EXIT
-              }
-            }
-            packet_outcome {
-              output {
-                dataplane_egress_port: 2
-                payload: "\273\273\273\273\273\273\000\000\000\000\000\001\b\000"
-              }
-            }
+        events {
+          assignment {
+            target: "hdr.ethernet.dstAddr"
           }
+          id: 2
+          source_info {
+            file: "e2e_tests/trace_tree/multicast_selector.p4"
+            line: 43
+            column: 42
+            source_fragment: "hdr.ethernet.dstAddr = 48w0xbbbbbbbbbbbb"
+          }
+          result_value: "206414982921147 (0xbbbbbbbbbbbb)"
+        }
+        events {
+          pipeline_stage {
+            stage_name: "egress"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 3
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: ENTER
+          }
+          id: 4
+        }
+        events {
+          pipeline_stage {
+            stage_name: "compute_checksum"
+            stage_kind: CONTROL
+            direction: EXIT
+          }
+          id: 5
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: ENTER
+          }
+          id: 6
+        }
+        events {
+          deparser_emit {
+            header_type: "ethernet_t"
+            byte_length: 14
+          }
+          id: 7
+        }
+        events {
+          pipeline_stage {
+            stage_name: "deparser"
+            stage_kind: DEPARSER
+            direction: EXIT
+          }
+          id: 8
+        }
+        output {
+          dataplane_egress_port: 2
+          payload: "\273\273\273\273\273\273\000\000\000\000\000\001\b\000"
         }
       }
     }

--- a/e2e_tests/trace_tree/no_fork.golden.txtpb
+++ b/e2e_tests/trace_tree/no_fork.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/no_fork.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,6 +58,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   table_lookup {
@@ -77,6 +84,7 @@ events {
     }
     action_name: "forward"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/no_fork.p4"
     line: 41
@@ -96,6 +104,7 @@ events {
       value: "\000\001"
     }
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/no_fork.p4"
     line: 41
@@ -107,6 +116,7 @@ events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 10
   source_info {
     file: "e2e_tests/trace_tree/no_fork.p4"
     line: 33
@@ -126,6 +136,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 11
 }
 events {
   pipeline_stage {
@@ -134,6 +145,7 @@ events {
     direction: ENTER
     dataplane_port: 1
   }
+  id: 12
 }
 events {
   pipeline_stage {
@@ -142,6 +154,7 @@ events {
     direction: EXIT
     dataplane_port: 1
   }
+  id: 13
 }
 events {
   pipeline_stage {
@@ -150,6 +163,7 @@ events {
     direction: ENTER
     dataplane_port: 1
   }
+  id: 14
 }
 events {
   pipeline_stage {
@@ -158,6 +172,7 @@ events {
     direction: EXIT
     dataplane_port: 1
   }
+  id: 15
 }
 events {
   pipeline_stage {
@@ -165,12 +180,14 @@ events {
     stage_kind: DEPARSER
     direction: ENTER
   }
+  id: 16
 }
 events {
   deparser_emit {
     header_type: "ethernet_t"
     byte_length: 14
   }
+  id: 17
 }
 events {
   pipeline_stage {
@@ -178,10 +195,9 @@ events {
     stage_kind: DEPARSER
     direction: EXIT
   }
+  id: 18
 }
-packet_outcome {
-  output {
-    dataplane_egress_port: 1
-    payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-  }
+output {
+  dataplane_egress_port: 1
+  payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
 }

--- a/e2e_tests/trace_tree/recirculate.golden.txtpb
+++ b/e2e_tests/trace_tree/recirculate.golden.txtpb
@@ -159,14 +159,8 @@ events {
   }
   id: 17
 }
-events {
-  id: 18
-  continuation_trigger {
-    kind: RECIRCULATE
-  }
-}
 continuation {
-  cause: 18
+  kind: RECIRCULATE
   next {
     events {
       packet_ingress {

--- a/e2e_tests/trace_tree/recirculate.golden.txtpb
+++ b/e2e_tests/trace_tree/recirculate.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/recirculate.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/recirculate.p4"
     line: 33
@@ -72,6 +80,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 9
 }
 events {
   pipeline_stage {
@@ -80,12 +89,14 @@ events {
     direction: ENTER
     dataplane_port: 1
   }
+  id: 10
 }
 events {
   branch {
     control_name: "MyEgress"
     taken: true
   }
+  id: 11
   source_info {
     file: "e2e_tests/trace_tree/recirculate.p4"
     line: 39
@@ -105,6 +116,7 @@ events {
     direction: EXIT
     dataplane_port: 1
   }
+  id: 12
 }
 events {
   pipeline_stage {
@@ -113,6 +125,7 @@ events {
     direction: ENTER
     dataplane_port: 1
   }
+  id: 13
 }
 events {
   pipeline_stage {
@@ -121,6 +134,7 @@ events {
     direction: EXIT
     dataplane_port: 1
   }
+  id: 14
 }
 events {
   pipeline_stage {
@@ -128,12 +142,14 @@ events {
     stage_kind: DEPARSER
     direction: ENTER
   }
+  id: 15
 }
 events {
   deparser_emit {
     header_type: "ethernet_t"
     byte_length: 14
   }
+  id: 16
 }
 events {
   pipeline_stage {
@@ -141,162 +157,174 @@ events {
     stage_kind: DEPARSER
     direction: EXIT
   }
+  id: 17
 }
-fork_outcome {
-  reason: RECIRCULATE
-  branches {
-    label: "recirculate"
-    subtree {
-      events {
-        packet_ingress {
-        }
+continuation {
+  next {
+    events {
+      packet_ingress {
       }
-      events {
-        pipeline_stage {
-          stage_name: "parser"
-          stage_kind: PARSER
-          direction: ENTER
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "parser"
+        stage_kind: PARSER
+        direction: ENTER
       }
-      events {
-        parser_transition {
-          parser_name: "MyParser"
-          from_state: "start"
-          to_state: "accept"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/recirculate.p4"
-          line: 22
-          column: 10
-          source_fragment: "start"
-        }
+      id: 2
+    }
+    events {
+      parser_transition {
+        parser_name: "MyParser"
+        from_state: "start"
+        to_state: "accept"
       }
-      events {
-        pipeline_stage {
-          stage_name: "parser"
-          stage_kind: PARSER
-          direction: EXIT
-        }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/recirculate.p4"
+        line: 22
+        column: 10
+        source_fragment: "start"
       }
-      events {
-        pipeline_stage {
-          stage_name: "verify_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 0
-        }
+    }
+    events {
+      pipeline_stage {
+        stage_name: "parser"
+        stage_kind: PARSER
+        direction: EXIT
       }
-      events {
-        pipeline_stage {
-          stage_name: "verify_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 0
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "verify_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 0
       }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 0
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "verify_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 0
       }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/recirculate.p4"
-          line: 33
-          column: 30
-          source_fragment: "smeta.egress_spec = 9w1"
-        }
-        result_value: "1"
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 0
       }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 0
-        }
+      id: 7
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 8
+      source_info {
+        file: "e2e_tests/trace_tree/recirculate.p4"
+        line: 33
+        column: 30
+        source_fragment: "smeta.egress_spec = 9w1"
       }
-      events {
-        branch {
-          control_name: "MyEgress"
-          taken: false
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/recirculate.p4"
-          line: 39
-          column: 12
-          source_fragment: "smeta.instance_type == 0"
-        }
-        variable_values {
-          key: "smeta.instance_type"
-          value: "4"
-        }
-        result_value: "false"
+      result_value: "1"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 0
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 9
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 10
+    }
+    events {
+      branch {
+        control_name: "MyEgress"
+        taken: false
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 11
+      source_info {
+        file: "e2e_tests/trace_tree/recirculate.p4"
+        line: 39
+        column: 12
+        source_fragment: "smeta.instance_type == 0"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      variable_values {
+        key: "smeta.instance_type"
+        value: "4"
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      result_value: "false"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 12
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 13
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
+      id: 14
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 15
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 16
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 17
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/recirculate.golden.txtpb
+++ b/e2e_tests/trace_tree/recirculate.golden.txtpb
@@ -159,7 +159,14 @@ events {
   }
   id: 17
 }
+events {
+  id: 18
+  continuation_trigger {
+    kind: RECIRCULATE
+  }
+}
 continuation {
+  cause: 18
   next {
     events {
       packet_ingress {

--- a/e2e_tests/trace_tree/resubmit.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit.golden.txtpb
@@ -100,7 +100,14 @@ events {
   }
   id: 10
 }
+events {
+  id: 11
+  continuation_trigger {
+    kind: RESUBMIT
+  }
+}
 continuation {
+  cause: 11
   next {
     events {
       packet_ingress {

--- a/e2e_tests/trace_tree/resubmit.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit.golden.txtpb
@@ -100,14 +100,8 @@ events {
   }
   id: 10
 }
-events {
-  id: 11
-  continuation_trigger {
-    kind: RESUBMIT
-  }
-}
 continuation {
-  cause: 11
+  kind: RESUBMIT
   next {
     events {
       packet_ingress {

--- a/e2e_tests/trace_tree/resubmit.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/resubmit.p4"
     line: 22
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,11 +58,13 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/resubmit.p4"
     line: 34
@@ -70,6 +78,7 @@ events {
     control_name: "MyIngress"
     taken: true
   }
+  id: 9
   source_info {
     file: "e2e_tests/trace_tree/resubmit.p4"
     line: 35
@@ -89,162 +98,174 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 10
 }
-fork_outcome {
-  reason: RESUBMIT
-  branches {
-    label: "resubmit"
-    subtree {
-      events {
-        packet_ingress {
-        }
+continuation {
+  next {
+    events {
+      packet_ingress {
       }
-      events {
-        pipeline_stage {
-          stage_name: "parser"
-          stage_kind: PARSER
-          direction: ENTER
-        }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "parser"
+        stage_kind: PARSER
+        direction: ENTER
       }
-      events {
-        parser_transition {
-          parser_name: "MyParser"
-          from_state: "start"
-          to_state: "accept"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/resubmit.p4"
-          line: 22
-          column: 10
-          source_fragment: "start"
-        }
+      id: 2
+    }
+    events {
+      parser_transition {
+        parser_name: "MyParser"
+        from_state: "start"
+        to_state: "accept"
       }
-      events {
-        pipeline_stage {
-          stage_name: "parser"
-          stage_kind: PARSER
-          direction: EXIT
-        }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/resubmit.p4"
+        line: 22
+        column: 10
+        source_fragment: "start"
       }
-      events {
-        pipeline_stage {
-          stage_name: "verify_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 0
-        }
+    }
+    events {
+      pipeline_stage {
+        stage_name: "parser"
+        stage_kind: PARSER
+        direction: EXIT
       }
-      events {
-        pipeline_stage {
-          stage_name: "verify_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 0
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "verify_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 0
       }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 0
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "verify_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 0
       }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/resubmit.p4"
-          line: 34
-          column: 26
-          source_fragment: "smeta.egress_spec = 9w1"
-        }
-        result_value: "1"
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 0
       }
-      events {
-        branch {
-          control_name: "MyIngress"
-          taken: false
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/resubmit.p4"
-          line: 35
-          column: 12
-          source_fragment: "smeta.instance_type == 0"
-        }
-        variable_values {
-          key: "smeta.instance_type"
-          value: "6"
-        }
-        result_value: "false"
+      id: 7
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
       }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 0
-        }
+      id: 8
+      source_info {
+        file: "e2e_tests/trace_tree/resubmit.p4"
+        line: 34
+        column: 26
+        source_fragment: "smeta.egress_spec = 9w1"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      result_value: "1"
+    }
+    events {
+      branch {
+        control_name: "MyIngress"
+        taken: false
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      id: 9
+      source_info {
+        file: "e2e_tests/trace_tree/resubmit.p4"
+        line: 35
+        column: 12
+        source_fragment: "smeta.instance_type == 0"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      variable_values {
+        key: "smeta.instance_type"
+        value: "6"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      result_value: "false"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 0
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 10
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 11
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 12
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 13
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
+      id: 14
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 15
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 16
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 17
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/e2e_tests/trace_tree/resubmit_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit_preserve_meta.golden.txtpb
@@ -1,0 +1,312 @@
+events {
+  packet_ingress {
+  }
+  id: 1
+}
+events {
+  pipeline_stage {
+    stage_name: "parser"
+    stage_kind: PARSER
+    direction: ENTER
+  }
+  id: 2
+}
+events {
+  parser_transition {
+    parser_name: "MyParser"
+    from_state: "start"
+    to_state: "accept"
+  }
+  id: 3
+  source_info {
+    file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
+    line: 29
+    column: 10
+    source_fragment: "start"
+  }
+}
+events {
+  pipeline_stage {
+    stage_name: "parser"
+    stage_kind: PARSER
+    direction: EXIT
+  }
+  id: 4
+}
+events {
+  pipeline_stage {
+    stage_name: "verify_checksum"
+    stage_kind: CONTROL
+    direction: ENTER
+    dataplane_port: 0
+  }
+  id: 5
+}
+events {
+  pipeline_stage {
+    stage_name: "verify_checksum"
+    stage_kind: CONTROL
+    direction: EXIT
+    dataplane_port: 0
+  }
+  id: 6
+}
+events {
+  pipeline_stage {
+    stage_name: "ingress"
+    stage_kind: CONTROL
+    direction: ENTER
+    dataplane_port: 0
+  }
+  id: 7
+}
+events {
+  assignment {
+    target: "smeta.egress_spec"
+  }
+  id: 8
+  source_info {
+    file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
+    line: 41
+    column: 26
+    source_fragment: "smeta.egress_spec = 9w1"
+  }
+  result_value: "1"
+}
+events {
+  branch {
+    control_name: "MyIngress"
+    taken: true
+  }
+  id: 9
+  source_info {
+    file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
+    line: 42
+    column: 12
+    source_fragment: "smeta.instance_type == 0"
+  }
+  variable_values {
+    key: "smeta.instance_type"
+    value: "0"
+  }
+  result_value: "true"
+}
+events {
+  assignment {
+    target: "meta.tag"
+  }
+  id: 10
+  source_info {
+    file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
+    line: 43
+    column: 21
+    source_fragment: "meta.tag = 16w0xbeef"
+  }
+  result_value: "48879 (0xbeef)"
+}
+events {
+  pipeline_stage {
+    stage_name: "ingress"
+    stage_kind: CONTROL
+    direction: EXIT
+    dataplane_port: 0
+  }
+  id: 11
+}
+events {
+  id: 12
+  continuation_trigger {
+    kind: RESUBMIT
+    preserved_fields {
+      key: "tag"
+      value: "48879"
+    }
+  }
+}
+continuation {
+  cause: 12
+  next {
+    events {
+      packet_ingress {
+      }
+      id: 1
+    }
+    events {
+      pipeline_stage {
+        stage_name: "parser"
+        stage_kind: PARSER
+        direction: ENTER
+      }
+      id: 2
+    }
+    events {
+      parser_transition {
+        parser_name: "MyParser"
+        from_state: "start"
+        to_state: "accept"
+      }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
+        line: 29
+        column: 10
+        source_fragment: "start"
+      }
+    }
+    events {
+      pipeline_stage {
+        stage_name: "parser"
+        stage_kind: PARSER
+        direction: EXIT
+      }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "verify_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 0
+      }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "verify_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 0
+      }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 0
+      }
+      id: 7
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
+      }
+      id: 8
+      source_info {
+        file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
+        line: 41
+        column: 26
+        source_fragment: "smeta.egress_spec = 9w1"
+      }
+      result_value: "1"
+    }
+    events {
+      branch {
+        control_name: "MyIngress"
+        taken: false
+      }
+      id: 9
+      source_info {
+        file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
+        line: 42
+        column: 12
+        source_fragment: "smeta.instance_type == 0"
+      }
+      variable_values {
+        key: "smeta.instance_type"
+        value: "6"
+      }
+      result_value: "false"
+    }
+    events {
+      assignment {
+        target: "hdr.ethernet.etherType"
+      }
+      id: 10
+      source_info {
+        file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
+        line: 47
+        column: 35
+        source_fragment: "hdr.ethernet.etherType = meta.tag"
+      }
+      variable_values {
+        key: "meta.tag"
+        value: "48879 (0xbeef)"
+      }
+      result_value: "48879 (0xbeef)"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 0
+      }
+      id: 11
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
+      }
+      id: 12
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
+      }
+      id: 13
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
+      }
+      id: 14
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
+      }
+      id: 15
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 16
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 17
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 18
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\276\357"
+    }
+  }
+}

--- a/e2e_tests/trace_tree/resubmit_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit_preserve_meta.golden.txtpb
@@ -113,18 +113,8 @@ events {
   }
   id: 11
 }
-events {
-  id: 12
-  continuation_trigger {
-    kind: RESUBMIT
-    preserved_fields {
-      key: "tag"
-      value: "48879"
-    }
-  }
-}
 continuation {
-  cause: 12
+  kind: RESUBMIT
   next {
     events {
       packet_ingress {
@@ -308,5 +298,9 @@ continuation {
       dataplane_egress_port: 1
       payload: "\377\377\377\377\377\377\000\000\000\000\000\001\276\357"
     }
+  }
+  preserved_fields {
+    key: "tag"
+    value: "48879"
   }
 }

--- a/e2e_tests/trace_tree/resubmit_preserve_meta.p4
+++ b/e2e_tests/trace_tree/resubmit_preserve_meta.p4
@@ -1,0 +1,62 @@
+/* resubmit_preserve_meta.p4 — verify ContinuationEvent.preserved_fields.
+ *
+ * First ingress pass (instance_type == 0): sets meta.tag = 0xBEEF and calls
+ * resubmit_preserving_field_list(0). The simulator should emit a ContinuationEvent
+ * with preserved_fields["tag"] = "48879" (0xBEEF in decimal).
+ *
+ * Second pass (instance_type == RESUBMIT = 6): tag is restored from the field list;
+ * it's written into etherType so the preserved value is visible in the output packet.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t { ethernet_t ethernet; }
+
+struct metadata_t {
+    @field_list(0)
+    bit<16> tag;
+}
+
+parser MyParser(packet_in pkt, out headers_t hdr,
+                inout metadata_t meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) { apply {} }
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta,
+                  inout standard_metadata_t smeta) {
+    apply {
+        smeta.egress_spec = 1;
+        if (smeta.instance_type == 0) {
+            meta.tag = 16w0xBEEF;
+            resubmit_preserving_field_list(0);
+        } else {
+            // Second pass: write preserved tag into etherType for observability.
+            hdr.ethernet.etherType = meta.tag;
+        }
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta,
+                 inout standard_metadata_t smeta) {
+    apply {}
+}
+
+control MyDeparser(packet_out pkt, in headers_t hdr) {
+    apply { pkt.emit(hdr.ethernet); }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(),
+         MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/e2e_tests/trace_tree/resubmit_preserve_meta.stf
+++ b/e2e_tests/trace_tree/resubmit_preserve_meta.stf
@@ -1,0 +1,3 @@
+# resubmit_preserve_meta.stf — send an ethernet packet; verify etherType = 0xBEEF on output.
+packet 0 FFFFFFFFFFFF 000000000001 0800
+expect 1 FFFFFFFFFFFF 000000000001 BEEF

--- a/e2e_tests/trace_tree/selector_exit.golden.txtpb
+++ b/e2e_tests/trace_tree/selector_exit.golden.txtpb
@@ -1,6 +1,7 @@
 events {
   packet_ingress {
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -8,6 +9,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -15,6 +17,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/trace_tree/selector_exit.p4"
     line: 24
@@ -28,6 +31,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -36,6 +40,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -44,6 +49,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -52,6 +58,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 7
 }
 events {
   table_lookup {
@@ -71,6 +78,7 @@ events {
     }
     action_name: "set_port"
   }
+  id: 8
   source_info {
     file: "e2e_tests/trace_tree/selector_exit.p4"
     line: 60
@@ -82,263 +90,276 @@ events {
     value: "281474976710655 (0xffffffffffff)"
   }
 }
-fork_outcome {
-  reason: ACTION_SELECTOR
+choice {
+  cause: 8
   branches {
-    label: "member_0"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_port"
-          params {
-            key: "port"
-            value: "\000\001"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 60
-          column: 8
-          source_fragment: "selector_table.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 36
-          column: 53
-          source_fragment: "smeta.egress_spec = port"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_port"
+        params {
           key: "port"
-          value: "1"
+          value: "\000\001"
         }
-        result_value: "1"
       }
-      events {
-        table_lookup {
-          table_name: "after_selector"
-          hit: true
-          matched_entry {
-            table_id: 41238816
-            match {
-              field_id: 1
-              exact {
-                value: "\b\000"
-              }
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/selector_exit.p4"
+        line: 60
+        column: 8
+        source_fragment: "selector_table.apply()"
+      }
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
+      }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/selector_exit.p4"
+        line: 36
+        column: 53
+        source_fragment: "smeta.egress_spec = port"
+      }
+      variable_values {
+        key: "port"
+        value: "1"
+      }
+      result_value: "1"
+    }
+    events {
+      table_lookup {
+        table_name: "after_selector"
+        hit: true
+        matched_entry {
+          table_id: 41238816
+          match {
+            field_id: 1
+            exact {
+              value: "\b\000"
             }
-            action {
-              action {
-                action_id: 21723794
-              }
-            }
-            is_const: true
           }
-          action_name: "overwrite"
+          action {
+            action {
+              action_id: 21723794
+            }
+          }
+          is_const: true
         }
-        source_info {
-          file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 61
-          column: 8
-          source_fragment: "after_selector.apply()"
-        }
-        variable_values {
-          key: "1"
-          value: "2048 (0x800)"
-        }
+        action_name: "overwrite"
       }
-      events {
-        action_execution {
-          action_name: "overwrite"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 61
-          column: 8
-          source_fragment: "after_selector.apply()"
-        }
+      id: 3
+      source_info {
+        file: "e2e_tests/trace_tree/selector_exit.p4"
+        line: 61
+        column: 8
+        source_fragment: "after_selector.apply()"
       }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 52
-          column: 43
-          source_fragment: "smeta.egress_spec = 9w9"
-        }
-        result_value: "9"
+      variable_values {
+        key: "1"
+        value: "2048 (0x800)"
       }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
-        }
+    }
+    events {
+      action_execution {
+        action_name: "overwrite"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 9
-        }
+      id: 4
+      source_info {
+        file: "e2e_tests/trace_tree/selector_exit.p4"
+        line: 61
+        column: 8
+        source_fragment: "after_selector.apply()"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 9
-        }
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 9
-        }
+      id: 5
+      source_info {
+        file: "e2e_tests/trace_tree/selector_exit.p4"
+        line: 52
+        column: 43
+        source_fragment: "smeta.egress_spec = 9w9"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 9
-        }
+      result_value: "9"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 9
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 9
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 8
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 9
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 9
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 9
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 9
       }
+      id: 10
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 11
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 12
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 13
+    }
+    output {
+      dataplane_egress_port: 9
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
   branches {
-    label: "member_1"
-    subtree {
-      events {
-        action_execution {
-          action_name: "set_port_and_exit"
-          params {
-            key: "port_2"
-            value: "\000\001"
-          }
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 60
-          column: 8
-          source_fragment: "selector_table.apply()"
-        }
-      }
-      events {
-        assignment {
-          target: "smeta.egress_spec"
-        }
-        source_info {
-          file: "e2e_tests/trace_tree/selector_exit.p4"
-          line: 37
-          column: 62
-          source_fragment: "smeta.egress_spec = port"
-        }
-        variable_values {
+    events {
+      action_execution {
+        action_name: "set_port_and_exit"
+        params {
           key: "port_2"
-          value: "1"
-        }
-        result_value: "1"
-      }
-      events {
-        pipeline_stage {
-          stage_name: "ingress"
-          stage_kind: CONTROL
-          direction: EXIT
+          value: "\000\001"
         }
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 1
+      source_info {
+        file: "e2e_tests/trace_tree/selector_exit.p4"
+        line: 60
+        column: 8
+        source_fragment: "selector_table.apply()"
       }
-      events {
-        pipeline_stage {
-          stage_name: "egress"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+    }
+    events {
+      assignment {
+        target: "smeta.egress_spec"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: ENTER
-          dataplane_port: 1
-        }
+      id: 2
+      source_info {
+        file: "e2e_tests/trace_tree/selector_exit.p4"
+        line: 37
+        column: 62
+        source_fragment: "smeta.egress_spec = port"
       }
-      events {
-        pipeline_stage {
-          stage_name: "compute_checksum"
-          stage_kind: CONTROL
-          direction: EXIT
-          dataplane_port: 1
-        }
+      variable_values {
+        key: "port_2"
+        value: "1"
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: ENTER
-        }
+      result_value: "1"
+    }
+    events {
+      pipeline_stage {
+        stage_name: "ingress"
+        stage_kind: CONTROL
+        direction: EXIT
       }
-      events {
-        deparser_emit {
-          header_type: "ethernet_t"
-          byte_length: 14
-        }
+      id: 3
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
-      events {
-        pipeline_stage {
-          stage_name: "deparser"
-          stage_kind: DEPARSER
-          direction: EXIT
-        }
+      id: 4
+    }
+    events {
+      pipeline_stage {
+        stage_name: "egress"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
       }
-      packet_outcome {
-        output {
-          dataplane_egress_port: 1
-          payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
-        }
+      id: 5
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: ENTER
+        dataplane_port: 1
       }
+      id: 6
+    }
+    events {
+      pipeline_stage {
+        stage_name: "compute_checksum"
+        stage_kind: CONTROL
+        direction: EXIT
+        dataplane_port: 1
+      }
+      id: 7
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: ENTER
+      }
+      id: 8
+    }
+    events {
+      deparser_emit {
+        header_type: "ethernet_t"
+        byte_length: 14
+      }
+      id: 9
+    }
+    events {
+      pipeline_stage {
+        stage_name: "deparser"
+        stage_kind: DEPARSER
+        direction: EXIT
+      }
+      id: 10
+    }
+    output {
+      dataplane_egress_port: 1
+      payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000"
     }
   }
 }

--- a/examples/tutorial.t
+++ b/examples/tutorial.t
@@ -97,7 +97,7 @@ an IPv4 frame that matches, and an ARP frame that doesn't.
     table port_table: miss -> drop
     action drop
     mark_to_drop()
-    drop (reason: mark_to_drop)
+    drop
   PASS
 
 Now the trace tells a much richer story. The first packet (etherType
@@ -197,7 +197,7 @@ The human-readable trace is compact but lossy -- it omits source
 locations and raw byte payloads. The --format=textproto flag outputs
 the full trace tree as a protocol buffer:
 
-  $ 4ward run --format=textproto passthrough.p4 - << 'EOF' | grep -A 10 parser_transition
+  $ 4ward run --format=textproto passthrough.p4 - << 'EOF' | grep -A 11 parser_transition
   > packet 0 FFFFFFFFFFFF 000000000001 0800
   > expect 1 FFFFFFFFFFFF 000000000001 0800
   > EOF
@@ -206,6 +206,7 @@ the full trace tree as a protocol buffer:
       from_state: "start"
       to_state: "accept"
     }
+    id: 3
     source_info {
       file: "passthrough.p4"
       line: 25

--- a/grpc/EnrichedTraceGoldenTest.kt
+++ b/grpc/EnrichedTraceGoldenTest.kt
@@ -52,6 +52,14 @@ class EnrichedTraceGoldenTest {
     val response = harness.injectPacketP4rt(p4rtPort, payload)
     val actual = response.trace
 
+    if (UPDATE) {
+      fourward.bazel.repoRoot
+        .resolve(GOLDEN_PATH)
+        .toFile()
+        .writeText(TextFormat.printer().printToString(actual))
+      return
+    }
+
     val golden = loadGolden()
     if (actual != golden) {
       fail(
@@ -107,5 +115,6 @@ class EnrichedTraceGoldenTest {
 
   companion object {
     private const val GOLDEN_PATH = "grpc/enriched_trace.golden.txtpb"
+    private val UPDATE = System.getProperty("update") == "true"
   }
 }

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -561,12 +561,8 @@ class SaiP4E2ETest {
     )
 
     // Output packet in the trace outcome should have P4RT encoding.
-    assertTrue("should have packet outcome", trace.hasPacketOutcome())
-    assertTrue("should have output", trace.packetOutcome.hasOutput())
-    assertTrue(
-      "egress port should have P4RT encoding",
-      !trace.packetOutcome.output.p4RtEgressPort.isEmpty,
-    )
+    assertTrue("should have output", trace.hasOutput())
+    assertTrue("egress port should have P4RT encoding", !trace.output.p4RtEgressPort.isEmpty)
   }
 
   @Test

--- a/grpc/TraceEnricher.kt
+++ b/grpc/TraceEnricher.kt
@@ -47,27 +47,41 @@ object TraceEnricher {
     }
 
     when (tree.outcomeCase) {
-      TraceTree.OutcomeCase.FORK_OUTCOME -> {
-        val fork = tree.forkOutcome
-        for (i in 0 until fork.branchesCount) {
-          val branch = fork.getBranches(i)
-          val enrichedSubtree = enrichTree(branch.subtree, pt, translator)
-          if (enrichedSubtree !== branch.subtree) {
-            lazyBuilder()
-              .forkOutcomeBuilder
-              .setBranches(i, branch.toBuilder().setSubtree(enrichedSubtree))
+      TraceTree.OutcomeCase.REPLICATION -> {
+        val rep = tree.replication
+        for (i in 0 until rep.branchesCount) {
+          val enriched = enrichTree(rep.getBranches(i), pt, translator)
+          if (enriched !== rep.getBranches(i)) {
+            lazyBuilder().replicationBuilder.setBranches(i, enriched)
           }
         }
       }
-      TraceTree.OutcomeCase.PACKET_OUTCOME -> {
-        if (pt != null && tree.packetOutcome.hasOutput()) {
-          val output = tree.packetOutcome.output
+      TraceTree.OutcomeCase.CHOICE -> {
+        val choice = tree.choice
+        for (i in 0 until choice.branchesCount) {
+          val enriched = enrichTree(choice.getBranches(i), pt, translator)
+          if (enriched !== choice.getBranches(i)) {
+            lazyBuilder().choiceBuilder.setBranches(i, enriched)
+          }
+        }
+      }
+      TraceTree.OutcomeCase.CONTINUATION -> {
+        val cont = tree.continuation
+        val enrichedNext = enrichTree(cont.next, pt, translator)
+        if (enrichedNext !== cont.next) {
+          lazyBuilder().continuationBuilder.setNext(enrichedNext)
+        }
+      }
+      TraceTree.OutcomeCase.OUTPUT -> {
+        if (pt != null) {
+          val output = tree.output
           val p4rtPort = pt.dataplaneToP4rt(DataplanePort.fromProto(output.dataplaneEgressPort))
           if (p4rtPort != null) {
-            lazyBuilder().packetOutcomeBuilder.outputBuilder.setP4RtEgressPort(p4rtPort)
+            lazyBuilder().outputBuilder.setP4RtEgressPort(p4rtPort)
           }
         }
       }
+      TraceTree.OutcomeCase.DROP,
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,
       null -> {}
     }

--- a/grpc/TraceEnricherTest.kt
+++ b/grpc/TraceEnricherTest.kt
@@ -3,13 +3,9 @@ package fourward.grpc
 import com.google.protobuf.ByteString
 import fourward.CloneSessionLookupEvent
 import fourward.Drop
-import fourward.DropReason
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.OutputPacket
 import fourward.PacketIngressEvent
-import fourward.PacketOutcome
+import fourward.Replication
 import fourward.TableLookupEvent
 import fourward.TraceEvent
 import fourward.TraceTree
@@ -60,7 +56,7 @@ class TraceEnricherTest {
     val trace = simpleTrace(ingressPort = 0, egressPort = 0)
     val enriched = TraceEnricher.enrich(trace, translator)
 
-    val output = enriched.packetOutcome.output
+    val output = enriched.output
     assertEquals(0, output.dataplaneEgressPort)
     assertEquals(ByteString.copyFromUtf8("Ethernet1"), output.p4RtEgressPort)
   }
@@ -206,35 +202,24 @@ class TraceEnricherTest {
 
     val branch1 =
       TraceTree.newBuilder()
-        .setPacketOutcome(
-          PacketOutcome.newBuilder()
-            .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(0).setPayload(EMPTY))
-        )
+        .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(0).setPayload(EMPTY))
         .build()
     val branch2 =
       TraceTree.newBuilder()
-        .setPacketOutcome(
-          PacketOutcome.newBuilder()
-            .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(EMPTY))
-        )
+        .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(1).setPayload(EMPTY))
         .build()
 
     val trace =
       TraceTree.newBuilder()
-        .setForkOutcome(
-          Fork.newBuilder()
-            .setReason(ForkReason.MULTICAST)
-            .addBranches(ForkBranch.newBuilder().setLabel("replica_0").setSubtree(branch1))
-            .addBranches(ForkBranch.newBuilder().setLabel("replica_1").setSubtree(branch2))
-        )
+        .setReplication(Replication.newBuilder().addBranches(branch1).addBranches(branch2))
         .build()
 
     val enriched = TraceEnricher.enrich(trace, translator)
 
-    val out0 = enriched.forkOutcome.getBranches(0).subtree.packetOutcome.output
+    val out0 = enriched.replication.getBranches(0).output
     assertEquals(ByteString.copyFromUtf8("Ethernet0"), out0.p4RtEgressPort)
 
-    val out1 = enriched.forkOutcome.getBranches(1).subtree.packetOutcome.output
+    val out1 = enriched.replication.getBranches(1).output
     assertEquals(ByteString.copyFromUtf8("Ethernet1"), out1.p4RtEgressPort)
   }
 
@@ -243,12 +228,7 @@ class TraceEnricherTest {
     val translator = portTranslator()
     translator.p4rtToDataplane(PORT_TYPE, "Ethernet0")
 
-    val trace =
-      TraceTree.newBuilder()
-        .setPacketOutcome(
-          PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP))
-        )
-        .build()
+    val trace = TraceTree.newBuilder().setDrop(Drop.getDefaultInstance()).build()
 
     assertSame(trace, TraceEnricher.enrich(trace, translator))
   }
@@ -263,10 +243,7 @@ class TraceEnricherTest {
         TraceEvent.newBuilder()
           .setPacketIngress(PacketIngressEvent.newBuilder().setDataplaneIngressPort(ingressPort))
       )
-      .setPacketOutcome(
-        PacketOutcome.newBuilder()
-          .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(egressPort).setPayload(EMPTY))
-      )
+      .setOutput(OutputPacket.newBuilder().setDataplaneEgressPort(egressPort).setPayload(EMPTY))
       .build()
 
   private fun traceWithIngress(ingressPort: Int): TraceTree =

--- a/grpc/enriched_trace.golden.txtpb
+++ b/grpc/enriched_trace.golden.txtpb
@@ -3,6 +3,7 @@ events {
     dataplane_ingress_port: 1
     p4rt_ingress_port: "Ethernet0"
   }
+  id: 1
 }
 events {
   pipeline_stage {
@@ -10,6 +11,7 @@ events {
     stage_kind: PARSER
     direction: ENTER
   }
+  id: 2
 }
 events {
   parser_transition {
@@ -17,6 +19,7 @@ events {
     from_state: "start"
     to_state: "accept"
   }
+  id: 3
   source_info {
     file: "e2e_tests/translated_port/translated_port.p4"
     line: 30
@@ -30,6 +33,7 @@ events {
     stage_kind: PARSER
     direction: EXIT
   }
+  id: 4
 }
 events {
   pipeline_stage {
@@ -38,6 +42,7 @@ events {
     direction: ENTER
     dataplane_port: 1
   }
+  id: 5
 }
 events {
   pipeline_stage {
@@ -46,6 +51,7 @@ events {
     direction: EXIT
     dataplane_port: 1
   }
+  id: 6
 }
 events {
   pipeline_stage {
@@ -54,6 +60,7 @@ events {
     direction: ENTER
     dataplane_port: 1
   }
+  id: 7
 }
 events {
   table_lookup {
@@ -97,6 +104,7 @@ events {
       }
     }
   }
+  id: 8
   source_info {
     file: "e2e_tests/translated_port/translated_port.p4"
     line: 50
@@ -116,6 +124,7 @@ events {
       value: "\000"
     }
   }
+  id: 9
   source_info {
     file: "e2e_tests/translated_port/translated_port.p4"
     line: 50
@@ -127,6 +136,7 @@ events {
   assignment {
     target: "smeta.egress_spec"
   }
+  id: 10
   source_info {
     file: "e2e_tests/translated_port/translated_port.p4"
     line: 42
@@ -146,6 +156,7 @@ events {
     direction: EXIT
     dataplane_port: 1
   }
+  id: 11
 }
 events {
   pipeline_stage {
@@ -154,6 +165,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 12
 }
 events {
   pipeline_stage {
@@ -162,6 +174,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 13
 }
 events {
   pipeline_stage {
@@ -170,6 +183,7 @@ events {
     direction: ENTER
     dataplane_port: 0
   }
+  id: 14
 }
 events {
   pipeline_stage {
@@ -178,6 +192,7 @@ events {
     direction: EXIT
     dataplane_port: 0
   }
+  id: 15
 }
 events {
   pipeline_stage {
@@ -185,12 +200,14 @@ events {
     stage_kind: DEPARSER
     direction: ENTER
   }
+  id: 16
 }
 events {
   deparser_emit {
     header_type: "ethernet_t"
     byte_length: 14
   }
+  id: 17
 }
 events {
   pipeline_stage {
@@ -198,11 +215,9 @@ events {
     stage_kind: DEPARSER
     direction: EXIT
   }
+  id: 18
 }
-packet_outcome {
-  output {
-    payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000\336\255\276\357"
-    p4rt_egress_port: "Ethernet1"
-  }
+output {
+  payload: "\377\377\377\377\377\377\000\000\000\000\000\001\b\000\336\255\276\357"
+  p4rt_egress_port: "Ethernet1"
 }
-

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -44,8 +44,8 @@ interface Architecture {
 /**
  * The result of running a packet through the pipeline.
  *
- * The [trace] tree carries the complete execution trace. Leaf nodes contain [PacketOutcome]s
- * (output packets or drops); fork nodes represent non-deterministic choice points.
+ * The [trace] tree carries the complete execution trace. Leaf nodes are [Output] or [Drop];
+ * interior nodes ([Replication], [Choice], [Continuation]) represent branching and looping.
  */
 data class PipelineResult(val trace: TraceTree) {
   /** All possible outcome sets, derived from the trace tree's fork structure. */

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -201,19 +201,8 @@ internal fun handleActionSelectorFork(
 }
 
 /** Returns a copy of [tree] with the first [count] events removed, preserving the outcome. */
-private fun dropPrefixEvents(tree: TraceTree, count: Int): TraceTree {
-  val b = TraceTree.newBuilder().addAllEvents(tree.eventsList.drop(count))
-  when (tree.outcomeCase) {
-    TraceTree.OutcomeCase.REPLICATION -> b.setReplication(tree.replication)
-    TraceTree.OutcomeCase.CHOICE -> b.setChoice(tree.choice)
-    TraceTree.OutcomeCase.CONTINUATION -> b.setContinuation(tree.continuation)
-    TraceTree.OutcomeCase.OUTPUT -> b.setOutput(tree.output)
-    TraceTree.OutcomeCase.DROP -> b.setDrop(tree.drop)
-    TraceTree.OutcomeCase.OUTCOME_NOT_SET,
-    null -> {}
-  }
-  return b.build()
-}
+private fun dropPrefixEvents(tree: TraceTree, count: Int): TraceTree =
+  tree.withEvents(tree.eventsList.drop(count))
 
 /**
  * Handles extern methods shared across PSA and PNA: Register, Random, Counter, Hash, Meter,

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -191,7 +191,7 @@ internal fun handleActionSelectorFork(
 ): TraceTree {
   val prefixLength = fork.eventsBeforeFork.size
   // The last event in eventsBeforeFork is the TableLookupEvent for the selector — it's the cause.
-  val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+  val causeId = fork.eventsBeforeFork.lastOrNull()?.id
   val branches =
     fork.members.map { member ->
       val newSelectors = currentSelectors + (fork.tableName to member.memberId)

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -178,7 +178,7 @@ internal fun runControlStage(
  *
  * On the first encounter with an action selector group hit, the [Interpreter] throws
  * [ActionSelectorFork] with the list of group members and the trace events accumulated before the
- * fork. This method builds a fork [TraceTree] with one branch per member, re-executing via
+ * fork. This method builds a [Choice] [TraceTree] with one branch per member, re-executing via
  * [reExecute] with the forced member selection added to [currentSelectors].
  *
  * The re-execution produces identical events up to the fork point (deterministic replay), so the
@@ -190,19 +190,29 @@ internal fun handleActionSelectorFork(
   reExecute: (Map<String, Int>) -> TraceTree,
 ): TraceTree {
   val prefixLength = fork.eventsBeforeFork.size
+  // The last event in eventsBeforeFork is the TableLookupEvent for the selector — it's the cause.
+  val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
   val branches =
     fork.members.map { member ->
       val newSelectors = currentSelectors + (fork.tableName to member.memberId)
-      val subtree = reExecute(newSelectors)
-      val stripped = TraceTree.newBuilder().addAllEvents(subtree.eventsList.drop(prefixLength))
-      if (subtree.hasPacketOutcome()) stripped.setPacketOutcome(subtree.packetOutcome)
-      if (subtree.hasForkOutcome()) stripped.setForkOutcome(subtree.forkOutcome)
-      fourward.ForkBranch.newBuilder()
-        .setLabel("member_${member.memberId}")
-        .setSubtree(stripped.build())
-        .build()
+      dropPrefixEvents(reExecute(newSelectors), prefixLength)
     }
-  return buildForkTree(fork.eventsBeforeFork, fourward.ForkReason.ACTION_SELECTOR, branches)
+  return buildChoiceTree(fork.eventsBeforeFork, causeId, branches)
+}
+
+/** Returns a copy of [tree] with the first [count] events removed, preserving the outcome. */
+private fun dropPrefixEvents(tree: TraceTree, count: Int): TraceTree {
+  val b = TraceTree.newBuilder().addAllEvents(tree.eventsList.drop(count))
+  when (tree.outcomeCase) {
+    TraceTree.OutcomeCase.REPLICATION -> b.setReplication(tree.replication)
+    TraceTree.OutcomeCase.CHOICE -> b.setChoice(tree.choice)
+    TraceTree.OutcomeCase.CONTINUATION -> b.setContinuation(tree.continuation)
+    TraceTree.OutcomeCase.OUTPUT -> b.setOutput(tree.output)
+    TraceTree.OutcomeCase.DROP -> b.setDrop(tree.drop)
+    TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+    null -> {}
+  }
+  return b.build()
 }
 
 /**

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -80,7 +80,7 @@ class Environment {
  * Holds the input packet buffer, the output (emit) buffer, and the execution trace. Created once
  * per packet in the architecture's [processPacket] and threaded through the interpreter.
  */
-class PacketContext(packet: PacketBits, initialBitOffset: Int = 0) {
+class PacketContext(packet: PacketBits, initialBitOffset: Int = 0, firstEventId: Long = 1L) {
 
   constructor(
     payload: ByteArray,
@@ -150,13 +150,16 @@ class PacketContext(packet: PacketBits, initialBitOffset: Int = 0) {
   // -------------------------------------------------------------------------
 
   private val traceEvents: MutableList<TraceEvent> = mutableListOf()
-  private var nextEventId: Long = 1L
+  private var nextEventId: Long = firstEventId
 
   fun addTraceEvent(event: TraceEvent) {
     traceEvents.add(event.toBuilder().setId(nextEventId++).build())
   }
 
   fun getEvents(): List<TraceEvent> = traceEvents.toList()
+
+  /** Returns the id that will be assigned to the next event added. */
+  fun peekNextEventId(): Long = nextEventId
 
   /** Returns the id of the last added event, or 0 if no events have been added. */
   fun lastEventId(): Long = nextEventId - 1L

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -164,9 +164,9 @@ class PacketContext(packet: PacketBits, initialBitOffset: Int = 0, firstEventId:
   /** Returns the id of the last added event, or 0 if no events have been added. */
   fun lastEventId(): Long = nextEventId - 1L
 
-  /** Returns the id of the last added event matching [predicate], or 0 if none. */
-  fun lastEventIdWhere(predicate: (TraceEvent) -> Boolean): Long =
-    traceEvents.lastOrNull(predicate)?.id ?: 0L
+  /** Returns the id of the last added event matching [predicate], or null if none. */
+  fun lastEventIdWhere(predicate: (TraceEvent) -> Boolean): Long? =
+    traceEvents.lastOrNull(predicate)?.id
 }
 
 /**

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -150,12 +150,20 @@ class PacketContext(packet: PacketBits, initialBitOffset: Int = 0) {
   // -------------------------------------------------------------------------
 
   private val traceEvents: MutableList<TraceEvent> = mutableListOf()
+  private var nextEventId: Long = 1L
 
   fun addTraceEvent(event: TraceEvent) {
-    traceEvents.add(event)
+    traceEvents.add(event.toBuilder().setId(nextEventId++).build())
   }
 
   fun getEvents(): List<TraceEvent> = traceEvents.toList()
+
+  /** Returns the id of the last added event, or 0 if no events have been added. */
+  fun lastEventId(): Long = nextEventId - 1L
+
+  /** Returns the id of the last added event matching [predicate], or 0 if none. */
+  fun lastEventIdWhere(predicate: (TraceEvent) -> Boolean): Long =
+    traceEvents.lastOrNull(predicate)?.id ?: 0L
 }
 
 /**

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -161,9 +161,6 @@ class PacketContext(packet: PacketBits, initialBitOffset: Int = 0, firstEventId:
   /** Returns the id that will be assigned to the next event added. */
   fun peekNextEventId(): Long = nextEventId
 
-  /** Returns the id of the last added event, or 0 if no events have been added. */
-  fun lastEventId(): Long = nextEventId - 1L
-
   /** Returns the id of the last added event matching [predicate], or null if none. */
   fun lastEventIdWhere(predicate: (TraceEvent) -> Boolean): Long? =
     traceEvents.lastOrNull(predicate)?.id

--- a/simulator/EnvironmentTest.kt
+++ b/simulator/EnvironmentTest.kt
@@ -191,13 +191,19 @@ class EnvironmentTest {
   }
 
   @Test
-  fun `addTraceEvent records events in order`() {
+  fun `addTraceEvent records events in order with assigned ids`() {
     val pktCtx = PacketContext(byteArrayOf())
     val event1 = TraceEvent.newBuilder().setMarkToDrop(MarkToDropEvent.getDefaultInstance()).build()
     val event2 = TraceEvent.newBuilder().setMarkToDrop(MarkToDropEvent.getDefaultInstance()).build()
     pktCtx.addTraceEvent(event1)
     pktCtx.addTraceEvent(event2)
-    assertEquals(listOf(event1, event2), pktCtx.getEvents())
+    val events = pktCtx.getEvents()
+    assertEquals(2, events.size)
+    assertEquals(1L, events[0].id)
+    assertEquals(2L, events[1].id)
+    // Event content is preserved (ignoring the stamped id).
+    assertEquals(event1.markToDrop, events[0].markToDrop)
+    assertEquals(event2.markToDrop, events[1].markToDrop)
   }
 
   @Test

--- a/simulator/InterpreterTraceEventTest.kt
+++ b/simulator/InterpreterTraceEventTest.kt
@@ -1,7 +1,6 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
-import fourward.DropReason
 import fourward.Expr
 import fourward.MarkToDropEvent
 import fourward.MethodCall
@@ -49,12 +48,7 @@ class InterpreterTraceEventTest {
     require(call is ExternCall.FreeFunction && call.name == "mark_to_drop") {
       "unexpected extern: $call"
     }
-    eval.addTraceEvent(
-      eval
-        .traceEventBuilder()
-        .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
-        .build()
-    )
+    eval.addTraceEvent(eval.traceEventBuilder().setMarkToDrop(MarkToDropEvent.newBuilder()).build())
     val smeta = eval.evalArg(0) as StructVal
     val portBits = smeta.bitWidth("egress_spec")
     smeta.fields["egress_spec"] = BitVal((1L shl portBits) - 1, portBits)
@@ -93,7 +87,7 @@ class InterpreterTraceEventTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  fun `mark_to_drop emits MarkToDropEvent with MARK_TO_DROP reason`() {
+  fun `mark_to_drop emits MarkToDropEvent`() {
     val config = controlConfig("MyIngress", markToDropStmt())
     val env = standardMetadataEnv()
     val pktCtx = PacketContext(byteArrayOf())
@@ -102,7 +96,6 @@ class InterpreterTraceEventTest {
 
     val markToDropEvents = pktCtx.getEvents().filter { it.hasMarkToDrop() }
     assertEquals("expected exactly one MarkToDropEvent", 1, markToDropEvents.size)
-    assertEquals(DropReason.MARK_TO_DROP, markToDropEvents[0].markToDrop.reason)
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -1,11 +1,7 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
-import fourward.DropReason
 import fourward.ExternInstanceDecl
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.PipelineStage
 import fourward.TraceTree
 import fourward.TypeDecl
@@ -171,7 +167,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       bindStageParams(env, pipeline.mainControl.blockName, pipeline.blockParams, values)
       runControlStage(interpreter, ctx, env, pipeline.mainControl)
     } catch (_: AssertionFailureException) {
-      return buildDropTrace(ctx.getEvents(), DropReason.ASSERTION_FAILURE)
+      return buildDropTrace(ctx.getEvents(), ctx.lastEventIdWhere { it.hasAssertion() })
     } catch (fork: ActionSelectorFork) {
       return handleActionSelectorFork(fork, selectorMembers) { newSelectors ->
         processPacketRecursive(
@@ -200,11 +196,15 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     runControlStage(interpreter, ctx, env, pipeline.mainDeparser)
     val deparsedBytes = ctx.deparsedPayload()
 
-    val mirrorBranches = buildMirrorBranches(pipeline, deparsedBytes, forwardingState)
+    val mirrorTrees = buildMirrorTrees(pipeline, deparsedBytes, forwardingState)
 
     if (forwardingState.dropped && !forwardingState.recirculate) {
-      // Dropped with mirror: emit only mirror branches.
-      return buildForkTree(ctx.getEvents(), ForkReason.CLONE, mirrorBranches)
+      // Dropped: if mirrors were requested they still go out; original is silently dropped.
+      return if (mirrorTrees.isEmpty()) {
+        buildDropTrace(ctx.getEvents())
+      } else {
+        buildReplicationTree(ctx.getEvents(), cause = 0L, mirrorTrees)
+      }
     }
 
     if (forwardingState.recirculate) {
@@ -217,26 +217,21 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
           passNumber = passNumber + 1,
           depth = depth + 1,
         )
-      val recircBranch =
-        ForkBranch.newBuilder().setLabel("recirculate").setSubtree(recircTree).build()
       // Mirror is independent of recirculation — emit both if requested.
-      val branches = mirrorBranches + recircBranch
-      val reason = if (mirrorBranches.isNotEmpty()) ForkReason.CLONE else ForkReason.RECIRCULATE
-      return TraceTree.newBuilder()
-        .addAllEvents(ctx.getEvents())
-        .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
-        .build()
+      return if (mirrorTrees.isEmpty()) {
+        buildContinuationTree(ctx.getEvents(), next = recircTree)
+      } else {
+        val continuationBranch = buildContinuationTree(emptyList(), next = recircTree)
+        buildReplicationTree(ctx.getEvents(), cause = 0L, listOf(continuationBranch) + mirrorTrees)
+      }
     }
 
     val originalTree = buildOutputTrace(ctx.getEvents(), forwardingState.destPort, deparsedBytes)
-
-    if (mirrorBranches.isNotEmpty()) {
-      val originalBranch =
-        ForkBranch.newBuilder().setLabel("original").setSubtree(originalTree).build()
-      return buildForkTree(emptyList(), ForkReason.CLONE, listOf(originalBranch) + mirrorBranches)
+    return if (mirrorTrees.isEmpty()) {
+      originalTree
+    } else {
+      buildReplicationTree(emptyList(), cause = 0L, listOf(originalTree) + mirrorTrees)
     }
-
-    return originalTree
   }
 
   // ---------------------------------------------------------------------------
@@ -414,24 +409,22 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
   // ---------------------------------------------------------------------------
 
   /**
-   * Builds mirror branches if `mirror_packet()` was called during main control.
+   * Builds mirror output subtrees if `mirror_packet()` was called during main control.
    *
    * PNA mirrors the deparsed packet (post-modification), matching DPDK SoftNIC behavior. Each
    * replica in the clone session outputs the deparsed bytes on the replica's egress port. Unlike
    * PSA clones (which run through a separate egress pipeline), PNA mirror replicas emit directly
    * because PNA has no separate egress stage for mirrored packets to traverse.
    */
-  private fun buildMirrorBranches(
+  private fun buildMirrorTrees(
     pipeline: PipelineConfig,
     deparsedBytes: ByteArray,
     forwardingState: ForwardingState,
-  ): List<ForkBranch> {
+  ): List<TraceTree> {
     val sessionId = forwardingState.mirrorSessionId ?: return emptyList()
     val session = pipeline.tableStore.getCloneSession(sessionId) ?: return emptyList()
     return session.replicasList.map { replica ->
-      val port = replicaPort(replica)
-      val subtree = buildOutputTrace(emptyList(), port, deparsedBytes)
-      ForkBranch.newBuilder().setLabel("mirror_port_$port").setSubtree(subtree).build()
+      buildOutputTrace(emptyList(), replicaPort(replica), deparsedBytes)
     }
   }
 

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -204,7 +204,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       return if (mirrorTrees.isEmpty()) {
         buildDropTrace(ctx.getEvents())
       } else {
-        buildReplicationTree(ctx.getEvents(), branches = mirrorTrees)
+        buildReplicationTree(ctx.getEvents(), mirrorTrees)
       }
     }
 
@@ -232,7 +232,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
             kind = Continuation.Kind.RECIRCULATE,
             next = recircTree,
           )
-        buildReplicationTree(ctx.getEvents(), branches = listOf(continuationBranch) + mirrorTrees)
+        buildReplicationTree(ctx.getEvents(), listOf(continuationBranch) + mirrorTrees)
       }
     }
 
@@ -240,7 +240,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     return if (mirrorTrees.isEmpty()) {
       originalTree
     } else {
-      buildReplicationTree(emptyList(), branches = listOf(originalTree) + mirrorTrees)
+      buildReplicationTree(emptyList(), listOf(originalTree) + mirrorTrees)
     }
   }
 

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -1,6 +1,7 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
+import fourward.ContinuationEvent
 import fourward.ExternInstanceDecl
 import fourward.PipelineStage
 import fourward.TraceTree
@@ -208,6 +209,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     }
 
     if (forwardingState.recirculate) {
+      val recircCauseId = ctx.lastEventIdWhere { it.hasContinuationTrigger() }
       val recircTree =
         processPacketRecursive(
           pipeline,
@@ -219,10 +221,14 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
         )
       // Mirror is independent of recirculation — emit both if requested.
       return if (mirrorTrees.isEmpty()) {
-        buildContinuationTree(ctx.getEvents(), next = recircTree)
+        buildContinuationTree(ctx.getEvents(), cause = recircCauseId, next = recircTree)
       } else {
         val continuationBranch = buildContinuationTree(emptyList(), next = recircTree)
-        buildReplicationTree(ctx.getEvents(), cause = 0L, listOf(continuationBranch) + mirrorTrees)
+        buildReplicationTree(
+          ctx.getEvents(),
+          cause = recircCauseId,
+          listOf(continuationBranch) + mirrorTrees,
+        )
       }
     }
 
@@ -332,6 +338,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
         UnitVal
       }
       "recirculate" -> {
+        eval.addTraceEvent(continuationTriggerEvent(ContinuationEvent.Kind.RECIRCULATE))
         forwardingState.recirculate = true
         UnitVal
       }

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -204,7 +204,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
       return if (mirrorTrees.isEmpty()) {
         buildDropTrace(ctx.getEvents())
       } else {
-        buildReplicationTree(ctx.getEvents(), cause = 0L, mirrorTrees)
+        buildReplicationTree(ctx.getEvents(), branches = mirrorTrees)
       }
     }
 
@@ -236,7 +236,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     return if (mirrorTrees.isEmpty()) {
       originalTree
     } else {
-      buildReplicationTree(emptyList(), cause = 0L, listOf(originalTree) + mirrorTrees)
+      buildReplicationTree(emptyList(), branches = listOf(originalTree) + mirrorTrees)
     }
   }
 

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -1,7 +1,7 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
-import fourward.ContinuationEvent
+import fourward.Continuation
 import fourward.ExternInstanceDecl
 import fourward.PipelineStage
 import fourward.TraceTree
@@ -209,7 +209,6 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     }
 
     if (forwardingState.recirculate) {
-      val recircCauseId = ctx.lastEventIdWhere { it.hasContinuationTrigger() }
       val recircTree =
         processPacketRecursive(
           pipeline,
@@ -221,14 +220,19 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
         )
       // Mirror is independent of recirculation — emit both if requested.
       return if (mirrorTrees.isEmpty()) {
-        buildContinuationTree(ctx.getEvents(), cause = recircCauseId, next = recircTree)
-      } else {
-        val continuationBranch = buildContinuationTree(emptyList(), next = recircTree)
-        buildReplicationTree(
+        buildContinuationTree(
           ctx.getEvents(),
-          cause = recircCauseId,
-          listOf(continuationBranch) + mirrorTrees,
+          kind = Continuation.Kind.RECIRCULATE,
+          next = recircTree,
         )
+      } else {
+        val continuationBranch =
+          buildContinuationTree(
+            emptyList(),
+            kind = Continuation.Kind.RECIRCULATE,
+            next = recircTree,
+          )
+        buildReplicationTree(ctx.getEvents(), branches = listOf(continuationBranch) + mirrorTrees)
       }
     }
 
@@ -338,7 +342,6 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
         UnitVal
       }
       "recirculate" -> {
-        eval.addTraceEvent(continuationTriggerEvent(ContinuationEvent.Kind.RECIRCULATE))
         forwardingState.recirculate = true
         UnitVal
       }

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -5,6 +5,7 @@ import fourward.Architecture
 import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
+import fourward.ContinuationEvent
 import fourward.ControlDecl
 import fourward.EnumDecl
 import fourward.Expr
@@ -452,6 +453,33 @@ class PNAArchitectureTest {
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("recirculation depth exceeded"))
     }
+  }
+
+  @Test
+  fun `recirculate emits ContinuationEvent and anchors Continuation cause`() {
+    // First pass (loopedback=false): call recirculate().
+    // Second pass (loopedback=true): send to port 5.
+    val boolType = Type.newBuilder().setBoolean(true).build()
+    val loopedback = fieldAccess(nameRef("istd"), "loopedback", boolType)
+    val config =
+      pnaConfig(
+        mainControlStmts =
+          listOf(
+            ifStmt(
+              condition = loopedback,
+              thenStmts = listOf(sendToPort(5)),
+              elseStmts = listOf(recirculate()),
+            )
+          )
+      )
+    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), TableStore())
+
+    // Trace should show a CONTINUATION anchored by a RECIRCULATE ContinuationEvent.
+    val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }
+    assertEquals(ContinuationEvent.Kind.RECIRCULATE, contEvent.continuationTrigger.kind)
+    assertEquals(contEvent.id, result.trace.continuation.cause)
+    // Second pass exits on port 5.
+    assertEquals(5, result.possibleOutcomes.single().single().dataplaneEgressPort)
   }
 
   @Test

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -6,12 +6,10 @@ import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
 import fourward.ControlDecl
-import fourward.DropReason
 import fourward.EnumDecl
 import fourward.Expr
 import fourward.ExternInstanceDecl
 import fourward.FieldDecl
-import fourward.ForkReason
 import fourward.HeaderDecl
 import fourward.ParamDecl
 import fourward.ParserDecl
@@ -302,8 +300,7 @@ class PNAArchitectureTest {
     val config = pnaConfig()
     val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -324,8 +321,7 @@ class PNAArchitectureTest {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(5), dropPacket()))
     val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -463,9 +459,7 @@ class PNAArchitectureTest {
     val config = pnaConfig(mainControlStmts = listOf(externCall("assert", boolLit(false))))
     val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.ASSERTION_FAILURE, result.trace.packetOutcome.drop.reason)
+    assertTrue(result.trace.hasDrop())
   }
 
   // ---------------------------------------------------------------------------
@@ -545,17 +539,15 @@ class PNAArchitectureTest {
   }
 
   @Test
-  fun `mirror_packet trace has CLONE fork reason`() {
+  fun `mirror_packet trace has REPLICATION outcome`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(2), mirrorPacket(0, 100)))
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
     val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    assertEquals("original", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("mirror_port_5", result.trace.forkOutcome.branchesList[1].label)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(2, result.trace.replication.branchesList.size)
   }
 
   @Test

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -5,7 +5,7 @@ import fourward.Architecture
 import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
-import fourward.ContinuationEvent
+import fourward.Continuation
 import fourward.ControlDecl
 import fourward.EnumDecl
 import fourward.Expr
@@ -456,7 +456,7 @@ class PNAArchitectureTest {
   }
 
   @Test
-  fun `recirculate emits ContinuationEvent and anchors Continuation cause`() {
+  fun `recirculate emits Continuation with RECIRCULATE kind`() {
     // First pass (loopedback=false): call recirculate().
     // Second pass (loopedback=true): send to port 5.
     val boolType = Type.newBuilder().setBoolean(true).build()
@@ -472,12 +472,11 @@ class PNAArchitectureTest {
             )
           )
       )
-    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), TableStore())
+    val result =
+      PNAArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), TableStore())
 
-    // Trace should show a CONTINUATION anchored by a RECIRCULATE ContinuationEvent.
-    val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }
-    assertEquals(ContinuationEvent.Kind.RECIRCULATE, contEvent.continuationTrigger.kind)
-    assertEquals(contEvent.id, result.trace.continuation.cause)
+    // Trace should show a CONTINUATION with RECIRCULATE kind.
+    assertEquals(Continuation.Kind.RECIRCULATE, result.trace.continuation.kind)
     // Second pass exits on port 5.
     assertEquals(5, result.possibleOutcomes.single().single().dataplaneEgressPort)
   }

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -472,7 +472,7 @@ class PNAArchitectureTest {
             )
           )
       )
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), TableStore())
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), TableStore())
 
     // Trace should show a CONTINUATION anchored by a RECIRCULATE ContinuationEvent.
     val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -24,6 +24,7 @@ import fourward.Transition
 import fourward.Type
 import fourward.TypeDecl
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -575,6 +576,8 @@ class PNAArchitectureTest {
 
     assertTrue(result.trace.hasReplication())
     assertEquals(2, result.trace.replication.branchesList.size)
+    // mirror_packet has no triggering lookup event — cause must be absent.
+    assertFalse(result.trace.replication.hasCause())
   }
 
   @Test

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -160,7 +160,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     // === Traffic Manager: I2E clone + multicast/unicast ===
     val i2eCloneBranches = buildI2ECloneBranches(pipeline, packet, ingress.output, selectorMembers)
-    val originalTree = buildOriginalEgressPath(pipeline, ingress, depth, selectorMembers)
+    val originalTree =
+      buildOriginalEgressPath(
+        pipeline,
+        ingress,
+        depth,
+        selectorMembers,
+        firstEventId = ingress.nextEventId,
+      )
 
     if (i2eCloneBranches.isNotEmpty()) {
       val causeId = ingress.cloneLookupEventId
@@ -177,13 +184,21 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     ingress: IngressResult,
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
+    firstEventId: Long = 1L,
   ): TraceTree {
     val egressState = EgressState(pipeline, ingress.output)
     val multicastGroup =
       (ingress.output?.fields?.get("multicast_group") as? BitVal)?.bits?.value?.toInt() ?: 0
 
     if (multicastGroup != 0) {
-      return multicastEgressTree(egressState, ingress, multicastGroup, depth, selectorMembers)
+      return multicastEgressTree(
+        egressState,
+        ingress,
+        multicastGroup,
+        depth,
+        selectorMembers,
+        firstEventId,
+      )
     }
 
     val egressPort =
@@ -197,6 +212,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       PACKET_PATH_NORMAL_UNICAST,
       depth,
       selectorMembers,
+      firstEventId,
     )
   }
 
@@ -216,6 +232,10 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val cloneLookupEventId: Long = 0L,
     /** Id of the ContinuationEvent when resubmit was requested, or 0 if none. */
     val continuationEventId: Long = 0L,
+    /**
+     * First event id the egress pipeline should use, to avoid collisions when events are merged.
+     */
+    val nextEventId: Long = 1L,
   )
 
   private fun runIngressPipeline(
@@ -265,6 +285,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           byteArrayOf(),
           dropped = true,
           dropTriggerId = ctx.lastEventIdWhere { it.hasMarkToDrop() },
+          nextEventId = ctx.peekNextEventId(),
         )
       }
 
@@ -278,6 +299,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         byteArrayOf(),
         dropped = true,
         dropTriggerId = ctx.lastEventIdWhere { it.hasAssertion() },
+        nextEventId = ctx.peekNextEventId(),
       )
     }
 
@@ -299,6 +321,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       dropped = false,
       cloneLookupEventId = cloneLookupId,
       continuationEventId = if (resubmit) ctx.lastEventId() else 0L,
+      nextEventId = ctx.peekNextEventId(),
     )
   }
 
@@ -313,20 +336,28 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     multicastGroup: Int,
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
+    firstEventId: Long = 1L,
   ): TraceTree {
     val group = egressState.pipeline.tableStore.getMulticastGroup(multicastGroup)
     if (group == null) {
       // Multicast to unconfigured group — the lookup miss is the trigger for the drop.
-      // cause = 0 here because this event is added directly (not through PacketContext).
+      val missEvent =
+        multicastGroupMissEvent(multicastGroup).toBuilder().setId(firstEventId).build()
       return TraceTree.newBuilder()
-        .addEvents(multicastGroupMissEvent(multicastGroup))
-        .setDrop(fourward.Drop.newBuilder())
+        .addEvents(missEvent)
+        .setDrop(fourward.Drop.newBuilder().setTrigger(firstEventId))
         .build()
     }
 
+    val hitEvent =
+      multicastGroupLookupEvent(multicastGroup, group.replicasCount)
+        .toBuilder()
+        .setId(firstEventId)
+        .build()
     val branches =
       group.replicasList.map { replica ->
         val port = replicaPort(replica)
+        // Each replica runs its own independent egress pass — ids start at 1 in each branch node.
         runEgressWithPostProcessing(
           egressState,
           ingress.deparsedBytes,
@@ -337,10 +368,11 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           selectorMembers,
         )
       }
-    // cause = 0: the lookup event is added inline (not via PacketContext), so its id isn't stamped.
     return TraceTree.newBuilder()
-      .addEvents(multicastGroupLookupEvent(multicastGroup, group.replicasCount))
-      .setReplication(fourward.Replication.newBuilder().addAllBranches(branches))
+      .addEvents(hitEvent)
+      .setReplication(
+        fourward.Replication.newBuilder().setCause(firstEventId).addAllBranches(branches)
+      )
       .build()
   }
 
@@ -363,6 +395,8 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val dropTriggerId: Long = 0L,
     /** Id of the CloneSessionLookupEvent for E2E clone, or 0 if none. */
     val cloneLookupEventId: Long = 0L,
+    /** Next event id after the last egress event (for appending continuation events). */
+    val nextEventId: Long = 1L,
   )
 
   /**
@@ -377,6 +411,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     packetPath: String,
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
+    firstEventId: Long = 1L,
   ): TraceTree {
     val core: EgressCoreResult
     try {
@@ -388,6 +423,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           instance,
           packetPath,
           selectorMembers,
+          firstEventId,
         )
     } catch (fork: ActionSelectorFork) {
       return handleActionSelectorFork(fork, selectorMembers) { newSelectors ->
@@ -399,6 +435,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           packetPath,
           depth,
           newSelectors,
+          firstEventId,
         )
       }
     }
@@ -420,7 +457,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val isRecirculate = egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG
     val outputTree =
       if (isRecirculate) {
-        val contEventId = (core.events.maxOfOrNull { it.id } ?: 0L) + 1L
+        val contEventId = core.nextEventId
         val contEvent =
           continuationTriggerEvent(ContinuationEvent.Kind.RECIRCULATE)
             .toBuilder()
@@ -457,9 +494,10 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     instance: Int,
     packetPath: String,
     selectorMembers: Map<String, Int> = emptyMap(),
+    firstEventId: Long = 1L,
   ): EgressCoreResult {
     val p = state.pipeline
-    val egressCtx = PacketContext(packet)
+    val egressCtx = PacketContext(packet, firstEventId = firstEventId)
     val egressEnv = Environment()
     val egressValues = createDefaultValues(p.config, p.typesByName)
 
@@ -489,6 +527,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         byteArrayOf(),
         egressOutput,
         dropTriggerId = egressCtx.lastEventIdWhere { it.hasAssertion() },
+        nextEventId = egressCtx.peekNextEventId(),
       )
     }
 
@@ -508,6 +547,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       outputBytes,
       egressOutput,
       dropTriggerId,
+      nextEventId = egressCtx.peekNextEventId(),
     )
   }
 

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -226,12 +226,12 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val output: StructVal?,
     val deparsedBytes: ByteArray,
     val dropped: Boolean,
-    /** Id of the event that caused a drop (MarkToDropEvent or AssertionEvent), or 0 if none. */
-    val dropTriggerId: Long = 0L,
-    /** Id of the CloneSessionLookupEvent when an I2E clone was requested, or 0 if none. */
-    val cloneLookupEventId: Long = 0L,
-    /** Id of the ContinuationEvent when resubmit was requested, or 0 if none. */
-    val continuationEventId: Long = 0L,
+    /** Id of the event that caused a drop (MarkToDropEvent or AssertionEvent), or null if none. */
+    val dropTriggerId: Long? = null,
+    /** Id of the CloneSessionLookupEvent when an I2E clone was requested, or null if none. */
+    val cloneLookupEventId: Long? = null,
+    /** Id of the ContinuationEvent when resubmit was requested, or null if none. */
+    val continuationEventId: Long? = null,
     /**
      * First event id the egress pipeline should use, to avoid collisions when events are merged.
      */
@@ -320,7 +320,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       deparsedBytes,
       dropped = false,
       cloneLookupEventId = cloneLookupId,
-      continuationEventId = if (resubmit) ctx.lastEventId() else 0L,
+      continuationEventId = if (resubmit) ctx.lastEventId() else null,
       nextEventId = ctx.peekNextEventId(),
     )
   }
@@ -391,10 +391,10 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val dropped: Boolean,
     val deparsedBytes: ByteArray,
     val output: StructVal?,
-    /** Id of the event that caused a drop, or 0 if none. */
-    val dropTriggerId: Long = 0L,
-    /** Id of the ContinuationEvent when recirculate was requested, or 0 if none. */
-    val recirculateCauseId: Long = 0L,
+    /** Id of the event that caused a drop, or null if none. */
+    val dropTriggerId: Long? = null,
+    /** Id of the ContinuationEvent when recirculate was requested, or null if none. */
+    val recirculateCauseId: Long? = null,
   )
 
   /**
@@ -452,7 +452,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     // Recirculate: the same packet loops back to ingress — modeled as a Continuation.
     // runEgressCore already emitted the ContinuationEvent and stored its id in recirculateCauseId.
     val outputTree =
-      if (core.recirculateCauseId != 0L) {
+      if (core.recirculateCauseId != null) {
         val recircTree =
           processPacketRecursive(
             state.pipeline,
@@ -537,7 +537,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       if (!dropped && egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG) {
         egressCtx.addTraceEvent(continuationTriggerEvent(ContinuationEvent.Kind.RECIRCULATE))
         egressCtx.lastEventId()
-      } else 0L
+      } else null
 
     return EgressCoreResult(egressCtx.getEvents(), dropped, outputBytes, egressOutput, dropTriggerId, recirculateCauseId)
   }

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -1,11 +1,7 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
-import fourward.DropReason
 import fourward.ExternInstanceDecl
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.PipelineStage
 import fourward.TraceEvent
 import fourward.TraceTree
@@ -137,12 +133,13 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       val i2eCloneBranches =
         buildI2ECloneBranches(pipeline, packet, ingress.output, selectorMembers)
       if (i2eCloneBranches.isNotEmpty()) {
-        return buildForkTree(ingress.events, ForkReason.CLONE, i2eCloneBranches)
+        val causeId = ingress.cloneLookupEventId
+        return buildReplicationTree(ingress.events, causeId, i2eCloneBranches)
       }
-      return buildDropTrace(ingress.events, ingress.dropReason)
+      return buildDropTrace(ingress.events, ingress.dropTriggerId)
     }
 
-    // Resubmit: loop original bytes back to ingress. Suppresses I2E clone.
+    // Resubmit: the same packet re-enters ingress — modeled as a Continuation.
     val resubmit = (ingress.output?.fields?.get("resubmit") as? BoolVal)?.value == true
     if (resubmit) {
       val resubmitTree =
@@ -153,11 +150,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           PACKET_PATH_RESUBMIT,
           depth = depth + 1,
         )
-      return buildForkTree(
-        ingress.events,
-        ForkReason.RESUBMIT,
-        listOf(ForkBranch.newBuilder().setLabel("resubmit").setSubtree(resubmitTree).build()),
-      )
+      return buildContinuationTree(ingress.events, next = resubmitTree)
     }
 
     // === Traffic Manager: I2E clone + multicast/unicast ===
@@ -165,22 +158,12 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val originalTree = buildOriginalEgressPath(pipeline, ingress, depth, selectorMembers)
 
     if (i2eCloneBranches.isNotEmpty()) {
-      val originalBranch =
-        ForkBranch.newBuilder().setLabel("original").setSubtree(originalTree).build()
-      return buildForkTree(
-        ingress.events,
-        ForkReason.CLONE,
-        listOf(originalBranch) + i2eCloneBranches,
-      )
+      val causeId = ingress.cloneLookupEventId
+      return buildReplicationTree(ingress.events, causeId, listOf(originalTree) + i2eCloneBranches)
     }
 
     // No I2E clone: flatten ingress + original egress into a single trace.
-    return TraceTree.newBuilder()
-      .addAllEvents(ingress.events)
-      .addAllEvents(originalTree.eventsList)
-      .also { if (originalTree.hasPacketOutcome()) it.setPacketOutcome(originalTree.packetOutcome) }
-      .also { if (originalTree.hasForkOutcome()) it.setForkOutcome(originalTree.forkOutcome) }
-      .build()
+    return prependEvents(originalTree, ingress.events)
   }
 
   /** Builds the egress path for the original (non-cloned) packet: multicast or unicast. */
@@ -222,7 +205,10 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val output: StructVal?,
     val deparsedBytes: ByteArray,
     val dropped: Boolean,
-    val dropReason: DropReason = DropReason.MARK_TO_DROP,
+    /** Id of the event that caused a drop (MarkToDropEvent or AssertionEvent), or 0 if none. */
+    val dropTriggerId: Long = 0L,
+    /** Id of the CloneSessionLookupEvent when an I2E clone was requested, or 0 if none. */
+    val cloneLookupEventId: Long = 0L,
   )
 
   private fun runIngressPipeline(
@@ -266,7 +252,13 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       // --- Ingress drop check (PSA: drop=true by default) ---
       val dropped = (output?.fields?.get("drop") as? BoolVal)?.value != false
       if (dropped) {
-        return IngressResult(ctx.getEvents(), output, byteArrayOf(), dropped = true)
+        return IngressResult(
+          ctx.getEvents(),
+          output,
+          byteArrayOf(),
+          dropped = true,
+          dropTriggerId = ctx.lastEventIdWhere { it.hasMarkToDrop() },
+        )
       }
 
       // --- Ingress Deparser ---
@@ -278,19 +270,28 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         output,
         byteArrayOf(),
         dropped = true,
-        dropReason = DropReason.ASSERTION_FAILURE,
+        dropTriggerId = ctx.lastEventIdWhere { it.hasAssertion() },
       )
     }
 
+    // Capture clone lookup event id before I2E clone branch building reads it.
+    val cloneLookupId =
+      ctx.lastEventIdWhere { it.hasCloneSessionLookup() && it.cloneSessionLookup.sessionFound }
     val deparsedBytes = ctx.deparsedPayload()
-    return IngressResult(ctx.getEvents(), output, deparsedBytes, dropped = false)
+    return IngressResult(
+      ctx.getEvents(),
+      output,
+      deparsedBytes,
+      dropped = false,
+      cloneLookupEventId = cloneLookupId,
+    )
   }
 
   // ---------------------------------------------------------------------------
   // Traffic Manager: multicast
   // ---------------------------------------------------------------------------
 
-  /** Builds a multicast fork TraceTree (without ingress events — caller prepends those). */
+  /** Builds a multicast Replication TraceTree (without ingress events — caller prepends those). */
   private fun multicastEgressTree(
     egressState: EgressState,
     ingress: IngressResult,
@@ -300,31 +301,31 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   ): TraceTree {
     val group = egressState.pipeline.tableStore.getMulticastGroup(multicastGroup)
     if (group == null) {
-      return buildDropTrace(listOf(multicastGroupMissEvent(multicastGroup)))
+      // Multicast to unconfigured group — the lookup miss is the trigger for the drop.
+      // cause = 0 here because this event is added directly (not through PacketContext).
+      return TraceTree.newBuilder()
+        .addEvents(multicastGroupMissEvent(multicastGroup))
+        .setDrop(fourward.Drop.newBuilder())
+        .build()
     }
 
-    val lookupEvent = multicastGroupLookupEvent(multicastGroup, group.replicasCount)
     val branches =
       group.replicasList.map { replica ->
         val port = replicaPort(replica)
-        val subtree =
-          runEgressWithPostProcessing(
-            egressState,
-            ingress.deparsedBytes,
-            port,
-            replica.instance,
-            PACKET_PATH_NORMAL_MULTICAST,
-            depth,
-            selectorMembers,
-          )
-        ForkBranch.newBuilder()
-          .setLabel("replica_${replica.instance}_port_$port")
-          .setSubtree(subtree)
-          .build()
+        runEgressWithPostProcessing(
+          egressState,
+          ingress.deparsedBytes,
+          port,
+          replica.instance,
+          PACKET_PATH_NORMAL_MULTICAST,
+          depth,
+          selectorMembers,
+        )
       }
+    // cause = 0: the lookup event is added inline (not via PacketContext), so its id isn't stamped.
     return TraceTree.newBuilder()
-      .addEvents(lookupEvent)
-      .setForkOutcome(Fork.newBuilder().setReason(ForkReason.MULTICAST).addAllBranches(branches))
+      .addEvents(multicastGroupLookupEvent(multicastGroup, group.replicasCount))
+      .setReplication(fourward.Replication.newBuilder().addAllBranches(branches))
       .build()
   }
 
@@ -343,7 +344,10 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val dropped: Boolean,
     val deparsedBytes: ByteArray,
     val output: StructVal?,
-    val dropReason: DropReason = DropReason.MARK_TO_DROP,
+    /** Id of the event that caused a drop, or 0 if none. */
+    val dropTriggerId: Long = 0L,
+    /** Id of the CloneSessionLookupEvent for E2E clone, or 0 if none. */
+    val cloneLookupEventId: Long = 0L,
   )
 
   /**
@@ -386,15 +390,16 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     // E2E clone: uses deparsed bytes from this egress pass. Independent of drop decision.
     val e2eCloneBranches = buildE2ECloneBranches(state.pipeline, core, selectorMembers)
+    val cloneLookupId = core.cloneLookupEventId
 
     if (core.dropped) {
       if (e2eCloneBranches.isNotEmpty()) {
-        return buildForkTree(core.events, ForkReason.CLONE, e2eCloneBranches)
+        return buildReplicationTree(core.events, cloneLookupId, e2eCloneBranches)
       }
-      return buildDropTrace(core.events, core.dropReason)
+      return buildDropTrace(core.events, core.dropTriggerId)
     }
 
-    // Recirculate: loop deparsed bytes back to ingress.
+    // Recirculate: the same packet loops back to ingress — modeled as a Continuation.
     val isRecirculate = egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG
     val outputTree =
       if (isRecirculate) {
@@ -406,22 +411,13 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
             PACKET_PATH_RECIRCULATE,
             depth = depth + 1,
           )
-        TraceTree.newBuilder()
-          .addAllEvents(core.events)
-          .setForkOutcome(
-            Fork.newBuilder()
-              .setReason(ForkReason.RECIRCULATE)
-              .addBranches(ForkBranch.newBuilder().setLabel("recirculate").setSubtree(recircTree))
-          )
-          .build()
+        buildContinuationTree(core.events, next = recircTree)
       } else {
         buildOutputTrace(core.events, egressPort, core.deparsedBytes)
       }
 
     if (e2eCloneBranches.isNotEmpty()) {
-      val originalBranch =
-        ForkBranch.newBuilder().setLabel("original").setSubtree(outputTree).build()
-      return buildForkTree(emptyList(), ForkReason.CLONE, listOf(originalBranch) + e2eCloneBranches)
+      return buildReplicationTree(emptyList(), cloneLookupId, listOf(outputTree) + e2eCloneBranches)
     }
 
     return outputTree
@@ -469,7 +465,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         dropped = true,
         byteArrayOf(),
         egressOutput,
-        dropReason = DropReason.ASSERTION_FAILURE,
+        dropTriggerId = egressCtx.lastEventIdWhere { it.hasAssertion() },
       )
     }
 
@@ -481,7 +477,15 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     runControlStage(egressInterpreter, egressCtx, egressEnv, p.egressDeparser)
 
     val outputBytes = egressCtx.deparsedPayload()
-    return EgressCoreResult(egressCtx.getEvents(), dropped, outputBytes, egressOutput)
+    val dropTriggerId = if (dropped) egressCtx.lastEventIdWhere { it.hasMarkToDrop() } else 0L
+    // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
+    return EgressCoreResult(
+      egressCtx.getEvents(),
+      dropped,
+      outputBytes,
+      egressOutput,
+      dropTriggerId,
+    )
   }
 
   // ---------------------------------------------------------------------------
@@ -500,19 +504,13 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     originalPacket: PacketBits,
     ingressOutput: StructVal?,
     selectorMembers: Map<String, Int> = emptyMap(),
-  ): List<ForkBranch> =
+  ): List<TraceTree> =
     // I2E clones don't carry ingress output metadata to egress — egress gets a fresh EgressState
     // with no ingressOutput. Clones do not produce further clones (no chained cloning in PSA).
-    buildCloneBranches(
-      pipeline,
-      ingressOutput,
-      originalPacket,
-      PACKET_PATH_CLONE_I2E,
-      selectorMembers,
-    )
+    buildCloneTrees(pipeline, ingressOutput, originalPacket, PACKET_PATH_CLONE_I2E, selectorMembers)
 
   /**
-   * Builds E2E clone branches if the egress output metadata requests cloning.
+   * Builds E2E clone subtrees if the egress output metadata requests cloning.
    *
    * E2E clones use the deparsed bytes from the current egress pass. Each replica produces a fresh
    * egress execution with `packet_path = CLONE_E2E`. Chained E2E cloning is suppressed (PSA spec:
@@ -522,8 +520,8 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     pipeline: PipelineConfig,
     core: EgressCoreResult,
     selectorMembers: Map<String, Int> = emptyMap(),
-  ): List<ForkBranch> =
-    buildCloneBranches(
+  ): List<TraceTree> =
+    buildCloneTrees(
       pipeline,
       core.output,
       PacketBits.ofBytes(core.deparsedBytes),
@@ -532,19 +530,19 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     )
 
   /**
-   * Shared clone branch builder for both I2E and E2E cloning.
+   * Shared clone subtree builder for both I2E and E2E cloning.
    *
    * Checks the clone flag in [cloneMetadata], looks up the clone session, and runs a fresh egress
    * for each replica. Clone egress runs via [runEgressCore] directly (no post-processing), which
    * prevents chained cloning.
    */
-  private fun buildCloneBranches(
+  private fun buildCloneTrees(
     pipeline: PipelineConfig,
     cloneMetadata: StructVal?,
     clonePacket: PacketBits,
     packetPath: String,
     selectorMembers: Map<String, Int> = emptyMap(),
-  ): List<ForkBranch> {
+  ): List<TraceTree> {
     if ((cloneMetadata?.fields?.get("clone") as? BoolVal)?.value != true) return emptyList()
     val sessionId =
       (cloneMetadata.fields["clone_session_id"] as? BitVal)?.bits?.value?.toInt()
@@ -553,9 +551,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val cloneState = EgressState(pipeline, ingressOutput = null)
     return session.replicasList.map { replica ->
       val port = replicaPort(replica)
-      val subtree =
-        runCloneEgress(cloneState, clonePacket, port, replica.instance, packetPath, selectorMembers)
-      ForkBranch.newBuilder().setLabel("clone_port_$port").setSubtree(subtree).build()
+      runCloneEgress(cloneState, clonePacket, port, replica.instance, packetPath, selectorMembers)
     }
   }
 
@@ -574,7 +570,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     selectorMembers: Map<String, Int>,
   ): TraceTree {
     fun egressToTrace(result: EgressCoreResult): TraceTree =
-      if (result.dropped) buildDropTrace(result.events, result.dropReason)
+      if (result.dropped) buildDropTrace(result.events, result.dropTriggerId)
       else buildOutputTrace(result.events, egressPort, result.deparsedBytes)
     return try {
       egressToTrace(
@@ -706,7 +702,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
   // Hash helpers (evalGetHash, hashDataArg, sumWords) live in Hash.kt.
   // Action selector fork handling (handleActionSelectorFork) and trace helpers
-  // (buildForkTree) live in ArchitectureHelpers.kt and TraceHelpers.kt.
+  // live in ArchitectureHelpers.kt and TraceHelpers.kt.
 
   private companion object {
     // PSA_PacketPath_t enum values (PSA spec §6.1).

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -135,7 +135,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         buildI2ECloneBranches(pipeline, packet, ingress.output, selectorMembers)
       if (i2eCloneBranches.isNotEmpty()) {
         val causeId = ingress.cloneLookupEventId
-        return buildReplicationTree(ingress.events, causeId, i2eCloneBranches)
+        return buildReplicationTree(ingress.events, i2eCloneBranches, causeId)
       }
       return buildDropTrace(ingress.events, ingress.dropTriggerId)
     }
@@ -171,7 +171,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     if (i2eCloneBranches.isNotEmpty()) {
       val causeId = ingress.cloneLookupEventId
-      return buildReplicationTree(ingress.events, causeId, listOf(originalTree) + i2eCloneBranches)
+      return buildReplicationTree(ingress.events, listOf(originalTree) + i2eCloneBranches, causeId)
     }
 
     // No I2E clone: flatten ingress + original egress into a single trace.
@@ -435,7 +435,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     if (core.dropped) {
       if (e2eCloneBranches.isNotEmpty()) {
         // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
-        return buildReplicationTree(core.events, branches = e2eCloneBranches)
+        return buildReplicationTree(core.events, e2eCloneBranches)
       }
       return buildDropTrace(core.events, core.dropTriggerId)
     }
@@ -458,7 +458,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     if (e2eCloneBranches.isNotEmpty()) {
       // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
-      return buildReplicationTree(emptyList(), branches = listOf(outputTree) + e2eCloneBranches)
+      return buildReplicationTree(emptyList(), listOf(outputTree) + e2eCloneBranches)
     }
 
     return outputTree

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -334,10 +334,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       // Multicast to unconfigured group — the lookup miss is the trigger for the drop.
       val missEvent =
         multicastGroupMissEvent(multicastGroup).toBuilder().setId(firstEventId).build()
-      return TraceTree.newBuilder()
-        .addEvents(missEvent)
-        .setDrop(fourward.Drop.newBuilder().setCause(firstEventId))
-        .build()
+      return buildDropTrace(listOf(missEvent), causeId = firstEventId)
     }
 
     val hitEvent =
@@ -359,12 +356,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           selectorMembers,
         )
       }
-    return TraceTree.newBuilder()
-      .addEvents(hitEvent)
-      .setReplication(
-        fourward.Replication.newBuilder().setCause(firstEventId).addAllBranches(branches)
-      )
-      .build()
+    return buildReplicationTree(listOf(hitEvent), branches, cause = firstEventId)
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -137,7 +137,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         val causeId = ingress.cloneLookupEventId
         return buildReplicationTree(ingress.events, i2eCloneBranches, causeId)
       }
-      return buildDropTrace(ingress.events, ingress.dropTriggerId)
+      return buildDropTrace(ingress.events, ingress.dropCauseId)
     }
 
     // Resubmit: the same packet re-enters ingress — modeled as a Continuation.
@@ -227,7 +227,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val deparsedBytes: ByteArray,
     val dropped: Boolean,
     /** Id of the event that caused a drop (MarkToDropEvent or AssertionEvent), or null if none. */
-    val dropTriggerId: Long? = null,
+    val dropCauseId: Long? = null,
     /** Id of the CloneSessionLookupEvent when an I2E clone was requested, or null if none. */
     val cloneLookupEventId: Long? = null,
     /**
@@ -282,7 +282,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           output,
           byteArrayOf(),
           dropped = true,
-          dropTriggerId = ctx.lastEventIdWhere { it.hasMarkToDrop() },
+          dropCauseId = ctx.lastEventIdWhere { it.hasMarkToDrop() },
           nextEventId = ctx.peekNextEventId(),
         )
       }
@@ -296,7 +296,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         output,
         byteArrayOf(),
         dropped = true,
-        dropTriggerId = ctx.lastEventIdWhere { it.hasAssertion() },
+        dropCauseId = ctx.lastEventIdWhere { it.hasAssertion() },
         nextEventId = ctx.peekNextEventId(),
       )
     }
@@ -336,7 +336,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         multicastGroupMissEvent(multicastGroup).toBuilder().setId(firstEventId).build()
       return TraceTree.newBuilder()
         .addEvents(missEvent)
-        .setDrop(fourward.Drop.newBuilder().setTrigger(firstEventId))
+        .setDrop(fourward.Drop.newBuilder().setCause(firstEventId))
         .build()
     }
 
@@ -383,7 +383,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val deparsedBytes: ByteArray,
     val output: StructVal?,
     /** Id of the event that caused a drop, or null if none. */
-    val dropTriggerId: Long? = null,
+    val dropCauseId: Long? = null,
     /** Whether this egress pass should recirculate. */
     val recirculate: Boolean = false,
   )
@@ -437,7 +437,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
         return buildReplicationTree(core.events, e2eCloneBranches)
       }
-      return buildDropTrace(core.events, core.dropTriggerId)
+      return buildDropTrace(core.events, core.dropCauseId)
     }
 
     // Recirculate: the same packet loops back to ingress — modeled as a Continuation.
@@ -507,7 +507,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         dropped = true,
         byteArrayOf(),
         egressOutput,
-        dropTriggerId = egressCtx.lastEventIdWhere { it.hasAssertion() },
+        dropCauseId = egressCtx.lastEventIdWhere { it.hasAssertion() },
       )
     }
 
@@ -519,14 +519,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     runControlStage(egressInterpreter, egressCtx, egressEnv, p.egressDeparser)
 
     val outputBytes = egressCtx.deparsedPayload()
-    val dropTriggerId = if (dropped) egressCtx.lastEventIdWhere { it.hasMarkToDrop() } else null
+    val dropCauseId = if (dropped) egressCtx.lastEventIdWhere { it.hasMarkToDrop() } else null
     val recirculate = !dropped && egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG
     return EgressCoreResult(
       egressCtx.getEvents(),
       dropped,
       outputBytes,
       egressOutput,
-      dropTriggerId,
+      dropCauseId,
       recirculate,
     )
   }
@@ -613,7 +613,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     selectorMembers: Map<String, Int>,
   ): TraceTree {
     fun egressToTrace(result: EgressCoreResult): TraceTree =
-      if (result.dropped) buildDropTrace(result.events, result.dropTriggerId)
+      if (result.dropped) buildDropTrace(result.events, result.dropCauseId)
       else buildOutputTrace(result.events, egressPort, result.deparsedBytes)
     return try {
       egressToTrace(

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -1,6 +1,7 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
+import fourward.ContinuationEvent
 import fourward.ExternInstanceDecl
 import fourward.PipelineStage
 import fourward.TraceEvent
@@ -150,7 +151,11 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           PACKET_PATH_RESUBMIT,
           depth = depth + 1,
         )
-      return buildContinuationTree(ingress.events, next = resubmitTree)
+      return buildContinuationTree(
+        ingress.events,
+        cause = ingress.continuationEventId,
+        next = resubmitTree,
+      )
     }
 
     // === Traffic Manager: I2E clone + multicast/unicast ===
@@ -209,6 +214,8 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val dropTriggerId: Long = 0L,
     /** Id of the CloneSessionLookupEvent when an I2E clone was requested, or 0 if none. */
     val cloneLookupEventId: Long = 0L,
+    /** Id of the ContinuationEvent when resubmit was requested, or 0 if none. */
+    val continuationEventId: Long = 0L,
   )
 
   private fun runIngressPipeline(
@@ -278,12 +285,20 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val cloneLookupId =
       ctx.lastEventIdWhere { it.hasCloneSessionLookup() && it.cloneSessionLookup.sessionFound }
     val deparsedBytes = ctx.deparsedPayload()
+
+    // Emit continuation event if resubmit was requested — must happen after the deparser so the
+    // event appears at the end of the ingress trace and can anchor Continuation.cause.
+    val resubmit = (output?.fields?.get("resubmit") as? BoolVal)?.value == true
+    if (resubmit) {
+      ctx.addTraceEvent(continuationTriggerEvent(ContinuationEvent.Kind.RESUBMIT))
+    }
     return IngressResult(
       ctx.getEvents(),
       output,
       deparsedBytes,
       dropped = false,
       cloneLookupEventId = cloneLookupId,
+      continuationEventId = if (resubmit) ctx.lastEventId() else 0L,
     )
   }
 
@@ -400,9 +415,17 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     }
 
     // Recirculate: the same packet loops back to ingress — modeled as a Continuation.
+    // PSA recirculate is port-based (not an explicit call), so we append a ContinuationEvent with
+    // a manually computed id — the PacketContext is no longer live at this point.
     val isRecirculate = egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG
     val outputTree =
       if (isRecirculate) {
+        val contEventId = (core.events.maxOfOrNull { it.id } ?: 0L) + 1L
+        val contEvent =
+          continuationTriggerEvent(ContinuationEvent.Kind.RECIRCULATE)
+            .toBuilder()
+            .setId(contEventId)
+            .build()
         val recircTree =
           processPacketRecursive(
             state.pipeline,
@@ -411,7 +434,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
             PACKET_PATH_RECIRCULATE,
             depth = depth + 1,
           )
-        buildContinuationTree(core.events, next = recircTree)
+        buildContinuationTree(core.events + contEvent, cause = contEventId, next = recircTree)
       } else {
         buildOutputTrace(core.events, egressPort, core.deparsedBytes)
       }

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -393,10 +393,8 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val output: StructVal?,
     /** Id of the event that caused a drop, or 0 if none. */
     val dropTriggerId: Long = 0L,
-    /** Id of the CloneSessionLookupEvent for E2E clone, or 0 if none. */
-    val cloneLookupEventId: Long = 0L,
-    /** Next event id after the last egress event (for appending continuation events). */
-    val nextEventId: Long = 1L,
+    /** Id of the ContinuationEvent when recirculate was requested, or 0 if none. */
+    val recirculateCauseId: Long = 0L,
   )
 
   /**
@@ -442,27 +440,19 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     // E2E clone: uses deparsed bytes from this egress pass. Independent of drop decision.
     val e2eCloneBranches = buildE2ECloneBranches(state.pipeline, core, selectorMembers)
-    val cloneLookupId = core.cloneLookupEventId
 
     if (core.dropped) {
       if (e2eCloneBranches.isNotEmpty()) {
-        return buildReplicationTree(core.events, cloneLookupId, e2eCloneBranches)
+        // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
+        return buildReplicationTree(core.events, 0L, e2eCloneBranches)
       }
       return buildDropTrace(core.events, core.dropTriggerId)
     }
 
     // Recirculate: the same packet loops back to ingress — modeled as a Continuation.
-    // PSA recirculate is port-based (not an explicit call), so we append a ContinuationEvent with
-    // a manually computed id — the PacketContext is no longer live at this point.
-    val isRecirculate = egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG
+    // runEgressCore already emitted the ContinuationEvent and stored its id in recirculateCauseId.
     val outputTree =
-      if (isRecirculate) {
-        val contEventId = core.nextEventId
-        val contEvent =
-          continuationTriggerEvent(ContinuationEvent.Kind.RECIRCULATE)
-            .toBuilder()
-            .setId(contEventId)
-            .build()
+      if (core.recirculateCauseId != 0L) {
         val recircTree =
           processPacketRecursive(
             state.pipeline,
@@ -471,13 +461,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
             PACKET_PATH_RECIRCULATE,
             depth = depth + 1,
           )
-        buildContinuationTree(core.events + contEvent, cause = contEventId, next = recircTree)
+        buildContinuationTree(core.events, cause = core.recirculateCauseId, next = recircTree)
       } else {
         buildOutputTrace(core.events, egressPort, core.deparsedBytes)
       }
 
     if (e2eCloneBranches.isNotEmpty()) {
-      return buildReplicationTree(emptyList(), cloneLookupId, listOf(outputTree) + e2eCloneBranches)
+      // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
+      return buildReplicationTree(emptyList(), 0L, listOf(outputTree) + e2eCloneBranches)
     }
 
     return outputTree
@@ -527,7 +518,6 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         byteArrayOf(),
         egressOutput,
         dropTriggerId = egressCtx.lastEventIdWhere { it.hasAssertion() },
-        nextEventId = egressCtx.peekNextEventId(),
       )
     }
 
@@ -540,15 +530,16 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     val outputBytes = egressCtx.deparsedPayload()
     val dropTriggerId = if (dropped) egressCtx.lastEventIdWhere { it.hasMarkToDrop() } else 0L
-    // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
-    return EgressCoreResult(
-      egressCtx.getEvents(),
-      dropped,
-      outputBytes,
-      egressOutput,
-      dropTriggerId,
-      nextEventId = egressCtx.peekNextEventId(),
-    )
+
+    // PSA recirculate is port-based. Emit the ContinuationEvent here while ctx is still live,
+    // so all event emission goes through PacketContext.addTraceEvent uniformly.
+    val recirculateCauseId =
+      if (!dropped && egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG) {
+        egressCtx.addTraceEvent(continuationTriggerEvent(ContinuationEvent.Kind.RECIRCULATE))
+        egressCtx.lastEventId()
+      } else 0L
+
+    return EgressCoreResult(egressCtx.getEvents(), dropped, outputBytes, egressOutput, dropTriggerId, recirculateCauseId)
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -1,7 +1,7 @@
 package fourward.simulator
 
 import fourward.BehavioralConfig
-import fourward.ContinuationEvent
+import fourward.Continuation
 import fourward.ExternInstanceDecl
 import fourward.PipelineStage
 import fourward.TraceEvent
@@ -153,7 +153,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
         )
       return buildContinuationTree(
         ingress.events,
-        cause = ingress.continuationEventId,
+        kind = Continuation.Kind.RESUBMIT,
         next = resubmitTree,
       )
     }
@@ -230,8 +230,6 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val dropTriggerId: Long? = null,
     /** Id of the CloneSessionLookupEvent when an I2E clone was requested, or null if none. */
     val cloneLookupEventId: Long? = null,
-    /** Id of the ContinuationEvent when resubmit was requested, or null if none. */
-    val continuationEventId: Long? = null,
     /**
      * First event id the egress pipeline should use, to avoid collisions when events are merged.
      */
@@ -308,19 +306,12 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
       ctx.lastEventIdWhere { it.hasCloneSessionLookup() && it.cloneSessionLookup.sessionFound }
     val deparsedBytes = ctx.deparsedPayload()
 
-    // Emit continuation event if resubmit was requested — must happen after the deparser so the
-    // event appears at the end of the ingress trace and can anchor Continuation.cause.
-    val resubmit = (output?.fields?.get("resubmit") as? BoolVal)?.value == true
-    if (resubmit) {
-      ctx.addTraceEvent(continuationTriggerEvent(ContinuationEvent.Kind.RESUBMIT))
-    }
     return IngressResult(
       ctx.getEvents(),
       output,
       deparsedBytes,
       dropped = false,
       cloneLookupEventId = cloneLookupId,
-      continuationEventId = if (resubmit) ctx.lastEventId() else null,
       nextEventId = ctx.peekNextEventId(),
     )
   }
@@ -393,8 +384,8 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val output: StructVal?,
     /** Id of the event that caused a drop, or null if none. */
     val dropTriggerId: Long? = null,
-    /** Id of the ContinuationEvent when recirculate was requested, or null if none. */
-    val recirculateCauseId: Long? = null,
+    /** Whether this egress pass should recirculate. */
+    val recirculate: Boolean = false,
   )
 
   /**
@@ -444,15 +435,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     if (core.dropped) {
       if (e2eCloneBranches.isNotEmpty()) {
         // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
-        return buildReplicationTree(core.events, 0L, e2eCloneBranches)
+        return buildReplicationTree(core.events, branches = e2eCloneBranches)
       }
       return buildDropTrace(core.events, core.dropTriggerId)
     }
 
     // Recirculate: the same packet loops back to ingress — modeled as a Continuation.
-    // runEgressCore already emitted the ContinuationEvent and stored its id in recirculateCauseId.
     val outputTree =
-      if (core.recirculateCauseId != null) {
+      if (core.recirculate) {
         val recircTree =
           processPacketRecursive(
             state.pipeline,
@@ -461,14 +451,14 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
             PACKET_PATH_RECIRCULATE,
             depth = depth + 1,
           )
-        buildContinuationTree(core.events, cause = core.recirculateCauseId, next = recircTree)
+        buildContinuationTree(core.events, kind = Continuation.Kind.RECIRCULATE, next = recircTree)
       } else {
         buildOutputTrace(core.events, egressPort, core.deparsedBytes)
       }
 
     if (e2eCloneBranches.isNotEmpty()) {
       // PSA E2E clone sessions don't emit a CloneSessionLookupEvent in the current impl.
-      return buildReplicationTree(emptyList(), 0L, listOf(outputTree) + e2eCloneBranches)
+      return buildReplicationTree(emptyList(), branches = listOf(outputTree) + e2eCloneBranches)
     }
 
     return outputTree
@@ -529,17 +519,16 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     runControlStage(egressInterpreter, egressCtx, egressEnv, p.egressDeparser)
 
     val outputBytes = egressCtx.deparsedPayload()
-    val dropTriggerId = if (dropped) egressCtx.lastEventIdWhere { it.hasMarkToDrop() } else 0L
-
-    // PSA recirculate is port-based. Emit the ContinuationEvent here while ctx is still live,
-    // so all event emission goes through PacketContext.addTraceEvent uniformly.
-    val recirculateCauseId =
-      if (!dropped && egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG) {
-        egressCtx.addTraceEvent(continuationTriggerEvent(ContinuationEvent.Kind.RECIRCULATE))
-        egressCtx.lastEventId()
-      } else null
-
-    return EgressCoreResult(egressCtx.getEvents(), dropped, outputBytes, egressOutput, dropTriggerId, recirculateCauseId)
+    val dropTriggerId = if (dropped) egressCtx.lastEventIdWhere { it.hasMarkToDrop() } else null
+    val recirculate = !dropped && egressPort.toUInt().toLong() == PSA_PORT_RECIRCULATE_LONG
+    return EgressCoreResult(
+      egressCtx.getEvents(),
+      dropped,
+      outputBytes,
+      egressOutput,
+      dropTriggerId,
+      recirculate,
+    )
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -7,13 +7,11 @@ import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
 import fourward.ControlDecl
-import fourward.DropReason
 import fourward.EnumDecl
 import fourward.Expr
 import fourward.ExternInstanceDecl
 import fourward.FieldAccess
 import fourward.FieldDecl
-import fourward.ForkReason
 import fourward.Literal
 import fourward.MethodCall
 import fourward.MethodCallStmt
@@ -350,9 +348,7 @@ class PSAArchitectureTest {
     val config = psaConfig()
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -501,11 +497,11 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
-    assertEquals("replica_0_port_2", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("replica_1_port_3", result.trace.forkOutcome.branchesList[1].label)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(2, result.trace.replication.branchesCount)
+    // Branches are in replica order; each outputs to its assigned port.
+    assertEquals(2, result.trace.replication.branchesList[0].output.dataplaneEgressPort)
+    assertEquals(3, result.trace.replication.branchesList[1].output.dataplaneEgressPort)
   }
 
   @Test
@@ -514,9 +510,7 @@ class PSAArchitectureTest {
     val config = psaConfig(ingressStmts = listOf(multicast(99)))
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
+    assertTrue(result.trace.hasDrop())
   }
 
   // ---------------------------------------------------------------------------
@@ -969,10 +963,11 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    assertEquals("original", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("clone_port_5", result.trace.forkOutcome.branchesList[1].label)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(2, result.trace.replication.branchesCount)
+    // Branch[0] is the original (port 2), branch[1] is the I2E clone (port 5).
+    assertEquals(2, result.trace.replication.branchesList[0].output.dataplaneEgressPort)
+    assertEquals(5, result.trace.replication.branchesList[1].output.dataplaneEgressPort)
   }
 
   @Test
@@ -1022,13 +1017,11 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0xDD.toByte()), store)
 
-    // Clone fork exists even though original drops — E2E clone is processed independently.
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    assertEquals(1, result.trace.forkOutcome.branchesCount)
-    assertEquals("clone_port_9", result.trace.forkOutcome.branchesList[0].label)
+    // Clone replication exists even though original drops — E2E clone is processed independently.
+    assertTrue(result.trace.hasReplication())
+    assertEquals(1, result.trace.replication.branchesCount)
     // Clone also dropped by the same egress control.
-    assertTrue(result.trace.forkOutcome.branchesList[0].subtree.packetOutcome.hasDrop())
+    assertTrue(result.trace.replication.branchesList[0].hasDrop())
   }
 
   @Test
@@ -1050,13 +1043,13 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
-    // E2E clone fork is in the egress subtree, flattened into the top-level trace since
+    // E2E clone replication is in the egress subtree, flattened into the top-level trace since
     // there's no I2E clone.
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
-    assertEquals("original", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("clone_port_8", result.trace.forkOutcome.branchesList[1].label)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(2, result.trace.replication.branchesCount)
+    // Branch[0] is the original output (port 2), branch[1] is the E2E clone (port 8).
+    assertEquals(2, result.trace.replication.branchesList[0].output.dataplaneEgressPort)
+    assertEquals(8, result.trace.replication.branchesList[1].output.dataplaneEgressPort)
   }
 
   @Test
@@ -1124,10 +1117,8 @@ class PSAArchitectureTest {
     // Packet recirculates once, then forwards on port 5.
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
-    // Trace should show a RECIRCULATE fork.
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
-    assertEquals("recirculate", result.trace.forkOutcome.branchesList[0].label)
+    // Trace should show a CONTINUATION (recirculate loops back to ingress).
+    assertTrue(result.trace.hasContinuation())
   }
 
   @Test
@@ -1136,9 +1127,7 @@ class PSAArchitectureTest {
     val config = psaConfig(ingressStmts = listOf(sendToPort(2)), egressStmts = listOf(egressDrop()))
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -1148,8 +1137,7 @@ class PSAArchitectureTest {
       psaConfig(ingressStmts = listOf(sendToPort(2), externCall("ingress_drop", nameRef("ostd"))))
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -1194,9 +1182,8 @@ class PSAArchitectureTest {
 
     assertEquals(1, outputs.size)
     assertEquals(7, outputs[0].dataplaneEgressPort)
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
-    assertEquals("resubmit", result.trace.forkOutcome.branchesList[0].label)
+    // Resubmit is a Continuation: the same packet re-enters ingress.
+    assertTrue(result.trace.hasContinuation())
   }
 
   @Test
@@ -1231,8 +1218,7 @@ class PSAArchitectureTest {
       psaConfig(ingressStmts = listOf(resubmitStmt())) // drop=true by default, resubmit=true
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -1259,7 +1245,7 @@ class PSAArchitectureTest {
     // Resubmit wins: packet loops back, then exits on port 5. No clone on port 9.
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
-    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasContinuation())
   }
 
   @Test
@@ -1483,14 +1469,11 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
-    // Should produce an ACTION_SELECTOR fork with 2 member branches.
-    assertTrue("expected fork outcome", result.trace.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
-    assertEquals("member_0", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("member_1", result.trace.forkOutcome.branchesList[1].label)
+    // Should produce an ACTION_SELECTOR choice with 2 member branches.
+    assertTrue("expected choice outcome", result.trace.hasChoice())
+    assertEquals(2, result.trace.choice.branchesCount)
 
-    // Alternative fork: 2 possible worlds, each with 1 output (send_to_port(1) post-table).
+    // Alternative choice: 2 possible worlds, each with 1 output (send_to_port(1) post-table).
     val outcomes = result.possibleOutcomes
     assertEquals(2, outcomes.size)
     assertTrue(outcomes.all { world -> world.size == 1 && world[0].dataplaneEgressPort == 1 })
@@ -1506,8 +1489,7 @@ class PSAArchitectureTest {
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     // No fork — table miss falls through to default action, packet dropped by PSA default.
-    assertTrue("expected drop (no fork)", result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue("expected drop (no fork)", result.trace.hasDrop())
   }
 
   @Test
@@ -1520,12 +1502,10 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
-    assertTrue("expected fork outcome", result.trace.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, result.trace.forkOutcome.reason)
-    assertEquals(1, result.trace.forkOutcome.branchesCount)
-    assertEquals("member_0", result.trace.forkOutcome.branchesList[0].label)
+    assertTrue("expected choice outcome", result.trace.hasChoice())
+    assertEquals(1, result.trace.choice.branchesCount)
 
-    // Alternative fork: 1 possible world with 1 output.
+    // Alternative choice: 1 possible world with 1 output.
     val outcomes = result.possibleOutcomes
     assertEquals(1, outcomes.size)
     assertEquals(1, outcomes[0].size)
@@ -1544,14 +1524,11 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
-    // Egress fork: ACTION_SELECTOR with 2 member branches.
-    assertTrue("expected fork outcome", result.trace.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
-    assertEquals("member_0", result.trace.forkOutcome.branchesList[0].label)
-    assertEquals("member_1", result.trace.forkOutcome.branchesList[1].label)
+    // Egress choice: ACTION_SELECTOR with 2 member branches.
+    assertTrue("expected choice outcome", result.trace.hasChoice())
+    assertEquals(2, result.trace.choice.branchesCount)
 
-    // Alternative fork: 2 possible worlds, each with 1 output.
+    // Alternative choice: 2 possible worlds, each with 1 output.
     val outcomes = result.possibleOutcomes
     assertEquals(2, outcomes.size)
     assertTrue(outcomes.all { world -> world.size == 1 && world[0].dataplaneEgressPort == 1 })
@@ -1571,21 +1548,19 @@ class PSAArchitectureTest {
 
     val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
-    // Top-level fork is CLONE (I2E clone) — parallel.
-    assertTrue("expected clone fork", result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    // Top-level outcome is REPLICATION (I2E clone) — branches[0]=original, branches[1]=clone.
+    assertTrue("expected replication (I2E clone)", result.trace.hasReplication())
+    assertEquals(2, result.trace.replication.branchesCount)
 
-    // Original branch: egress action selector fork with 2 members.
-    val originalBranch = result.trace.forkOutcome.branchesList.first { it.label == "original" }
-    assertTrue("expected fork in original", originalBranch.subtree.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, originalBranch.subtree.forkOutcome.reason)
-    assertEquals(2, originalBranch.subtree.forkOutcome.branchesCount)
+    // Original branch: egress action selector choice with 2 members.
+    val originalBranch = result.trace.replication.branchesList[0]
+    assertTrue("expected choice in original", originalBranch.hasChoice())
+    assertEquals(2, originalBranch.choice.branchesCount)
 
-    // Clone branch: also hits the egress table, producing its own action selector fork.
-    val cloneBranch = result.trace.forkOutcome.branchesList.first { it.label.startsWith("clone_") }
-    assertTrue("expected fork in clone", cloneBranch.subtree.hasForkOutcome())
-    assertEquals(ForkReason.ACTION_SELECTOR, cloneBranch.subtree.forkOutcome.reason)
-    assertEquals(2, cloneBranch.subtree.forkOutcome.branchesCount)
+    // Clone branch: also hits the egress table, producing its own action selector choice.
+    val cloneBranch = result.trace.replication.branchesList[1]
+    assertTrue("expected choice in clone", cloneBranch.hasChoice())
+    assertEquals(2, cloneBranch.choice.branchesCount)
 
     // Parallel clone × alternative selector: 2 members × 2 members = 4 possible worlds,
     // each with 2 outputs (one from original, one from clone).

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -3,6 +3,7 @@ package fourward.simulator
 import com.google.protobuf.ByteString
 import fourward.Architecture
 import fourward.AssignmentStmt
+import fourward.ContinuationEvent
 import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
@@ -502,6 +503,11 @@ class PSAArchitectureTest {
     // Branches are in replica order; each outputs to its assigned port.
     assertEquals(2, result.trace.replication.branchesList[0].output.dataplaneEgressPort)
     assertEquals(3, result.trace.replication.branchesList[1].output.dataplaneEgressPort)
+    // Replication.cause should reference the multicast group lookup event by id.
+    val causeId = result.trace.replication.cause
+    assertTrue("Replication.cause should be non-zero", causeId > 0)
+    val lookupEvent = result.trace.eventsList.single { it.id == causeId }
+    assertTrue(lookupEvent.hasMulticastGroupLookup())
   }
 
   @Test
@@ -1117,8 +1123,10 @@ class PSAArchitectureTest {
     // Packet recirculates once, then forwards on port 5.
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
-    // Trace should show a CONTINUATION (recirculate loops back to ingress).
-    assertTrue(result.trace.hasContinuation())
+    // Trace should show a CONTINUATION anchored by a RECIRCULATE ContinuationEvent.
+    val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }
+    assertEquals(ContinuationEvent.Kind.RECIRCULATE, contEvent.continuationTrigger.kind)
+    assertEquals(contEvent.id, result.trace.continuation.cause)
   }
 
   @Test
@@ -1182,8 +1190,10 @@ class PSAArchitectureTest {
 
     assertEquals(1, outputs.size)
     assertEquals(7, outputs[0].dataplaneEgressPort)
-    // Resubmit is a Continuation: the same packet re-enters ingress.
-    assertTrue(result.trace.hasContinuation())
+    // Resubmit is a Continuation anchored by a RESUBMIT ContinuationEvent.
+    val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }
+    assertEquals(ContinuationEvent.Kind.RESUBMIT, contEvent.continuationTrigger.kind)
+    assertEquals(contEvent.id, result.trace.continuation.cause)
   }
 
   @Test
@@ -1245,7 +1255,9 @@ class PSAArchitectureTest {
     // Resubmit wins: packet loops back, then exits on port 5. No clone on port 9.
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
-    assertTrue(result.trace.hasContinuation())
+    val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }
+    assertEquals(ContinuationEvent.Kind.RESUBMIT, contEvent.continuationTrigger.kind)
+    assertEquals(contEvent.id, result.trace.continuation.cause)
   }
 
   @Test

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -3,10 +3,10 @@ package fourward.simulator
 import com.google.protobuf.ByteString
 import fourward.Architecture
 import fourward.AssignmentStmt
-import fourward.ContinuationEvent
 import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
+import fourward.Continuation
 import fourward.ControlDecl
 import fourward.EnumDecl
 import fourward.Expr
@@ -1123,10 +1123,8 @@ class PSAArchitectureTest {
     // Packet recirculates once, then forwards on port 5.
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
-    // Trace should show a CONTINUATION anchored by a RECIRCULATE ContinuationEvent.
-    val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }
-    assertEquals(ContinuationEvent.Kind.RECIRCULATE, contEvent.continuationTrigger.kind)
-    assertEquals(contEvent.id, result.trace.continuation.cause)
+    // Trace should show a CONTINUATION with RECIRCULATE kind.
+    assertEquals(Continuation.Kind.RECIRCULATE, result.trace.continuation.kind)
   }
 
   @Test
@@ -1190,10 +1188,8 @@ class PSAArchitectureTest {
 
     assertEquals(1, outputs.size)
     assertEquals(7, outputs[0].dataplaneEgressPort)
-    // Resubmit is a Continuation anchored by a RESUBMIT ContinuationEvent.
-    val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }
-    assertEquals(ContinuationEvent.Kind.RESUBMIT, contEvent.continuationTrigger.kind)
-    assertEquals(contEvent.id, result.trace.continuation.cause)
+    // Resubmit is a Continuation with RESUBMIT kind.
+    assertEquals(Continuation.Kind.RESUBMIT, result.trace.continuation.kind)
   }
 
   @Test
@@ -1255,9 +1251,7 @@ class PSAArchitectureTest {
     // Resubmit wins: packet loops back, then exits on port 5. No clone on port 9.
     assertEquals(1, outputs.size)
     assertEquals(5, outputs[0].dataplaneEgressPort)
-    val contEvent = result.trace.eventsList.single { it.hasContinuationTrigger() }
-    assertEquals(ContinuationEvent.Kind.RESUBMIT, contEvent.continuationTrigger.kind)
-    assertEquals(contEvent.id, result.trace.continuation.cause)
+    assertEquals(Continuation.Kind.RESUBMIT, result.trace.continuation.kind)
   }
 
   @Test

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -108,6 +108,7 @@ private fun collectFromEvent(
     TraceEvent.EventCase.ASSERTION,
     TraceEvent.EventCase.CLONE,
     TraceEvent.EventCase.MARK_TO_DROP,
+    TraceEvent.EventCase.CONTINUATION_TRIGGER,
     TraceEvent.EventCase.DEPARSER_EMIT,
     TraceEvent.EventCase.EVENT_NOT_SET,
     null -> {}

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -44,12 +44,18 @@ private fun collectEntities(
     collectFromEvent(event, snapshot, tableStore, staticEntries, out)
   }
   when (trace.outcomeCase) {
-    TraceTree.OutcomeCase.FORK_OUTCOME -> {
-      for (branch in trace.forkOutcome.branchesList) {
-        collectEntities(branch.subtree, snapshot, tableStore, staticEntries, out)
+    TraceTree.OutcomeCase.REPLICATION ->
+      for (branch in trace.replication.branchesList) {
+        collectEntities(branch, snapshot, tableStore, staticEntries, out)
       }
-    }
-    TraceTree.OutcomeCase.PACKET_OUTCOME,
+    TraceTree.OutcomeCase.CHOICE ->
+      for (branch in trace.choice.branchesList) {
+        collectEntities(branch, snapshot, tableStore, staticEntries, out)
+      }
+    TraceTree.OutcomeCase.CONTINUATION ->
+      collectEntities(trace.continuation.next, snapshot, tableStore, staticEntries, out)
+    TraceTree.OutcomeCase.OUTPUT,
+    TraceTree.OutcomeCase.DROP,
     TraceTree.OutcomeCase.OUTCOME_NOT_SET,
     null -> {}
   }

--- a/simulator/ReproducerExtractor.kt
+++ b/simulator/ReproducerExtractor.kt
@@ -108,7 +108,6 @@ private fun collectFromEvent(
     TraceEvent.EventCase.ASSERTION,
     TraceEvent.EventCase.CLONE,
     TraceEvent.EventCase.MARK_TO_DROP,
-    TraceEvent.EventCase.CONTINUATION_TRIGGER,
     TraceEvent.EventCase.DEPARSER_EMIT,
     TraceEvent.EventCase.EVENT_NOT_SET,
     null -> {}

--- a/simulator/ReproducerExtractorTest.kt
+++ b/simulator/ReproducerExtractorTest.kt
@@ -3,11 +3,7 @@ package fourward.simulator
 import com.google.protobuf.ByteString
 import fourward.CloneSessionLookupEvent
 import fourward.Drop
-import fourward.DropReason
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
-import fourward.PacketOutcome
+import fourward.Replication
 import fourward.TableLookupEvent
 import fourward.TraceEvent
 import fourward.TraceTree
@@ -68,8 +64,7 @@ class ReproducerExtractorTest {
       )
       .build()
 
-  private fun dropOutcome(): PacketOutcome =
-    PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(DropReason.MARK_TO_DROP)).build()
+  private fun dropOutcome(): Drop = Drop.getDefaultInstance()
 
   private fun emptyTableStore(): TableStore = TableStore()
 
@@ -107,7 +102,7 @@ class ReproducerExtractorTest {
 
   @Test
   fun `empty trace produces no entities`() {
-    val trace = TraceTree.newBuilder().setPacketOutcome(dropOutcome()).build()
+    val trace = TraceTree.newBuilder().setDrop(dropOutcome()).build()
     val entities = extract(trace, emptyTableStore())
     assertTrue(entities.isEmpty())
   }
@@ -116,10 +111,7 @@ class ReproducerExtractorTest {
   fun `table hit extracts matched entry`() {
     val entry = tableEntry(tableId = 1, matchValue = byteArrayOf(0x08, 0x00), actionId = 10)
     val trace =
-      TraceTree.newBuilder()
-        .addEvents(tableLookupHit(entry))
-        .setPacketOutcome(dropOutcome())
-        .build()
+      TraceTree.newBuilder().addEvents(tableLookupHit(entry)).setDrop(dropOutcome()).build()
 
     val entities = extract(trace, emptyTableStore())
 
@@ -130,8 +122,7 @@ class ReproducerExtractorTest {
 
   @Test
   fun `table miss produces no entities`() {
-    val trace =
-      TraceTree.newBuilder().addEvents(tableLookupMiss()).setPacketOutcome(dropOutcome()).build()
+    val trace = TraceTree.newBuilder().addEvents(tableLookupMiss()).setDrop(dropOutcome()).build()
 
     val entities = extract(trace, emptyTableStore())
     assertTrue(entities.isEmpty())
@@ -147,10 +138,7 @@ class ReproducerExtractorTest {
         .build()
 
     val trace =
-      TraceTree.newBuilder()
-        .addEvents(tableLookupHit(entry))
-        .setPacketOutcome(dropOutcome())
-        .build()
+      TraceTree.newBuilder().addEvents(tableLookupHit(entry)).setDrop(dropOutcome()).build()
 
     val entities = extract(trace, emptyTableStore(), listOf(staticUpdate))
     assertTrue("static entry should be excluded", entities.isEmpty())
@@ -163,7 +151,7 @@ class ReproducerExtractorTest {
       TraceTree.newBuilder()
         .addEvents(tableLookupHit(entry))
         .addEvents(tableLookupHit(entry))
-        .setPacketOutcome(dropOutcome())
+        .setDrop(dropOutcome())
         .build()
 
     val entities = extract(trace, emptyTableStore())
@@ -172,7 +160,7 @@ class ReproducerExtractorTest {
 
   @Test
   fun `register seed dependencies extract register entries`() {
-    val trace = TraceTree.newBuilder().setPacketOutcome(dropOutcome()).build()
+    val trace = TraceTree.newBuilder().setDrop(dropOutcome()).build()
     val store = tableStoreWithRegister()
     val entities =
       extractReproducerEntities(
@@ -211,7 +199,7 @@ class ReproducerExtractorTest {
     val trace =
       TraceTree.newBuilder()
         .addEvents(cloneSessionLookup(sessionId = 42, found = true))
-        .setPacketOutcome(dropOutcome())
+        .setDrop(dropOutcome())
         .build()
 
     val entities = extract(trace, store)
@@ -226,7 +214,7 @@ class ReproducerExtractorTest {
     val trace =
       TraceTree.newBuilder()
         .addEvents(cloneSessionLookup(sessionId = 99, found = false))
-        .setPacketOutcome(dropOutcome())
+        .setDrop(dropOutcome())
         .build()
 
     val entities = extract(trace, emptyTableStore())
@@ -240,26 +228,13 @@ class ReproducerExtractorTest {
 
     val trace =
       TraceTree.newBuilder()
-        .setForkOutcome(
-          Fork.newBuilder()
-            .setReason(ForkReason.CLONE)
+        .setReplication(
+          Replication.newBuilder()
             .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("original")
-                .setSubtree(
-                  TraceTree.newBuilder()
-                    .addEvents(tableLookupHit(entry1))
-                    .setPacketOutcome(dropOutcome())
-                )
+              TraceTree.newBuilder().addEvents(tableLookupHit(entry1)).setDrop(dropOutcome())
             )
             .addBranches(
-              ForkBranch.newBuilder()
-                .setLabel("clone")
-                .setSubtree(
-                  TraceTree.newBuilder()
-                    .addEvents(tableLookupHit(entry2))
-                    .setPacketOutcome(dropOutcome())
-                )
+              TraceTree.newBuilder().addEvents(tableLookupHit(entry2)).setDrop(dropOutcome())
             )
         )
         .build()
@@ -316,10 +291,7 @@ class ReproducerExtractorTest {
         .build()
 
     val trace =
-      TraceTree.newBuilder()
-        .addEvents(tableLookupHit(entry))
-        .setPacketOutcome(dropOutcome())
-        .build()
+      TraceTree.newBuilder().addEvents(tableLookupHit(entry)).setDrop(dropOutcome()).build()
 
     val entities = extract(trace, store)
 
@@ -367,10 +339,7 @@ class ReproducerExtractorTest {
         .build()
 
     val trace =
-      TraceTree.newBuilder()
-        .addEvents(tableLookupHit(entry))
-        .setPacketOutcome(dropOutcome())
-        .build()
+      TraceTree.newBuilder().addEvents(tableLookupHit(entry)).setDrop(dropOutcome()).build()
 
     val entities = extract(trace, store)
 
@@ -422,10 +391,7 @@ class ReproducerExtractorTest {
     store.publishSnapshot()
 
     val trace =
-      TraceTree.newBuilder()
-        .addEvents(tableLookupMiss("MyTable"))
-        .setPacketOutcome(dropOutcome())
-        .build()
+      TraceTree.newBuilder().addEvents(tableLookupMiss("MyTable")).setDrop(dropOutcome()).build()
 
     val entities = extract(trace, store)
 
@@ -459,10 +425,7 @@ class ReproducerExtractorTest {
     store.publishSnapshot()
 
     val trace =
-      TraceTree.newBuilder()
-        .addEvents(tableLookupMiss("MyTable"))
-        .setPacketOutcome(dropOutcome())
-        .build()
+      TraceTree.newBuilder().addEvents(tableLookupMiss("MyTable")).setDrop(dropOutcome()).build()
 
     val entities = extract(trace, store)
     assertTrue("unmodified default should not be extracted", entities.isEmpty())
@@ -499,7 +462,7 @@ class ReproducerExtractorTest {
     val trace =
       TraceTree.newBuilder()
         .addEvents(multicastGroupLookup(groupId = 1))
-        .setPacketOutcome(dropOutcome())
+        .setDrop(dropOutcome())
         .build()
 
     val entities = extract(trace, store)
@@ -521,7 +484,7 @@ class ReproducerExtractorTest {
                 .setGroupFound(false)
             )
         )
-        .setPacketOutcome(dropOutcome())
+        .setDrop(dropOutcome())
         .build()
 
     val entities = extract(trace, emptyTableStore())

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -309,11 +309,12 @@ fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
         .map { collectPossibleOutcomes(it) }
         .reduceOrNull { acc, next ->
           acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
-        }
-        ?: listOf(emptyList())
+        } ?: listOf(emptyList())
     TraceTree.OutcomeCase.CHOICE ->
       // Each branch is a separate possible world; union their outcomes.
-      tree.choice.branchesList.flatMap { collectPossibleOutcomes(it) }.ifEmpty { listOf(emptyList()) }
+      tree.choice.branchesList
+        .flatMap { collectPossibleOutcomes(it) }
+        .ifEmpty { listOf(emptyList()) }
     TraceTree.OutcomeCase.CONTINUATION -> collectPossibleOutcomes(tree.continuation.next)
   }
 }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -303,19 +303,17 @@ fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
     TraceTree.OutcomeCase.DROP,
     TraceTree.OutcomeCase.OUTCOME_NOT_SET,
     null -> listOf(emptyList())
-    TraceTree.OutcomeCase.REPLICATION -> {
-      val branchOutcomes = tree.replication.branchesList.map { collectPossibleOutcomes(it) }
-      if (branchOutcomes.isEmpty()) return listOf(emptyList())
+    TraceTree.OutcomeCase.REPLICATION ->
       // Cartesian product: for each combination of one world per branch, concatenate packets.
-      branchOutcomes.reduce { acc, next ->
-        acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
-      }
-    }
-    TraceTree.OutcomeCase.CHOICE -> {
+      tree.replication.branchesList
+        .map { collectPossibleOutcomes(it) }
+        .reduceOrNull { acc, next ->
+          acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
+        }
+        ?: listOf(emptyList())
+    TraceTree.OutcomeCase.CHOICE ->
       // Each branch is a separate possible world; union their outcomes.
-      val branchOutcomes = tree.choice.branchesList.map { collectPossibleOutcomes(it) }
-      if (branchOutcomes.isEmpty()) listOf(emptyList()) else branchOutcomes.flatten()
-    }
+      tree.choice.branchesList.flatMap { collectPossibleOutcomes(it) }.ifEmpty { listOf(emptyList()) }
     TraceTree.OutcomeCase.CONTINUATION -> collectPossibleOutcomes(tree.continuation.next)
   }
 }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -287,40 +287,35 @@ class Simulator : TableDataReader {
 }
 
 /**
- * Collects all possible outcome sets from a trace tree, respecting fork semantics.
- * - **Parallel forks** (clone, multicast, resubmit, recirculate): outputs from all branches are
- *   combined within each possible world (Cartesian product of branch outcomes).
- * - **Alternative forks** (action selector): each branch is a separate possible world; outcomes are
- *   concatenated (union of branch outcomes).
- * - **Leaf (output):** one possible world with one packet.
- * - **Leaf (drop):** one possible world with no packets.
+ * Collects all possible outcome sets from a trace tree, respecting outcome semantics.
+ * - **Replication** (clone, multicast): all branches execute simultaneously — Cartesian product.
+ * - **Choice** (action selector): exactly one branch executes — union of branch outcomes.
+ * - **Continuation** (resubmit, recirculate): same packet, another pass — delegate to next.
+ * - **Output:** one possible world with one packet.
+ * - **Drop:** one possible world with no packets.
  *
  * Returns a non-empty list. Each inner list is one complete set of output packets that could result
  * from a single real execution.
  */
 fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
-  when (tree.outcomeCase) {
-    TraceTree.OutcomeCase.PACKET_OUTCOME ->
-      return if (tree.packetOutcome.hasOutput()) {
-        listOf(listOf(tree.packetOutcome.output))
-      } else {
-        listOf(emptyList())
-      }
+  return when (tree.outcomeCase) {
+    TraceTree.OutcomeCase.OUTPUT -> listOf(listOf(tree.output))
+    TraceTree.OutcomeCase.DROP,
     TraceTree.OutcomeCase.OUTCOME_NOT_SET,
-    null -> return listOf(emptyList())
-    TraceTree.OutcomeCase.FORK_OUTCOME -> {} // fall through to fork handling below
-  }
-  val fork = tree.forkOutcome
-  val branchOutcomes = fork.branchesList.map { collectPossibleOutcomes(it.subtree) }
-  if (branchOutcomes.isEmpty()) return listOf(emptyList())
-  return when (forkModeOf(fork.reason)) {
-    // Alternative: each branch adds its worlds to the result.
-    ForkMode.ALTERNATIVE -> branchOutcomes.flatten()
-    // Parallel: Cartesian product across branches — for each combination of one world per
-    // branch, concatenate the packets.
-    ForkMode.PARALLEL ->
+    null -> listOf(emptyList())
+    TraceTree.OutcomeCase.REPLICATION -> {
+      val branchOutcomes = tree.replication.branchesList.map { collectPossibleOutcomes(it) }
+      if (branchOutcomes.isEmpty()) return listOf(emptyList())
+      // Cartesian product: for each combination of one world per branch, concatenate packets.
       branchOutcomes.reduce { acc, next ->
         acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
       }
+    }
+    TraceTree.OutcomeCase.CHOICE -> {
+      // Each branch is a separate possible world; union their outcomes.
+      val branchOutcomes = tree.choice.branchesList.map { collectPossibleOutcomes(it) }
+      if (branchOutcomes.isEmpty()) listOf(emptyList()) else branchOutcomes.flatten()
+    }
+    TraceTree.OutcomeCase.CONTINUATION -> collectPossibleOutcomes(tree.continuation.next)
   }
 }

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -295,8 +295,7 @@ class SimulatorTest {
     sim.loadPipeline(config, dropPortOverride = 42)
 
     val result = sim.processPacket(ingressPort = 0, payload = byteArrayOf(0x01))
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -408,53 +407,35 @@ class SimulatorTest {
   }
 }
 
-/** Unit tests for [collectPossibleOutcomes] — the parallel vs alternative fork semantics. */
+/** Unit tests for [collectPossibleOutcomes] — the outcome type semantics. */
 class CollectPossibleOutcomesTest {
 
   private fun output(port: Int): fourward.TraceTree =
     fourward.TraceTree.newBuilder()
-      .setPacketOutcome(
-        fourward.PacketOutcome.newBuilder()
-          .setOutput(
-            fourward.OutputPacket.newBuilder()
-              .setDataplaneEgressPort(port)
-              .setPayload(com.google.protobuf.ByteString.copyFrom(byteArrayOf(0x01)))
-          )
+      .setOutput(
+        fourward.OutputPacket.newBuilder()
+          .setDataplaneEgressPort(port)
+          .setPayload(com.google.protobuf.ByteString.copyFrom(byteArrayOf(0x01)))
       )
       .build()
 
   private fun drop(): fourward.TraceTree =
+    fourward.TraceTree.newBuilder().setDrop(fourward.Drop.newBuilder()).build()
+
+  private fun replication(vararg branches: fourward.TraceTree): fourward.TraceTree =
     fourward.TraceTree.newBuilder()
-      .setPacketOutcome(
-        fourward.PacketOutcome.newBuilder()
-          .setDrop(fourward.Drop.newBuilder().setReason(fourward.DropReason.MARK_TO_DROP))
-      )
+      .setReplication(fourward.Replication.newBuilder().addAllBranches(branches.toList()))
       .build()
 
-  private fun fork(
-    reason: fourward.ForkReason,
-    vararg branches: Pair<String, fourward.TraceTree>,
-  ): fourward.TraceTree =
+  private fun choice(vararg branches: fourward.TraceTree): fourward.TraceTree =
     fourward.TraceTree.newBuilder()
-      .setForkOutcome(
-        fourward.Fork.newBuilder()
-          .setReason(reason)
-          .addAllBranches(
-            branches.map {
-              fourward.ForkBranch.newBuilder().setLabel(it.first).setSubtree(it.second).build()
-            }
-          )
-      )
+      .setChoice(fourward.Choice.newBuilder().addAllBranches(branches.toList()))
       .build()
-
-  private fun alternativeFork(
-    vararg branches: Pair<String, fourward.TraceTree>
-  ): fourward.TraceTree = fork(fourward.ForkReason.ACTION_SELECTOR, *branches)
 
   @Test
   fun `linear trace produces one world with one output`() {
     val outcomes = collectPossibleOutcomes(output(1))
-    assertEquals(listOf(listOf(output(1).packetOutcome.output)), outcomes)
+    assertEquals(listOf(listOf(output(1).output)), outcomes)
   }
 
   @Test
@@ -465,8 +446,8 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `parallel fork combines outputs within each world`() {
-    val tree = fork(fourward.ForkReason.CLONE, "original" to output(1), "clone" to output(2))
+  fun `replication combines outputs within each world`() {
+    val tree = replication(output(1), output(2))
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals("one world", 1, outcomes.size)
     assertEquals("two outputs", 2, outcomes[0].size)
@@ -475,9 +456,8 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `alternative fork produces one world per branch`() {
-    val tree =
-      alternativeFork("member_0" to output(1), "member_1" to output(2), "member_2" to output(3))
+  fun `choice produces one world per branch`() {
+    val tree = choice(output(1), output(2), output(3))
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals("three worlds", 3, outcomes.size)
     assertEquals(1, outcomes[0].single().dataplaneEgressPort)
@@ -486,26 +466,20 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `alternative inside parallel produces Cartesian product`() {
-    // Clone (parallel) with 2 branches, each containing a 2-member selector (alternative).
-    val tree =
-      fork(
-        fourward.ForkReason.CLONE,
-        "original" to alternativeFork("m0" to output(1), "m1" to output(2)),
-        "clone" to alternativeFork("m0" to output(3), "m1" to output(4)),
-      )
+  fun `choice inside replication produces Cartesian product`() {
+    // Replication with 2 branches, each containing a 2-member choice.
+    val tree = replication(choice(output(1), output(2)), choice(output(3), output(4)))
     val outcomes = collectPossibleOutcomes(tree)
-    // 2 × 2 = 4 possible worlds, each with 2 outputs (one from original, one from clone).
+    // 2 × 2 = 4 possible worlds, each with 2 outputs (one per replication branch).
     assertEquals("2×2 Cartesian product", 4, outcomes.size)
     assertTrue(outcomes.all { it.size == 2 })
-    // Verify all 4 combinations exist.
     val portPairs = outcomes.map { world -> world.map { it.dataplaneEgressPort }.sorted() }.toSet()
     assertEquals(setOf(listOf(1, 3), listOf(1, 4), listOf(2, 3), listOf(2, 4)), portPairs)
   }
 
   @Test
-  fun `alternative with drop produces world with empty output`() {
-    val tree = alternativeFork("m0" to output(1), "m1" to drop())
+  fun `choice with drop produces world with empty output`() {
+    val tree = choice(output(1), drop())
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals(2, outcomes.size)
     assertEquals(1, outcomes[0].size)
@@ -513,9 +487,8 @@ class CollectPossibleOutcomesTest {
   }
 
   @Test
-  fun `multicast fork is parallel`() {
-    val tree =
-      fork(fourward.ForkReason.MULTICAST, "r0" to output(1), "r1" to output(2), "r2" to output(3))
+  fun `multicast replication combines all outputs`() {
+    val tree = replication(output(1), output(2), output(3))
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals("one world", 1, outcomes.size)
     assertEquals("three outputs", 3, outcomes[0].size)

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -35,8 +35,8 @@ internal fun buildOutputTrace(events: List<TraceEvent>, port: Int, payload: Byte
  */
 internal fun buildReplicationTree(
   events: List<TraceEvent>,
-  cause: Long? = null,
   branches: List<TraceTree>,
+  cause: Long? = null,
 ): TraceTree =
   TraceTree.newBuilder()
     .addAllEvents(events)

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -2,6 +2,7 @@ package fourward.simulator
 
 import fourward.Choice
 import fourward.Continuation
+import fourward.ContinuationEvent
 import fourward.Drop
 import fourward.MulticastGroupLookupEvent
 import fourward.OutputPacket
@@ -131,6 +132,20 @@ internal fun multicastGroupLookupEvent(groupId: Int, replicaCount: Int): TraceEv
         .setMulticastGroupId(groupId)
         .setGroupFound(true)
         .setReplicaCount(replicaCount)
+    )
+    .build()
+
+/**
+ * Creates a [TraceEvent] recording a resubmit or recirculate call — fired immediately before the
+ * packet re-enters the pipeline. Anchors [Continuation.cause].
+ */
+internal fun continuationTriggerEvent(
+  kind: ContinuationEvent.Kind,
+  preservedFields: Map<String, String> = emptyMap(),
+): TraceEvent =
+  TraceEvent.newBuilder()
+    .setContinuationTrigger(
+      ContinuationEvent.newBuilder().setKind(kind).putAllPreservedFields(preservedFields)
     )
     .build()
 

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -2,7 +2,6 @@ package fourward.simulator
 
 import fourward.Choice
 import fourward.Continuation
-import fourward.ContinuationEvent
 import fourward.Drop
 import fourward.MulticastGroupLookupEvent
 import fourward.OutputPacket
@@ -42,7 +41,9 @@ internal fun buildReplicationTree(
   TraceTree.newBuilder()
     .addAllEvents(events)
     .setReplication(
-      Replication.newBuilder().also { if (cause != null) it.setCause(cause) }.addAllBranches(branches)
+      Replication.newBuilder()
+        .also { if (cause != null) it.setCause(cause) }
+        .addAllBranches(branches)
     )
     .build()
 
@@ -57,23 +58,26 @@ internal fun buildChoiceTree(
 ): TraceTree =
   TraceTree.newBuilder()
     .addAllEvents(events)
-    .setChoice(Choice.newBuilder().also { if (cause != null) it.setCause(cause) }.addAllBranches(branches))
+    .setChoice(
+      Choice.newBuilder().also { if (cause != null) it.setCause(cause) }.addAllBranches(branches)
+    )
     .build()
 
 /**
  * Builds a [TraceTree] where the same packet continues as another pass. Used for resubmit,
- * recirculate, and forward stage transitions. [cause] is the id of the event that triggered the
- * re-parse; null when absent (forward transitions).
+ * recirculate, and forward stage transitions. [kind] is absent (KIND_UNSPECIFIED) for forward
+ * transitions; RESUBMIT or RECIRCULATE for backward ones.
  */
 internal fun buildContinuationTree(
   events: List<TraceEvent>,
-  cause: Long? = null,
+  kind: Continuation.Kind = Continuation.Kind.KIND_UNSPECIFIED,
+  preservedFields: Map<String, String> = emptyMap(),
   next: TraceTree,
 ): TraceTree =
   TraceTree.newBuilder()
     .addAllEvents(events)
     .setContinuation(
-      Continuation.newBuilder().also { if (cause != null) it.setCause(cause) }.setNext(next)
+      Continuation.newBuilder().setKind(kind).putAllPreservedFields(preservedFields).setNext(next)
     )
     .build()
 
@@ -135,20 +139,6 @@ internal fun multicastGroupLookupEvent(groupId: Int, replicaCount: Int): TraceEv
         .setMulticastGroupId(groupId)
         .setGroupFound(true)
         .setReplicaCount(replicaCount)
-    )
-    .build()
-
-/**
- * Creates a [TraceEvent] recording a resubmit or recirculate call — fired immediately before the
- * packet re-enters the pipeline. Anchors [Continuation.cause].
- */
-internal fun continuationTriggerEvent(
-  kind: ContinuationEvent.Kind,
-  preservedFields: Map<String, String> = emptyMap(),
-): TraceEvent =
-  TraceEvent.newBuilder()
-    .setContinuationTrigger(
-      ContinuationEvent.newBuilder().setKind(kind).putAllPreservedFields(preservedFields)
     )
     .build()
 

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -64,13 +64,12 @@ internal fun buildChoiceTree(
     .build()
 
 /**
- * Builds a [TraceTree] where the same packet continues as another pass. Used for resubmit,
- * recirculate, and forward stage transitions. [kind] is absent (KIND_UNSPECIFIED) for forward
- * transitions; RESUBMIT or RECIRCULATE for backward ones.
+ * Builds a [TraceTree] where the same packet continues as another pass. Used for resubmit and
+ * recirculate. [kind] must be RESUBMIT or RECIRCULATE.
  */
 internal fun buildContinuationTree(
   events: List<TraceEvent>,
-  kind: Continuation.Kind = Continuation.Kind.KIND_UNSPECIFIED,
+  kind: Continuation.Kind,
   preservedFields: Map<String, String> = emptyMap(),
   next: TraceTree,
 ): TraceTree =

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -13,8 +13,8 @@ import fourward.TraceEvent
 import fourward.TraceTree
 
 /** Builds a [TraceTree] representing a dropped packet with the given trace events. */
-internal fun buildDropTrace(events: List<TraceEvent>, triggerId: Long? = null): TraceTree {
-  val drop = Drop.newBuilder().also { if (triggerId != null) it.setTrigger(triggerId) }.build()
+internal fun buildDropTrace(events: List<TraceEvent>, causeId: Long? = null): TraceTree {
+  val drop = Drop.newBuilder().also { if (causeId != null) it.setCause(causeId) }.build()
   return TraceTree.newBuilder().addAllEvents(events).setDrop(drop).build()
 }
 

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -74,23 +74,30 @@ internal fun buildContinuationTree(
     .build()
 
 /**
- * Prepends [prefix] events to [tree], returning a new [TraceTree] with the same outcome. Used when
- * flattening sequential pipeline stages into a single node.
+ * Returns a copy of [tree] with its events replaced by [events], preserving the outcome. The single
+ * source of truth for "copy a TraceTree with different events" — avoids duplicating the exhaustive
+ * outcome dispatch in every caller.
  */
-internal fun prependEvents(tree: TraceTree, prefix: List<TraceEvent>): TraceTree {
-  if (prefix.isEmpty()) return tree
-  val b = TraceTree.newBuilder().addAllEvents(prefix).addAllEvents(tree.eventsList)
-  when (tree.outcomeCase) {
-    TraceTree.OutcomeCase.REPLICATION -> b.setReplication(tree.replication)
-    TraceTree.OutcomeCase.CHOICE -> b.setChoice(tree.choice)
-    TraceTree.OutcomeCase.CONTINUATION -> b.setContinuation(tree.continuation)
-    TraceTree.OutcomeCase.OUTPUT -> b.setOutput(tree.output)
-    TraceTree.OutcomeCase.DROP -> b.setDrop(tree.drop)
+internal fun TraceTree.withEvents(events: List<TraceEvent>): TraceTree {
+  val b = TraceTree.newBuilder().addAllEvents(events)
+  when (outcomeCase) {
+    TraceTree.OutcomeCase.REPLICATION -> b.setReplication(replication)
+    TraceTree.OutcomeCase.CHOICE -> b.setChoice(choice)
+    TraceTree.OutcomeCase.CONTINUATION -> b.setContinuation(continuation)
+    TraceTree.OutcomeCase.OUTPUT -> b.setOutput(output)
+    TraceTree.OutcomeCase.DROP -> b.setDrop(drop)
     TraceTree.OutcomeCase.OUTCOME_NOT_SET,
     null -> {}
   }
   return b.build()
 }
+
+/**
+ * Prepends [prefix] events to [tree], returning a new [TraceTree] with the same outcome. Used when
+ * flattening sequential pipeline stages into a single node.
+ */
+internal fun prependEvents(tree: TraceTree, prefix: List<TraceEvent>): TraceTree =
+  if (prefix.isEmpty()) tree else tree.withEvents(prefix + tree.eventsList)
 
 /** Creates a [TraceEvent] recording the packet's ingress port. */
 internal fun packetIngressEvent(ingressPort: DataplanePort): TraceEvent =

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -14,8 +14,8 @@ import fourward.TraceEvent
 import fourward.TraceTree
 
 /** Builds a [TraceTree] representing a dropped packet with the given trace events. */
-internal fun buildDropTrace(events: List<TraceEvent>, triggerId: Long = 0L): TraceTree {
-  val drop = Drop.newBuilder().also { if (triggerId != 0L) it.setTrigger(triggerId) }.build()
+internal fun buildDropTrace(events: List<TraceEvent>, triggerId: Long? = null): TraceTree {
+  val drop = Drop.newBuilder().also { if (triggerId != null) it.setTrigger(triggerId) }.build()
   return TraceTree.newBuilder().addAllEvents(events).setDrop(drop).build()
 }
 
@@ -31,16 +31,19 @@ internal fun buildOutputTrace(events: List<TraceEvent>, port: Int, payload: Byte
 
 /**
  * Builds a [TraceTree] where all branches execute simultaneously (clone, multicast). [cause] is the
- * id of the CloneSessionLookupEvent or MulticastGroupLookupEvent that triggered the replication.
+ * id of the CloneSessionLookupEvent or MulticastGroupLookupEvent that triggered the replication, or
+ * null when there is no triggering event (e.g. PNA mirror_packet).
  */
 internal fun buildReplicationTree(
   events: List<TraceEvent>,
-  cause: Long,
+  cause: Long? = null,
   branches: List<TraceTree>,
 ): TraceTree =
   TraceTree.newBuilder()
     .addAllEvents(events)
-    .setReplication(Replication.newBuilder().setCause(cause).addAllBranches(branches))
+    .setReplication(
+      Replication.newBuilder().also { if (cause != null) it.setCause(cause) }.addAllBranches(branches)
+    )
     .build()
 
 /**
@@ -49,28 +52,28 @@ internal fun buildReplicationTree(
  */
 internal fun buildChoiceTree(
   events: List<TraceEvent>,
-  cause: Long,
+  cause: Long?,
   branches: List<TraceTree>,
 ): TraceTree =
   TraceTree.newBuilder()
     .addAllEvents(events)
-    .setChoice(Choice.newBuilder().setCause(cause).addAllBranches(branches))
+    .setChoice(Choice.newBuilder().also { if (cause != null) it.setCause(cause) }.addAllBranches(branches))
     .build()
 
 /**
  * Builds a [TraceTree] where the same packet continues as another pass. Used for resubmit,
  * recirculate, and forward stage transitions. [cause] is the id of the event that triggered the
- * re-parse; 0 when absent (forward transitions).
+ * re-parse; null when absent (forward transitions).
  */
 internal fun buildContinuationTree(
   events: List<TraceEvent>,
-  cause: Long = 0L,
+  cause: Long? = null,
   next: TraceTree,
 ): TraceTree =
   TraceTree.newBuilder()
     .addAllEvents(events)
     .setContinuation(
-      Continuation.newBuilder().also { if (cause != 0L) it.setCause(cause) }.setNext(next)
+      Continuation.newBuilder().also { if (cause != null) it.setCause(cause) }.setNext(next)
     )
     .build()
 

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -1,64 +1,95 @@
 package fourward.simulator
 
+import fourward.Choice
+import fourward.Continuation
 import fourward.Drop
-import fourward.DropReason
-import fourward.Fork
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.MulticastGroupLookupEvent
+import fourward.OutputPacket
 import fourward.PacketIngressEvent
-import fourward.PacketOutcome
 import fourward.PipelineStage
 import fourward.PipelineStageEvent
+import fourward.Replication
 import fourward.TraceEvent
 import fourward.TraceTree
 
-/**
- * Whether a fork's branches all happen (parallel) or only one happens (alternative).
- * - **Parallel** (clone, multicast, resubmit, recirculate): all branches execute simultaneously.
- *   Output packets are the union of all branch outputs.
- * - **Alternative** (action selector): exactly one branch executes at runtime. Each branch is a
- *   "possible world" — a distinct possible outcome set.
- */
-enum class ForkMode {
-  PARALLEL,
-  ALTERNATIVE,
-}
-
-/**
- * Maps a [ForkReason] to its [ForkMode].
- *
- * Exhaustive — adding a new [ForkReason] without updating this function is a compile error.
- */
-fun forkModeOf(reason: ForkReason): ForkMode =
-  when (reason) {
-    ForkReason.ACTION_SELECTOR -> ForkMode.ALTERNATIVE
-    ForkReason.CLONE,
-    ForkReason.MULTICAST,
-    ForkReason.RESUBMIT,
-    ForkReason.RECIRCULATE -> ForkMode.PARALLEL
-    ForkReason.FORK_REASON_UNSPECIFIED,
-    ForkReason.UNRECOGNIZED -> error("unexpected fork reason: $reason")
-  }
-
-/** Builds a [TraceTree] representing a dropped packet with the given trace events and reason. */
-internal fun buildDropTrace(
-  events: List<TraceEvent>,
-  reason: DropReason = DropReason.MARK_TO_DROP,
-): TraceTree {
-  val outcome = PacketOutcome.newBuilder().setDrop(Drop.newBuilder().setReason(reason)).build()
-  return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
+/** Builds a [TraceTree] representing a dropped packet with the given trace events. */
+internal fun buildDropTrace(events: List<TraceEvent>, triggerId: Long = 0L): TraceTree {
+  val drop = Drop.newBuilder().also { if (triggerId != 0L) it.setTrigger(triggerId) }.build()
+  return TraceTree.newBuilder().addAllEvents(events).setDrop(drop).build()
 }
 
 /** Builds a [TraceTree] representing a packet output on the given port. */
 internal fun buildOutputTrace(events: List<TraceEvent>, port: Int, payload: ByteArray): TraceTree {
   val output =
-    fourward.OutputPacket.newBuilder()
+    OutputPacket.newBuilder()
       .setDataplaneEgressPort(port)
       .setPayload(com.google.protobuf.ByteString.copyFrom(payload))
       .build()
-  val outcome = PacketOutcome.newBuilder().setOutput(output).build()
-  return TraceTree.newBuilder().addAllEvents(events).setPacketOutcome(outcome).build()
+  return TraceTree.newBuilder().addAllEvents(events).setOutput(output).build()
+}
+
+/**
+ * Builds a [TraceTree] where all branches execute simultaneously (clone, multicast). [cause] is the
+ * id of the CloneSessionLookupEvent or MulticastGroupLookupEvent that triggered the replication.
+ */
+internal fun buildReplicationTree(
+  events: List<TraceEvent>,
+  cause: Long,
+  branches: List<TraceTree>,
+): TraceTree =
+  TraceTree.newBuilder()
+    .addAllEvents(events)
+    .setReplication(Replication.newBuilder().setCause(cause).addAllBranches(branches))
+    .build()
+
+/**
+ * Builds a [TraceTree] where exactly one branch executes at runtime (action selector). [cause] is
+ * the id of the TableLookupEvent for the selector table.
+ */
+internal fun buildChoiceTree(
+  events: List<TraceEvent>,
+  cause: Long,
+  branches: List<TraceTree>,
+): TraceTree =
+  TraceTree.newBuilder()
+    .addAllEvents(events)
+    .setChoice(Choice.newBuilder().setCause(cause).addAllBranches(branches))
+    .build()
+
+/**
+ * Builds a [TraceTree] where the same packet continues as another pass. Used for resubmit,
+ * recirculate, and forward stage transitions. [cause] is the id of the event that triggered the
+ * re-parse; 0 when absent (forward transitions).
+ */
+internal fun buildContinuationTree(
+  events: List<TraceEvent>,
+  cause: Long = 0L,
+  next: TraceTree,
+): TraceTree =
+  TraceTree.newBuilder()
+    .addAllEvents(events)
+    .setContinuation(
+      Continuation.newBuilder().also { if (cause != 0L) it.setCause(cause) }.setNext(next)
+    )
+    .build()
+
+/**
+ * Prepends [prefix] events to [tree], returning a new [TraceTree] with the same outcome. Used when
+ * flattening sequential pipeline stages into a single node.
+ */
+internal fun prependEvents(tree: TraceTree, prefix: List<TraceEvent>): TraceTree {
+  if (prefix.isEmpty()) return tree
+  val b = TraceTree.newBuilder().addAllEvents(prefix).addAllEvents(tree.eventsList)
+  when (tree.outcomeCase) {
+    TraceTree.OutcomeCase.REPLICATION -> b.setReplication(tree.replication)
+    TraceTree.OutcomeCase.CHOICE -> b.setChoice(tree.choice)
+    TraceTree.OutcomeCase.CONTINUATION -> b.setContinuation(tree.continuation)
+    TraceTree.OutcomeCase.OUTPUT -> b.setOutput(tree.output)
+    TraceTree.OutcomeCase.DROP -> b.setDrop(tree.drop)
+    TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+    null -> {}
+  }
+  return b.build()
 }
 
 /** Creates a [TraceEvent] recording the packet's ingress port. */
@@ -102,15 +133,4 @@ internal fun multicastGroupMissEvent(groupId: Int): TraceEvent =
     .setMulticastGroupLookup(
       MulticastGroupLookupEvent.newBuilder().setMulticastGroupId(groupId).setGroupFound(false)
     )
-    .build()
-
-/** Builds a [TraceTree] with a fork outcome from accumulated events and branches. */
-internal fun buildForkTree(
-  events: List<TraceEvent>,
-  reason: ForkReason,
-  branches: List<ForkBranch>,
-): TraceTree =
-  TraceTree.newBuilder()
-    .addAllEvents(events)
-    .setForkOutcome(Fork.newBuilder().setReason(reason).addAllBranches(branches))
     .build()

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -472,11 +472,7 @@ class V1ModelArchitecture(
     original: TraceTree,
     clones: List<TraceTree>,
   ): PipelineResult {
-    val branches =
-      buildList(clones.size + 1) {
-        add(original)
-        addAll(clones)
-      }
+    val branches = listOf(original) + clones
     val causeId = eventsBeforeFork.lastOrNull()?.id
     return PipelineResult(buildReplicationTree(eventsBeforeFork, branches, causeId))
   }

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -337,7 +337,7 @@ class V1ModelArchitecture(
         fork.replicas.map(buildBranch)
       }
     val causeId = fork.eventsBeforeFork.lastOrNull()?.id
-    return PipelineResult(buildReplicationTree(fork.eventsBeforeFork, causeId, branches))
+    return PipelineResult(buildReplicationTree(fork.eventsBeforeFork, branches, causeId))
   }
 
   /**
@@ -478,7 +478,7 @@ class V1ModelArchitecture(
         addAll(clones)
       }
     val causeId = eventsBeforeFork.lastOrNull()?.id
-    return PipelineResult(buildReplicationTree(eventsBeforeFork, causeId, branches))
+    return PipelineResult(buildReplicationTree(eventsBeforeFork, branches, causeId))
   }
 
   /** Resubmit: the same packet re-enters the pipeline — modeled as a Continuation. */

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -3,6 +3,7 @@ package fourward.simulator
 import fourward.BehavioralConfig
 import fourward.CloneEvent
 import fourward.CloneSessionLookupEvent
+import fourward.ContinuationEvent
 import fourward.DropReason
 import fourward.LogMessageEvent
 import fourward.MarkToDropEvent
@@ -494,7 +495,10 @@ class V1ModelArchitecture(
         preservedMetadata = fork.preservedMetadata,
       )
     val next = buildTraceTree(ctx, decisions).trace
-    return PipelineResult(buildContinuationTree(fork.eventsBeforeFork, next = next))
+    val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+    return PipelineResult(
+      buildContinuationTree(fork.eventsBeforeFork, cause = causeId, next = next)
+    )
   }
 
   /** Recirculate: the deparsed packet re-enters the pipeline — modeled as a Continuation. */
@@ -511,7 +515,10 @@ class V1ModelArchitecture(
       )
     val next =
       buildTraceTree(ctx.copy(packet = PacketBits.ofBytes(fork.deparsedBytes)), decisions).trace
-    return PipelineResult(buildContinuationTree(fork.eventsBeforeFork, next = next))
+    val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+    return PipelineResult(
+      buildContinuationTree(fork.eventsBeforeFork, cause = causeId, next = next)
+    )
   }
 
   /**
@@ -731,11 +738,14 @@ class V1ModelArchitecture(
     val outputBytes = truncateOutput(s.packetCtx.deparsedPayload(), s.pendingOps.truncateBytes)
 
     if (s.pendingOps.recirculate) {
-      throw RecirculateFork(
-        outputBytes,
-        s.packetCtx.getEvents(),
-        snapshotPreservedMetadata(s, s.pendingOps.recirculateFieldListId),
+      val preservedMeta = snapshotPreservedMetadata(s, s.pendingOps.recirculateFieldListId)
+      s.packetCtx.addTraceEvent(
+        continuationTriggerEvent(
+          ContinuationEvent.Kind.RECIRCULATE,
+          formatPreservedMeta(preservedMeta),
+        )
       )
+      throw RecirculateFork(outputBytes, s.packetCtx.getEvents(), preservedMeta)
     }
 
     val egressPort =
@@ -823,10 +833,14 @@ class V1ModelArchitecture(
       }
     }
     if (s.pendingOps.resubmit) {
-      throw ResubmitFork(
-        s.packetCtx.getEvents(),
-        snapshotPreservedMetadata(s, s.pendingOps.resubmitFieldListId),
+      val preservedMeta = snapshotPreservedMetadata(s, s.pendingOps.resubmitFieldListId)
+      s.packetCtx.addTraceEvent(
+        continuationTriggerEvent(
+          ContinuationEvent.Kind.RESUBMIT,
+          formatPreservedMeta(preservedMeta),
+        )
       )
+      throw ResubmitFork(s.packetCtx.getEvents(), preservedMeta)
     }
     val mcastGrp = (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
     if (mcastGrp != 0) {
@@ -907,6 +921,19 @@ class V1ModelArchitecture(
         .mapNotNull { decl -> allFields[decl.name]?.let { decl.name to it } }
         .toMap()
     return preserved.ifEmpty { null }
+  }
+
+  /** Converts a [Value] snapshot to a string for [ContinuationEvent.preserved_fields]. */
+  private fun formatPreservedMeta(meta: Map<String, Value>?): Map<String, String> {
+    if (meta == null) return emptyMap()
+    return meta.mapValues { (_, v) ->
+      when (v) {
+        is BitVal -> v.bits.value.toString()
+        is BoolVal -> v.value.toString()
+        is EnumVal -> v.member
+        else -> v.toString()
+      }
+    }
   }
 
   /** Post-egress drop check: mark_to_drop() in egress sets egress_spec to drop port. */

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -4,8 +4,6 @@ import fourward.BehavioralConfig
 import fourward.CloneEvent
 import fourward.CloneSessionLookupEvent
 import fourward.DropReason
-import fourward.ForkBranch
-import fourward.ForkReason
 import fourward.LogMessageEvent
 import fourward.MarkToDropEvent
 import fourward.PipelineStage
@@ -175,13 +173,8 @@ class V1ModelArchitecture(
         fork.members.map(buildBranch)
       }
 
-    val branches =
-      fork.members.zip(traces).map { (member, trace) ->
-        ForkBranch.newBuilder().setLabel("member_${member.memberId}").setSubtree(trace).build()
-      }
-    return PipelineResult(
-      buildForkTree(fork.eventsBeforeFork, ForkReason.ACTION_SELECTOR, branches)
-    )
+    val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+    return PipelineResult(buildChoiceTree(fork.eventsBeforeFork, causeId, traces))
   }
 
   // -------------------------------------------------------------------------
@@ -233,7 +226,7 @@ class V1ModelArchitecture(
     } catch (nestedFork: ForkException) {
       handleFork(ctx, nestedFork).trace
     } catch (_: AssertionFailureException) {
-      buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+      buildDropTrace(s.packetCtx.getEvents(), s.packetCtx.lastEventIdWhere { it.hasAssertion() })
     }
   }
 
@@ -305,13 +298,19 @@ class V1ModelArchitecture(
       if (selectorFork.duringIngress) {
         ingressEgressBoundary(ctx, s)
         if (egressPortIsDropPort(s)) {
-          return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+          return buildDropTrace(
+            s.packetCtx.getEvents(),
+            s.packetCtx.lastEventIdWhere { it.hasMarkToDrop() },
+          )
         }
         return runEgressAndDeparser(ctx, s)
       }
       return runPostEgressAndDeparser(ctx, s)
     } catch (_: AssertionFailureException) {
-      return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+      return buildDropTrace(
+        s.packetCtx.getEvents(),
+        s.packetCtx.lastEventIdWhere { it.hasAssertion() },
+      )
     }
   }
 
@@ -331,20 +330,14 @@ class V1ModelArchitecture(
         pipelineTail = { c, s -> runEgressAndDeparser(c, s) },
       )
     }
-    val results =
+    val branches =
       if (INTRA_PACKET_PARALLELISM_ENABLED) {
         fork.replicas.parallelStream().map(buildBranch).toList()
       } else {
         fork.replicas.map(buildBranch)
       }
-    val branches =
-      fork.replicas.zip(results).map { (replica, trace) ->
-        ForkBranch.newBuilder()
-          .setLabel("replica_${replica.rid}_port_${replica.port}")
-          .setSubtree(trace)
-          .build()
-      }
-    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.MULTICAST, branches))
+    val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+    return PipelineResult(buildReplicationTree(fork.eventsBeforeFork, causeId, branches))
   }
 
   /**
@@ -362,7 +355,10 @@ class V1ModelArchitecture(
         pipelineTail = { c, s ->
           ingressEgressBoundary(c, s)
           if (egressPortIsDropPort(s))
-            buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+            buildDropTrace(
+              s.packetCtx.getEvents(),
+              s.packetCtx.lastEventIdWhere { it.hasMarkToDrop() },
+            )
           else runEgressAndDeparser(c, s)
         },
       )
@@ -370,7 +366,6 @@ class V1ModelArchitecture(
     return assembleCloneFork(
       fork.eventsBeforeFork,
       original,
-      fork.replicas,
       buildCloneBranches(
         cloneCtx,
         fork.replicas,
@@ -402,7 +397,10 @@ class V1ModelArchitecture(
         configure = { s -> s.pendingOps.egressCloneSessionId = null },
         pipelineTail = { _, s ->
           if (egressSpecIsDropPort(s))
-            buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+            buildDropTrace(
+              s.packetCtx.getEvents(),
+              s.packetCtx.lastEventIdWhere { it.hasMarkToDrop() },
+            )
           else runDeparser(s)
         },
       )
@@ -410,7 +408,6 @@ class V1ModelArchitecture(
     return assembleCloneFork(
       fork.eventsBeforeFork,
       original,
-      fork.replicas,
       buildCloneBranches(
         cloneCtx,
         fork.replicas,
@@ -423,7 +420,10 @@ class V1ModelArchitecture(
         resetEgressSpec(s)
         runControlStages(s, s.egressControls, dataplanePort = readEgressPort(s))
         if (egressSpecIsDropPort(s))
-          buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+          buildDropTrace(
+            s.packetCtx.getEvents(),
+            s.packetCtx.lastEventIdWhere { it.hasMarkToDrop() },
+          )
         else runDeparser(s)
       },
     )
@@ -466,29 +466,22 @@ class V1ModelArchitecture(
     }
   }
 
-  /** Assembles the "original" branch + clone branches into a CLONE fork result. */
+  /** Assembles the "original" branch + clone branches into a Replication result. */
   private fun assembleCloneFork(
     eventsBeforeFork: List<TraceEvent>,
     original: TraceTree,
-    replicas: List<Replica>,
     clones: List<TraceTree>,
   ): PipelineResult {
     val branches =
-      buildList(replicas.size + 1) {
-        add(ForkBranch.newBuilder().setLabel("original").setSubtree(original).build())
-        replicas.zip(clones).mapTo(this) { (replica, trace) ->
-          ForkBranch.newBuilder()
-            .setLabel(
-              if (replicas.size == 1) "clone" else "clone_${replica.rid}_port_${replica.port}"
-            )
-            .setSubtree(trace)
-            .build()
-        }
+      buildList(clones.size + 1) {
+        add(original)
+        addAll(clones)
       }
-    return PipelineResult(buildForkTree(eventsBeforeFork, ForkReason.CLONE, branches))
+    val causeId = eventsBeforeFork.lastOrNull()?.id ?: 0L
+    return PipelineResult(buildReplicationTree(eventsBeforeFork, causeId, branches))
   }
 
-  /** Resubmit: restarts the pipeline with preserved metadata. */
+  /** Resubmit: the same packet re-enters the pipeline — modeled as a Continuation. */
   private fun buildResubmitForkTree(
     ctx: PipelineContext,
     fork: ResubmitFork,
@@ -500,15 +493,11 @@ class V1ModelArchitecture(
         instanceTypeOverride = RESUBMIT_INSTANCE_TYPE,
         preservedMetadata = fork.preservedMetadata,
       )
-    val branch =
-      ForkBranch.newBuilder()
-        .setLabel("resubmit")
-        .setSubtree(buildTraceTree(ctx, decisions).trace)
-        .build()
-    return PipelineResult(buildForkTree(fork.eventsBeforeFork, ForkReason.RESUBMIT, listOf(branch)))
+    val next = buildTraceTree(ctx, decisions).trace
+    return PipelineResult(buildContinuationTree(fork.eventsBeforeFork, next = next))
   }
 
-  /** Recirculate: restarts the pipeline with deparsed bytes. */
+  /** Recirculate: the deparsed packet re-enters the pipeline — modeled as a Continuation. */
   private fun buildRecirculateForkTree(
     ctx: PipelineContext,
     fork: RecirculateFork,
@@ -520,16 +509,9 @@ class V1ModelArchitecture(
         instanceTypeOverride = RECIRC_INSTANCE_TYPE,
         preservedMetadata = fork.preservedMetadata,
       )
-    val branch =
-      ForkBranch.newBuilder()
-        .setLabel("recirculate")
-        .setSubtree(
-          buildTraceTree(ctx.copy(packet = PacketBits.ofBytes(fork.deparsedBytes)), decisions).trace
-        )
-        .build()
-    return PipelineResult(
-      buildForkTree(fork.eventsBeforeFork, ForkReason.RECIRCULATE, listOf(branch))
-    )
+    val next =
+      buildTraceTree(ctx.copy(packet = PacketBits.ofBytes(fork.deparsedBytes)), decisions).trace
+    return PipelineResult(buildContinuationTree(fork.eventsBeforeFork, next = next))
   }
 
   /**
@@ -665,7 +647,8 @@ class V1ModelArchitecture(
     s.packetCtx.addTraceEvent(packetIngressEvent(ctx.ingressPort))
     val parserExitDrop = runParser(s)
     s.postParserEnv = s.env.deepCopy()
-    if (parserExitDrop) return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+    // Parser exit drops the packet without a mark_to_drop() call — trigger is absent.
+    if (parserExitDrop) return buildDropTrace(s.packetCtx.getEvents())
 
     // An assert()/assume() failure anywhere in the pipeline drops the packet.
     try {
@@ -680,13 +663,19 @@ class V1ModelArchitecture(
       // --- Ingress→egress boundary (traffic manager) ---
       ingressEgressBoundary(ctx, s)
       if (egressPortIsDropPort(s)) {
-        return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+        return buildDropTrace(
+          s.packetCtx.getEvents(),
+          s.packetCtx.lastEventIdWhere { it.hasMarkToDrop() },
+        )
       }
 
       // --- Egress + deparser ---
       return runEgressAndDeparser(ctx, s)
     } catch (_: AssertionFailureException) {
-      return buildDropTrace(s.packetCtx.getEvents(), DropReason.ASSERTION_FAILURE)
+      return buildDropTrace(
+        s.packetCtx.getEvents(),
+        s.packetCtx.lastEventIdWhere { it.hasAssertion() },
+      )
     }
   }
 
@@ -701,7 +690,10 @@ class V1ModelArchitecture(
     postEgressBoundary(ctx, s)
 
     if (egressSpecIsDropPort(s)) {
-      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+      return buildDropTrace(
+        s.packetCtx.getEvents(),
+        s.packetCtx.lastEventIdWhere { it.hasMarkToDrop() },
+      )
     }
 
     return runDeparser(s)
@@ -715,7 +707,10 @@ class V1ModelArchitecture(
     postEgressBoundary(ctx, s)
 
     if (egressSpecIsDropPort(s)) {
-      return buildDropTrace(s.packetCtx.getEvents(), DropReason.MARK_TO_DROP)
+      return buildDropTrace(
+        s.packetCtx.getEvents(),
+        s.packetCtx.lastEventIdWhere { it.hasMarkToDrop() },
+      )
     }
 
     return runDeparser(s)

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -924,17 +924,8 @@ class V1ModelArchitecture(
   }
 
   /** Converts a [Value] snapshot to a string for [ContinuationEvent.preserved_fields]. */
-  private fun formatPreservedMeta(meta: Map<String, Value>?): Map<String, String> {
-    if (meta == null) return emptyMap()
-    return meta.mapValues { (_, v) ->
-      when (v) {
-        is BitVal -> v.bits.value.toString()
-        is BoolVal -> v.value.toString()
-        is EnumVal -> v.member
-        else -> v.toString()
-      }
-    }
-  }
+  private fun formatPreservedMeta(meta: Map<String, Value>?): Map<String, String> =
+    meta?.mapValues { (_, v) -> formatValue(v) } ?: emptyMap()
 
   /** Post-egress drop check: mark_to_drop() in egress sets egress_spec to drop port. */
   private fun egressSpecIsDropPort(s: PipelineState): Boolean =

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -3,8 +3,7 @@ package fourward.simulator
 import fourward.BehavioralConfig
 import fourward.CloneEvent
 import fourward.CloneSessionLookupEvent
-import fourward.ContinuationEvent
-import fourward.DropReason
+import fourward.Continuation
 import fourward.LogMessageEvent
 import fourward.MarkToDropEvent
 import fourward.PipelineStage
@@ -495,9 +494,13 @@ class V1ModelArchitecture(
         preservedMetadata = fork.preservedMetadata,
       )
     val next = buildTraceTree(ctx, decisions).trace
-    val causeId = fork.eventsBeforeFork.lastOrNull()?.id
     return PipelineResult(
-      buildContinuationTree(fork.eventsBeforeFork, cause = causeId, next = next)
+      buildContinuationTree(
+        fork.eventsBeforeFork,
+        kind = Continuation.Kind.RESUBMIT,
+        preservedFields = formatPreservedMeta(fork.preservedMetadata),
+        next = next,
+      )
     )
   }
 
@@ -515,9 +518,13 @@ class V1ModelArchitecture(
       )
     val next =
       buildTraceTree(ctx.copy(packet = PacketBits.ofBytes(fork.deparsedBytes)), decisions).trace
-    val causeId = fork.eventsBeforeFork.lastOrNull()?.id
     return PipelineResult(
-      buildContinuationTree(fork.eventsBeforeFork, cause = causeId, next = next)
+      buildContinuationTree(
+        fork.eventsBeforeFork,
+        kind = Continuation.Kind.RECIRCULATE,
+        preservedFields = formatPreservedMeta(fork.preservedMetadata),
+        next = next,
+      )
     )
   }
 
@@ -739,12 +746,6 @@ class V1ModelArchitecture(
 
     if (s.pendingOps.recirculate) {
       val preservedMeta = snapshotPreservedMetadata(s, s.pendingOps.recirculateFieldListId)
-      s.packetCtx.addTraceEvent(
-        continuationTriggerEvent(
-          ContinuationEvent.Kind.RECIRCULATE,
-          formatPreservedMeta(preservedMeta),
-        )
-      )
       throw RecirculateFork(outputBytes, s.packetCtx.getEvents(), preservedMeta)
     }
 
@@ -834,12 +835,6 @@ class V1ModelArchitecture(
     }
     if (s.pendingOps.resubmit) {
       val preservedMeta = snapshotPreservedMetadata(s, s.pendingOps.resubmitFieldListId)
-      s.packetCtx.addTraceEvent(
-        continuationTriggerEvent(
-          ContinuationEvent.Kind.RESUBMIT,
-          formatPreservedMeta(preservedMeta),
-        )
-      )
       throw ResubmitFork(s.packetCtx.getEvents(), preservedMeta)
     }
     val mcastGrp = (s.standardMetadata.fields["mcast_grp"] as? BitVal)?.bits?.value?.toInt() ?: 0
@@ -923,7 +918,7 @@ class V1ModelArchitecture(
     return preserved.ifEmpty { null }
   }
 
-  /** Converts a [Value] snapshot to a string for [ContinuationEvent.preserved_fields]. */
+  /** Converts a [Value] snapshot to a string for [Continuation.preserved_fields]. */
   private fun formatPreservedMeta(meta: Map<String, Value>?): Map<String, String> =
     meta?.mapValues { (_, v) -> formatValue(v) } ?: emptyMap()
 
@@ -1058,10 +1053,7 @@ class V1ModelArchitecture(
       // mark_to_drop(standard_metadata): sets egress_spec to the drop port.
       "mark_to_drop" -> {
         eval.addTraceEvent(
-          eval
-            .traceEventBuilder()
-            .setMarkToDrop(MarkToDropEvent.newBuilder().setReason(DropReason.MARK_TO_DROP))
-            .build()
+          eval.traceEventBuilder().setMarkToDrop(MarkToDropEvent.newBuilder()).build()
         )
         val smeta = eval.evalArg(0) as StructVal
         smeta.fields["egress_spec"] = BitVal(dropPort, smeta.bitWidth("egress_spec"))

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -174,7 +174,7 @@ class V1ModelArchitecture(
         fork.members.map(buildBranch)
       }
 
-    val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+    val causeId = fork.eventsBeforeFork.lastOrNull()?.id
     return PipelineResult(buildChoiceTree(fork.eventsBeforeFork, causeId, traces))
   }
 
@@ -337,7 +337,7 @@ class V1ModelArchitecture(
       } else {
         fork.replicas.map(buildBranch)
       }
-    val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+    val causeId = fork.eventsBeforeFork.lastOrNull()?.id
     return PipelineResult(buildReplicationTree(fork.eventsBeforeFork, causeId, branches))
   }
 
@@ -478,7 +478,7 @@ class V1ModelArchitecture(
         add(original)
         addAll(clones)
       }
-    val causeId = eventsBeforeFork.lastOrNull()?.id ?: 0L
+    val causeId = eventsBeforeFork.lastOrNull()?.id
     return PipelineResult(buildReplicationTree(eventsBeforeFork, causeId, branches))
   }
 
@@ -495,7 +495,7 @@ class V1ModelArchitecture(
         preservedMetadata = fork.preservedMetadata,
       )
     val next = buildTraceTree(ctx, decisions).trace
-    val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+    val causeId = fork.eventsBeforeFork.lastOrNull()?.id
     return PipelineResult(
       buildContinuationTree(fork.eventsBeforeFork, cause = causeId, next = next)
     )
@@ -515,7 +515,7 @@ class V1ModelArchitecture(
       )
     val next =
       buildTraceTree(ctx.copy(packet = PacketBits.ofBytes(fork.deparsedBytes)), decisions).trace
-    val causeId = fork.eventsBeforeFork.lastOrNull()?.id ?: 0L
+    val causeId = fork.eventsBeforeFork.lastOrNull()?.id
     return PipelineResult(
       buildContinuationTree(fork.eventsBeforeFork, cause = causeId, next = next)
     )

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -6,6 +6,7 @@ import fourward.BehavioralConfig
 import fourward.BinaryOp
 import fourward.BinaryOperator
 import fourward.BlockStmt
+import fourward.Continuation
 import fourward.ControlDecl
 import fourward.ExitStmt
 import fourward.Expr
@@ -21,7 +22,6 @@ import fourward.PipelineStageEvent.Direction
 import fourward.StageKind
 import fourward.Stmt
 import fourward.StructDecl
-import fourward.Continuation
 import fourward.TraceEvent
 import fourward.TraceTree
 import fourward.Transition

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -21,6 +21,7 @@ import fourward.PipelineStageEvent.Direction
 import fourward.StageKind
 import fourward.Stmt
 import fourward.StructDecl
+import fourward.Continuation
 import fourward.TraceEvent
 import fourward.TraceTree
 import fourward.Transition
@@ -558,6 +559,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasDrop())
+    assertFalse(result.trace.drop.hasCause())
   }
 
   @Test
@@ -1074,6 +1076,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasContinuation())
+    assertEquals(Continuation.Kind.RESUBMIT, result.trace.continuation.kind)
   }
 
   @Test
@@ -1093,6 +1096,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasContinuation())
+    assertEquals(Continuation.Kind.RECIRCULATE, result.trace.continuation.kind)
   }
 
   @Test

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -7,12 +7,10 @@ import fourward.BinaryOp
 import fourward.BinaryOperator
 import fourward.BlockStmt
 import fourward.ControlDecl
-import fourward.DropReason
 import fourward.ExitStmt
 import fourward.Expr
 import fourward.FieldAccess
 import fourward.FieldDecl
-import fourward.ForkReason
 import fourward.IfStmt
 import fourward.Literal
 import fourward.ParamDecl
@@ -559,8 +557,7 @@ class V1ModelArchitectureTest {
       )
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -582,8 +579,7 @@ class V1ModelArchitectureTest {
       result.trace.eventsList.filter { it.hasPipelineStage() }.map { it.pipelineStage.stageName }
     assertTrue("egress should not appear in trace", "egress" !in stageNames)
     assertTrue("compute_checksum should not appear in trace", "compute_checksum" !in stageNames)
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -719,9 +715,8 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
-    assertEquals(2, result.trace.forkOutcome.branchesCount)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(2, result.trace.replication.branchesCount)
   }
 
   @Test
@@ -738,12 +733,8 @@ class V1ModelArchitectureTest {
     val payload = byteArrayOf(0xAA.toByte())
     val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(2, branches.size)
-    assertEquals("original", branches[0].label)
-    assertEquals("clone", branches[1].label)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(2, result.trace.replication.branchesCount)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
@@ -862,12 +853,8 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(2, branches.size)
-    assertEquals("original", branches[0].label)
-    assertEquals("clone", branches[1].label)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(2, result.trace.replication.branchesCount)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
@@ -926,13 +913,8 @@ class V1ModelArchitectureTest {
     val result =
       V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(3, branches.size)
-    assertEquals("original", branches[0].label)
-    assertEquals("clone_10_port_7", branches[1].label)
-    assertEquals("clone_20_port_8", branches[2].label)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(3, result.trace.replication.branchesCount)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(3, outputs.size)
@@ -963,11 +945,8 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(3, branches.size)
-    assertEquals("original", branches[0].label)
+    assertTrue(result.trace.hasReplication())
+    assertEquals(3, result.trace.replication.branchesCount)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(3, outputs.size)
@@ -1094,11 +1073,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(1, branches.size)
-    assertEquals("resubmit", branches[0].label)
+    assertTrue(result.trace.hasContinuation())
   }
 
   @Test
@@ -1117,11 +1092,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
-    val branches = result.trace.forkOutcome.branchesList
-    assertEquals(1, branches.size)
-    assertEquals("recirculate", branches[0].label)
+    assertTrue(result.trace.hasContinuation())
   }
 
   @Test
@@ -1136,7 +1107,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertFalse(result.trace.hasForkOutcome())
+    assertFalse(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(2, outputs[0].dataplaneEgressPort)
@@ -1154,7 +1125,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertFalse(result.trace.hasForkOutcome())
+    assertFalse(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
@@ -1174,7 +1145,7 @@ class V1ModelArchitectureTest {
       byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte())
     val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     assertEquals(5, outputs[0].payload.size())
@@ -1196,7 +1167,7 @@ class V1ModelArchitectureTest {
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte())
     val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     assertEquals(4, outputs[0].payload.size())
@@ -1293,7 +1264,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     // Original is dropped (mark_to_drop set egress_spec to drop port).
     // Clone survives on port 7.
@@ -1327,7 +1298,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     // Original is dropped (egress mark_to_drop). Clone survives on port 8.
     assertEquals(1, outputs.size)
@@ -1436,9 +1407,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     // Should be a drop.
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.MARK_TO_DROP, result.trace.packetOutcome.drop.reason)
+    assertTrue(result.trace.hasDrop())
 
     // Parser EXIT event must be present even though the parser exited early.
     val events = stageEvents(result.trace)
@@ -1494,8 +1463,7 @@ class V1ModelArchitectureTest {
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", dropPort, portBits))
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -1520,8 +1488,7 @@ class V1ModelArchitectureTest {
     val config = widePortConfig(portBits, markToDrop)
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -1585,8 +1552,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     // Both original and clone produce output (metadata was preserved, so no drop).
     assertEquals(2, outputs.size)
@@ -1631,8 +1597,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
     assertEquals(3, outputs[0].dataplaneEgressPort)
@@ -1719,8 +1684,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasContinuation())
     val outputs = result.possibleOutcomes.single()
     // Resubmit branch outputs (metadata was preserved, so no drop).
     assertEquals(1, outputs.size)
@@ -1772,8 +1736,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasForkOutcome())
-    assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
+    assertTrue(result.trace.hasContinuation())
     val outputs = result.possibleOutcomes.single()
     // Recirculate branch outputs (metadata was preserved, so no drop).
     assertEquals(1, outputs.size)
@@ -1817,7 +1780,7 @@ class V1ModelArchitectureTest {
 
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
-    assertTrue(result.trace.hasForkOutcome())
+    assertTrue(result.trace.hasReplication())
     val outputs = result.possibleOutcomes.single()
     // Clone should NOT drop: not_preserved was reset to 0, so 0x1234 check is false.
     assertEquals(2, outputs.size)
@@ -1844,25 +1807,21 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `assert false drops packet with ASSERTION_FAILURE reason`() {
+  fun `assert false drops packet`() {
     val config = v1modelConfig(externCall("assert", boolLit(false)))
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.ASSERTION_FAILURE, result.trace.packetOutcome.drop.reason)
+    assertTrue(result.trace.hasDrop())
     // Trace should contain a failing assertion event.
     assertTrue(result.trace.eventsList.any { it.hasAssertion() && !it.assertion.passed })
   }
 
   @Test
-  fun `assume false drops packet with ASSERTION_FAILURE reason`() {
+  fun `assume false drops packet`() {
     val config = v1modelConfig(externCall("assume", boolLit(false)))
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.ASSERTION_FAILURE, result.trace.packetOutcome.drop.reason)
+    assertTrue(result.trace.hasDrop())
   }
 
   // ---------------------------------------------------------------------------
@@ -1902,7 +1861,7 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `egress assert false drops packet with ASSERTION_FAILURE reason`() {
+  fun `egress assert false drops packet`() {
     val config =
       v1modelConfig(
         ingressStmts =
@@ -1911,9 +1870,7 @@ class V1ModelArchitectureTest {
       )
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
-    assertEquals(DropReason.ASSERTION_FAILURE, result.trace.packetOutcome.drop.reason)
+    assertTrue(result.trace.hasDrop())
   }
 
   // ---------------------------------------------------------------------------
@@ -1929,8 +1886,7 @@ class V1ModelArchitectureTest {
       V1ModelArchitecture(config, dropPortOverride = DataplanePort.fromUnsignedLong(42))
         .processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -1955,8 +1911,7 @@ class V1ModelArchitectureTest {
       V1ModelArchitecture(config, dropPortOverride = DataplanePort.fromUnsignedLong(42))
         .processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   @Test
@@ -1968,8 +1923,7 @@ class V1ModelArchitectureTest {
       V1ModelArchitecture(config, dropPortOverride = null)
         .processPacket(port(0), byteArrayOf(0x01), TableStore())
 
-    assertTrue(result.trace.hasPacketOutcome())
-    assertTrue(result.trace.packetOutcome.hasDrop())
+    assertTrue(result.trace.hasDrop())
   }
 
   companion object {

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -48,79 +48,83 @@ message OutputPacket {
 //
 // A complete record of every decision the simulator made while processing a
 // packet.  Events within a node are ordered chronologically.  At
-// non-deterministic choice points the tree forks: each branch represents one
-// possible outcome and contains its own subtree of events.
+// branch points the tree forks: each branch represents one possible execution
+// path and contains its own subtree of events.
 //
-// Every node terminates: either forking (fork_outcome) or reaching a final
-// packet fate (packet_outcome).  A zero-fork tree has a single
-// packet_outcome at the root.
+// Every node terminates with exactly one outcome — a fork (Replication or
+// Choice), a Continuation into another pass, an Output, or a Drop.
 // =============================================================================
 
 // Recursive trace structure: a sequence of events followed by an outcome.
-// Shared prefix events (e.g. the parser trace before a selector fork) live in
-// the parent node; per-branch events live in the fork's subtrees.
+// Shared prefix events live in the parent node; per-branch events in subtrees.
 message TraceTree {
   repeated TraceEvent events = 1;
+  reserved 2,
+      3;  // formerly fork_outcome (Fork) and packet_outcome (PacketOutcome)
   oneof outcome {
-    Fork fork_outcome = 2;
-    PacketOutcome packet_outcome = 3;
+    // All branches happen simultaneously; outputs are the union.
+    // Cause: clone session or multicast group lookup that triggered the copies.
+    Replication replication = 4;
+
+    // Exactly one branch happens at runtime (possible worlds).
+    // Cause: the table-apply event for the action selector.
+    Choice choice = 5;
+
+    // The same packet continues as another parser-to-deparser pass.
+    // Cause: the resubmit/recirculate primitive (absent for forward
+    // transitions).
+    Continuation continuation = 6;
+
+    // Terminal: packet emitted on a port.
+    OutputPacket output = 7;
+
+    // Terminal: packet discarded.
+    Drop drop = 8;
   }
 }
 
-// A non-deterministic choice point where execution forks into multiple
-// possible paths.
-//
-// Forks come in two flavors (see ForkMode):
-//
-//  • **Parallel** (clone, multicast, resubmit, recirculate) — all branches
-//    execute simultaneously in a single real execution.  The packet outputs
-//    are the union of all branch outputs.
-//
-//  • **Alternative** (action selector) — exactly one branch executes at
-//    runtime (determined by a hash function).  Each branch represents one
-//    *possible world*; the trace tree explores all of them.
-//
-// This distinction matters when collecting output packets from the tree:
-// parallel branches are combined (union), while alternative branches are
-// kept separate (each is a distinct possible outcome set).
-message Fork {
-  ForkReason reason = 1;
-  repeated ForkBranch branches = 2;
+// All branches execute; their output packets are the union.
+// Used for clone (I2E/E2E) and multicast replication.
+// `cause` references the CloneSessionLookupEvent or MulticastGroupLookupEvent
+// whose id is in the enclosing node's events stream.
+message Replication {
+  uint64 cause = 1;                 // id of the typed event that triggered this
+  repeated TraceTree branches = 2;  // ≥ 1 branch
 }
 
-// One branch of a fork.  The label describes this particular outcome (e.g. the
-// action selector member name or "clone"/"original").
-message ForkBranch {
-  string label = 1;
-  TraceTree subtree = 2;
+// Exactly one branch executes at runtime.
+// Used for action selector groups (the selected member is unknown statically).
+// `cause` references the TableLookupEvent for the selector table.
+message Choice {
+  uint64 cause = 1;                 // id of the typed event that triggered this
+  repeated TraceTree branches = 2;  // ≥ 2 branches
 }
 
-// Whether a fork's branches all happen or only one happens is determined by
-// the ForkReason.  See ForkMode in the simulator Kotlin code.
-enum ForkReason {
-  FORK_REASON_UNSPECIFIED = 0;
-  ACTION_SELECTOR = 1;  // Alternative: one member is selected by hash.
-  CLONE = 2;            // Parallel: original + clone(s) all execute.
-  MULTICAST = 3;        // Parallel: one replica per multicast group member.
-  RESUBMIT = 4;         // Parallel: packet re-enters the pipeline.
-  RECIRCULATE = 5;      // Parallel: deparsed packet loops back.
+// The same packet continues as another parser-to-deparser pass.
+// Used for resubmit, recirculate, and forward stage transitions.
+// `cause` is absent for normal forward transitions; present for backward ones
+// when a specific event recorded the primitive (e.g. a recirculate/resubmit).
+message Continuation {
+  optional uint64 cause = 1;  // id of the event that triggered the re-parse
+  TraceTree next = 2;         // exactly one successor
 }
 
-// The terminal fate of a packet: either output on a port or dropped.
-message PacketOutcome {
-  oneof outcome {
-    OutputPacket output = 1;
-    Drop drop = 2;
-  }
-}
-
-// A packet that was dropped (as opposed to MarkToDropEvent, which records the
-// mark_to_drop() call site in the trace).
+// A packet that was dropped.  `trigger` is absent when the packet fell off the
+// end of the pipeline with no forwarding decision (the implicit default).
+// When present, the referenced event's type identifies the cause:
+//   MarkToDropEvent  → explicit mark_to_drop() call
+//   AssertionEvent   → assert()/assume() failure
+//   MulticastGroupLookupEvent with group_found=false → multicast to empty group
 message Drop {
-  DropReason reason = 1;
+  optional uint64 trigger = 1;  // id of the event that caused the drop, if any
 }
 
 message TraceEvent {
+  // Trace-global identifier, assigned by the simulator in emission order.
+  // Referenced by Replication.cause, Choice.cause, Continuation.cause, and
+  // Drop.trigger to identify which event triggered each outcome.
+  uint64 id = 16;
+
   oneof event {
     // Pipeline lifecycle.
     PacketIngressEvent packet_ingress = 8;
@@ -299,11 +303,9 @@ message AssignmentEvent {
   string target = 1;  // LHS field path (e.g. "standard_metadata.egress_spec")
 }
 
+// Used only by MarkToDropEvent to classify the call site.
+// Drop.trigger identifies the cause by referencing the event directly.
 enum DropReason {
   DROP_REASON_UNSPECIFIED = 0;
-  MARK_TO_DROP = 1;   // explicit mark_to_drop()
-  PARSER_REJECT = 2;  // parser transitioned to reject state
-  PIPELINE_EXECUTION_LIMIT_REACHED =
-      3;                  // too many fork branches (exponential blowup guard)
-  ASSERTION_FAILURE = 4;  // assert() or assume() failed
+  MARK_TO_DROP = 1;  // explicit mark_to_drop()
 }

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -151,6 +151,10 @@ message TraceEvent {
 
     // Packet fate.
     MarkToDropEvent mark_to_drop = 6;
+    // Fired immediately before the packet re-enters the pipeline (resubmit or
+    // recirculate). Anchors the Continuation node's cause field and carries the
+    // preserved field snapshot.
+    ContinuationEvent continuation_trigger = 17;
 
     // Deparser.
     DeparserEmitEvent deparser_emit = 13;
@@ -221,6 +225,22 @@ message ExternCallEvent {
 // fate — the actual drop is represented by Drop in PacketOutcome.
 message MarkToDropEvent {
   DropReason reason = 1;
+}
+
+// Fired immediately before the packet re-enters the pipeline (resubmit or
+// recirculate). Anchors Continuation.cause — consumers can resolve the
+// triggering call site from this event.
+message ContinuationEvent {
+  enum Kind {
+    KIND_UNSPECIFIED = 0;
+    RESUBMIT = 1;
+    RECIRCULATE = 2;
+  }
+  Kind kind = 1;
+  // Metadata fields preserved across the loop: field path → formatted value.
+  // Only populated for v1model, where field lists explicitly name preserved
+  // fields. PSA and PNA pass metadata implicitly through the deparser/parser.
+  map<string, string> preserved_fields = 2;
 }
 
 // Fired when the P4 program calls clone().

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -69,7 +69,8 @@ message TraceTree {
     Choice choice = 5;
 
     // The same packet continues as another parser-to-deparser pass.
-    // Kind: RESUBMIT, RECIRCULATE, or absent for forward transitions.
+    // Kind: RESUBMIT or RECIRCULATE; KIND_UNSPECIFIED is the proto default
+    // but not emitted by any architecture.
     Continuation continuation = 6;
 
     // Terminal: packet emitted on a port.
@@ -98,10 +99,10 @@ message Choice {
 }
 
 // The same packet continues as another parser-to-deparser pass.
-// Used for resubmit, recirculate, and forward stage transitions.
+// Used for resubmit and recirculate.
 message Continuation {
   enum Kind {
-    KIND_UNSPECIFIED = 0;  // normal forward transition (e.g. ingress → egress)
+    KIND_UNSPECIFIED = 0;  // proto3 required default; not emitted by any architecture
     RESUBMIT = 1;
     RECIRCULATE = 2;
   }

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -102,7 +102,8 @@ message Choice {
 // Used for resubmit and recirculate.
 message Continuation {
   enum Kind {
-    KIND_UNSPECIFIED = 0;  // proto3 required default; not emitted by any architecture
+    KIND_UNSPECIFIED =
+        0;  // proto3 required default; not emitted by any architecture
     RESUBMIT = 1;
     RECIRCULATE = 2;
   }

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -62,22 +62,22 @@ message TraceTree {
   oneof outcome {
     // All branches happen simultaneously; outputs are the union.
     // Cause: clone session or multicast group lookup that triggered the copies.
-    Replication replication = 4;
+    Replication replication = 2;
 
     // Exactly one branch happens at runtime (possible worlds).
     // Cause: the table-apply event for the action selector.
-    Choice choice = 5;
+    Choice choice = 3;
 
     // The same packet continues as another parser-to-deparser pass.
     // Kind: RESUBMIT or RECIRCULATE; KIND_UNSPECIFIED is the proto default
     // but not emitted by any architecture.
-    Continuation continuation = 6;
+    Continuation continuation = 4;
 
     // Terminal: packet emitted on a port.
-    OutputPacket output = 7;
+    OutputPacket output = 5;
 
     // Terminal: packet discarded.
-    Drop drop = 8;
+    Drop drop = 6;
   }
 }
 

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -114,20 +114,19 @@ message Continuation {
   map<string, string> preserved_fields = 3;
 }
 
-// A packet that was dropped.  `trigger` is absent when the packet fell off the
+// A packet that was dropped.  `cause` is absent when the packet fell off the
 // end of the pipeline with no forwarding decision (the implicit default).
 // When present, the referenced event's type identifies the cause:
-//   MarkToDropEvent                                    → explicit
-//   mark_to_drop() call AssertionEvent                                     →
-//   assert()/assume() failure MulticastGroupLookupEvent with group_found=false
-//   → multicast to empty group
+//   MarkToDropEvent                            → explicit mark_to_drop() call
+//   AssertionEvent                             → assert()/assume() failure
+//   MulticastGroupLookupEvent(group_found=false) → multicast to empty group
 message Drop {
-  optional uint64 trigger = 1;  // id of the event that caused the drop, if any
+  optional uint64 cause = 1;  // id of the event that caused the drop, if any
 }
 
 message TraceEvent {
   // Trace-global identifier, assigned by the simulator in emission order.
-  // Referenced by Replication.cause, Choice.cause, and Drop.trigger to
+  // Referenced by Replication.cause, Choice.cause, and Drop.cause to
   // identify which event triggered each outcome.
   uint64 id = 16;
 

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -59,8 +59,6 @@ message OutputPacket {
 // Shared prefix events live in the parent node; per-branch events in subtrees.
 message TraceTree {
   repeated TraceEvent events = 1;
-  reserved 2,
-      3;  // formerly fork_outcome (Fork) and packet_outcome (PacketOutcome)
   oneof outcome {
     // All branches happen simultaneously; outputs are the union.
     // Cause: clone session or multicast group lookup that triggered the copies.
@@ -71,8 +69,7 @@ message TraceTree {
     Choice choice = 5;
 
     // The same packet continues as another parser-to-deparser pass.
-    // Cause: the resubmit/recirculate primitive (absent for forward
-    // transitions).
+    // Kind: RESUBMIT, RECIRCULATE, or absent for forward transitions.
     Continuation continuation = 6;
 
     // Terminal: packet emitted on a port.
@@ -84,9 +81,9 @@ message TraceTree {
 }
 
 // All branches execute; their output packets are the union.
-// Used for clone (I2E/E2E) and multicast replication.
-// `cause` references the CloneSessionLookupEvent or MulticastGroupLookupEvent
-// whose id is in the enclosing node's events stream.
+// Used for any mechanism that sends copies to multiple ports (clone, multicast,
+// mirror). `cause` references the lookup event that triggered the copies, if
+// any.
 message Replication {
   uint64 cause = 1;                 // id of the typed event that triggered this
   repeated TraceTree branches = 2;  // ≥ 1 branch
@@ -102,27 +99,35 @@ message Choice {
 
 // The same packet continues as another parser-to-deparser pass.
 // Used for resubmit, recirculate, and forward stage transitions.
-// `cause` is absent for normal forward transitions; present for backward ones
-// when a specific event recorded the primitive (e.g. a recirculate/resubmit).
 message Continuation {
-  optional uint64 cause = 1;  // id of the event that triggered the re-parse
-  TraceTree next = 2;         // exactly one successor
+  enum Kind {
+    KIND_UNSPECIFIED = 0;  // normal forward transition (e.g. ingress → egress)
+    RESUBMIT = 1;
+    RECIRCULATE = 2;
+  }
+  Kind kind = 1;
+  TraceTree next = 2;
+  // Metadata fields preserved across the loop: field path → formatted value.
+  // Only populated for v1model @field_list snapshots; other architectures pass
+  // metadata implicitly through the deparser/parser.
+  map<string, string> preserved_fields = 3;
 }
 
 // A packet that was dropped.  `trigger` is absent when the packet fell off the
 // end of the pipeline with no forwarding decision (the implicit default).
 // When present, the referenced event's type identifies the cause:
-//   MarkToDropEvent  → explicit mark_to_drop() call
-//   AssertionEvent   → assert()/assume() failure
-//   MulticastGroupLookupEvent with group_found=false → multicast to empty group
+//   MarkToDropEvent                                    → explicit
+//   mark_to_drop() call AssertionEvent                                     →
+//   assert()/assume() failure MulticastGroupLookupEvent with group_found=false
+//   → multicast to empty group
 message Drop {
   optional uint64 trigger = 1;  // id of the event that caused the drop, if any
 }
 
 message TraceEvent {
   // Trace-global identifier, assigned by the simulator in emission order.
-  // Referenced by Replication.cause, Choice.cause, Continuation.cause, and
-  // Drop.trigger to identify which event triggered each outcome.
+  // Referenced by Replication.cause, Choice.cause, and Drop.trigger to
+  // identify which event triggered each outcome.
   uint64 id = 16;
 
   oneof event {
@@ -151,10 +156,6 @@ message TraceEvent {
 
     // Packet fate.
     MarkToDropEvent mark_to_drop = 6;
-    // Fired immediately before the packet re-enters the pipeline (resubmit or
-    // recirculate). Anchors the Continuation node's cause field and carries the
-    // preserved field snapshot.
-    ContinuationEvent continuation_trigger = 17;
 
     // Deparser.
     DeparserEmitEvent deparser_emit = 13;
@@ -223,25 +224,7 @@ message ExternCallEvent {
 
 // Fired when mark_to_drop() is called. Records the call site, not the packet
 // fate — the actual drop is represented by Drop in PacketOutcome.
-message MarkToDropEvent {
-  DropReason reason = 1;
-}
-
-// Fired immediately before the packet re-enters the pipeline (resubmit or
-// recirculate). Anchors Continuation.cause — consumers can resolve the
-// triggering call site from this event.
-message ContinuationEvent {
-  enum Kind {
-    KIND_UNSPECIFIED = 0;
-    RESUBMIT = 1;
-    RECIRCULATE = 2;
-  }
-  Kind kind = 1;
-  // Metadata fields preserved across the loop: field path → formatted value.
-  // Only populated for v1model, where field lists explicitly name preserved
-  // fields. PSA and PNA pass metadata implicitly through the deparser/parser.
-  map<string, string> preserved_fields = 2;
-}
+message MarkToDropEvent {}
 
 // Fired when the P4 program calls clone().
 message CloneEvent {
@@ -321,11 +304,4 @@ message DeparserEmitEvent {
 // in TraceEvent.variable_values and TraceEvent.result_value.
 message AssignmentEvent {
   string target = 1;  // LHS field path (e.g. "standard_metadata.egress_spec")
-}
-
-// Used only by MarkToDropEvent to classify the call site.
-// Drop.trigger identifies the cause by referencing the event directly.
-enum DropReason {
-  DROP_REASON_UNSPECIFIED = 0;
-  MARK_TO_DROP = 1;  // explicit mark_to_drop()
 }

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -86,7 +86,7 @@ message TraceTree {
 // mirror). `cause` references the lookup event that triggered the copies, if
 // any.
 message Replication {
-  uint64 cause = 1;                 // id of the typed event that triggered this
+  optional uint64 cause = 1;        // id of the typed event that triggered this
   repeated TraceTree branches = 2;  // ≥ 1 branch
 }
 
@@ -94,7 +94,7 @@ message Replication {
 // Used for action selector groups (the selected member is unknown statically).
 // `cause` references the TableLookupEvent for the selector table.
 message Choice {
-  uint64 cause = 1;                 // id of the typed event that triggered this
+  optional uint64 cause = 1;        // id of the typed event that triggered this
   repeated TraceTree branches = 2;  // ≥ 2 branches
 }
 


### PR DESCRIPTION
## What changed

Delivers typed trace tree outcomes and cleans up the supporting data model.

### Typed outcomes

Replaces the old `fork_outcome`/`packet_outcome` union with five strongly-typed
outcome variants on `TraceTree`: `Replication`, `Choice`, `Continuation`,
`Output`, `Drop`. Each carries only the fields relevant to its kind.

### `Continuation` carries kind + preserved fields

Resubmit and recirculate are modeled as `Continuation` nodes with a `Kind` enum
(`RESUBMIT` / `RECIRCULATE`) and an optional `preserved_fields` map (v1model
`@field_list` snapshots). No separate `ContinuationEvent` is needed — the
outcome node itself is the right home for this information.

### PSA id-collision fix

Ingress and egress `PacketContext` instances previously both started at id=1,
producing duplicate event ids after `prependEvents` merged them. Fixed via
`firstEventId` on `PacketContext`.

### Other cleanup

- `DropReason` enum and `MarkToDropEvent.reason` removed — redundant; the
  cause is identifiable from the referenced event's type via `Drop.trigger`.
- `TraceTree.reserved` removed — unnecessary overhead in an experimental project.
- `Replication` comment made architecture-agnostic (clone, multicast, mirror).
- Cause sentinel `Long = 0L` replaced with `Long?` / `null` throughout.
- `TraceFormatter` renders `continuation`, `resubmit`, `recirculate` with
  optional `(preserved: …)` suffix.

## Tests

- `TraceFormatterTest`: continuation rendering with/without preserved fields.
- `PSAArchitectureTest`: three continuation tests assert `Continuation.kind`
  and `Replication.cause` wiring; multicast test verifies the lookup event link.
- `PNAArchitectureTest`: new test recirculates once, asserts `Kind.RECIRCULATE`.
- Golden trace tree tests updated for resubmit, recirculate, resubmit_preserve_meta.