### PR TITLE
Consolidate encodeMinWidth(Int) onto the BigInteger encoder

### DIFF
--- a/grpc/TypeTranslator.kt
+++ b/grpc/TypeTranslator.kt
@@ -23,16 +23,7 @@ fun ByteString.toHex(): String = toByteArray().joinToString("") { "%02x".format(
 /**
  * Minimum-width unsigned big-endian encoding of a non-negative integer (P4Runtime canonical form).
  */
-fun encodeMinWidth(value: Int): ByteString {
-  if (value == 0) return ByteString.copyFrom(byteArrayOf(0))
-  val bytes = mutableListOf<Byte>()
-  var v = value
-  while (v > 0) {
-    bytes.add(0, (v and 0xFF).toByte())
-    v = v shr 8
-  }
-  return ByteString.copyFrom(bytes.toByteArray())
-}
+fun encodeMinWidth(value: Int): ByteString = encodeMinWidth(BigInteger.valueOf(value.toLong()))
 
 /**
  * Minimum-width unsigned big-endian encoding of a non-negative [BigInteger] (P4Runtime canonical

--- a/grpc/TypeTranslatorTest.kt
+++ b/grpc/TypeTranslatorTest.kt
@@ -932,6 +932,21 @@ class TypeTranslatorTest {
     assertThrows(IllegalArgumentException::class.java) { encodeMinWidth(BigInteger.valueOf(-1)) }
   }
 
+  @Test
+  fun `encodeMinWidth of Int matches the BigInteger encoding`() {
+    // The Int overload delegates to the BigInteger one, so it shares the canonical form across the
+    // boundary cases (zero, high-bit sign byte, multi-byte) and the same fail-loud rejection of
+    // negatives (previously a negative Int silently produced an empty bytestring).
+    for (value in listOf(0, 1, 0x80, 255, 256, 511, Int.MAX_VALUE)) {
+      assertArrayEquals(
+        "encodeMinWidth($value)",
+        encodeMinWidth(BigInteger.valueOf(value.toLong())).toByteArray(),
+        encodeMinWidth(value).toByteArray(),
+      )
+    }
+    assertThrows(IllegalArgumentException::class.java) { encodeMinWidth(-1) }
+  }
+
   private fun packetInWithMeta(value: ByteArray): P4RuntimeOuterClass.PacketIn =
     P4RuntimeOuterClass.PacketIn.newBuilder()
       .setPayload(ByteString.copyFrom(byteArrayOf(0x00)))
@@ -1303,20 +1318,9 @@ class TypeTranslatorTest {
       .setDataplaneValue(ByteString.copyFrom(dataplaneValue))
       .build()
 
-  private fun p4rtBytes(value: Int): ByteArray = encodeMinWidth(value)
+  private fun p4rtBytes(value: Int): ByteArray = encodeMinWidth(value).toByteArray()
 
-  private fun dpBytes(value: Int): ByteArray = encodeMinWidth(value)
-
-  private fun encodeMinWidth(value: Int): ByteArray {
-    if (value == 0) return byteArrayOf(0)
-    val bytes = mutableListOf<Byte>()
-    var v = value
-    while (v > 0) {
-      bytes.add(0, (v and 0xFF).toByte())
-      v = v shr 8
-    }
-    return bytes.toByteArray()
-  }
+  private fun dpBytes(value: Int): ByteArray = encodeMinWidth(value).toByteArray()
 
   /** Wraps a ByteArray as ByteString. */
   private fun bs(bytes: ByteArray): ByteString = ByteString.copyFrom(bytes)


### PR DESCRIPTION
Follow-up cleanup after #770. `encodeMinWidth(Int)` hand-rolled the P4Runtime §8.3 shortest-form encoding that `encodeMinWidth(BigInteger)` already expresses (via `canonicalize`). Two encoders for one spec rule, free to drift.

Now the `Int` overload is a one-liner delegating to the `BigInteger` one. As a bonus it inherits the fail-loud `require(value >= 0)` — previously a negative `Int` silently produced an empty bytestring. All seven call sites pass non-negative ports/indices/counters, so the guard is purely defensive (verified).

Also removed a stale private copy of the same hand-rolled loop from `TypeTranslatorTest` — `p4rtBytes`/`dpBytes` now route through the production function — and added a test pinning that the `Int` and `BigInteger` overloads agree across the boundary cases and both reject negatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)