### PR TITLE
Group runtime service limitations

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -32,7 +32,7 @@ Legend:
 | Recirculate | Supported | Supported | Supported | PNA recirculate tracks pass count. |
 | Registers | Supported | Supported | Supported | Reproducers seed the packet-start register values read by the trace. |
 | Counters | Supported | Supported | Supported | Direct counters increment on table hits; PSA/PNA `Counter.count()` updates P4Runtime-readable counter state. |
-| Meters | Stub | Stub | Stub | Stubbed by design: configs round-trip, but meter externs always return GREEN and rate behavior is out of scope. |
+| Meters | Stub | Stub | Stub | Stubbed by design: configs round-trip, but meter externs always return GREEN and runtime rate behavior is out of scope. |
 | Checksums | Supported | Supported | Supported | v1model checksum externs and PSA/PNA `InternetChecksum` are implemented. |
 | Hash externs | Supported | Supported | Supported | PSA/PNA support documented hash forms and algorithms. |
 | Random externs | Supported | Supported | Supported | v1model `random()` and PSA/PNA `Random.read()` are implemented. |
@@ -57,7 +57,7 @@ Legend:
 | Action profile members/groups | Supported | CRUD, max size, empty groups, and selector references are tested. |
 | One-shot action selector entries | Supported | Validated and covered by table-store/write-validation tests. |
 | Counter entries | Supported | Indirect and direct counter read/write are tested. |
-| Meter entries | Partial | Config read/write works; token-bucket/rate behavior is permanently out of scope and meters always return GREEN. |
+| Meter entries | Partial | Config read/write works; runtime rate behavior is permanently out of scope and meters always return GREEN. |
 | Register entries | Supported | MODIFY/read semantics and bounds checks are tested. |
 | PRE clone sessions | Supported | CRUD and Read support are tested. |
 | PRE multicast groups | Supported | CRUD and Read support are tested. |
@@ -66,9 +66,9 @@ Legend:
 | p4-constraints | Supported | `@entry_restriction` and `@action_restriction` are enforced on Write. |
 | `StreamChannel` PacketIO | Supported | PacketOut/PacketIn flow, ordering, and invalid message handling are tested. |
 | DigestEntry configuration | Rejected | Digest configuration is rejected with UNIMPLEMENTED. |
-| Digest stream delivery/ack | Out of scope | There is no control-plane digest queue or stream-delivery model. |
+| Digest stream delivery/ack | Out of scope | Asynchronous controller queues are outside the simulator runtime model. |
 | Idle timeout configuration | Rejected | `idle_timeout_ns` is rejected with UNIMPLEMENTED. |
-| Idle timeout notifications | Out of scope | There is no wall-clock time model. |
+| Idle timeout notifications | Out of scope | Wall-clock expiry is outside the simulator runtime model. |
 | `ValueSetEntry` | Partial | `MODIFY` and Read are supported; `INSERT` and `DELETE` are rejected with INVALID_ARGUMENT. |
 | `ExternEntry` | Rejected | Dedicated entity types are supported instead. |
 | P4Data complex table values | Out of scope | No current program exposes complex P4Data in P4Runtime-visible fields. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -32,6 +32,25 @@ guilt — just write it down so someone can find it later.
   counters (indirect + direct), and `Random.read()`. Add-on-miss externs (`add_entry`,
   `allocate_flow_id`, `set_entry_expire_time`, `restart_expire_timer`) are stubs.
   37 STF corpus tests, 31 compile-only tests, 33 p4testgen symbolic tests.
+
+## Runtime services outside the simulator model
+
+4ward models deterministic packet execution and explicit control-plane state.
+It does not model autonomous runtime services that depend on elapsed time,
+traffic rates, or asynchronous controller queues.
+
+- **Meter rate behavior is permanently out of scope.** Meter configs can be
+  written and read back via P4Runtime, but token buckets, refill timing,
+  per-color packet counts, and rate-based color transitions are not modeled.
+  Meter externs always return GREEN.
+- **Digest delivery is permanently out of scope.** v1model `digest()` and
+  PSA/PNA `Digest.pack()` are accepted as no-ops, and P4Runtime
+  `DigestEntry` configuration is rejected with UNIMPLEMENTED. There is no
+  control-plane digest queue, stream-delivery model, or ack state.
+- **Idle timeout notifications are permanently out of scope.** P4Runtime
+  `idle_timeout_ns` configuration is rejected with UNIMPLEMENTED because
+  there is no wall-clock time model to expire idle table entries.
+
 ## Externs
 
 - **No user-defined extern functions.** Extern functions declared in P4
@@ -39,12 +58,11 @@ guilt — just write it down so someone can find it later.
   executed — their semantics exist only in architecture-specific libraries.
   Blocks 1 corpus test (`extern-funcs-bmv2`).
 - **Meters always return GREEN by design.** `meter.execute_meter()` and
-  `direct_meter.read()` always return GREEN (0). P4Runtime meter configs can be
-  written and read back, but token buckets, refill timing, and rate-based color
-  transitions are permanently out of scope: 4ward is a deterministic packet
-  simulator with no wall-clock traffic-rate model.
+  `direct_meter.read()` always return GREEN (0). See
+  [Runtime services outside the simulator model](#runtime-services-outside-the-simulator-model).
 - **`digest` is a no-op stub.** v1model `digest()` and PSA/PNA `Digest.pack()`
-  are accepted but do not deliver messages to the control plane.
+  are accepted but do not deliver messages to the control plane. See
+  [Runtime services outside the simulator model](#runtime-services-outside-the-simulator-model).
 
 ## v1model gaps
 
@@ -73,13 +91,7 @@ guilt — just write it down so someone can find it later.
   to forward-allocate mappings, and provide explicit `TypeTranslation` entries
   for architecture-defined ports (like the CPU port) that auto-allocation
   cannot assign correctly.
-- **Direct meters always return GREEN by design.** Direct meter configs can be
-  written and read via P4Runtime, but `direct_meter.read()` does not consume or
-  refill buckets. It always returns the default color (GREEN).
-- **No digest delivery or idle timeouts (by design).** Both need runtime
-  machinery that is outside the reference simulator: there is no control-plane
-  digest queue or stream-delivery model, and no wall-clock time to expire idle
-  entries. These are explicitly out of scope.
+
 ## Simulator
 
 - **Fork-point resume is v1model only.** When the trace tree forks (action

--- a/docs/P4RUNTIME_COMPLIANCE.md
+++ b/docs/P4RUNTIME_COMPLIANCE.md
@@ -147,7 +147,7 @@ UNIMPLEMENTED (rejection is tested), **N/A** = out of scope
 | 9.51 | Indirect counter read/write | Y | TableStoreTest, ConformanceTest #46-48 |
 | 9.52 | Direct meter config | Y | TableStoreTest, ConformanceTest #55-57 |
 | 9.53 | Indirect meter config | Y | TableStoreTest, ConformanceTest #49-51 |
-| 9.54 | MeterCounterData (per-color packet counts) | N/A | Requires hardware-level metering; reference simulator implements config only |
+| 9.54 | MeterCounterData (per-color packet counts) | N/A | Runtime meter rate behavior is outside the simulator model |
 
 ### Packet replication engine (spec §9.5)
 
@@ -242,9 +242,9 @@ UNIMPLEMENTED (rejection is tested), **N/A** = out of scope
 | 14.2 | PacketOut with table entries forwards correctly | Y | ConformanceTest #14 |
 | 14.3 | Multiple packets preserve ordering | Y | ConformanceTest #15 |
 | 14.4 | StreamError on invalid stream message | Y | ConformanceTest #67 |
-| 14.5 | Digest delivery | N/A | Out of scope — no control-plane digest queue or stream-delivery model |
+| 14.5 | Digest delivery | N/A | Out of scope — asynchronous controller queues are outside the simulator model |
 | 14.6 | DigestListAck handling | N/A | Digests out of scope |
-| 14.7 | Idle timeout notifications | N/A | Out of scope — no wall-clock time in a reference simulator |
+| 14.7 | Idle timeout notifications | N/A | Out of scope — wall-clock expiry is outside the simulator model |
 | 14.8 | Architecture-specific `other` messages | Y | Rejected with StreamError; ConformanceTest #67 |
 
 ### Capabilities (spec §17)
@@ -285,7 +285,8 @@ justification, or noted as out-of-scope. Key decisions:
 - **§9.1.5 Preinitialized tables**: Const entry load, readback, and immutability tested (#114-116).
 - **§9.1.8 Idle timeout**: Rejected with UNIMPLEMENTED; tested (#117).
 - **§9.2.2 Action profile groups**: Empty groups and full member replacement tested (#118-119); watch_port N/A.
-- **§9.4.3 MeterCounterData**: N/A — per-color counting requires hardware-level metering.
+- **§9.4.3 MeterCounterData**: N/A — per-color counting requires runtime
+  meter rate behavior, which is outside the simulator model.
 - **§10 Error reporting**: Per-update structured errors tested (#120-121).
 - **§11 Atomicity**: Guaranteed by design (single mutex serializes all reads/writes).
 - **§12.1 Write batch ordering**: Cross-entity-type dependency ordering tested (#122).

--- a/userdocs/concepts/architectures.md
+++ b/userdocs/concepts/architectures.md
@@ -91,8 +91,8 @@ Multiple calls use last-writer-wins semantics. All of these produce
   generic array storage.
 - `counter.count(index)` / `direct_counter.count()` increments a counter
   (fire-and-forget).
-- `meter.execute_meter(index, out color)` always returns GREEN — there are no
-  real packet rates in the simulator.
+- `meter.execute_meter(index, out color)` always returns GREEN — runtime meter
+  rate behavior is outside the simulator model.
 
 ## PSA
 
@@ -227,11 +227,12 @@ The main input metadata (`pna_main_input_metadata_t`):
 
 These limitations apply to all architectures:
 
-- **Meters always return GREEN** because the simulator has no real packet rates.
+- **Meters always return GREEN** because runtime meter rate behavior is outside
+  the simulator model.
 - **Counters are fire-and-forget** and can't be read from P4 logic (only via
   P4Runtime Read from the control plane).
-- **Digest is a no-op** because there's no control-plane receiver in the
-  simulator.
+- **Digest is a no-op** because asynchronous controller queues are outside the
+  simulator model.
 
 See [LIMITATIONS.md]({{ config.repo_url }}/blob/main/docs/LIMITATIONS.md)
 for the full list.


### PR DESCRIPTION
## Summary
- Add a central limitations section for runtime services outside the simulator model
- Align meter, digest delivery, and idle timeout wording across compatibility, compliance, and user docs

## Tests
- ./tools/format.sh
- ./tools/lint.sh