### PR TITLE
Honor controller_header for packet IO

### DIFF
--- a/fourward_cc/dataplane_client_e2e_test.cc
+++ b/fourward_cc/dataplane_client_e2e_test.cc
@@ -230,6 +230,10 @@ p4::v1::PacketOut BuildSaiSubmitToEgressPacketOut(
   submit_to_ingress->set_metadata_id(
       PacketOutMetadataId(p4info, "submit_to_ingress"));
   submit_to_ingress->set_value(std::string(1, '\0'));
+
+  p4::v1::PacketMetadata* unused_pad = packet.add_metadata();
+  unused_pad->set_metadata_id(PacketOutMetadataId(p4info, "unused_pad"));
+  unused_pad->set_value(std::string(1, '\0'));
   return packet;
 }
 

--- a/grpc/BitLevelSerializationTest.kt
+++ b/grpc/BitLevelSerializationTest.kt
@@ -43,6 +43,75 @@ class BitLevelSerializationTest {
   }
 
   @Test
+  fun `controller_header annotations are emitted into behavioral IR`() {
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      @controller_header("packet_out")
+      header CompletelyArbitraryOutboundName_t {
+        bit<9> egress_port;
+        bit<1> submit_to_ingress;
+        @padding
+        bit<6> unused_pad;
+      }
+
+      @controller_header("packet_in")
+      header CompletelyArbitraryInboundName_t {
+        bit<9> ingress_port;
+        bit<7> reason;
+      }
+
+      header ethernet_t { bit<48> dst; bit<48> src; bit<16> etype; }
+      struct headers_t {
+        CompletelyArbitraryOutboundName_t out_hdr;
+        CompletelyArbitraryInboundName_t in_hdr;
+        ethernet_t eth;
+      }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start {
+          pkt.extract(hdr.out_hdr);
+          pkt.extract(hdr.eth);
+          transition accept;
+        }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.egress_spec = h.out_hdr.egress_port; }
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply {
+          h.out_hdr.setInvalid();
+          h.in_hdr.setValid();
+          h.in_hdr.ingress_port = sm.ingress_port;
+          h.in_hdr.reason = 0;
+        }
+      }
+      control D(packet_out pkt, in headers_t h) {
+        apply {
+          pkt.emit(h.in_hdr);
+          pkt.emit(h.eth);
+        }
+      }
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val packetOutHeader =
+      config.device.behavioral.typesList.single { it.name == "CompletelyArbitraryOutboundName_t" }
+    val packetInHeader =
+      config.device.behavioral.typesList.single { it.name == "CompletelyArbitraryInboundName_t" }
+
+    assertEquals("packet_out", packetOutHeader.header.controllerHeader)
+    assertEquals("packet_in", packetInHeader.header.controllerHeader)
+  }
+
+  @Test
   fun `compiled program runs in simulator`() {
     val config =
       compileInlineP4(

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -32,7 +32,8 @@ sealed interface PortOverride {
 
 /**
  * Three-state configuration for the CPU port.
- * - [Auto]: derive from p4info (`2^portBits - 2`). This is the default.
+ * - [Auto]: derive from the architecture dataplane port width (`2^portBits - 2`). This is the
+ *   default.
  * - [Override]: use an explicit port value (dataplane integer or P4RT name).
  * - [Disabled]: no CPU port, even if the p4info has `ControllerPacketMetadata`. Packets egressing
  *   on what would have been the CPU port are treated as regular output; PacketOut is rejected.
@@ -70,7 +71,7 @@ private constructor(
   /** The CPU port for PacketOut packets (v1model convention: 2^portBits - 2). */
   val cpuPort: Int,
 ) {
-  data class FieldDef(val id: Int, val name: String, val bitWidth: Int)
+  data class FieldDef(val id: Int?, val name: String, val bitWidth: Int)
 
   private val packetOutHeaderBits: Int = packetOutFields.sumOf { it.bitWidth }
 
@@ -78,8 +79,7 @@ private constructor(
   val packetOutHeaderBytes: Int = (packetOutHeaderBits + 7) / 8
 
   /**
-   * Total bits of the serialized packet_in header, derived from p4info field widths. Correctness
-   * depends on p4info matching the behavioral config's `packet_in_header_t` type definition.
+   * Total bits of the serialized packet_in header, derived from @controller_header("packet_in").
    */
   val packetInHeaderBits: Int = packetInFields.sumOf { it.bitWidth }
 
@@ -125,24 +125,27 @@ private constructor(
 
   /** Packs PacketOut metadata into a bit-packed binary header. */
   fun serializePacketOut(metadata: List<PacketMetadata>): ByteArray {
+    validatePacketOutMetadata(metadata)
     val metadataById = metadata.associateBy { it.metadataId }
     return packFields(packetOutFields, metadataById)
   }
 
   /**
-   * Packs the PacketOut header and payload into a continuous bit stream. The header fields are
-   * packed at bit granularity followed immediately by the payload bits — no inter-field padding.
-   * This avoids the corruption that byte-concatenation causes for non-byte-aligned headers.
+   * Packs the PacketOut controller header followed immediately by the byte payload.
+   *
+   * The P4Runtime spec defines PacketOut metadata from the P4 header annotated
+   * `@controller_header("packet_out")`. The P4 parser extracts that header's declared fields, then
+   * continues at the next bit. Therefore fields present in the annotated header but absent from
+   * P4Info, such as `@padding` fields, are serialized as zero bits in their declared positions, and
+   * no extra byte-alignment gap is inserted before the payload.
    */
   @Suppress("MagicNumber")
   fun packPacketOut(metadata: List<PacketMetadata>, payload: ByteArray): ByteArray {
-    // When the header is byte-aligned, serializePacketOut produces exact-width bytes
-    // and byte-concatenation with the payload introduces no padding gap.
-    if (packetOutHeaderBits % 8 == 0) return serializePacketOut(metadata) + payload
+    validatePacketOutMetadata(metadata)
     val metadataById = metadata.associateBy { it.metadataId }
     val acc = BitAccumulator()
     for (field in packetOutFields) {
-      val raw = metadataById[field.id]?.value?.toByteArray() ?: ByteArray(0)
+      val raw = field.id?.let { metadataById[it]?.value?.toByteArray() } ?: ByteArray(0)
       var v = 0L
       for (b in raw) v = (v shl 8) or (b.toLong() and 0xFF)
       if (field.bitWidth < Long.SIZE_BITS) v = v and ((1L shl field.bitWidth) - 1)
@@ -150,6 +153,16 @@ private constructor(
     }
     acc.appendRawBytes(payload, 0, payload.size * 8)
     return acc.toByteArray()
+  }
+
+  private fun validatePacketOutMetadata(metadata: List<PacketMetadata>) {
+    val expected = packetOutFields.mapNotNull { it.id }.toSet()
+    val actual = metadata.map { it.metadataId }
+    require(actual.size == actual.toSet().size) { "duplicate packet_out metadata ID" }
+    require(actual.toSet() == expected) {
+      "packet_out metadata IDs must match P4Info: expected ${expected.sorted()}, " +
+        "got ${actual.sorted()}"
+    }
   }
 
   /** Number of meaningful packet bits in [packPacketOut]'s byte-aligned output. */
@@ -161,12 +174,11 @@ private constructor(
    * `@controller_header("packet_in")` bits into metadata fields and returns the remaining packet as
    * the payload.
    *
-   * The metadata is read positionally from the header bit stream according to each field's
-   * p4info-declared width — never reconstructed from simulator state or program-specific field
-   * names. This is the inverse of the deparser's controller-header emit, so the metadata reflects
-   * exactly what the P4 program assigned (e.g. a punted-but-dropped packet reports its intended
-   * egress port, not the CPU port it physically left on). Generic by construction: it works for any
-   * P4 program's `packet_in` layout.
+   * The metadata is read positionally from the annotated header bit stream. Fields omitted from
+   * P4Info, such as padding, are consumed but not reported. Values are never reconstructed from
+   * simulator state or program-specific field names, so PacketIn reflects exactly what the P4
+   * program assigned (e.g. a punted-but-dropped packet reports its intended egress port, not the
+   * CPU port it physically left on).
    */
   fun decodePacketIn(deparsedPayload: ByteString): PacketIn =
     PacketIn.newBuilder()
@@ -183,10 +195,11 @@ private constructor(
         "$packetInHeaderBits-bit packet_in controller header"
     }
     var bitOffset = 0
-    return packetInFields.map { field ->
+    return packetInFields.mapNotNull { field ->
       val value = readBits(bytes, bitOffset, field.bitWidth)
       bitOffset += field.bitWidth
-      PacketMetadata.newBuilder().setMetadataId(field.id).setValue(encodeMinWidth(value)).build()
+      val id = field.id ?: return@mapNotNull null
+      PacketMetadata.newBuilder().setMetadataId(id).setValue(encodeMinWidth(value)).build()
     }
   }
 
@@ -216,7 +229,7 @@ private constructor(
     var bits = 0L
     var totalBits = 0
     for (field in fields) {
-      val value = metadata[field.id]?.value?.toByteArray() ?: ByteArray(0)
+      val value = field.id?.let { metadata[it]?.value?.toByteArray() } ?: ByteArray(0)
       var v = 0L
       for (b in value) v = (v shl 8) or (b.toLong() and 0xFF)
       if (field.bitWidth < Long.SIZE_BITS) v = v and ((1L shl field.bitWidth) - 1)
@@ -251,51 +264,82 @@ private constructor(
       val packetOutMeta =
         p4info.controllerPacketMetadataList.find { it.preamble.name == "packet_out" } ?: return null
 
-      // Build header-type → field-name → bitwidth map from behavioral config.
-      val headerWidths = buildMap {
-        for (type in behavioral.typesList) {
-          if (type.hasHeader()) {
-            put(type.name, type.header.fieldsList.associate { it.name to bitWidth(it.type) })
-          }
-        }
+      val packetOutMetaByName = packetOutMeta.metadataList.associateBy { it.name }
+      val packetOutType = controllerHeaderLayout(behavioral, "packet_out")
+      val packetOutFieldNames = packetOutType.map { it.name }.toSet()
+      val unknownPacketOutMetadata =
+        packetOutMeta.metadataList.map { it.name } - packetOutFieldNames
+      require(unknownPacketOutMetadata.isEmpty()) {
+        "packet_out metadata field(s) not found in @controller_header(\"packet_out\"): " +
+          unknownPacketOutMetadata.joinToString()
       }
-
-      val packetOutType = headerWidths["packet_out_header_t"]
       val packetOutFields =
-        packetOutMeta.metadataList.map { meta ->
+        packetOutType.map { field ->
           FieldDef(
-            id = meta.id,
-            name = meta.name,
-            bitWidth =
-              if (meta.bitwidth > 0) meta.bitwidth
-              else
-                packetOutType?.get(meta.name)
-                  ?: error("cannot determine bitwidth for packet_out.${meta.name}"),
+            id = packetOutMetaByName[field.name]?.id,
+            name = field.name,
+            bitWidth = field.bitWidth,
           )
         }
 
-      // CPU port = 2^portBits - 2 (v1model convention; drop port is 2^W - 1).
-      val portBits =
-        packetOutFields.find { it.name == "egress_port" }?.bitWidth ?: DEFAULT_PORT_BITS
-      val cpuPort = cpuPortOverride ?: ((1 shl portBits) - 2)
+      val cpuPort = cpuPortOverride ?: deriveAutoCpuPort(architectureIngressPortBits(behavioral))
 
       val packetInMeta =
         p4info.controllerPacketMetadataList.find { it.preamble.name == "packet_in" }
-      val packetInType = headerWidths["packet_in_header_t"]
+      val packetInType = packetInMeta?.let { controllerHeaderLayout(behavioral, "packet_in") }
+      val packetInMetaByName = packetInMeta?.metadataList?.associateBy { it.name }
+      val packetInFieldNames = packetInType?.map { it.name }?.toSet() ?: emptySet()
+      val unknownPacketInMetadata =
+        packetInMeta?.metadataList?.map { it.name }?.minus(packetInFieldNames) ?: emptyList()
+      require(unknownPacketInMetadata.isEmpty()) {
+        "packet_in metadata field(s) not found in @controller_header(\"packet_in\"): " +
+          unknownPacketInMetadata.joinToString()
+      }
       val packetInFields =
-        packetInMeta?.metadataList?.map { meta ->
+        packetInType?.map { field ->
           FieldDef(
-            id = meta.id,
-            name = meta.name,
-            bitWidth =
-              if (meta.bitwidth > 0) meta.bitwidth else packetInType?.get(meta.name) ?: portBits,
+            id = packetInMetaByName?.get(field.name)?.id,
+            name = field.name,
+            bitWidth = field.bitWidth,
           )
         } ?: emptyList()
 
       return PacketHeaderCodec(packetOutFields, packetInFields, cpuPort)
     }
 
-    private const val DEFAULT_PORT_BITS = 9
+    private const val STANDARD_METADATA_TYPE = "standard_metadata_t"
+
+    private fun controllerHeaderLayout(
+      behavioral: BehavioralConfig,
+      controllerHeader: String,
+    ): List<FieldDef> {
+      val matches =
+        behavioral.typesList.filter {
+          it.hasHeader() && it.header.controllerHeader == controllerHeader
+        }
+      require(matches.size == 1) {
+        "expected exactly one header annotated @controller_header(\"$controllerHeader\"), " +
+          "found ${matches.size}"
+      }
+      return matches.single().header.fieldsList.map { FieldDef(null, it.name, bitWidth(it.type)) }
+    }
+
+    private fun architectureIngressPortBits(behavioral: BehavioralConfig): Int {
+      val standardMetadata =
+        behavioral.typesList.singleOrNull { it.name == STANDARD_METADATA_TYPE && it.hasStruct() }
+      require(standardMetadata != null) { "$STANDARD_METADATA_TYPE not found in behavioral IR" }
+      val ingressPort =
+        standardMetadata.struct.fieldsList.singleOrNull { it.name == "ingress_port" }
+      require(ingressPort != null) { "$STANDARD_METADATA_TYPE has no ingress_port field" }
+      return bitWidth(ingressPort.type)
+    }
+
+    private fun deriveAutoCpuPort(portBits: Int): Int {
+      require(portBits in 1..Int.SIZE_BITS) {
+        "automatic CPU port derivation requires a 1..32-bit dataplane port, got $portBits bits"
+      }
+      return BigInteger.ONE.shiftLeft(portBits).subtract(BigInteger.TWO).toInt()
+    }
 
     private fun bitWidth(type: Type): Int =
       when (type.kindCase) {

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -10,6 +10,7 @@ import fourward.BehavioralConfig
 import fourward.BitType
 import fourward.FieldDecl
 import fourward.HeaderDecl
+import fourward.StructDecl
 import fourward.Type
 import fourward.TypeDecl
 import fourward.simulator.BitAccumulator
@@ -18,6 +19,7 @@ import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import p4.config.v1.P4InfoOuterClass.ControllerPacketMetadata
 import p4.config.v1.P4InfoOuterClass.P4Info
@@ -55,6 +57,147 @@ class PacketHeaderCodecTest {
     assertEquals(510, codec.cpuPort)
   }
 
+  @Test
+  @Suppress("MagicNumber")
+  fun `create resolves packet io headers by controller_header annotation, not type name`() {
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+            .addMetadata(metaWithBitwidth(2, "submit_to_ingress", 1))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(3, "ingress_port", 5))
+            .addMetadata(metaWithBitwidth(4, "reason", 3))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("ArbitraryPacketOutName_t")
+            .setHeader(
+              controllerHeader(
+                "packet_out",
+                bitField("egress_port", 8),
+                bitField("submit_to_ingress", 1),
+                bitField("unused_pad", 7),
+              )
+            )
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("AnotherArbitraryPacketInName_t")
+            .setHeader(
+              controllerHeader("packet_in", bitField("ingress_port", 5), bitField("reason", 3))
+            )
+        )
+        .build()
+
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
+
+    assertEquals(2, codec.packetOutHeaderBytes)
+    assertEquals(1, codec.packetInHeaderBytes)
+    val packed =
+      codec.packPacketOut(
+        listOf(buildMetadata(1, byteArrayOf(0x12)), buildMetadata(2, byteArrayOf(1))),
+        byteArrayOf(0x34),
+      )
+    assertArrayEquals(byteArrayOf(0x12, 0x80.toByte(), 0x34), packed)
+  }
+
+  @Test
+  fun `create rejects packet_out metadata without packet_out controller header`() {
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("PacketOut_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+        )
+        .build()
+
+    assertThrows(IllegalArgumentException::class.java) {
+      PacketHeaderCodec.create(p4info, behavioral)
+    }
+  }
+
+  @Test
+  fun `create rejects packet_in metadata without packet_in controller header`() {
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(2, "ingress_port", 8))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("PacketOut_t")
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("PacketIn_t")
+            .setHeader(HeaderDecl.newBuilder().addFields(bitField("ingress_port", 8)))
+        )
+        .addTypes(standardMetadataType())
+        .build()
+
+    assertThrows(IllegalArgumentException::class.java) {
+      PacketHeaderCodec.create(p4info, behavioral)
+    }
+  }
+
+  @Test
+  fun `create rejects duplicate controller headers for one direction`() {
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("PacketOutA_t")
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("PacketOutB_t")
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
+        )
+        .build()
+
+    assertThrows(IllegalArgumentException::class.java) {
+      PacketHeaderCodec.create(p4info, behavioral)
+    }
+  }
+
   // =========================================================================
   // packPacketOut
   // =========================================================================
@@ -63,6 +206,7 @@ class PacketHeaderCodecTest {
   @Suppress("MagicNumber")
   fun `packPacketOut bit-packs non-byte-aligned header with payload`() {
     // 5-bit packet_out header (port=1 = 0b00001) + 2-byte payload (0xAA 0xBB).
+    // The annotated P4 header is 5 bits, so the payload begins immediately after bit 5.
     // Continuous bit stream: 00001_10101010_10111011_000
     // = 00001101 01010101 11011000
     // = 0x0D     0x55     0xD8
@@ -84,15 +228,15 @@ class PacketHeaderCodecTest {
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_out_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("port", 5)))
+            .setHeader(controllerHeader("packet_out", bitField("port", 5)))
         )
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_in_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("ingress_port", 8)))
+            .setHeader(controllerHeader("packet_in", bitField("ingress_port", 8)))
         )
         .build()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     val metadata = listOf(buildMetadata(id = 1, value = byteArrayOf(1))) // port=1
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
@@ -100,6 +244,112 @@ class PacketHeaderCodecTest {
 
     assertEquals(3, packed.size)
     assertArrayEquals(byteArrayOf(0x0D, 0x55, 0xD8.toByte()), packed)
+    assertEquals(21, codec.packedPacketOutBitLength(payload.size))
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `packPacketOut includes behavioral padding fields omitted from p4info`() {
+    val (p4info, behavioral) = buildSaiLikeConfig()
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
+    val metadata =
+      listOf(
+        buildMetadata(id = 1, value = byteArrayOf(1)), // egress_port=1
+        buildMetadata(id = 2, value = byteArrayOf(1)), // submit_to_ingress=1
+      )
+    val payload = byteArrayOf(0x74, 0x65)
+
+    val packed = codec.packPacketOut(metadata, payload)
+
+    // Behavioral packet_out_header_t is 9 + 1 + 6 bits. The P4Info metadata omits unused_pad,
+    // but the parser still extracts those declared header bits before the Ethernet payload.
+    assertArrayEquals(byteArrayOf(0x00, 0xC0.toByte(), 0x74, 0x65), packed)
+    assertEquals(32, codec.packedPacketOutBitLength(payload.size))
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `packPacketOut includes 39-bit controller header before payload`() {
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 32))
+            .addMetadata(metaWithBitwidth(2, "submit_to_ingress", 1))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(
+              controllerHeader(
+                "packet_out",
+                bitField("egress_port", 32),
+                bitField("submit_to_ingress", 1),
+                bitField("unused_pad", 6),
+              )
+            )
+        )
+        .build()
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
+    val metadata =
+      listOf(
+        buildMetadata(id = 1, value = byteArrayOf(0, 0, 0, 1)),
+        buildMetadata(id = 2, value = byteArrayOf(1)),
+      )
+    val payload = byteArrayOf(0x74, 0x65)
+
+    val packed = codec.packPacketOut(metadata, payload)
+
+    assertArrayEquals(byteArrayOf(0, 0, 0, 1, 0x80.toByte(), 0xE8.toByte(), 0xCA.toByte()), packed)
+    assertEquals(55, codec.packedPacketOutBitLength(payload.size))
+  }
+
+  @Test
+  fun `packPacketOut rejects missing metadata field`() {
+    val (p4info, behavioral) = buildSaiLikeConfig()
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
+
+    assertThrows(IllegalArgumentException::class.java) {
+      codec.packPacketOut(listOf(buildMetadata(id = 1, value = byteArrayOf(1))), byteArrayOf())
+    }
+  }
+
+  @Test
+  fun `packPacketOut rejects unknown metadata field`() {
+    val (p4info, behavioral) = buildSaiLikeConfig()
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
+
+    assertThrows(IllegalArgumentException::class.java) {
+      codec.packPacketOut(
+        listOf(
+          buildMetadata(id = 1, value = byteArrayOf(1)),
+          buildMetadata(id = 2, value = byteArrayOf(0)),
+          buildMetadata(id = 99, value = byteArrayOf(0)),
+        ),
+        byteArrayOf(),
+      )
+    }
+  }
+
+  @Test
+  fun `packPacketOut rejects duplicate metadata field`() {
+    val (p4info, behavioral) = buildSaiLikeConfig()
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
+
+    assertThrows(IllegalArgumentException::class.java) {
+      codec.packPacketOut(
+        listOf(
+          buildMetadata(id = 1, value = byteArrayOf(1)),
+          buildMetadata(id = 1, value = byteArrayOf(2)),
+          buildMetadata(id = 2, value = byteArrayOf(0)),
+        ),
+        byteArrayOf(),
+      )
+    }
   }
 
   @Test
@@ -126,18 +376,20 @@ class PacketHeaderCodecTest {
           TypeDecl.newBuilder()
             .setName("packet_out_header_t")
             .setHeader(
-              HeaderDecl.newBuilder()
-                .addFields(bitField("egress_port", 8))
-                .addFields(bitField("submit_to_ingress", 8))
+              controllerHeader(
+                "packet_out",
+                bitField("egress_port", 8),
+                bitField("submit_to_ingress", 8),
+              )
             )
         )
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_in_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("ingress_port", 8)))
+            .setHeader(controllerHeader("packet_in", bitField("ingress_port", 8)))
         )
         .build()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     val metadata =
       listOf(
@@ -157,7 +409,7 @@ class PacketHeaderCodecTest {
   @Test
   fun `serializePacketOut packs all-zero fields correctly`() {
     val (p4info, behavioral) = buildSaiLikeConfig()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     val metadata =
       listOf(
@@ -175,7 +427,7 @@ class PacketHeaderCodecTest {
   @Suppress("MagicNumber")
   fun `serializePacketOut packs egress_port=1 correctly`() {
     val (p4info, behavioral) = buildSaiLikeConfig()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     val metadata =
       listOf(
@@ -193,7 +445,7 @@ class PacketHeaderCodecTest {
   @Suppress("MagicNumber")
   fun `serializePacketOut packs submit_to_ingress=1 correctly`() {
     val (p4info, behavioral) = buildSaiLikeConfig()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     val metadata =
       listOf(
@@ -211,7 +463,7 @@ class PacketHeaderCodecTest {
   @Suppress("MagicNumber")
   fun `serializePacketOut packs both fields correctly`() {
     val (p4info, behavioral) = buildSaiLikeConfig()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     val metadata =
       listOf(
@@ -233,7 +485,7 @@ class PacketHeaderCodecTest {
   @Suppress("MagicNumber")
   fun `decodePacketIn parses metadata from the deparsed header`() {
     val (p4info, behavioral) = buildSaiLikeConfig()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     // Deparser output: packet_in header (ingress_port=7, target_egress_port=511) followed by a
     // 2-byte payload. target_egress_port=511 is the DROP port — distinct from any actual egress
@@ -281,17 +533,15 @@ class PacketHeaderCodecTest {
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_out_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
         )
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_in_header_t")
-            .setHeader(
-              HeaderDecl.newBuilder().addFields(bitField("foo", 5)).addFields(bitField("bar", 11))
-            )
+            .setHeader(controllerHeader("packet_in", bitField("foo", 5), bitField("bar", 11)))
         )
         .build()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     // 16-bit header (foo=0x15, bar=0x2AB) + 1-byte payload.
     val acc = BitAccumulator()
@@ -310,6 +560,53 @@ class PacketHeaderCodecTest {
 
   @Test
   @Suppress("MagicNumber")
+  fun `decodePacketIn strips behavioral padding fields omitted from p4info`() {
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 8))
+        )
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_in"))
+            .addMetadata(metaWithBitwidth(2, "ingress_port", 9))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
+        )
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_in_header_t")
+            .setHeader(
+              controllerHeader("packet_in", bitField("ingress_port", 9), bitField("unused_pad", 7))
+            )
+        )
+        .build()
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
+
+    val acc = BitAccumulator()
+    acc.append(BigInteger.valueOf(7), 9) // ingress_port
+    acc.append(BigInteger.ZERO, 7) // unused_pad, not exposed in P4Info
+    acc.append(BigInteger.valueOf(0xBEEF), 16) // payload
+    val deparsed = com.google.protobuf.ByteString.copyFrom(acc.toByteArray())
+
+    val packetIn = codec.decodePacketIn(deparsed)
+
+    assertEquals(1, packetIn.metadataCount)
+    assertEquals(2, packetIn.getMetadata(0).metadataId)
+    assertEquals(7, bytesToInt(packetIn.getMetadata(0).value.toByteArray()))
+    assertArrayEquals(byteArrayOf(0xBE.toByte(), 0xEF.toByte()), packetIn.payload.toByteArray())
+  }
+
+  @Test
+  @Suppress("MagicNumber")
   fun `decodePacketIn with no packet_in controller header returns the payload verbatim`() {
     // A program that defines packet_out (so a codec exists) but no packet_in @controller_header —
     // e.g. it accepts PacketOut but never punts to the controller. There is no header to strip and
@@ -322,9 +619,15 @@ class PacketHeaderCodecTest {
             .addMetadata(metaWithBitwidth(1, "egress_port", 8))
         )
         .build()
-    // No behavioral config needed: the packet_out field carries its own bitwidth, and with no
-    // packet_in metadata there are zero packet_in fields regardless of the header types.
-    val codec = PacketHeaderCodec.create(p4info, BehavioralConfig.getDefaultInstance())!!
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
+        )
+        .build()
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
     assertEquals(0, codec.packetInHeaderBits)
 
     val payload = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
@@ -361,19 +664,17 @@ class PacketHeaderCodecTest {
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_out_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
         )
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_in_header_t")
             .setHeader(
-              HeaderDecl.newBuilder()
-                .addFields(bitField("ingress_port", 8))
-                .addFields(bitField("egress_port", 8))
+              controllerHeader("packet_in", bitField("ingress_port", 8), bitField("egress_port", 8))
             )
         )
         .build()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
     // 16-bit header (2 bytes) + 4-byte payload = 6 bytes total.
     val deparsed =
       com.google.protobuf.ByteString.copyFrom(
@@ -417,19 +718,17 @@ class PacketHeaderCodecTest {
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_out_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
         )
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_in_header_t")
             .setHeader(
-              HeaderDecl.newBuilder()
-                .addFields(bitField("field_a", 5))
-                .addFields(bitField("field_b", 5))
+              controllerHeader("packet_in", bitField("field_a", 5), bitField("field_b", 5))
             )
         )
         .build()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
     assertEquals(10, codec.packetInHeaderBits)
 
     val deparsed =
@@ -470,15 +769,15 @@ class PacketHeaderCodecTest {
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_out_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
         )
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_in_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("field_a", 6)))
+            .setHeader(controllerHeader("packet_in", bitField("field_a", 6)))
         )
         .build()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
 
     // Deparsed: 6 header bits (zeros) + 6 payload bits (0x3F = 0b111111) + 4 pad zeros
     // = 000000_11 1111_0000 = 0x03 0xF0
@@ -527,19 +826,17 @@ class PacketHeaderCodecTest {
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_out_header_t")
-            .setHeader(HeaderDecl.newBuilder().addFields(bitField("egress_port", 8)))
+            .setHeader(controllerHeader("packet_out", bitField("egress_port", 8)))
         )
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_in_header_t")
             .setHeader(
-              HeaderDecl.newBuilder()
-                .addFields(bitField("field_a", 5))
-                .addFields(bitField("field_b", 5))
+              controllerHeader("packet_in", bitField("field_a", 5), bitField("field_b", 5))
             )
         )
         .build()
-    val codec = PacketHeaderCodec.create(p4info, behavioral)!!
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 510)!!
     assertEquals(10, codec.packetInHeaderBits)
 
     // Simulate deparser output: 10 zero header bits + 0xDEADBEEF payload.
@@ -582,7 +879,7 @@ class PacketHeaderCodecTest {
    * - Behavioral config with header types for field width resolution.
    */
   @Suppress("MagicNumber")
-  private fun buildSaiLikeConfig(): Pair<P4Info, BehavioralConfig> {
+  private fun buildSaiLikeConfig(portBits: Int = 9): Pair<P4Info, BehavioralConfig> {
     val p4info =
       P4Info.newBuilder()
         .addControllerPacketMetadata(
@@ -605,21 +902,26 @@ class PacketHeaderCodecTest {
           TypeDecl.newBuilder()
             .setName("packet_out_header_t")
             .setHeader(
-              HeaderDecl.newBuilder()
-                .addFields(bitField("egress_port", 9))
-                .addFields(bitField("submit_to_ingress", 1))
-                .addFields(bitField("unused_pad", 6))
+              controllerHeader(
+                "packet_out",
+                bitField("egress_port", 9),
+                bitField("submit_to_ingress", 1),
+                bitField("unused_pad", 6),
+              )
             )
         )
         .addTypes(
           TypeDecl.newBuilder()
             .setName("packet_in_header_t")
             .setHeader(
-              HeaderDecl.newBuilder()
-                .addFields(bitField("ingress_port", 9))
-                .addFields(bitField("target_egress_port", 9))
+              controllerHeader(
+                "packet_in",
+                bitField("ingress_port", 9),
+                bitField("target_egress_port", 9),
+              )
             )
         )
+        .addTypes(standardMetadataType(portBits))
         .build()
 
     return p4info to behavioral
@@ -645,6 +947,15 @@ class PacketHeaderCodecTest {
       .setType(Type.newBuilder().setBit(BitType.newBuilder().setWidth(width)))
       .build()
 
+  private fun controllerHeader(name: String, vararg fields: FieldDecl): HeaderDecl =
+    HeaderDecl.newBuilder().setControllerHeader(name).addAllFields(fields.toList()).build()
+
+  private fun standardMetadataType(portBits: Int = 9): TypeDecl =
+    TypeDecl.newBuilder()
+      .setName("standard_metadata_t")
+      .setStruct(StructDecl.newBuilder().addFields(bitField("ingress_port", portBits)))
+      .build()
+
   // =========================================================================
   // CPU port override
   // =========================================================================
@@ -664,6 +975,59 @@ class PacketHeaderCodecTest {
     assertNotNull(codec)
     // Default: 2^9 - 2 = 510
     assertEquals(510, codec!!.cpuPort)
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `auto cpu port derives from architecture port width, not packet_out metadata width`() {
+    val p4info =
+      P4Info.newBuilder()
+        .addControllerPacketMetadata(
+          ControllerPacketMetadata.newBuilder()
+            .setPreamble(Preamble.newBuilder().setName("packet_out"))
+            .addMetadata(metaWithBitwidth(1, "egress_port", 32))
+            .addMetadata(metaWithBitwidth(2, "submit_to_ingress", 1))
+        )
+        .build()
+    val behavioral =
+      BehavioralConfig.newBuilder()
+        .addTypes(
+          TypeDecl.newBuilder()
+            .setName("packet_out_header_t")
+            .setHeader(
+              controllerHeader(
+                "packet_out",
+                bitField("egress_port", 32),
+                bitField("submit_to_ingress", 1),
+              )
+            )
+        )
+        .addTypes(standardMetadataType(portBits = 9))
+        .build()
+
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = null)
+
+    assertEquals(510, codec!!.cpuPort)
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `auto cpu port supports 32-bit architecture ports`() {
+    val (p4info, behavioral) = buildSaiLikeConfig(portBits = 32)
+
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = null)
+
+    assertEquals(0xFFFF_FFFEu.toInt(), codec!!.cpuPort)
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `auto cpu port rejects architecture ports wider than dataplane port field`() {
+    val (p4info, behavioral) = buildSaiLikeConfig(portBits = 33)
+
+    assertThrows(IllegalArgumentException::class.java) {
+      PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = null)
+    }
   }
 
   // =========================================================================

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -1947,6 +1947,7 @@ class SaiP4E2ETest {
       config.p4Info.controllerPacketMetadataList.find { it.preamble.name == "packet_out" }!!
     val egressPortId = packetOutMeta.metadataList.find { it.name == "egress_port" }!!.id
     val submitToIngressId = packetOutMeta.metadataList.find { it.name == "submit_to_ingress" }!!.id
+    val unusedPadId = packetOutMeta.metadataList.find { it.name == "unused_pad" }!!.id
 
     return P4RuntimeOuterClass.PacketOut.newBuilder()
       .setPayload(
@@ -1961,6 +1962,11 @@ class SaiP4E2ETest {
         P4RuntimeOuterClass.PacketMetadata.newBuilder()
           .setMetadataId(submitToIngressId)
           .setValue(ByteString.copyFrom(byteArrayOf(if (submitToIngress) 1 else 0)))
+      )
+      .addMetadata(
+        P4RuntimeOuterClass.PacketMetadata.newBuilder()
+          .setMetadataId(unusedPadId)
+          .setValue(ByteString.copyFrom(byteArrayOf(0)))
       )
       .build()
   }

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -541,6 +541,14 @@ void FourWardBackend::emitTypeDecls(const IR::P4Program* program) {
       auto* td = behavioral_->add_types();
       td->set_name(hdr->name.name.c_str());
       auto* hdecl = td->mutable_header();
+      if (const auto* ann = hdr->getAnnotation("controller_header"_cs)) {
+        if (ann->getExpr().size() == 1) {
+          if (const auto* value =
+                  ann->getExpr().at(0)->to<IR::StringLiteral>()) {
+            hdecl->set_controller_header(value->value.c_str());
+          }
+        }
+      }
       for (const auto* field : hdr->fields) {
         auto* fd = hdecl->add_fields();
         fd->set_name(field->name.name.c_str());

--- a/p4c_backend/main.cpp
+++ b/p4c_backend/main.cpp
@@ -287,12 +287,13 @@ int main(int argc, char* const argv[]) {
     auto entries = *p4Runtime.entries;
     fixConstEntryPriorities(program, *p4Runtime.p4Info, &entries);
 
-    // Parse @p4runtime_translation_mappings annotations (not handled by the
-    // standard frontend) so extractTypeTranslations can read them as expression
-    // lists.  Must happen before the midend, which eliminates Type_Newtype.
+    // Parse annotations the backend reads directly. Must happen before the
+    // midend, which eliminates Type_Newtype and preserves header declarations
+    // for behavioral IR emission.
     P4::ParseAnnotations parseTranslationMappings(
         "FourWard", false,
-        {{"p4runtime_translation_mappings"_cs,
+        {PARSE("controller_header"_cs, StringLiteral),
+         {"p4runtime_translation_mappings"_cs,
           &P4::ParseAnnotations::parseExpressionList}});
     program = program->apply(parseTranslationMappings);
 

--- a/simulator/ir.proto
+++ b/simulator/ir.proto
@@ -234,6 +234,9 @@ message TypeDecl {
 
 message HeaderDecl {
   repeated FieldDecl fields = 1;
+  // Value of @controller_header, e.g. "packet_out" or "packet_in". Empty for
+  // ordinary headers.
+  string controller_header = 2;
 }
 message StructDecl {
   repeated FieldDecl fields = 1;


### PR DESCRIPTION
## What changed

PacketOut and PacketIn header layouts now come from the P4 headers annotated with `@controller_header("packet_out")` and `@controller_header("packet_in")`, matching the P4Runtime spec.

This removes the old type-name dependency on `packet_out_header_t` / `packet_in_header_t`. The codec now requires exactly one annotated header for each P4Info direction it needs, rejects unknown metadata, and preserves annotated header fields that are absent from P4Info by treating them as zero-filled packet bits for PacketOut and consumed-but-not-reported bits for PacketIn.

CPU-port auto derivation now uses the architecture dataplane port width (`standard_metadata_t.ingress_port`) instead of the PacketOut metadata width. PacketOut metadata may be wider than the dataplane port, and 32-bit dataplane ports are supported at the existing `Int`/`uint32` service boundary. Wider dataplane ports fail loudly instead of truncating.

## Why

Issue #779 exposed a PacketOut bit shift when P4Info exposed 33 bits of metadata (`egress_port` + `submit_to_ingress`) but the P4 parser extracted a 39-bit `@controller_header("packet_out")` header with 6 padding bits. The old codec packed only the P4Info-visible fields, so payload bits slid into the parser-visible padding region.

## Validation

I reproduced the old failure on `origin/main` by adding the focused 39-bit regression there: expected byte 4 was `0x80`, old code produced `0xBA`.

On this branch:

- `bazel test //grpc:PacketHeaderCodecTest --test_filter='packPacketOut includes 39-bit controller header before payload'`
- `bazel test //grpc:PacketHeaderCodecTest //grpc:BitLevelSerializationTest`
- `./tools/format.sh`
- `./tools/lint.sh`

Fixes #779.
