### PR TITLE
Stub v1model digest extern

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -36,7 +36,7 @@ Legend:
 | Checksums | Supported | Supported | Supported | v1model checksum externs and PSA/PNA `InternetChecksum` are implemented. |
 | Hash externs | Supported | Supported | Supported | PSA/PNA support documented hash forms and algorithms. |
 | Random externs | Supported | Supported | Supported | v1model `random()` and PSA/PNA `Random.read()` are implemented. |
-| Digest externs | Unsupported | Stub | Stub | PSA/PNA `Digest.pack` is a no-op; v1model `digest()` is not implemented. |
+| Digest externs | Stub | Stub | Stub | v1model `digest()` and PSA/PNA `Digest.pack()` are no-ops. |
 | v1model `truncate()` | Supported | N/A | N/A | Caps the emitted packet length after deparser; repeated calls keep the shortest requested length. |
 | PNA add-on-miss externs | N/A | N/A | Stub | `add_entry`, `allocate_flow_id`, and timer externs are simplified stubs. |
 | User-defined extern functions | Unsupported | Unsupported | Unsupported | Architecture libraries define executable extern semantics. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -43,9 +43,8 @@ guilt — just write it down so someone can find it later.
   written and read back, but token buckets, refill timing, and rate-based color
   transitions are permanently out of scope: 4ward is a deterministic packet
   simulator with no wall-clock traffic-rate model.
-- **`digest` is a no-op stub.** PSA `Digest.pack()` is accepted but doesn't
-  deliver messages to the control plane. v1model `digest()` is not
-  implemented and will crash at runtime.
+- **`digest` is a no-op stub.** v1model `digest()` and PSA/PNA `Digest.pack()`
+  are accepted but do not deliver messages to the control plane.
 
 ## v1model gaps
 

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -1166,6 +1166,9 @@ class V1ModelArchitecture(
         eval.writeOutArg(0, BitVal(BitVector(randomInInclusiveRange(lo, hi), resultWidth)))
         UnitVal
       }
+      // digest(receiver, data): accepted as a no-op. Digest delivery is intentionally out of
+      // scope because the simulator has no control-plane digest queue or stream-delivery model.
+      "digest" -> UnitVal
       // log_msg(msg) / log_msg(msg, data): debug output with {} placeholders.
       // Defined in v1model.p4 — emits a trace event with the interpolated message.
       "log_msg" -> {

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -696,6 +696,20 @@ class V1ModelArchitectureTest {
   }
 
   @Test
+  fun `digest is accepted as no-op stub`() {
+    val config =
+      v1modelConfig(
+        externCall("digest", bit(0, 32), bit(0xBEEFL, 16)),
+        assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
+      )
+    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(5, outputs[0].dataplaneEgressPort)
+  }
+
+  @Test
   fun `multicast fork trace tree has fork node`() {
     val config = v1modelConfig(assignField("sm", "mcast_grp", 1, 16))
     val tableStore = TableStore()


### PR DESCRIPTION
## Summary
- Accept v1model `digest(receiver, data)` as a no-op stub
- Add a v1model regression test showing `digest()` does not block forwarding
- Update compatibility and limitations docs to mark digest externs stubbed across architectures

## Tests
- bazel test //simulator:V1ModelArchitectureTest --test_filter='digest is accepted' (failed before implementation, passed after)
- bazel test //simulator:V1ModelArchitectureTest //simulator:PSAArchitectureTest //simulator:PNAArchitectureTest
- ./tools/format.sh
- ./tools/lint.sh