### PR TITLE
docs: centralize repo URL via mkdocs-macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
 
 
   docs:
-    if: github.event_name == 'push'  # deploy docs only on main pushes
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -62,6 +61,7 @@ jobs:
         run: pip install 'mkdocs-material>=9,<10' mkdocs-glightbox mkdocs-macros-plugin && mkdocs build --strict
 
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push'
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           # Clone gh-pages into a standalone repo (avoids worktree issues with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build docs
-        run: pip install 'mkdocs-material>=9,<10' mkdocs-glightbox && mkdocs build --strict
+        run: pip install 'mkdocs-material>=9,<10' mkdocs-glightbox mkdocs-macros-plugin && mkdocs build --strict
 
       - name: Deploy to GitHub Pages
         run: |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,10 @@ plugins:
   - search
   - glightbox
   - meta
+  - macros
 
 extra:
+  repo: https://github.com/smolkaj/4ward
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/smolkaj/4ward

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,8 +16,6 @@ plugins:
   - macros
 
 extra:
-  repo: https://github.com/smolkaj/4ward
-  repo_raw: https://raw.githubusercontent.com/smolkaj/4ward
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/smolkaj/4ward

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ plugins:
 
 extra:
   repo: https://github.com/smolkaj/4ward
+  repo_raw: https://raw.githubusercontent.com/smolkaj/4ward
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/smolkaj/4ward

--- a/userdocs/README.md
+++ b/userdocs/README.md
@@ -8,7 +8,7 @@ User-facing documentation for 4ward, built with
 **Local preview:**
 
 ```sh
-pip install mkdocs-material mkdocs-glightbox
+pip install mkdocs-material mkdocs-glightbox mkdocs-macros-plugin
 mkdocs serve        # http://localhost:8000
 ```
 

--- a/userdocs/concepts/architecture-modifications.md
+++ b/userdocs/concepts/architecture-modifications.md
@@ -76,7 +76,7 @@ Adding a completely new P4 architecture (e.g., PNA, TNA) requires changes to
 4ward: a Kotlin class that implements the `Architecture` interface and handles
 the architecture's pipeline stages, externs, and non-deterministic operations.
 
-Use [`V1ModelArchitecture.kt`]({{ repo }}/blob/main/simulator/V1ModelArchitecture.kt)
+Use [`V1ModelArchitecture.kt`]({{ config.repo_url }}/blob/main/simulator/V1ModelArchitecture.kt)
 as the reference implementation.
 
 ### Step 1: Implement `Architecture`
@@ -123,7 +123,7 @@ private fun createExternHandler(state: State): ExternHandler =
 
 ### Step 3: Register
 
-Add your architecture to the dispatcher in [`Simulator.kt`]({{ repo }}/blob/main/simulator/Simulator.kt):
+Add your architecture to the dispatcher in [`Simulator.kt`]({{ config.repo_url }}/blob/main/simulator/Simulator.kt):
 
 ```kotlin
 architecture = when (archName) {

--- a/userdocs/concepts/architecture-modifications.md
+++ b/userdocs/concepts/architecture-modifications.md
@@ -76,7 +76,7 @@ Adding a completely new P4 architecture (e.g., PNA, TNA) requires changes to
 4ward: a Kotlin class that implements the `Architecture` interface and handles
 the architecture's pipeline stages, externs, and non-deterministic operations.
 
-Use [`V1ModelArchitecture.kt`](https://github.com/smolkaj/4ward/blob/main/simulator/V1ModelArchitecture.kt)
+Use [`V1ModelArchitecture.kt`]({{ repo }}/blob/main/simulator/V1ModelArchitecture.kt)
 as the reference implementation.
 
 ### Step 1: Implement `Architecture`
@@ -123,7 +123,7 @@ private fun createExternHandler(state: State): ExternHandler =
 
 ### Step 3: Register
 
-Add your architecture to the dispatcher in [`Simulator.kt`](https://github.com/smolkaj/4ward/blob/main/simulator/Simulator.kt):
+Add your architecture to the dispatcher in [`Simulator.kt`]({{ repo }}/blob/main/simulator/Simulator.kt):
 
 ```kotlin
 architecture = when (archName) {

--- a/userdocs/concepts/architectures.md
+++ b/userdocs/concepts/architectures.md
@@ -233,5 +233,5 @@ These limitations apply to all architectures:
 - **Digest is a no-op** because there's no control-plane receiver in the
   simulator.
 
-See [LIMITATIONS.md](https://github.com/smolkaj/4ward/blob/main/docs/LIMITATIONS.md)
+See [LIMITATIONS.md]({{ repo }}/blob/main/docs/LIMITATIONS.md)
 for the full list.

--- a/userdocs/concepts/architectures.md
+++ b/userdocs/concepts/architectures.md
@@ -233,5 +233,5 @@ These limitations apply to all architectures:
 - **Digest is a no-op** because there's no control-plane receiver in the
   simulator.
 
-See [LIMITATIONS.md]({{ repo }}/blob/main/docs/LIMITATIONS.md)
+See [LIMITATIONS.md]({{ config.repo_url }}/blob/main/docs/LIMITATIONS.md)
 for the full list.

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -5,7 +5,7 @@ description: "How 4ward trace trees capture every possible packet outcome — pa
 # Trace Trees
 
 Every packet 4ward processes produces a **trace tree**
-([`TraceTree`](https://github.com/smolkaj/4ward/blob/main/simulator/simulator.proto)
+([`TraceTree`]({{ repo }}/blob/main/simulator/simulator.proto)
 in `simulator.proto`) — a complete record of every decision the simulator
 made. Most packets take a single path through the
 pipeline and produce a linear trace. At non-deterministic choice points (action

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -5,7 +5,7 @@ description: "How 4ward trace trees capture every possible packet outcome — pa
 # Trace Trees
 
 Every packet 4ward processes produces a **trace tree**
-([`TraceTree`]({{ repo }}/blob/main/simulator/simulator.proto)
+([`TraceTree`]({{ config.repo_url }}/blob/main/simulator/simulator.proto)
 in `simulator.proto`) — a complete record of every decision the simulator
 made. Most packets take a single path through the
 pipeline and produce a linear trace. At non-deterministic choice points (action

--- a/userdocs/examples.md
+++ b/userdocs/examples.md
@@ -9,11 +9,11 @@ works with the [CLI](getting-started/cli.md) and the
 [web playground](getting-started/playground.md).
 
 For a guided walkthrough using these examples, see the
-[tutorial]({{ repo }}/blob/main/examples/tutorial.t).
+[tutorial]({{ config.repo_url }}/blob/main/examples/tutorial.t).
 
 ## passthrough
 
-**Source:** [`examples/passthrough.p4`]({{ repo }}/blob/main/examples/passthrough.p4)
+**Source:** [`examples/passthrough.p4`]({{ config.repo_url }}/blob/main/examples/passthrough.p4)
 
 The simplest possible v1model program. Parses an Ethernet header, hardcodes
 every packet to port 1, emits it unchanged. No tables, no actions.
@@ -41,7 +41,7 @@ parser, ingress (no events), and output on port 1.
 
 ## basic_table
 
-**Source:** [`examples/basic_table.p4`]({{ repo }}/blob/main/examples/basic_table.p4)
+**Source:** [`examples/basic_table.p4`]({{ config.repo_url }}/blob/main/examples/basic_table.p4)
 
 An exact-match table keyed on `etherType`. Matching packets are forwarded to
 a specified port; non-matching packets are dropped.

--- a/userdocs/examples.md
+++ b/userdocs/examples.md
@@ -9,11 +9,11 @@ works with the [CLI](getting-started/cli.md) and the
 [web playground](getting-started/playground.md).
 
 For a guided walkthrough using these examples, see the
-[tutorial](https://github.com/smolkaj/4ward/blob/main/examples/tutorial.t).
+[tutorial]({{ repo }}/blob/main/examples/tutorial.t).
 
 ## passthrough
 
-**Source:** [`examples/passthrough.p4`](https://github.com/smolkaj/4ward/blob/main/examples/passthrough.p4)
+**Source:** [`examples/passthrough.p4`]({{ repo }}/blob/main/examples/passthrough.p4)
 
 The simplest possible v1model program. Parses an Ethernet header, hardcodes
 every packet to port 1, emits it unchanged. No tables, no actions.
@@ -41,7 +41,7 @@ parser, ingress (no events), and output on port 1.
 
 ## basic_table
 
-**Source:** [`examples/basic_table.p4`](https://github.com/smolkaj/4ward/blob/main/examples/basic_table.p4)
+**Source:** [`examples/basic_table.p4`]({{ repo }}/blob/main/examples/basic_table.p4)
 
 An exact-match table keyed on `etherType`. Matching packets are forwarded to
 a specified port; non-matching packets are dropped.

--- a/userdocs/getting-started/cli.md
+++ b/userdocs/getting-started/cli.md
@@ -10,7 +10,7 @@ from the terminal.
 ## Setup
 
 ```sh
-git clone https://github.com/smolkaj/4ward.git && cd 4ward
+git clone {{ repo }}.git && cd 4ward
 ```
 
 An alias makes the examples below easier to type:
@@ -109,7 +109,7 @@ programs, split the work:
 
 ## What's next
 
-- **Tutorial** — the full [hands-on walkthrough](https://github.com/smolkaj/4ward/blob/main/examples/tutorial.t),
+- **Tutorial** — the full [hands-on walkthrough]({{ repo }}/blob/main/examples/tutorial.t),
   CI-verified so it's always up to date.
 - **STF format** — full syntax for [table entries, match types, and
   clone/multicast setup](../reference/stf.md).

--- a/userdocs/getting-started/cli.md
+++ b/userdocs/getting-started/cli.md
@@ -10,7 +10,7 @@ from the terminal.
 ## Setup
 
 ```sh
-git clone {{ repo }}.git && cd 4ward
+git clone {{ config.repo_url }}.git && cd 4ward
 ```
 
 An alias makes the examples below easier to type:
@@ -109,7 +109,7 @@ programs, split the work:
 
 ## What's next
 
-- **Tutorial** — the full [hands-on walkthrough]({{ repo }}/blob/main/examples/tutorial.t),
+- **Tutorial** — the full [hands-on walkthrough]({{ config.repo_url }}/blob/main/examples/tutorial.t),
   CI-verified so it's always up to date.
 - **STF format** — full syntax for [table entries, match types, and
   clone/multicast setup](../reference/stf.md).

--- a/userdocs/getting-started/playground.md
+++ b/userdocs/getting-started/playground.md
@@ -7,14 +7,14 @@ description: "Get started with the 4ward web playground: edit P4, install table 
 The playground is the fastest way to try 4ward — edit, compile, and trace P4
 programs in the browser.
 
-![4ward Web Playground]({{ repo_raw }}/main/docs/playground.gif)
+![4ward Web Playground](../assets/playground.gif)
 
 ## Start the server
 
 Clone and build if you haven't already:
 
 ```sh
-git clone {{ repo }}.git && cd 4ward
+git clone {{ config.repo_url }}.git && cd 4ward
 ```
 
 Then start the playground:

--- a/userdocs/getting-started/playground.md
+++ b/userdocs/getting-started/playground.md
@@ -7,7 +7,7 @@ description: "Get started with the 4ward web playground: edit P4, install table 
 The playground is the fastest way to try 4ward — edit, compile, and trace P4
 programs in the browser.
 
-![4ward Web Playground]({{ repo | replace("github.com", "raw.githubusercontent.com") }}/main/docs/playground.gif)
+![4ward Web Playground]({{ repo_raw }}/main/docs/playground.gif)
 
 ## Start the server
 

--- a/userdocs/getting-started/playground.md
+++ b/userdocs/getting-started/playground.md
@@ -7,14 +7,14 @@ description: "Get started with the 4ward web playground: edit P4, install table 
 The playground is the fastest way to try 4ward — edit, compile, and trace P4
 programs in the browser.
 
-![4ward Web Playground](https://raw.githubusercontent.com/smolkaj/4ward/main/docs/playground.gif)
+![4ward Web Playground]({{ repo | replace("github.com", "raw.githubusercontent.com") }}/main/docs/playground.gif)
 
 ## Start the server
 
 Clone and build if you haven't already:
 
 ```sh
-git clone https://github.com/smolkaj/4ward.git && cd 4ward
+git clone {{ repo }}.git && cd 4ward
 ```
 
 Then start the playground:

--- a/userdocs/index.md
+++ b/userdocs/index.md
@@ -18,7 +18,7 @@ all possible outcomes in a single pass.
 
 !!! tip "Prefer to get your hands dirty?"
 
-    Jump straight to the **[hands-on tutorial]({{ repo }}/blob/main/examples/tutorial.t)** — compile a P4 program, send packets, read traces, all from the terminal. Every command is CI-verified, so it always works.
+    Jump straight to the **[hands-on tutorial]({{ config.repo_url }}/blob/main/examples/tutorial.t)** — compile a P4 program, send packets, read traces, all from the terminal. Every command is CI-verified, so it always works.
 
 ## Pick your entry point
 

--- a/userdocs/index.md
+++ b/userdocs/index.md
@@ -18,7 +18,7 @@ all possible outcomes in a single pass.
 
 !!! tip "Prefer to get your hands dirty?"
 
-    Jump straight to the **[hands-on tutorial](https://github.com/smolkaj/4ward/blob/main/examples/tutorial.t)** — compile a P4 program, send packets, read traces, all from the terminal. Every command is CI-verified, so it always works.
+    Jump straight to the **[hands-on tutorial]({{ repo }}/blob/main/examples/tutorial.t)** — compile a P4 program, send packets, read traces, all from the terminal. Every command is CI-verified, so it always works.
 
 ## Pick your entry point
 

--- a/userdocs/reference/embedding-cc.md
+++ b/userdocs/reference/embedding-cc.md
@@ -85,7 +85,7 @@ absl::Status RunAgainstFourward() {
 
 Options cover `device_id`, the listening `port` (unset by default — the
 kernel picks an ephemeral port), `drop_port`, `cpu_port`, and
-`startup_timeout`. See [`fourward_server.h`](https://github.com/smolkaj/4ward/blob/main/fourward_cc/fourward_server.h)
+`startup_timeout`. See [`fourward_server.h`]({{ repo }}/blob/main/fourward_cc/fourward_server.h)
 for the full API.
 
 ## Startup contract
@@ -103,7 +103,7 @@ languages.
 
 ## Related
 
-- [`fourward_cc/`](https://github.com/smolkaj/4ward/tree/main/fourward_cc)
+- [`fourward_cc/`]({{ repo }}/tree/main/fourward_cc)
   — source of the wrapper.
 - [gRPC API reference](grpc.md) — server flags, RPC surface, and proto
   definitions.

--- a/userdocs/reference/embedding-cc.md
+++ b/userdocs/reference/embedding-cc.md
@@ -85,7 +85,7 @@ absl::Status RunAgainstFourward() {
 
 Options cover `device_id`, the listening `port` (unset by default — the
 kernel picks an ephemeral port), `drop_port`, `cpu_port`, and
-`startup_timeout`. See [`fourward_server.h`]({{ repo }}/blob/main/fourward_cc/fourward_server.h)
+`startup_timeout`. See [`fourward_server.h`]({{ config.repo_url }}/blob/main/fourward_cc/fourward_server.h)
 for the full API.
 
 ## Startup contract
@@ -103,7 +103,7 @@ languages.
 
 ## Related
 
-- [`fourward_cc/`]({{ repo }}/tree/main/fourward_cc)
+- [`fourward_cc/`]({{ config.repo_url }}/tree/main/fourward_cc)
   — source of the wrapper.
 - [gRPC API reference](grpc.md) — server flags, RPC surface, and proto
   definitions.

--- a/userdocs/reference/errors.md
+++ b/userdocs/reference/errors.md
@@ -73,5 +73,5 @@ INTERNAL: undefined variable: x (at my_program.p4:42:3)
 
 ## All error messages
 
-See [`grpc/golden_errors/`](https://github.com/smolkaj/4ward/tree/main/grpc/golden_errors)
+See [`grpc/golden_errors/`]({{ repo }}/tree/main/grpc/golden_errors)
 for the complete list of golden-tested error messages.

--- a/userdocs/reference/errors.md
+++ b/userdocs/reference/errors.md
@@ -73,5 +73,5 @@ INTERNAL: undefined variable: x (at my_program.p4:42:3)
 
 ## All error messages
 
-See [`grpc/golden_errors/`]({{ repo }}/tree/main/grpc/golden_errors)
+See [`grpc/golden_errors/`]({{ config.repo_url }}/tree/main/grpc/golden_errors)
 for the complete list of golden-tested error messages.

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -50,7 +50,7 @@ become primary for a role. The highest `election_id` wins.
 
 ## Dataplane service
 
-Defined in [`dataplane.proto`]({{ repo }}/blob/main/grpc/dataplane.proto).
+Defined in [`dataplane.proto`]({{ config.repo_url }}/blob/main/grpc/dataplane.proto).
 For packet injection and result observation — not part of the P4Runtime spec.
 
 ### `InjectPacket`
@@ -239,7 +239,7 @@ BMv2 hashes to one action selector member, while 4ward explores all 16
 to build the complete trace tree — that's the whole point.
 
 For full details on the benchmark methodology, build flags, and caveats,
-see [PERFORMANCE.md]({{ repo }}/blob/main/docs/PERFORMANCE.md).
+see [PERFORMANCE.md]({{ config.repo_url }}/blob/main/docs/PERFORMANCE.md).
 
 ## Error codes
 

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -50,7 +50,7 @@ become primary for a role. The highest `election_id` wins.
 
 ## Dataplane service
 
-Defined in [`dataplane.proto`](https://github.com/smolkaj/4ward/blob/main/grpc/dataplane.proto).
+Defined in [`dataplane.proto`]({{ repo }}/blob/main/grpc/dataplane.proto).
 For packet injection and result observation — not part of the P4Runtime spec.
 
 ### `InjectPacket`
@@ -239,7 +239,7 @@ BMv2 hashes to one action selector member, while 4ward explores all 16
 to build the complete trace tree — that's the whole point.
 
 For full details on the benchmark methodology, build flags, and caveats,
-see [PERFORMANCE.md](https://github.com/smolkaj/4ward/blob/main/docs/PERFORMANCE.md).
+see [PERFORMANCE.md]({{ repo }}/blob/main/docs/PERFORMANCE.md).
 
 ## Error codes
 

--- a/userdocs/reference/playground.md
+++ b/userdocs/reference/playground.md
@@ -111,5 +111,5 @@ available to external tools:
 - Sending another packet overwrites the previous result (no history).
 - The Monaco editor requires an internet connection (loaded from CDN).
 
-See [LIMITATIONS.md]({{ repo }}/blob/main/docs/LIMITATIONS.md)
+See [LIMITATIONS.md]({{ config.repo_url }}/blob/main/docs/LIMITATIONS.md)
 for the full list.

--- a/userdocs/reference/playground.md
+++ b/userdocs/reference/playground.md
@@ -111,5 +111,5 @@ available to external tools:
 - Sending another packet overwrites the previous result (no history).
 - The Monaco editor requires an internet connection (loaded from CDN).
 
-See [LIMITATIONS.md](https://github.com/smolkaj/4ward/blob/main/docs/LIMITATIONS.md)
+See [LIMITATIONS.md]({{ repo }}/blob/main/docs/LIMITATIONS.md)
 for the full list.

--- a/userdocs/reference/stf.md
+++ b/userdocs/reference/stf.md
@@ -10,7 +10,7 @@ and widely used across the P4 ecosystem (p4c,
 [BMv2](https://github.com/p4lang/behavioral-model),
 [p4testgen](https://github.com/p4lang/p4c/tree/main/backends/p4tools/modules/testgen)).
 4ward uses the same format for compatibility. See the
-[`e2e_tests/`]({{ repo }}/tree/main/e2e_tests)
+[`e2e_tests/`]({{ config.repo_url }}/tree/main/e2e_tests)
 directory for real-world examples.
 
 Lines starting with `#` are comments, and tokens are whitespace-separated.

--- a/userdocs/reference/stf.md
+++ b/userdocs/reference/stf.md
@@ -10,7 +10,7 @@ and widely used across the P4 ecosystem (p4c,
 [BMv2](https://github.com/p4lang/behavioral-model),
 [p4testgen](https://github.com/p4lang/p4c/tree/main/backends/p4tools/modules/testgen)).
 4ward uses the same format for compatibility. See the
-[`e2e_tests/`](https://github.com/smolkaj/4ward/tree/main/e2e_tests)
+[`e2e_tests/`]({{ repo }}/tree/main/e2e_tests)
 directory for real-world examples.
 
 Lines starting with `#` are comments, and tokens are whitespace-separated.


### PR DESCRIPTION
## Summary

Prep for transferring the repo to a new GitHub org. Adds the
[mkdocs-macros](https://mkdocs-macros-plugin.readthedocs.io/) plugin and
replaces all ~20 hardcoded `github.com/smolkaj/4ward` URLs across userdocs
with `{{ config.repo_url }}`, sourced from the built-in `repo_url` config
key already in `mkdocs.yml`. No custom variables needed.

Also moves `docs/playground.gif` into `userdocs/assets/` so it's served
locally instead of fetched from `raw.githubusercontent.com` — one fewer
external dependency.

On transfer day, updating `repo_url` and `repo_name` in `mkdocs.yml`
updates all rendered docs. The social link is the only remaining hardcoded
URL in the config.

- `mkdocs.yml`: add `macros` plugin
- `ci.yml`: add `mkdocs-macros-plugin` to the pip install
- `userdocs/README.md`: add `mkdocs-macros-plugin` to local preview install
- 12 userdocs markdown files: hardcoded URLs → `{{ config.repo_url }}`
- `userdocs/assets/playground.gif`: local copy (was fetched from GitHub raw)

## Test plan

- [x] `mkdocs build --strict` passes locally
- [x] Spot-checked rendered HTML for correct URL expansion
- [x] Gif renders correctly as local asset
- [ ] CI docs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)