### PR TITLE
Update links after org transfer

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -90,7 +90,7 @@ bazel_dep(name = "googleapis-java", version = "1.1.5")
 # exports, and the macOS build fix).
 #
 # Why: our e2e_tests/p4testgen PNA suite needs the drop-by-default fix
-# (p4lang/p4c#5569), which is still open upstream. The smolkaj/p4c fork is
+# (p4lang/p4c#5569), which is still open upstream. The 4ward-p4/p4c fork is
 # upstream main plus that single patch; PR #5570 (PNA STF backend) is already
 # in upstream main.
 #
@@ -100,7 +100,7 @@ bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
 git_override(
     module_name = "p4c",
     commit = "93932df3cc9fe7de596ad257f6eee7bcddc0fd58",
-    remote = "https://github.com/smolkaj/p4c.git",
+    remote = "https://github.com/4ward-p4/p4c.git",
 )
 
 # p4-constraints validates @entry_restriction / @action_restriction annotations.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
   <br><br>
   <strong>Your P4 programs, finally explained.</strong>
   <br><br>
-  <a href="https://github.com/smolkaj/4ward/actions/workflows/ci.yml"><img src="https://github.com/smolkaj/4ward/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://smolkaj.github.io/4ward/"><img src="https://img.shields.io/badge/docs-4ward-blue" alt="Docs"></a>
-  <a href="https://smolkaj.github.io/4ward/main/"><img src="https://img.shields.io/badge/coverage-report-blue" alt="Coverage"></a>
+  <a href="https://github.com/4ward-p4/4ward/actions/workflows/ci.yml"><img src="https://github.com/4ward-p4/4ward/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://4ward-p4.github.io/4ward/"><img src="https://img.shields.io/badge/docs-4ward-blue" alt="Docs"></a>
+  <a href="https://4ward-p4.github.io/4ward/main/"><img src="https://img.shields.io/badge/coverage-report-blue" alt="Coverage"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>
 
@@ -90,7 +90,7 @@ C++20 compiler for the p4c backend. Everything else is hermetic — Bazel
 handles it.
 
 ```sh
-git clone https://github.com/smolkaj/4ward.git && cd 4ward
+git clone https://github.com/4ward-p4/4ward.git && cd 4ward
 bazel build //...   # build everything
 bazel test //...    # run all tests
 ```
@@ -281,7 +281,7 @@ ergonomics (sealed classes, pattern matching).
 > [!IMPORTANT]
 > **You don't need Kotlin to contribute to — or use — 4ward.**
 > [AI writes the code](docs/AI_WORKFLOW.md); C++ projects embed via
-> [`//fourward_cc:dataplane_client`](https://smolkaj.github.io/4ward/reference/embedding-cc/);
+> [`//fourward_cc:dataplane_client`](https://4ward-p4.github.io/4ward/reference/embedding-cc/);
 > any gRPC client works in any language.
 
 ## Project structure
@@ -306,7 +306,7 @@ ergonomics (sealed classes, pattern matching).
 │   ├── sai_p4/             SAI P4 test fixtures
 │   └── <feature>/          Hand-written feature tests (passthrough, lpm, …)
 ├── designs/                Design documents
-├── userdocs/               User-facing documentation (MkDocs → smolkaj.github.io/4ward/)
+├── userdocs/               User-facing documentation (MkDocs → 4ward-p4.github.io/4ward/)
 ├── docs/                   Developer documentation (architecture, roadmap, testing)
 └── tools/                  Developer scripts (format, lint, coverage, …)
 ```
@@ -323,10 +323,10 @@ report in about 5. No flakes, no "works on my machine." See for yourself on the
 
 ## Documentation
 
-**[User documentation](https://smolkaj.github.io/4ward/)** — getting started
+**[User documentation](https://4ward-p4.github.io/4ward/)** — getting started
 guides, reference pages, and concept explainers for the web playground, CLI,
-gRPC API, and [C++ library](https://smolkaj.github.io/4ward/reference/embedding-cc/)
-(including composable [gtest matchers](https://smolkaj.github.io/4ward/reference/dataplane-matchers/)).
+gRPC API, and [C++ library](https://4ward-p4.github.io/4ward/reference/embedding-cc/)
+(including composable [gtest matchers](https://4ward-p4.github.io/4ward/reference/dataplane-matchers/)).
 
 **[Tutorial](examples/tutorial.t)** — a hands-on walkthrough from hello
 world to machine-readable trace output. Doubles as a regression test (cram

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@ thousandth, you're welcome.
 
 ## The easiest way to contribute
 
-Check the [roadmap](ROADMAP.md) and [issue tracker](https://github.com/smolkaj/4ward/issues)
+Check the [roadmap](ROADMAP.md) and [issue tracker](https://github.com/4ward-p4/4ward/issues)
 for open work — or add a new STF test for an untested edge case and make it
 pass. STF contributions are great because they're **naturally well-scoped** —
 you know exactly when you're done (the test passes), and you don't need to
@@ -15,7 +15,7 @@ understand the whole codebase to get started.
 
 ```sh
 # Clone and build — that's really all there is to it.
-git clone https://github.com/smolkaj/4ward
+git clone https://github.com/4ward-p4/4ward
 cd 4ward
 bazel build //...
 bazel test //...

--- a/docs/ENTRY_POINTS.md
+++ b/docs/ENTRY_POINTS.md
@@ -169,7 +169,7 @@ auto dataplane = server.NewDataplaneStub();
 
 **When to use:** Any C++ project that wants to use 4ward.
 
-See the [user-facing embedding guide](https://smolkaj.github.io/4ward/reference/embedding-cc/)
+See the [user-facing embedding guide](https://4ward-p4.github.io/4ward/reference/embedding-cc/)
 for the Bazel setup and full example.
 
 ## Intrinsic port configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,4 +3,4 @@
 Developer-facing documentation. Start with [`ARCHITECTURE.md`](ARCHITECTURE.md).
 For a quick support overview, see [`COMPATIBILITY.md`](COMPATIBILITY.md).
 For the user-facing site, see [`userdocs/`](../userdocs/) →
-[smolkaj.github.io/4ward](https://smolkaj.github.io/4ward/).
+[4ward-p4.github.io/4ward](https://4ward-p4.github.io/4ward/).

--- a/examples/tutorial.t
+++ b/examples/tutorial.t
@@ -9,7 +9,7 @@ everything you need to know.
 
 To try it yourself, clone the repo and set up a shell alias:
 
-$ git clone https://github.com/smolkaj/4ward.git && cd 4ward
+$ git clone https://github.com/4ward-p4/4ward.git && cd 4ward
 $ alias 4ward='bazel run //cli:4ward --'
 
 With that alias, every command below will work as shown. The example

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: 4ward
 site_description: Glass-box P4 simulator — trace every decision your packet makes.
-site_url: https://smolka.st/4ward/
-repo_url: https://github.com/smolkaj/4ward
-repo_name: smolkaj/4ward
+site_url: https://4ward-p4.github.io/4ward/
+repo_url: https://github.com/4ward-p4/4ward
+repo_name: 4ward-p4/4ward
 edit_uri: edit/main/userdocs/
 
 docs_dir: userdocs
@@ -18,7 +18,7 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/smolkaj/4ward
+      link: https://github.com/4ward-p4/4ward
 
 extra_css:
   - stylesheets/extra.css

--- a/simulator/DirectResourceUsageTest.kt
+++ b/simulator/DirectResourceUsageTest.kt
@@ -104,7 +104,7 @@ class DirectResourceUsageTest {
   // -------------------------------------------------------------------------
   // v1model + action profile/selector: counters fire implicitly on every hit,
   // so counter_data must be accepted even for actions that don't call count().
-  // Regression tests for https://github.com/smolkaj/4ward/issues/737.
+  // Regression tests for https://github.com/4ward-p4/4ward/issues/737.
   // -------------------------------------------------------------------------
 
   @Test

--- a/userdocs/README.md
+++ b/userdocs/README.md
@@ -3,7 +3,7 @@
 User-facing documentation for 4ward, built with
 [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
 
-**Live site:** https://smolkaj.github.io/4ward/
+**Live site:** https://4ward-p4.github.io/4ward/
 
 **Local preview:**
 


### PR DESCRIPTION
## Summary

Update active repository and documentation links after transferring 4ward and its p4c fork to the 4ward-p4 organization.

- point the p4c git_override at 4ward-p4/p4c
- update MkDocs repo metadata and social link
- update README badges, docs links, clone commands, and contributor docs
- keep historical design/PR references unchanged so they continue to describe past work

## Test plan

- [x] /tmp/4ward-mkdocs-venv/bin/mkdocs build --strict
- [x] shallow fetch pinned p4c commit from https://github.com/4ward-p4/p4c.git
- [x] spot-check rendered docs expand {{ config.repo_url }} to https://github.com/4ward-p4/4ward