### PR TITLE
fix: 1-bit payload shift in fork branches with non-byte-aligned headers

### DIFF
--- a/grpc/BitLevelSerializationTest.kt
+++ b/grpc/BitLevelSerializationTest.kt
@@ -1,12 +1,14 @@
 package fourward.grpc
 
-import com.google.protobuf.ByteString
 import fourward.e2e.compileInlineP4
+import fourward.grpc.FourwardTestHarness.Companion.buildMulticastGroup
+import fourward.simulator.BitAccumulator
+import java.math.BigInteger
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import p4.v1.P4RuntimeOuterClass
 
 class BitLevelSerializationTest {
 
@@ -805,83 +807,44 @@ class BitLevelSerializationTest {
     harness.use {
       it.loadPipeline(config)
 
-      // Install multicast group 1 with one replica on port "1".
-      it.installEntry(
-        P4RuntimeOuterClass.Entity.newBuilder()
-          .setPacketReplicationEngineEntry(
-            P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
-              .setMulticastGroupEntry(
-                P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
-                  .setMulticastGroupId(1)
-                  .addReplicas(
-                    P4RuntimeOuterClass.Replica.newBuilder()
-                      .setPort(ByteString.copyFromUtf8("1"))
-                      .setInstance(1)
-                  )
-              )
-          )
-          .build()
-      )
+      it.installEntry(buildMulticastGroup(groupId = 1, ports = listOf(1)))
 
-      // Build the input: 7-bit header (port=0) bit-packed with a 14-byte Ethernet
-      // payload. The packed layout in 15 bytes:
-      //   bits[0..6]   = header = 0b0000000
-      //   bits[7..118] = Ethernet payload (14 bytes × 8 bits)
-      //   bit[119]     = trailing zero (padding to byte boundary)
-      //
       // The Ethernet frame uses a 0xFF/0x00 alternating pattern so a 1-bit shift
       // is immediately visible in the first output byte (0xFF correct, 0xFE shifted).
       val ethPayload =
         byteArrayOf(
           0xFF.toByte(),
-          0x00.toByte(), // dst_mac bytes 0-1
+          0, // dst_mac [0..1]
           0xFF.toByte(),
-          0x00.toByte(), // dst_mac bytes 2-3
+          0, // dst_mac [2..3]
           0xFF.toByte(),
-          0x00.toByte(), // dst_mac bytes 4-5
+          0, // dst_mac [4..5]
           0xFF.toByte(),
-          0x00.toByte(), // src_mac bytes 0-1
+          0, // src_mac [0..1]
           0xFF.toByte(),
-          0x00.toByte(), // src_mac bytes 2-3
+          0, // src_mac [2..3]
           0xFF.toByte(),
-          0x00.toByte(), // src_mac bytes 4-5
-          0x08.toByte(),
-          0x00.toByte(), // EtherType = IPv4
+          0, // src_mac [4..5]
+          0x08,
+          0, // EtherType = IPv4
         )
 
-      // Pack the 7-bit header (port=0, all zeros) followed by ethPayload into 15
-      // bytes.  Each ethPayload byte straddles two output bytes because of the
-      // 7-bit offset.
-      val packed = ByteArray(15)
-      for (i in ethPayload.indices) {
-        val b = ethPayload[i].toInt() and 0xFF
-        val bitPos = 7 + i * 8
-        val byteIdx = bitPos / 8
-        val shift = bitPos % 8
-        packed[byteIdx] = (packed[byteIdx].toInt() or (b ushr shift)).toByte()
-        if (shift > 0) {
-          packed[byteIdx + 1] = (packed[byteIdx + 1].toInt() or (b shl (8 - shift))).toByte()
-        }
-      }
+      // Pack the 7-bit header (port=0) followed by ethPayload into a continuous bit stream.
+      val acc = BitAccumulator()
+      acc.append(BigInteger.ZERO, 7)
+      acc.appendRawBytes(ethPayload, 0, ethPayload.size * 8)
+      val packed = acc.toByteArray()
 
       val result = it.simulatePacket(ingressPort = 0, payload = packed)
       val outputs = result.single().packetsList
       assertEquals("multicast group 1 should produce one replica", 1, outputs.size)
       val outputBytes = outputs.single().payload.toByteArray()
 
-      // The deparser emits nothing; the output is the unparsed remainder (bits 7
-      // onward from the packed input), which should be exactly the Ethernet payload.
-      // A 1-bit shift bug would produce 0xFE as the first byte instead of 0xFF.
+      // The deparser emits nothing; the output is the unparsed remainder starting at
+      // bit 7 (113 bits = 15 bytes with a trailing alignment byte). A 1-bit shift bug
+      // would produce 0xFE as the first byte instead of 0xFF.
       assertTrue("output should contain at least the Ethernet payload", outputBytes.size >= 14)
-      assertEquals(
-        "first Ethernet byte should be 0xFF (not 0xFE = 1-bit-shifted)",
-        0xFF.toByte(),
-        outputBytes[0],
-      )
-      assertEquals("second Ethernet byte should be 0x00", 0x00.toByte(), outputBytes[1])
-      assertEquals("third Ethernet byte should be 0xFF", 0xFF.toByte(), outputBytes[2])
-      assertEquals("EtherType high byte should be 0x08", 0x08.toByte(), outputBytes[12])
-      assertEquals("EtherType low byte should be 0x00", 0x00.toByte(), outputBytes[13])
+      assertArrayEquals(ethPayload, outputBytes.copyOfRange(0, 14))
     }
   }
 }

--- a/grpc/BitLevelSerializationTest.kt
+++ b/grpc/BitLevelSerializationTest.kt
@@ -1,10 +1,12 @@
 package fourward.grpc
 
+import com.google.protobuf.ByteString
 import fourward.e2e.compileInlineP4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import p4.v1.P4RuntimeOuterClass
 
 class BitLevelSerializationTest {
 
@@ -754,5 +756,132 @@ class BitLevelSerializationTest {
       "not_preserved field should have no field_list_ids",
       notPreserved.fieldListIdsList.isEmpty(),
     )
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `non-byte-aligned header does not shift payload on fork branches`() {
+    // Regression test for: https://github.com/4ward-p4/4ward/issues/779
+    //
+    // When the packet_out_header is non-byte-aligned, the parser leaves the cursor
+    // at a non-byte-aligned bit offset (e.g. 7 bits for a 7-bit header). The old
+    // fork mechanism recorded bytesConsumed = ceil(7/8) = 1 byte = 8 bits, which
+    // caused the multicast/clone branch to initialise its PacketContext 1 bit too
+    // late, shifting the entire unparsed payload by 1 bit in the output.
+    //
+    // The fix records bitsConsumed (exact bit count) and passes it as the initial
+    // bit offset when creating the branch PacketContext.
+    val config =
+      compileInlineP4(
+        """
+      #include <core.p4>
+      #include <v1model.p4>
+
+      // 7-bit header: non-byte-aligned. After extraction, bitOffset=7.
+      @controller_header("packet_out")
+      header packet_out_t { bit<7> port; }
+
+      struct headers_t { packet_out_t pkt_out; }
+      struct meta_t {}
+
+      parser P(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t sm) {
+        state start {
+          pkt.extract(hdr.pkt_out);
+          transition accept; // rest of packet is left as unparsed remainder
+        }
+      }
+      control VC(inout headers_t h, inout meta_t m) { apply {} }
+      control CC(inout headers_t h, inout meta_t m) { apply {} }
+      control Ig(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) {
+        apply { sm.mcast_grp = 1; } // trigger MulticastFork
+      }
+      control Eg(inout headers_t h, inout meta_t m, inout standard_metadata_t sm) { apply {} }
+      control D(packet_out pkt, in headers_t h) { apply {} } // emit nothing; output = unparsed remainder
+      V1Switch(P(), VC(), Ig(), Eg(), CC(), D()) main;
+      """
+      )
+
+    val harness = FourwardTestHarness()
+    harness.use {
+      it.loadPipeline(config)
+
+      // Install multicast group 1 with one replica on port "1".
+      it.installEntry(
+        P4RuntimeOuterClass.Entity.newBuilder()
+          .setPacketReplicationEngineEntry(
+            P4RuntimeOuterClass.PacketReplicationEngineEntry.newBuilder()
+              .setMulticastGroupEntry(
+                P4RuntimeOuterClass.MulticastGroupEntry.newBuilder()
+                  .setMulticastGroupId(1)
+                  .addReplicas(
+                    P4RuntimeOuterClass.Replica.newBuilder()
+                      .setPort(ByteString.copyFromUtf8("1"))
+                      .setInstance(1)
+                  )
+              )
+          )
+          .build()
+      )
+
+      // Build the input: 7-bit header (port=0) bit-packed with a 14-byte Ethernet
+      // payload. The packed layout in 15 bytes:
+      //   bits[0..6]   = header = 0b0000000
+      //   bits[7..118] = Ethernet payload (14 bytes × 8 bits)
+      //   bit[119]     = trailing zero (padding to byte boundary)
+      //
+      // The Ethernet frame uses a 0xFF/0x00 alternating pattern so a 1-bit shift
+      // is immediately visible in the first output byte (0xFF correct, 0xFE shifted).
+      val ethPayload =
+        byteArrayOf(
+          0xFF.toByte(),
+          0x00.toByte(), // dst_mac bytes 0-1
+          0xFF.toByte(),
+          0x00.toByte(), // dst_mac bytes 2-3
+          0xFF.toByte(),
+          0x00.toByte(), // dst_mac bytes 4-5
+          0xFF.toByte(),
+          0x00.toByte(), // src_mac bytes 0-1
+          0xFF.toByte(),
+          0x00.toByte(), // src_mac bytes 2-3
+          0xFF.toByte(),
+          0x00.toByte(), // src_mac bytes 4-5
+          0x08.toByte(),
+          0x00.toByte(), // EtherType = IPv4
+        )
+
+      // Pack the 7-bit header (port=0, all zeros) followed by ethPayload into 15
+      // bytes.  Each ethPayload byte straddles two output bytes because of the
+      // 7-bit offset.
+      val packed = ByteArray(15)
+      for (i in ethPayload.indices) {
+        val b = ethPayload[i].toInt() and 0xFF
+        val bitPos = 7 + i * 8
+        val byteIdx = bitPos / 8
+        val shift = bitPos % 8
+        packed[byteIdx] = (packed[byteIdx].toInt() or (b ushr shift)).toByte()
+        if (shift > 0) {
+          packed[byteIdx + 1] = (packed[byteIdx + 1].toInt() or (b shl (8 - shift))).toByte()
+        }
+      }
+
+      val result = it.simulatePacket(ingressPort = 0, payload = packed)
+      val outputs = result.single().packetsList
+      assertEquals("multicast group 1 should produce one replica", 1, outputs.size)
+      val outputBytes = outputs.single().payload.toByteArray()
+
+      // The deparser emits nothing; the output is the unparsed remainder (bits 7
+      // onward from the packed input), which should be exactly the Ethernet payload.
+      // A 1-bit shift bug would produce 0xFE as the first byte instead of 0xFF.
+      assertTrue("output should contain at least the Ethernet payload", outputBytes.size >= 14)
+      assertEquals(
+        "first Ethernet byte should be 0xFF (not 0xFE = 1-bit-shifted)",
+        0xFF.toByte(),
+        outputBytes[0],
+      )
+      assertEquals("second Ethernet byte should be 0x00", 0x00.toByte(), outputBytes[1])
+      assertEquals("third Ethernet byte should be 0xFF", 0xFF.toByte(), outputBytes[2])
+      assertEquals("EtherType high byte should be 0x08", 0x08.toByte(), outputBytes[12])
+      assertEquals("EtherType low byte should be 0x00", 0x00.toByte(), outputBytes[13])
+    }
   }
 }

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -80,12 +80,12 @@ class Environment {
  * Holds the input packet buffer, the output (emit) buffer, and the execution trace. Created once
  * per packet in the architecture's [processPacket] and threaded through the interpreter.
  */
-class PacketContext(packet: PacketBits, initialOffset: Int = 0) {
+class PacketContext(packet: PacketBits, initialBitOffset: Int = 0) {
 
   constructor(
     payload: ByteArray,
-    initialOffset: Int = 0,
-  ) : this(PacketBits.ofBytes(payload), initialOffset)
+    initialBitOffset: Int = 0,
+  ) : this(PacketBits.ofBytes(payload), initialBitOffset)
 
   /** Original ingress packet length in bytes (for direct counter byte counts). */
   val payloadSize: Int = packet.packetByteLength
@@ -96,11 +96,11 @@ class PacketContext(packet: PacketBits, initialOffset: Int = 0) {
 
   /** Remaining bytes in the input packet, consumed by parser extract(). */
   private val buffer: ParserCursor =
-    ParserCursor(packet.backingBytesForParser(), initialOffset, packet.validBitLength)
+    ParserCursor(packet.backingBytesForParser(), initialBitOffset, packet.validBitLength)
 
-  /** Number of bytes consumed from the input buffer so far (parser extract position). */
-  val bytesConsumed: Int
-    get() = buffer.bytesConsumed
+  /** Exact number of bits consumed from the input buffer so far (parser extract position). */
+  val bitsConsumed: Int
+    get() = buffer.bitsConsumed
 
   /** Bit-level output buffer, written by deparser emit(). */
   private val outputBits = BitAccumulator()
@@ -178,23 +178,23 @@ open class ParserErrorException(val errorName: String, message: String) : Except
 @Suppress("MagicNumber")
 private class ParserCursor(
   private val data: ByteArray,
-  initialByteOffset: Int = 0,
+  initialBitOffset: Int = 0,
   private val validBitLength: Int = data.size * Byte.SIZE_BITS,
 ) {
   init {
     require(validBitLength in 0..data.size * Byte.SIZE_BITS) {
       "validBitLength must be between 0 and ${data.size * Byte.SIZE_BITS}, got $validBitLength"
     }
-    require(initialByteOffset * Byte.SIZE_BITS <= validBitLength) {
-      "initialByteOffset $initialByteOffset is past validBitLength $validBitLength"
+    require(initialBitOffset <= validBitLength) {
+      "initialBitOffset $initialBitOffset is past validBitLength $validBitLength"
     }
   }
 
-  private var bitOffset: Int = initialByteOffset * 8
+  private var bitOffset: Int = initialBitOffset
 
-  /** Number of whole bytes consumed from the start of the buffer. */
-  val bytesConsumed: Int
-    get() = (bitOffset + 7) / 8
+  /** Exact number of bits consumed from the start of the buffer. */
+  val bitsConsumed: Int
+    get() = bitOffset
 
   fun hasRemaining(): Boolean = bitOffset < validBitLength
 

--- a/simulator/Interpreter.kt
+++ b/simulator/Interpreter.kt
@@ -1023,7 +1023,7 @@ class Interpreter internal constructor(config: BehavioralConfig) {
           result.members,
           packetCtx!!.getEvents(),
           env.deepCopy(),
-          packetCtx!!.bytesConsumed,
+          packetCtx!!.bitsConsumed,
           currentSourceInfo,
         )
       }
@@ -1596,8 +1596,8 @@ class ActionSelectorFork(
   eventsBeforeFork: List<TraceEvent>,
   /** Deep copy of the environment at the fork point — each branch restores from this. */
   val forkPointEnv: Environment,
-  /** Parser buffer position at the fork point. */
-  val bytesConsumed: Int,
+  /** Exact parser bit position at the fork point (not rounded to bytes). */
+  val bitsConsumed: Int,
   /** Source info at the fork point (the table apply statement), for trace events in branches. */
   val sourceInfo: fourward.SourceInfo? = null,
   /**

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -196,12 +196,12 @@ class V1ModelArchitecture(
    */
   private fun createBranchState(
     ctx: PipelineContext,
-    bytesConsumed: Int,
+    bitsConsumed: Int,
     snapshotEnv: Environment,
     snapshotPendingOps: V1ModelPendingOps? = null,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): PipelineState {
-    val packetCtx = PacketContext(ctx.packet, bytesConsumed)
+    val packetCtx = PacketContext(ctx.packet, bitsConsumed)
     val env = snapshotEnv.deepCopy()
     val pendingOps = snapshotPendingOps?.copy() ?: V1ModelPendingOps()
     val standardMetadata = resolveStandardMetadata(ctx, env)
@@ -221,13 +221,13 @@ class V1ModelArchitecture(
    */
   private inline fun runBranch(
     ctx: PipelineContext,
-    bytesConsumed: Int,
+    bitsConsumed: Int,
     snapshotEnv: Environment,
     snapshotPendingOps: V1ModelPendingOps? = null,
     configure: (PipelineState) -> Unit = {},
     pipelineTail: (PipelineContext, PipelineState) -> TraceTree,
   ): TraceTree {
-    val s = createBranchState(ctx, bytesConsumed, snapshotEnv, snapshotPendingOps)
+    val s = createBranchState(ctx, bitsConsumed, snapshotEnv, snapshotPendingOps)
     configure(s)
     return try {
       pipelineTail(ctx, s)
@@ -278,7 +278,7 @@ class V1ModelArchitecture(
     member: TableStore.MemberAction,
   ): TraceTree {
     val fork = selectorFork.fork
-    val s = createBranchState(ctx, fork.bytesConsumed, fork.forkPointEnv, selectorFork.pendingOps)
+    val s = createBranchState(ctx, fork.bitsConsumed, fork.forkPointEnv, selectorFork.pendingOps)
     s.postParserEnv = selectorFork.postParserEnv
 
     try {
@@ -321,7 +321,7 @@ class V1ModelArchitecture(
     val buildBranch = { replica: Replica ->
       runBranch(
         ctx,
-        fork.bytesConsumed,
+        fork.bitsConsumed,
         fork.forkPointEnv,
         fork.forkPointPendingOps,
         configure = { s ->
@@ -356,7 +356,7 @@ class V1ModelArchitecture(
     val original =
       runBranch(
         ctx,
-        fork.bytesConsumed,
+        fork.bitsConsumed,
         fork.forkPointEnv,
         fork.forkPointPendingOps,
         configure = { s -> s.pendingOps.cloneSessionId = null },
@@ -375,7 +375,7 @@ class V1ModelArchitecture(
       buildCloneBranches(
         cloneCtx,
         fork.replicas,
-        fork.bytesConsumed,
+        fork.bitsConsumed,
         fork.postParserEnv,
         snapshotPendingOps = null,
         CLONE_I2E_INSTANCE_TYPE,
@@ -397,7 +397,7 @@ class V1ModelArchitecture(
     val original =
       runBranch(
         ctx,
-        fork.bytesConsumed,
+        fork.bitsConsumed,
         fork.forkPointEnv,
         fork.forkPointPendingOps,
         configure = { s -> s.pendingOps.egressCloneSessionId = null },
@@ -415,7 +415,7 @@ class V1ModelArchitecture(
       buildCloneBranches(
         cloneCtx,
         fork.replicas,
-        fork.bytesConsumed,
+        fork.bitsConsumed,
         fork.forkPointEnv,
         fork.forkPointPendingOps,
         CLONE_E2E_INSTANCE_TYPE,
@@ -435,7 +435,7 @@ class V1ModelArchitecture(
   private fun buildCloneBranches(
     ctx: PipelineContext,
     replicas: List<Replica>,
-    bytesConsumed: Int,
+    bitsConsumed: Int,
     snapshotEnv: Environment,
     snapshotPendingOps: V1ModelPendingOps?,
     instanceType: Long,
@@ -445,7 +445,7 @@ class V1ModelArchitecture(
     val buildBranch = { replica: Replica ->
       runBranch(
         ctx,
-        bytesConsumed,
+        bitsConsumed,
         snapshotEnv,
         snapshotPendingOps,
         configure = { s ->
@@ -821,7 +821,7 @@ class V1ModelArchitecture(
           s.packetCtx.getEvents(),
           snapshotPreservedMetadata(s, s.pendingOps.cloneFieldListId),
           s.env.deepCopy(),
-          s.packetCtx.bytesConsumed,
+          s.packetCtx.bitsConsumed,
           s.pendingOps.copy(),
           s.postParserEnv ?: error("no post-parser env for I2E clone"),
           session.truncateBytes,
@@ -844,7 +844,7 @@ class V1ModelArchitecture(
           replicas,
           s.packetCtx.getEvents(),
           s.env.deepCopy(),
-          s.packetCtx.bytesConsumed,
+          s.packetCtx.bitsConsumed,
           s.pendingOps.copy(),
         )
       }
@@ -870,7 +870,7 @@ class V1ModelArchitecture(
           s.packetCtx.getEvents(),
           snapshotPreservedMetadata(s, s.pendingOps.egressCloneFieldListId),
           s.env.deepCopy(),
-          s.packetCtx.bytesConsumed,
+          s.packetCtx.bitsConsumed,
           s.pendingOps.copy(),
           session.truncateBytes,
         )
@@ -1360,8 +1360,8 @@ internal class CloneFork(
   val preservedMetadata: Map<String, Value>? = null,
   /** Deep copy of the post-ingress environment (for the "original" branch). */
   val forkPointEnv: Environment,
-  /** Parser buffer position at the fork point. */
-  val bytesConsumed: Int,
+  /** Exact parser bit position at the fork point (not rounded to bytes). */
+  val bitsConsumed: Int,
   /** Pending operations at the fork point. */
   val forkPointPendingOps: V1ModelPendingOps,
   /** Post-parser env (for clone branches — BMv2: clone gets pre-ingress state). */
@@ -1381,8 +1381,8 @@ internal class EgressCloneFork(
   val preservedMetadata: Map<String, Value>? = null,
   /** Deep copy of the post-egress environment (for both branches). */
   val forkPointEnv: Environment,
-  /** Parser buffer position at the fork point. */
-  val bytesConsumed: Int,
+  /** Exact parser bit position at the fork point (not rounded to bytes). */
+  val bitsConsumed: Int,
   /** Pending operations at the fork point. */
   val forkPointPendingOps: V1ModelPendingOps,
   /** Clone session packet_length_bytes: 0 = no truncation, >0 = truncate to this many bytes. */
@@ -1395,8 +1395,8 @@ internal class MulticastFork(
   eventsBeforeFork: List<TraceEvent>,
   /** Deep copy of the environment at the fork point (post-ingress). */
   val forkPointEnv: Environment,
-  /** Parser buffer position at the fork point. */
-  val bytesConsumed: Int,
+  /** Exact parser bit position at the fork point (not rounded to bytes). */
+  val bitsConsumed: Int,
   /** Pending operations at the fork point. */
   val forkPointPendingOps: V1ModelPendingOps,
 ) : ForkException(eventsBeforeFork)


### PR DESCRIPTION
## The win

Fixes a 1-bit payload shift in fork branches (I2E clone, E2E clone, multicast, action selector) triggered by any `@controller_header("packet_out")` whose total bit width is not a multiple of 8.

This is the **fork tracking layer** fix for #779. See also #780, which independently fixes the **codec layer** (ensuring all `@controller_header` fields, including `@padding`, are included in the serialized byte stream). Both fixes address different parts of the same issue and are complementary.

## Root cause

When the parser extracts a non-byte-aligned header, the bit cursor stops at a non-byte-aligned position (e.g. `bitOffset=39`). The fork mechanism captured that position as:

```
bytesConsumed = ceil(bitOffset / 8)   // rounds 39 bits → 5 bytes = 40 bits
```

Each fork branch was then initialised with a `PacketContext` whose buffer started 1 bit too late. The deparser would then append the "unparsed remainder" starting at bit 40 instead of bit 39, dropping the first bit of the payload and shifting everything right by 1 bit.

The bug triggers with any non-byte-aligned `@controller_header("packet_out")` AND a fork (I2E clone, E2E clone, multicast, or action selector group).

## Fix

Replace `bytesConsumed` (byte-rounded) with `bitsConsumed` (exact bit count) everywhere the fork position is recorded or consumed:

- `CloneFork`, `EgressCloneFork`, `MulticastFork` (in `V1ModelArchitecture.kt`)
- `ActionSelectorFork` (in `Interpreter.kt`)
- `createBranchState()` / `runBranch()` / `buildCloneBranches()`
- `PacketContext` and `ParserCursor` in `Environment.kt`: constructor parameter renamed from `initialByteOffset` to `initialBitOffset`, with the implicit byte→bit multiplication removed.

## Test

Added `non-byte-aligned header does not shift payload on fork branches` in `BitLevelSerializationTest.kt`: a 7-bit `packet_out_header` is parsed (bitOffset=7 after extraction), the rest of the packet is forwarded to a multicast group as an unparsed remainder, and the output's first byte is checked to be `0xFF` (correct) rather than `0xFE` (1-bit-shifted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)