### PR TITLE
Clarify digest delivery scope

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -66,7 +66,7 @@ Legend:
 | p4-constraints | Supported | `@entry_restriction` and `@action_restriction` are enforced on Write. |
 | `StreamChannel` PacketIO | Supported | PacketOut/PacketIn flow, ordering, and invalid message handling are tested. |
 | DigestEntry configuration | Rejected | Digest configuration is rejected with UNIMPLEMENTED. |
-| Digest stream delivery/ack | Out of scope | There are no real packet rates to trigger digest delivery. |
+| Digest stream delivery/ack | Out of scope | There is no control-plane digest queue or stream-delivery model. |
 | Idle timeout configuration | Rejected | `idle_timeout_ns` is rejected with UNIMPLEMENTED. |
 | Idle timeout notifications | Out of scope | There is no wall-clock time model. |
 | `ValueSetEntry` | Partial | `MODIFY` and Read are supported; `INSERT` and `DELETE` are rejected with INVALID_ARGUMENT. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -76,10 +76,10 @@ guilt — just write it down so someone can find it later.
 - **Direct meters always return GREEN by design.** Direct meter configs can be
   written and read via P4Runtime, but `direct_meter.read()` does not consume or
   refill buckets. It always returns the default color (GREEN).
-- **No digests or idle timeouts (by design).** Both are inherently
-  time-dependent features that have no meaningful semantics in a reference
-  simulator: there are no real packet rates to trigger digests, and no
-  wall-clock time to expire idle entries. These are explicitly out of scope.
+- **No digest delivery or idle timeouts (by design).** Both need runtime
+  machinery that is outside the reference simulator: there is no control-plane
+  digest queue or stream-delivery model, and no wall-clock time to expire idle
+  entries. These are explicitly out of scope.
 ## Simulator
 
 - **Fork-point resume is v1model only.** When the trace tree forks (action

--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -242,7 +242,7 @@ UNIMPLEMENTED (rejection is tested), **N/A** = out of scope
 | 14.2 | PacketOut with table entries forwards correctly | Y | ConformanceTest #14 |
 | 14.3 | Multiple packets preserve ordering | Y | ConformanceTest #15 |
 | 14.4 | StreamError on invalid stream message | Y | ConformanceTest #67 |
-| 14.5 | Digest delivery | N/A | Out of scope — no real packet rates to trigger digests |
+| 14.5 | Digest delivery | N/A | Out of scope — no control-plane digest queue or stream-delivery model |
 | 14.6 | DigestListAck handling | N/A | Digests out of scope |
 | 14.7 | Idle timeout notifications | N/A | Out of scope — no wall-clock time in a reference simulator |
 | 14.8 | Architecture-specific `other` messages | Y | Rejected with StreamError; ConformanceTest #67 |


### PR DESCRIPTION
## Summary
- Replace stale rate-based digest delivery rationale with control-plane queue/stream-delivery wording
- Align compatibility, limitations, and P4Runtime compliance docs

## Tests
- ./tools/format.sh
- ./tools/lint.sh