### PR TITLE
[codex] Type dataplane ports at gRPC boundary

### DIFF
--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -385,6 +385,7 @@ kt_jvm_test(
     test_class = "fourward.grpc.TypeTranslatorTest",
     deps = [
         ":grpc",
+        "//simulator",
         "//simulator:ir_java_proto",
         "//simulator:p4info_java_proto",
         "//simulator:p4runtime_java_proto",

--- a/grpc/Bytestrings.kt
+++ b/grpc/Bytestrings.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString
 import fourward.simulator.toUnsignedBigInteger
 import io.grpc.Status
 import io.grpc.StatusException
+import java.nio.ByteBuffer
 import p4.v1.P4RuntimeOuterClass
 
 /**
@@ -72,6 +73,12 @@ fun canonicalize(value: ByteString): ByteString {
   var first = 0
   while (first < value.size() - 1 && value.byteAt(first).toInt() == 0) first++
   return if (first == 0) value else value.substring(first)
+}
+
+/** Encodes a proto `uint32` value in fixed-width big-endian form. */
+fun uint32Bytes(value: Long): ByteString {
+  require(value in 0..UInt.MAX_VALUE.toLong()) { "uint32 value out of range: $value" }
+  return ByteString.copyFrom(ByteBuffer.allocate(Int.SIZE_BYTES).putInt(value.toInt()).array())
 }
 
 /**

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -17,6 +17,7 @@ import fourward.SubscribeResultsRequest
 import fourward.SubscribeResultsResponse
 import fourward.SubscriptionActive
 import fourward.TraceTree
+import fourward.simulator.DataplanePort
 import fourward.simulator.RegisterSeedDependency
 import fourward.simulator.TableStore
 import fourward.simulator.extractReproducerEntities
@@ -173,12 +174,27 @@ class DataplaneService(
             @Suppress("TooGenericExceptionCaught") // Any translation/encoding failure should
             e: Exception // terminate this subscription stream, not crash the packet sender.
           ) {
-            close(e)
+            close(subscribeResultsFailure(e))
           }
         }
 
       awaitClose { handle.unsubscribe() }
     }
+
+  private fun subscribeResultsFailure(e: Exception): StatusException {
+    if (e is StatusException) return e
+    val detail = buildString {
+      append(
+        "SubscribeResults failed while enriching a packet result; check PacketIn " +
+          "@controller_header metadata and emitted CPU-port payload"
+      )
+      e.message?.let {
+        append(": ")
+        append(it)
+      }
+    }
+    return Status.INTERNAL.withDescription(detail).withCause(e).asException()
+  }
 
   override fun registerPrePacketHook(
     requests: Flow<PrePacketHookResponse>
@@ -227,15 +243,19 @@ class DataplaneService(
     }
   }
 
-  private fun resolveIngressPort(request: InjectPacketRequest, translator: TypeTranslator?): Int =
+  private fun resolveIngressPort(
+    request: InjectPacketRequest,
+    translator: TypeTranslator?,
+  ): DataplanePort =
     when (request.ingressPortCase) {
-      InjectPacketRequest.IngressPortCase.DATAPLANE_INGRESS_PORT -> request.dataplaneIngressPort
+      InjectPacketRequest.IngressPortCase.DATAPLANE_INGRESS_PORT ->
+        DataplanePort.fromProto(request.dataplaneIngressPort)
       InjectPacketRequest.IngressPortCase.P4RT_INGRESS_PORT ->
         (translator?.portTranslator
             ?: throw missingPortTranslation(request.p4RtIngressPort, translator))
           .p4rtToDataplane(request.p4RtIngressPort)
       InjectPacketRequest.IngressPortCase.INGRESSPORT_NOT_SET,
-      null -> 0
+      null -> DataplanePort.fromProto(0)
     }
 }
 
@@ -261,7 +281,7 @@ private fun missingPortTranslation(
 }
 
 private fun enrichResult(
-  ingressPort: Int,
+  ingressPort: DataplanePort,
   payload: ByteArray,
   tag: Long,
   possibleOutcomes: List<List<OutputPacket>>,
@@ -274,7 +294,7 @@ private fun enrichResult(
   return ProcessPacketResultProto.newBuilder()
     .setInputPacket(
       InputPacket.newBuilder()
-        .setDataplaneIngressPort(ingressPort)
+        .setDataplaneIngressPort(ingressPort.protoValue)
         .apply { pt?.dataplaneToP4rt(ingressPort)?.let { setP4RtIngressPort(it) } }
         .setPayload(ByteString.copyFrom(payload))
         .setTag(tag)
@@ -303,6 +323,7 @@ private fun OutputPacket.toDualEncoded(
 ): OutputPacket {
   val rawPayload = payload
   val pt = translator?.portTranslator
+  val egressPort = DataplanePort.fromProto(dataplaneEgressPort)
   return OutputPacket.newBuilder()
     .setDataplaneEgressPort(dataplaneEgressPort)
     .setPayload(rawPayload)
@@ -310,8 +331,8 @@ private fun OutputPacket.toDualEncoded(
       // Egress ports may come from P4 pipeline logic (e.g. the CPU port, hardcoded
       // by the architecture) that was never forward-allocated via a P4Runtime Write,
       // so a missing reverse mapping is expected — same as for ingress ports above.
-      pt?.dataplaneToP4rt(dataplaneEgressPort)?.let { setP4RtEgressPort(it) }
-      if (codec != null && dataplaneEgressPort == codec.cpuPort) {
+      pt?.dataplaneToP4rt(egressPort)?.let { setP4RtEgressPort(it) }
+      if (codec != null && egressPort == codec.cpuPort) {
         val rawPacketIn = codec.decodePacketIn(rawPayload)
         setPacketIn(translator?.translatePacketIn(rawPacketIn) ?: rawPacketIn)
       }

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -1,19 +1,36 @@
 package fourward.grpc
 
 import com.google.protobuf.ByteString
+import fourward.BehavioralConfig
+import fourward.BitType
 import fourward.DataplaneGrpcKt.DataplaneCoroutineStub
+import fourward.DeviceConfig
+import fourward.FieldDecl
+import fourward.HeaderDecl
 import fourward.InjectPacketRequest
+import fourward.OutputPacket
+import fourward.PipelineConfig
 import fourward.PrePacketHookInvocation
 import fourward.PrePacketHookResponse
+import fourward.StructDecl
 import fourward.SubscribeResultsRequest
 import fourward.SubscribeResultsResponse
+import fourward.TraceTree
+import fourward.TranslationEntry
+import fourward.Type
+import fourward.TypeDecl
+import fourward.TypeTranslation
 import fourward.e2e.compileInlineP4
 import fourward.grpc.FourwardTestHarness.Companion.assertGrpcError
 import fourward.grpc.FourwardTestHarness.Companion.buildEthernetFrame
 import fourward.grpc.FourwardTestHarness.Companion.buildExactEntry
 import fourward.grpc.FourwardTestHarness.Companion.buildMulticastGroup
 import fourward.grpc.FourwardTestHarness.Companion.loadConfig
+import fourward.simulator.DataplanePort
+import fourward.simulator.ProcessPacketResult
+import fourward.simulator.TableStore
 import io.grpc.Status
+import io.grpc.StatusException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -27,6 +44,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -34,6 +52,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
+import p4.config.v1.P4InfoOuterClass.ControllerPacketMetadata
+import p4.config.v1.P4InfoOuterClass.P4Info
+import p4.config.v1.P4InfoOuterClass.Preamble
 import p4.config.v1.P4Types
 
 class DataplaneServiceTest {
@@ -607,6 +628,155 @@ class DataplaneServiceTest {
     job.cancel()
   }
 
+  @Test
+  @Suppress("MagicNumber")
+  fun `SubscribeResults reverse translates uint32 CPU port with high bit set`() = runBlocking {
+    val cpuPort = DataplanePort.fromUnsignedLong(0xFFFF_FFFEL)
+    val p4info = packetIoP4InfoWithTranslatedPort()
+    val behavioral = packetIoBehavioralWithPortBits(32)
+    val typeTranslator =
+      TypeTranslator.create(
+        p4info,
+        listOf(
+          TypeTranslation.newBuilder()
+            .setTypeName("port_name_t")
+            .addEntries(
+              TranslationEntry.newBuilder()
+                .setSdnStr("CpuPort")
+                .setDataplaneValue(uint32Bytes(0xFFFF_FFFEL))
+            )
+            .build()
+        ),
+        portTypeName = "port_name_t",
+      )
+    val packetHeaderCodec = PacketHeaderCodec.createWithCpuPort(p4info, behavioral, cpuPort)
+    val output =
+      OutputPacket.newBuilder()
+        .setDataplaneEgressPort(cpuPort.protoValue)
+        .setPayload(ByteString.copyFrom(byteArrayOf(0x01, 0x02)))
+        .build()
+    val tableStore = TableStore()
+    val broker =
+      PacketBroker(
+        { _, _ ->
+          ProcessPacketResult(
+            trace = TraceTree.getDefaultInstance(),
+            possibleOutcomes = listOf(listOf(output)),
+            forwardingSnapshot = tableStore.snapshot,
+          )
+        },
+        Mutex(),
+      )
+    val service =
+      DataplaneService(broker) {
+        DataplaneService.PipelineSnapshot(
+          config =
+            PipelineConfig.newBuilder()
+              .setP4Info(p4info)
+              .setDevice(DeviceConfig.newBuilder().setBehavioral(behavioral))
+              .build(),
+          tableStore = tableStore,
+          typeTranslator = typeTranslator,
+          packetHeaderCodec = packetHeaderCodec,
+        )
+      }
+    val results = Channel<SubscribeResultsResponse>(UNLIMITED)
+    val job = launch {
+      service.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
+        results.send(it)
+      }
+    }
+
+    assertTrue(
+      "subscription should become active",
+      withTimeout(5000) { results.receive() }.hasActive(),
+    )
+
+    broker.processPacket(DataplanePort.fromProto(0), byteArrayOf())
+
+    val msg = withTimeout(5000) { results.receive() }
+    assertTrue("should be a result", msg.hasResult())
+    val packet = msg.result.possibleOutcomesList.single().getPackets(0)
+    assertEquals(0xFFFF_FFFEu.toInt(), packet.dataplaneEgressPort)
+    assertEquals(ByteString.copyFromUtf8("CpuPort"), packet.p4RtEgressPort)
+    assertTrue("should decode PacketIn for high-bit CPU port", packet.hasPacketIn())
+
+    job.cancel()
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `SubscribeResults reports enrichment failures as INTERNAL`() = runBlocking {
+    val cpuPort = DataplanePort.fromUnsignedLong(7)
+    val p4info = packetIoP4InfoWithTranslatedPort(packetInBits = 16)
+    val behavioral = packetIoBehavioralWithPortBits(portBits = 9, packetInBits = 16)
+    val packetHeaderCodec = PacketHeaderCodec.createWithCpuPort(p4info, behavioral, cpuPort)
+    val output =
+      OutputPacket.newBuilder()
+        .setDataplaneEgressPort(cpuPort.protoValue)
+        .setPayload(ByteString.EMPTY)
+        .build()
+    val tableStore = TableStore()
+    val broker =
+      PacketBroker(
+        { _, _ ->
+          ProcessPacketResult(
+            trace = TraceTree.getDefaultInstance(),
+            possibleOutcomes = listOf(listOf(output)),
+            forwardingSnapshot = tableStore.snapshot,
+          )
+        },
+        Mutex(),
+      )
+    val service =
+      DataplaneService(broker) {
+        DataplaneService.PipelineSnapshot(
+          config =
+            PipelineConfig.newBuilder()
+              .setP4Info(p4info)
+              .setDevice(DeviceConfig.newBuilder().setBehavioral(behavioral))
+              .build(),
+          tableStore = tableStore,
+          typeTranslator = null,
+          packetHeaderCodec = packetHeaderCodec,
+        )
+      }
+    val results = Channel<SubscribeResultsResponse>(UNLIMITED)
+    val collector = async {
+      try {
+        service.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
+          results.send(it)
+        }
+        null
+      } catch (e: StatusException) {
+        e
+      }
+    }
+
+    assertTrue(
+      "subscription should become active",
+      withTimeout(5000) { results.receive() }.hasActive(),
+    )
+
+    broker.processPacket(DataplanePort.fromProto(0), byteArrayOf())
+
+    val failure = withTimeout(5000) { collector.await() }!!
+    assertEquals(Status.Code.INTERNAL, failure.status.code)
+    val description = failure.status.description!!
+    assertTrue(
+      "status description should identify SubscribeResults enrichment",
+      description.contains("SubscribeResults failed while enriching a packet result"),
+    )
+    assertTrue(
+      "status description should point at PacketIn controller-header metadata",
+      description.contains("check PacketIn @controller_header metadata"),
+    )
+    assertTrue(
+      "status description should include the packet-header decoding cause",
+      description.contains("deparsed payload (0 bytes) is shorter"),
+    )
+  }
+
   // =========================================================================
   // PacketIn enrichment
   // =========================================================================
@@ -888,4 +1058,85 @@ class DataplaneServiceTest {
     assertTrue("first message should be SubscriptionActive", first.hasActive())
     return job to results
   }
+
+  private fun packetIoP4InfoWithTranslatedPort(packetInBits: Int? = null): P4Info =
+    P4Info.newBuilder()
+      .addControllerPacketMetadata(
+        ControllerPacketMetadata.newBuilder()
+          .setPreamble(Preamble.newBuilder().setName("packet_out"))
+          .addMetadata(
+            ControllerPacketMetadata.Metadata.newBuilder()
+              .setId(1)
+              .setName("egress_port")
+              .setBitwidth(32)
+          )
+      )
+      .apply {
+        if (packetInBits != null) {
+          addControllerPacketMetadata(
+            ControllerPacketMetadata.newBuilder()
+              .setPreamble(Preamble.newBuilder().setName("packet_in"))
+              .addMetadata(
+                ControllerPacketMetadata.Metadata.newBuilder()
+                  .setId(1)
+                  .setName("ingress_port")
+                  .setBitwidth(packetInBits)
+              )
+          )
+        }
+      }
+      .setTypeInfo(
+        P4Types.P4TypeInfo.newBuilder()
+          .putNewTypes(
+            "port_name_t",
+            P4Types.P4NewTypeSpec.newBuilder()
+              .setTranslatedType(
+                P4Types.P4NewTypeTranslation.newBuilder()
+                  .setUri("")
+                  .setSdnString(P4Types.P4NewTypeTranslation.SdnString.getDefaultInstance())
+              )
+              .build(),
+          )
+      )
+      .build()
+
+  private fun packetIoBehavioralWithPortBits(
+    portBits: Int,
+    packetInBits: Int? = null,
+  ): BehavioralConfig =
+    BehavioralConfig.newBuilder()
+      .addTypes(
+        TypeDecl.newBuilder()
+          .setName("packet_out_header_t")
+          .setHeader(
+            HeaderDecl.newBuilder()
+              .setControllerHeader("packet_out")
+              .addFields(bitField("egress_port", 32))
+          )
+      )
+      .apply {
+        if (packetInBits != null) {
+          addTypes(
+            TypeDecl.newBuilder()
+              .setName("packet_in_header_t")
+              .setHeader(
+                HeaderDecl.newBuilder()
+                  .setControllerHeader("packet_in")
+                  .addFields(bitField("ingress_port", packetInBits))
+              )
+          )
+        }
+      }
+      .addTypes(
+        TypeDecl.newBuilder()
+          .setName("standard_metadata_t")
+          .setStruct(StructDecl.newBuilder().addFields(bitField("ingress_port", portBits)))
+      )
+      .build()
+
+  private fun bitField(name: String, width: Int): FieldDecl =
+    FieldDecl.newBuilder().setName(name).setType(bitType(width)).build()
+
+  private fun bitType(width: Int): Type =
+    Type.newBuilder().setBit(BitType.newBuilder().setWidth(width)).build()
 }

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -8,6 +8,7 @@ import com.google.rpc.Code
 import fourward.DeviceConfig
 import fourward.OutputPacket
 import fourward.PipelineConfig
+import fourward.simulator.DataplanePort
 import fourward.simulator.PacketBits
 import fourward.simulator.Simulator
 import fourward.simulator.WriteResult
@@ -91,7 +92,7 @@ class P4RuntimeService(
     val referenceValidator: ReferenceValidator?,
     val constraintValidator: ConstraintValidator?,
     val packetHeaderCodec: PacketHeaderCodec?,
-    val resolvedDropPort: Int?,
+    val resolvedDropPort: DataplanePort?,
     val entityReader: EntityReader,
     val roleMap: RoleMap,
   )
@@ -258,7 +259,7 @@ class P4RuntimeService(
           is CpuPortConfig.Auto ->
             PacketHeaderCodec.create(fwdConfig.p4Info, deviceConfig.behavioral)
           is CpuPortConfig.Override ->
-            PacketHeaderCodec.create(
+            PacketHeaderCodec.createWithCpuPort(
               fwdConfig.p4Info,
               deviceConfig.behavioral,
               resolvePortOverride(
@@ -762,7 +763,7 @@ class P4RuntimeService(
     val translator = state.typeTranslator?.takeIf { it.hasTranslations }
     val cpuPort = codec.cpuPort
     return outputPackets
-      .filter { it.dataplaneEgressPort == cpuPort }
+      .filter { DataplanePort.fromProto(it.dataplaneEgressPort) == cpuPort }
       .map { outputPacket ->
         // Decode the @controller_header("packet_in") that the deparser emitted at the front of the
         // payload: metadata is parsed from the header bits, never reconstructed from port state.
@@ -774,9 +775,11 @@ class P4RuntimeService(
   }
 
   /** Extracts ingress port from PacketOut metadata, defaulting to port 0. */
-  private fun extractIngressPort(metadata: List<p4.v1.P4RuntimeOuterClass.PacketMetadata>): Int {
+  private fun extractIngressPort(
+    metadata: List<p4.v1.P4RuntimeOuterClass.PacketMetadata>
+  ): DataplanePort {
     val portMeta = metadata.find { it.metadataId == INGRESS_PORT_METADATA_ID }
-    return portMeta?.value?.toUnsignedInt() ?: 0
+    return DataplanePort.fromProto(portMeta?.value?.toUnsignedInt() ?: 0)
   }
 
   // ---------------------------------------------------------------------------
@@ -1152,7 +1155,7 @@ class P4RuntimeService(
     portOverride: PortOverride?,
     portTranslator: PortTranslator?,
     flagName: String,
-  ): Int? =
+  ): DataplanePort? =
     when (portOverride) {
       null -> null
       is PortOverride.Dataplane -> portOverride.port

--- a/grpc/PacketBroker.kt
+++ b/grpc/PacketBroker.kt
@@ -4,6 +4,7 @@ import fourward.OutputPacket
 import fourward.PrePacketHookInvocation
 import fourward.PrePacketHookResponse
 import fourward.TraceTree
+import fourward.simulator.DataplanePort
 import fourward.simulator.PacketBits
 import fourward.simulator.ProcessPacketResult
 import java.util.concurrent.atomic.AtomicReference
@@ -32,7 +33,7 @@ import p4.v1.P4RuntimeOuterClass
  *   acquired when a pre-packet hook is registered (to apply hook updates atomically).
  */
 class PacketBroker(
-  private val simulatorFn: (ingressPort: Int, packet: PacketBits) -> ProcessPacketResult,
+  private val simulatorFn: (ingressPort: DataplanePort, packet: PacketBits) -> ProcessPacketResult,
   private val writeMutex: Mutex,
 ) {
 
@@ -97,7 +98,7 @@ class PacketBroker(
 
   /** Delivered to each [subscribe] subscriber for every processed packet. */
   class SubscriptionResult(
-    val ingressPort: Int,
+    val ingressPort: DataplanePort,
     val packet: PacketBits,
     val possibleOutcomes: List<List<OutputPacket>>,
     val trace: TraceTree,
@@ -123,7 +124,7 @@ class PacketBroker(
   }
 
   suspend fun processPacket(
-    ingressPort: Int,
+    ingressPort: DataplanePort,
     payload: ByteArray,
     tag: Long = 0,
   ): ProcessPacketResult = processPacket(ingressPort, PacketBits.ofBytes(payload), tag)
@@ -135,7 +136,7 @@ class PacketBroker(
    * its updates atomically).
    */
   suspend fun processPacket(
-    ingressPort: Int,
+    ingressPort: DataplanePort,
     packet: PacketBits,
     tag: Long = 0,
   ): ProcessPacketResult {
@@ -151,7 +152,7 @@ class PacketBroker(
    * Used by [DataplaneService.injectPackets] to stream packets without buffering the entire batch.
    */
   suspend fun <T> withHookOnce(
-    block: suspend (processor: suspend (Int, ByteArray, Long) -> Unit) -> T
+    block: suspend (processor: suspend (DataplanePort, ByteArray, Long) -> Unit) -> T
   ): T {
     fireHookUnderMutex()
     return block { port, payload, tag ->
@@ -174,7 +175,7 @@ class PacketBroker(
   }
 
   private suspend fun dispatchToSubscribers(
-    ingressPort: Int,
+    ingressPort: DataplanePort,
     packet: PacketBits,
     result: ProcessPacketResult,
     tag: Long = 0,

--- a/grpc/PacketBrokerTest.kt
+++ b/grpc/PacketBrokerTest.kt
@@ -4,6 +4,7 @@ import fourward.OutputPacket
 import fourward.PrePacketHookInvocation
 import fourward.PrePacketHookResponse
 import fourward.TraceTree
+import fourward.simulator.DataplanePort
 import fourward.simulator.PacketBits
 import fourward.simulator.ProcessPacketResult
 import java.util.concurrent.atomic.AtomicInteger
@@ -15,6 +16,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PacketBrokerTest {
+
+  private fun port(value: Int): DataplanePort = DataplanePort.fromProto(value)
 
   private fun outputPacket(egressPort: Int, payload: ByteArray = byteArrayOf()) =
     OutputPacket.newBuilder()
@@ -31,9 +34,9 @@ class PacketBrokerTest {
 
   private fun fakeProcessor(
     vararg results: Pair<Int, ProcessPacketResult>
-  ): (Int, PacketBits) -> ProcessPacketResult {
+  ): (DataplanePort, PacketBits) -> ProcessPacketResult {
     val map = results.toMap()
-    return { port, _ -> map[port] ?: result() }
+    return { port, _ -> map[port.protoValue] ?: result() }
   }
 
   private fun broker(vararg results: Pair<Int, ProcessPacketResult>) =
@@ -44,7 +47,7 @@ class PacketBrokerTest {
     val expected = result(outputPacket(1, byteArrayOf(0xAB.toByte())))
     val broker = broker(0 to expected)
 
-    val actual = broker.processPacket(0, byteArrayOf(0x01))
+    val actual = broker.processPacket(port(0), byteArrayOf(0x01))
     assertEquals(expected.possibleOutcomes, actual.possibleOutcomes)
   }
 
@@ -60,7 +63,7 @@ class PacketBrokerTest {
         kotlinx.coroutines.sync.Mutex(),
       )
 
-    broker.processPacket(0, PacketBits.ofPaddedBytes(byteArrayOf(0xA0.toByte()), 4))
+    broker.processPacket(port(0), PacketBits.ofPaddedBytes(byteArrayOf(0xA0.toByte()), 4))
 
     assertEquals(4, capturedBitLength)
   }
@@ -73,10 +76,10 @@ class PacketBrokerTest {
     val received = mutableListOf<PacketBroker.SubscriptionResult>()
     broker.subscribe { received.add(it) }
 
-    broker.processPacket(0, byteArrayOf(0x01))
+    broker.processPacket(port(0), byteArrayOf(0x01))
 
     assertEquals(1, received.size)
-    assertEquals(0, received[0].ingressPort)
+    assertEquals(DataplanePort.fromProto(0), received[0].ingressPort)
     assertEquals(listOf(outputs), received[0].possibleOutcomes)
   }
 
@@ -87,7 +90,7 @@ class PacketBrokerTest {
     broker.subscribe { received.add(it) }
 
     broker.processPacket(
-      0,
+      port(0),
       PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xFF.toByte(), 0xFF.toByte()), 10),
     )
 
@@ -107,7 +110,7 @@ class PacketBrokerTest {
     broker.subscribe { received1.add(it) }
     broker.subscribe { received2.add(it) }
 
-    broker.processPacket(0, byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
 
     assertEquals(1, received1.size)
     assertEquals(1, received2.size)
@@ -116,7 +119,7 @@ class PacketBrokerTest {
   @Test
   fun `no subscribers does not cause errors`(): Unit = runBlocking {
     val broker = broker(0 to result(outputPacket(1)))
-    broker.processPacket(0, byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
   }
 
   @Test
@@ -126,11 +129,11 @@ class PacketBrokerTest {
     val received = mutableListOf<PacketBroker.SubscriptionResult>()
     val handle = broker.subscribe { received.add(it) }
 
-    broker.processPacket(0, byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
     assertEquals(1, received.size)
 
     handle.unsubscribe()
-    broker.processPacket(0, byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
     assertEquals("no new result after unsubscribe", 1, received.size)
   }
 
@@ -140,7 +143,7 @@ class PacketBrokerTest {
     val received = mutableListOf<PacketBroker.SubscriptionResult>()
     broker.subscribe { received.add(it) }
 
-    broker.processPacket(0, byteArrayOf(), tag = 42)
+    broker.processPacket(port(0), byteArrayOf(), tag = 42)
 
     assertEquals(1, received.size)
     assertEquals(42L, received[0].tag)
@@ -155,7 +158,7 @@ class PacketBrokerTest {
     broker.subscribe { received.add(it) }
 
     // The caller should get the result even though the first subscriber threw.
-    val callerResult = broker.processPacket(0, byteArrayOf())
+    val callerResult = broker.processPacket(port(0), byteArrayOf())
     assertEquals(1, callerResult.possibleOutcomes.single().size)
 
     // The second subscriber should still receive the result.
@@ -201,7 +204,7 @@ class PacketBrokerTest {
     val broker = broker(0 to result(outputPacket(1)))
     val hookCount = registerAutoRespondHook(broker)
 
-    broker.processPacket(0, byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
 
     assertEquals("hook should fire once per processPacket", 1, hookCount.get())
   }
@@ -211,9 +214,9 @@ class PacketBrokerTest {
     val broker = broker(0 to result(outputPacket(1)))
     val hookCount = registerAutoRespondHook(broker)
 
-    broker.processPacket(0, byteArrayOf())
-    broker.processPacket(0, byteArrayOf())
-    broker.processPacket(0, byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
 
     assertEquals("hook should fire once per processPacket", 3, hookCount.get())
   }
@@ -224,7 +227,7 @@ class PacketBrokerTest {
     val broker = broker(0 to expected)
 
     // No hook registered — should still work.
-    val actual = broker.processPacket(0, byteArrayOf())
+    val actual = broker.processPacket(port(0), byteArrayOf())
     assertEquals(expected.possibleOutcomes, actual.possibleOutcomes)
   }
 
@@ -234,9 +237,9 @@ class PacketBrokerTest {
     val hookCount = registerAutoRespondHook(broker)
 
     broker.withHookOnce { processPacket ->
-      processPacket(0, byteArrayOf(), 0)
-      processPacket(0, byteArrayOf(), 0)
-      processPacket(0, byteArrayOf(), 0)
+      processPacket(DataplanePort.fromProto(0), byteArrayOf(), 0)
+      processPacket(DataplanePort.fromProto(0), byteArrayOf(), 0)
+      processPacket(DataplanePort.fromProto(0), byteArrayOf(), 0)
     }
 
     assertEquals("hook should fire exactly once for the batch", 1, hookCount.get())
@@ -249,7 +252,7 @@ class PacketBrokerTest {
     val processed = AtomicInteger(0)
 
     broker.withHookOnce { processPacket ->
-      processPacket(0, byteArrayOf(), 0)
+      processPacket(DataplanePort.fromProto(0), byteArrayOf(), 0)
       processed.incrementAndGet()
     }
 
@@ -303,7 +306,7 @@ class PacketBrokerTest {
         start()
       }
 
-    broker.processPacket(0, byteArrayOf())
+    broker.processPacket(port(0), byteArrayOf())
 
     assertEquals("applyUpdates should receive the update", 1, appliedUpdates.size)
     assertEquals(p4.v1.P4RuntimeOuterClass.Update.Type.INSERT, appliedUpdates[0].type)

--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -10,6 +10,7 @@ import com.google.protobuf.ByteString
 import fourward.BehavioralConfig
 import fourward.Type
 import fourward.simulator.BitAccumulator
+import fourward.simulator.DataplanePort
 import java.math.BigInteger
 import p4.config.v1.P4InfoOuterClass.P4Info
 import p4.v1.P4RuntimeOuterClass.PacketIn
@@ -20,13 +21,14 @@ import p4.v1.P4RuntimeOuterClass.PacketMetadata
  * resolved at pipeline load time.
  */
 sealed interface PortOverride {
-  data class Dataplane(val port: Int) : PortOverride
+  data class Dataplane(val port: DataplanePort) : PortOverride
 
   data class P4rt(val name: String) : PortOverride
 
   companion object {
     /** Parses a CLI flag value: integer → [Dataplane], anything else → [P4rt]. */
-    fun fromFlag(value: String): PortOverride = value.toIntOrNull()?.let(::Dataplane) ?: P4rt(value)
+    fun fromFlag(value: String): PortOverride =
+      DataplanePort.fromUnsignedLiteralOrNull(value)?.let(::Dataplane) ?: P4rt(value)
   }
 }
 
@@ -69,7 +71,7 @@ private constructor(
   private val packetOutFields: List<FieldDef>,
   private val packetInFields: List<FieldDef>,
   /** The CPU port for PacketOut packets (v1model convention: 2^portBits - 2). */
-  val cpuPort: Int,
+  val cpuPort: DataplanePort,
 ) {
   data class FieldDef(val id: Int?, val name: String, val bitWidth: Int)
 
@@ -96,6 +98,10 @@ private constructor(
   @Suppress("MagicNumber")
   fun stripPacketInHeader(payload: ByteString): ByteString {
     if (packetInHeaderBits == 0) return payload
+    require(payload.size() * Byte.SIZE_BITS >= packetInHeaderBits) {
+      "deparsed payload (${payload.size()} bytes) is shorter than the " +
+        "$packetInHeaderBits-bit packet_in controller header"
+    }
     if (packetInHeaderBits % 8 == 0) return payload.substring(packetInHeaderBytes)
     val bytes = payload.toByteArray()
     // The deparsed byte array contains: headerBits + payloadBits + trailingPadBits,
@@ -260,6 +266,17 @@ private constructor(
       p4info: P4Info,
       behavioral: BehavioralConfig,
       cpuPortOverride: Int? = null,
+    ): PacketHeaderCodec? =
+      createWithCpuPort(
+        p4info,
+        behavioral,
+        cpuPortOverride?.toLong()?.let(DataplanePort::fromUnsignedLong),
+      )
+
+    fun createWithCpuPort(
+      p4info: P4Info,
+      behavioral: BehavioralConfig,
+      cpuPortOverride: DataplanePort? = null,
     ): PacketHeaderCodec? {
       val packetOutMeta =
         p4info.controllerPacketMetadataList.find { it.preamble.name == "packet_out" } ?: return null
@@ -334,11 +351,13 @@ private constructor(
       return bitWidth(ingressPort.type)
     }
 
-    private fun deriveAutoCpuPort(portBits: Int): Int {
+    private fun deriveAutoCpuPort(portBits: Int): DataplanePort {
       require(portBits in 1..Int.SIZE_BITS) {
         "automatic CPU port derivation requires a 1..32-bit dataplane port, got $portBits bits"
       }
-      return BigInteger.ONE.shiftLeft(portBits).subtract(BigInteger.TWO).toInt()
+      return DataplanePort.fromUnsignedLong(
+        BigInteger.ONE.shiftLeft(portBits).subtract(BigInteger.TWO).toLong()
+      )
     }
 
     private fun bitWidth(type: Type): Int =

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -14,6 +14,7 @@ import fourward.StructDecl
 import fourward.Type
 import fourward.TypeDecl
 import fourward.simulator.BitAccumulator
+import fourward.simulator.DataplanePort
 import java.math.BigInteger
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -54,7 +55,7 @@ class PacketHeaderCodecTest {
     // packet_in: 9-bit ingress_port + 9-bit target_egress_port = 18 bits = 3 bytes
     assertEquals(3, codec.packetInHeaderBytes)
     // CPU port = 2^9 - 2 = 510
-    assertEquals(510, codec.cpuPort)
+    assertEquals(510, codec.cpuPort.protoValue)
   }
 
   @Test
@@ -965,7 +966,7 @@ class PacketHeaderCodecTest {
     val (p4info, behavioral) = buildSaiLikeConfig()
     val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = 42)
     assertNotNull(codec)
-    assertEquals(42, codec!!.cpuPort)
+    assertEquals(42, codec!!.cpuPort.protoValue)
   }
 
   @Test
@@ -974,7 +975,7 @@ class PacketHeaderCodecTest {
     val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = null)
     assertNotNull(codec)
     // Default: 2^9 - 2 = 510
-    assertEquals(510, codec!!.cpuPort)
+    assertEquals(510, codec!!.cpuPort.protoValue)
   }
 
   @Test
@@ -1007,7 +1008,7 @@ class PacketHeaderCodecTest {
 
     val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = null)
 
-    assertEquals(510, codec!!.cpuPort)
+    assertEquals(510, codec!!.cpuPort.protoValue)
   }
 
   @Test
@@ -1017,7 +1018,8 @@ class PacketHeaderCodecTest {
 
     val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = null)
 
-    assertEquals(0xFFFF_FFFEu.toInt(), codec!!.cpuPort)
+    assertEquals(0xFFFF_FFFEu.toInt(), codec!!.cpuPort.protoValue)
+    assertEquals(0xFFFF_FFFEL, codec.cpuPort.unsignedLong)
   }
 
   @Test
@@ -1047,8 +1049,22 @@ class PacketHeaderCodecTest {
 
   @Test
   fun `fromFlag integer returns Override with Dataplane port`() {
-    assertEquals(CpuPortConfig.Override(PortOverride.Dataplane(510)), CpuPortConfig.fromFlag("510"))
-    assertEquals(CpuPortConfig.Override(PortOverride.Dataplane(0)), CpuPortConfig.fromFlag("0"))
+    assertEquals(
+      CpuPortConfig.Override(PortOverride.Dataplane(DataplanePort.fromUnsignedLong(510))),
+      CpuPortConfig.fromFlag("510"),
+    )
+    assertEquals(
+      CpuPortConfig.Override(PortOverride.Dataplane(DataplanePort.fromUnsignedLong(0))),
+      CpuPortConfig.fromFlag("0"),
+    )
+  }
+
+  @Test
+  fun `fromFlag hex integer returns Override with Dataplane port`() {
+    assertEquals(
+      CpuPortConfig.Override(PortOverride.Dataplane(DataplanePort.fromUnsignedLong(0xFFFF_FFFEL))),
+      CpuPortConfig.fromFlag("0xffff_fffe"),
+    )
   }
 
   @Test

--- a/grpc/PortOverrideTest.kt
+++ b/grpc/PortOverrideTest.kt
@@ -4,6 +4,7 @@ import fourward.PipelineConfig
 import fourward.TranslationEntry
 import fourward.TypeTranslation
 import fourward.grpc.FourwardTestHarness.Companion.loadConfig
+import fourward.simulator.DataplanePort
 import io.grpc.Status
 import org.junit.Test
 
@@ -32,8 +33,9 @@ class PortOverrideTest {
 
   @Test
   fun `dataplane cpu port still works`() {
-    FourwardTestHarness(cpuPortConfig = CpuPortConfig.Override(PortOverride.Dataplane(510))).use {
-      harness ->
+    val cpuPort =
+      CpuPortConfig.Override(PortOverride.Dataplane(DataplanePort.fromUnsignedLong(510)))
+    FourwardTestHarness(cpuPortConfig = cpuPort).use { harness ->
       harness.loadPipeline(loadTranslatedPort())
     }
   }

--- a/grpc/TraceEnricher.kt
+++ b/grpc/TraceEnricher.kt
@@ -2,6 +2,7 @@ package fourward.grpc
 
 import fourward.TraceEvent
 import fourward.TraceTree
+import fourward.simulator.DataplanePort
 import p4.v1.P4RuntimeOuterClass.Entity
 
 /**
@@ -61,7 +62,7 @@ object TraceEnricher {
       TraceTree.OutcomeCase.PACKET_OUTCOME -> {
         if (pt != null && tree.packetOutcome.hasOutput()) {
           val output = tree.packetOutcome.output
-          val p4rtPort = pt.dataplaneToP4rt(output.dataplaneEgressPort)
+          val p4rtPort = pt.dataplaneToP4rt(DataplanePort.fromProto(output.dataplaneEgressPort))
           if (p4rtPort != null) {
             lazyBuilder().packetOutcomeBuilder.outputBuilder.setP4RtEgressPort(p4rtPort)
           }
@@ -81,7 +82,8 @@ object TraceEnricher {
   ): TraceEvent? {
     if (event.hasPacketIngress() && pt != null) {
       val ingress = event.packetIngress
-      val p4rtPort = pt.dataplaneToP4rt(ingress.dataplaneIngressPort) ?: return null
+      val p4rtPort =
+        pt.dataplaneToP4rt(DataplanePort.fromProto(ingress.dataplaneIngressPort)) ?: return null
       return event
         .toBuilder()
         .setPacketIngress(ingress.toBuilder().setP4RtIngressPort(p4rtPort))
@@ -92,7 +94,8 @@ object TraceEnricher {
       val csl = event.cloneSessionLookup
       if (!csl.sessionFound) return null
       // Enriches the first replica's port only; per-replica details are in fork branch labels.
-      val p4rtPort = pt.dataplaneToP4rt(csl.dataplaneEgressPort) ?: return null
+      val p4rtPort =
+        pt.dataplaneToP4rt(DataplanePort.fromProto(csl.dataplaneEgressPort)) ?: return null
       return event
         .toBuilder()
         .setCloneSessionLookup(csl.toBuilder().setP4RtEgressPort(p4rtPort))

--- a/grpc/TypeTranslator.kt
+++ b/grpc/TypeTranslator.kt
@@ -3,6 +3,7 @@ package fourward.grpc
 import com.google.protobuf.ByteString
 import fourward.TranslationEntry
 import fourward.TypeTranslation
+import fourward.simulator.DataplanePort
 import java.math.BigInteger
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Logger
@@ -76,14 +77,14 @@ private enum class Direction {
  */
 class PortTranslator internal constructor(private val table: TranslationTable) {
   /** Translates a P4Runtime port ID to a dataplane port number. */
-  fun p4rtToDataplane(p4rtPort: ByteString): Int {
+  fun p4rtToDataplane(p4rtPort: ByteString): DataplanePort {
     val dp =
       if (table.isStringType) {
         table.lookupOrAllocateString(p4rtPort.toStringUtf8())
       } else {
         table.lookupOrAllocateBitstring(p4rtPort)
       }
-    return dp.toUnsignedInt()
+    return DataplanePort.fromProto(dp.toUnsignedInt())
   }
 
   /**
@@ -93,12 +94,14 @@ class PortTranslator internal constructor(private val table: TranslationTable) {
    * Only works for `sdn_string` port types (e.g. SAI P4). `sdn_bitwidth` types are not supported
    * because the caller provides a string name, not a bitstring.
    */
-  fun resolveExplicit(p4rtName: String): Int? =
-    table.lookupStringExplicit(p4rtName)?.toUnsignedInt()
+  fun resolveExplicit(p4rtName: String): DataplanePort? =
+    table.lookupStringExplicit(p4rtName)?.toUnsignedInt()?.let(DataplanePort::fromProto)
 
   /** Translates a dataplane port number to a P4Runtime port ID, or null if no mapping exists. */
-  fun dataplaneToP4rt(dataplanePort: Int): ByteString? =
-    when (val p4rtValue = table.reverseLookupOrNull(encodeMinWidth(dataplanePort))) {
+  fun dataplaneToP4rt(dataplanePort: DataplanePort): ByteString? =
+    when (
+      val p4rtValue = table.reverseLookupOrNull(encodeMinWidth(dataplanePort.unsignedBigInteger))
+    ) {
       is P4rtValue.Str -> ByteString.copyFromUtf8(p4rtValue.value)
       is P4rtValue.Bitstring -> p4rtValue.value
       null -> null
@@ -276,8 +279,11 @@ private constructor(
       if (replica.port.isEmpty) return replica
       val newPort: ByteString =
         when (direction) {
-          Direction.TO_DATAPLANE -> encodeMinWidth(pt.p4rtToDataplane(replica.port))
-          Direction.TO_P4RT -> pt.dataplaneToP4rt(replica.port.toUnsignedInt()) ?: return replica
+          Direction.TO_DATAPLANE ->
+            encodeMinWidth(pt.p4rtToDataplane(replica.port).unsignedBigInteger)
+          Direction.TO_P4RT ->
+            pt.dataplaneToP4rt(DataplanePort.fromProto(replica.port.toUnsignedInt()))
+              ?: return replica
         }
       return replica.toBuilder().setPort(newPort).build()
     }
@@ -815,20 +821,21 @@ internal class TranslationTable(
     )
 
   private fun putReverse(dataplaneValue: ByteString, p4rtValue: P4rtValue) {
-    reverse[encodeMinWidth(dataplaneValue.toUnsignedInt())] = p4rtValue
+    reverse[canonicalize(dataplaneValue)] = p4rtValue
   }
 
   /** Reverse-translates a data-plane value to its P4Runtime representation. */
   @Synchronized
   fun reverseLookup(dataplaneValue: ByteString): P4rtValue =
-    reverse[dataplaneValue]
+    reverse[canonicalize(dataplaneValue)]
       ?: throw TranslationException(
         "no reverse mapping for data-plane value 0x${dataplaneValue.toHex()}"
       )
 
   /** Like [reverseLookup] but returns null instead of throwing. */
   @Synchronized
-  fun reverseLookupOrNull(dataplaneValue: ByteString): P4rtValue? = reverse[dataplaneValue]
+  fun reverseLookupOrNull(dataplaneValue: ByteString): P4rtValue? =
+    reverse[canonicalize(dataplaneValue)]
 
   @Synchronized fun lookupStringExplicit(p4rtStr: String): ByteString? = stringForward[p4rtStr]
 
@@ -863,8 +870,8 @@ internal class TranslationTable(
       for (entry in proto.entriesList) {
         val dp = entry.dataplaneValue
         // Normalize to minimum-width so reverse lookups (which use
-        // encodeMinWidth) match regardless of the config's byte width.
-        val dpNorm = encodeMinWidth(dp.toUnsignedInt())
+        // canonical bytes) match regardless of the config's byte width.
+        val dpNorm = canonicalize(dp)
         table.reservedValues.add(dp.toUnsignedInt())
         table.putReverse(
           dpNorm,

--- a/grpc/TypeTranslatorTest.kt
+++ b/grpc/TypeTranslatorTest.kt
@@ -3,6 +3,7 @@ package fourward.grpc
 import com.google.protobuf.ByteString
 import fourward.TranslationEntry
 import fourward.TypeTranslation
+import fourward.simulator.DataplanePort
 import java.math.BigInteger
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -124,6 +125,42 @@ class TypeTranslatorTest {
 
     val result = translator.dataplaneToP4rt("port_name_t", dpBytes(0))
     assertEquals(P4rtValue.Str("Ethernet0"), result)
+  }
+
+  @Test
+  fun `explicit string mapping accepts uint32 dataplane values with high bit set`() {
+    val translator =
+      buildTranslator(
+        translation {
+          typeName = "port_name_t"
+          addEntries(stringEntry("CpuPort", uint32Bytes(0xFFFF_FFFEL).toByteArray()))
+        }
+      )
+
+    val result = translator.dataplaneToP4rt("port_name_t", uint32Bytes(0xFFFF_FFFEL).toByteArray())
+
+    assertEquals(P4rtValue.Str("CpuPort"), result)
+  }
+
+  @Test
+  fun `port translator reverse translates uint32 dataplane ports with high bit set`() {
+    val p4info = P4InfoOuterClass.P4Info.newBuilder().setTypeInfo(stringTypeInfo()).build()
+    val translator =
+      TypeTranslator.create(
+        p4info,
+        listOf(
+          translation {
+            typeName = "port_name_t"
+            addEntries(stringEntry("CpuPort", uint32Bytes(0xFFFF_FFFEL).toByteArray()))
+          }
+        ),
+        portTypeName = "port_name_t",
+      )
+
+    assertEquals(
+      ByteString.copyFromUtf8("CpuPort"),
+      translator.portTranslator?.dataplaneToP4rt(DataplanePort.fromProto(0xFFFF_FFFEu.toInt())),
+    )
   }
 
   // ===========================================================================

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -28,10 +28,17 @@ interface Architecture {
    * - Handling architecture-specific operations (clone, resubmit, etc.).
    * - Returning the trace tree (with packet outcomes at leaves).
    */
-  fun processPacket(ingressPort: UInt, payload: ByteArray, tableStore: TableStore): PipelineResult =
-    processPacket(ingressPort, PacketBits.ofBytes(payload), tableStore)
+  fun processPacket(
+    ingressPort: DataplanePort,
+    payload: ByteArray,
+    tableStore: TableStore,
+  ): PipelineResult = processPacket(ingressPort, PacketBits.ofBytes(payload), tableStore)
 
-  fun processPacket(ingressPort: UInt, packet: PacketBits, tableStore: TableStore): PipelineResult
+  fun processPacket(
+    ingressPort: DataplanePort,
+    packet: PacketBits,
+    tableStore: TableStore,
+  ): PipelineResult
 }
 
 /**

--- a/simulator/DataplanePort.kt
+++ b/simulator/DataplanePort.kt
@@ -1,0 +1,62 @@
+package fourward.simulator
+
+import java.math.BigInteger
+
+/**
+ * A dataplane port as P4Runtime serializes it: a proto `uint32` carried by Java/Kotlin as `Int`.
+ *
+ * Values above `Int.MAX_VALUE` are intentionally negative at the proto boundary. Keep the raw bits
+ * inside this type and choose an explicit view at each use site instead of letting signed `Int`
+ * operations leak into translation or packet routing.
+ */
+@JvmInline
+value class DataplanePort
+private constructor(
+  /**
+   * Raw proto `uint32` bits as exposed by Java/Kotlin generated accessors.
+   *
+   * This is a signed `Int`; use it only when writing back to a proto field with the same generated
+   * representation. Use [unsignedLong] or [unsignedBigInteger] for arithmetic and comparisons.
+   */
+  val protoValue: Int
+) {
+  val unsignedLong: Long
+    get() = protoValue.toLong() and UINT32_MASK
+
+  val unsignedBigInteger: BigInteger
+    get() = BigInteger.valueOf(unsignedLong)
+
+  override fun toString(): String = unsignedLong.toString()
+
+  companion object {
+    private const val UINT32_MASK = 0xFFFF_FFFFL
+    private val UINT32_MAX = BigInteger.valueOf(UINT32_MASK)
+    private val DECIMAL_LITERAL = Regex("[0-9][0-9_]*")
+    private val HEX_LITERAL = Regex("0[xX][0-9a-fA-F][0-9a-fA-F_]*")
+
+    /** Preserves the exact `uint32` bit pattern received from a generated proto accessor. */
+    fun fromProto(value: Int): DataplanePort = DataplanePort(value)
+
+    /**
+     * Parses an unsigned integer literal accepted by port CLI flags, or null when [value] is not a
+     * numeric literal. Decimal and `0x`/`0X` hexadecimal forms are supported, with optional `_`
+     * separators matching Kotlin's literal spelling.
+     */
+    @Suppress("MagicNumber")
+    fun fromUnsignedLiteralOrNull(value: String): DataplanePort? {
+      val parsed =
+        when {
+          DECIMAL_LITERAL.matches(value) -> BigInteger(value.replace("_", ""), 10)
+          HEX_LITERAL.matches(value) -> BigInteger(value.drop(2).replace("_", ""), 16)
+          else -> return null
+        }
+      require(parsed <= UINT32_MAX) { "dataplane port out of uint32 range: $value" }
+      return DataplanePort(parsed.toLong().toInt())
+    }
+
+    fun fromUnsignedLong(value: Long): DataplanePort {
+      require(value in 0..UINT32_MASK) { "dataplane port out of uint32 range: $value" }
+      return DataplanePort(value.toInt())
+    }
+  }
+}

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -77,7 +77,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
   }
 
   override fun processPacket(
-    ingressPort: UInt,
+    ingressPort: DataplanePort,
     packet: PacketBits,
     tableStore: TableStore,
   ): PipelineResult {
@@ -118,7 +118,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
   private fun processPacketRecursive(
     pipeline: PipelineConfig,
     packet: PacketBits,
-    ingressPort: UInt,
+    ingressPort: DataplanePort,
     packetPath: String,
     passNumber: Int,
     depth: Int,
@@ -243,10 +243,14 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
   // Metadata initialisation
   // ---------------------------------------------------------------------------
 
-  private fun initMetadata(values: Map<String, Value>, ingressPort: UInt, passNumber: Int) {
+  private fun initMetadata(
+    values: Map<String, Value>,
+    ingressPort: DataplanePort,
+    passNumber: Int,
+  ) {
     val loopedback = passNumber > 0
     val direction = DIRECTION_NET_TO_HOST
-    val portLong = ingressPort.toLong()
+    val portLong = ingressPort.unsignedLong
     // PassNumber_t is bit<3> (pna.p4), so truncate to 3 bits to avoid overflow.
     val passTruncated = (passNumber and 0x7).toLong()
 

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -3,9 +3,12 @@ package fourward.simulator
 import com.google.protobuf.ByteString
 import fourward.Architecture
 import fourward.BehavioralConfig
+import fourward.BinaryOp
+import fourward.BinaryOperator
 import fourward.ControlDecl
 import fourward.DropReason
 import fourward.EnumDecl
+import fourward.Expr
 import fourward.ExternInstanceDecl
 import fourward.FieldDecl
 import fourward.ForkReason
@@ -40,6 +43,8 @@ class PNAArchitectureTest {
   // ---------------------------------------------------------------------------
   // Helpers: minimal PNA config construction
   // ---------------------------------------------------------------------------
+
+  private fun port(value: Long): DataplanePort = DataplanePort.fromUnsignedLong(value)
 
   private fun field(name: String, width: Int): FieldDecl =
     FieldDecl.newBuilder().setName(name).setType(bitType(width)).build()
@@ -262,6 +267,13 @@ class PNAArchitectureTest {
   /** recirculate() — PNA free function with no arguments. */
   private fun recirculate(): Stmt = externCall("recirculate")
 
+  /** Binary EQ expression with boolean result type. */
+  private fun eq(left: Expr, right: Expr): Expr =
+    Expr.newBuilder()
+      .setBinaryOp(BinaryOp.newBuilder().setOp(BinaryOperator.EQ).setLeft(left).setRight(right))
+      .setType(Type.newBuilder().setBoolean(true))
+      .build()
+
   private fun counterInstance(name: String): ExternInstanceDecl =
     ExternInstanceDecl.newBuilder()
       .setTypeName("Counter")
@@ -288,7 +300,7 @@ class PNAArchitectureTest {
   @Test
   fun `PNA drops by default without send_to_port`() {
     val config = pnaConfig()
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -298,7 +310,7 @@ class PNAArchitectureTest {
   fun `send_to_port forwards packet`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(5)))
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = PNAArchitecture(config).processPacket(0u, payload, TableStore())
+    val result = PNAArchitecture(config).processPacket(port(0), payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -310,7 +322,7 @@ class PNAArchitectureTest {
   fun `drop_packet explicitly drops`() {
     // send_to_port then drop_packet — last writer wins, packet drops.
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(5), dropPacket()))
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -320,7 +332,7 @@ class PNAArchitectureTest {
   fun `send_to_port overrides drop_packet`() {
     // drop_packet then send_to_port — last writer wins, packet forwards.
     val config = pnaConfig(mainControlStmts = listOf(dropPacket(), sendToPort(5)))
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -328,9 +340,31 @@ class PNAArchitectureTest {
   }
 
   @Test
+  fun `uint32 ingress port with high bit set reaches PNA metadata unsigned`() {
+    val highBitPort = 0xFFFF_FFFEL
+    val isHighBitInputPort =
+      eq(fieldAccess(nameRef("istd"), "input_port", bitType(32)), bit(highBitPort, 32))
+    val config =
+      pnaConfig(
+        mainControlStmts =
+          listOf(ifStmt(condition = isHighBitInputPort, thenStmts = listOf(sendToPort(9))))
+      )
+    val result =
+      PNAArchitecture(config).processPacket(port(highBitPort), byteArrayOf(0x01), TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(9, outputs[0].dataplaneEgressPort)
+    assertEquals(
+      DataplanePort.fromUnsignedLong(highBitPort).protoValue,
+      result.trace.eventsList.first { it.hasPacketIngress() }.packetIngress.dataplaneIngressPort,
+    )
+  }
+
+  @Test
   fun `trace has enter-exit pairs for all 4 PNA stages`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(1)))
-    val result = PNAArchitecture(config).processPacket(7u, byteArrayOf(0x01), TableStore())
+    val result = PNAArchitecture(config).processPacket(port(7), byteArrayOf(0x01), TableStore())
     val events = result.trace.eventsList.filter { it.hasPacketIngress() || it.hasPipelineStage() }
 
     // First event: packet ingress.
@@ -372,7 +406,7 @@ class PNAArchitectureTest {
           )
       )
     val tableStore = TableStore()
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     // Packet should forward (register write doesn't affect drop).
     val outputs = result.possibleOutcomes.single()
@@ -394,8 +428,9 @@ class PNAArchitectureTest {
     val tableStore = TableStore()
     tableStore.loadMappings(p4info = p4InfoWithCounter("pkt_counter", 8))
 
-    PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01, 0x02, 0x03, 0x04), tableStore)
-    PNAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte(), 0xBB.toByte()), tableStore)
+    PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01, 0x02, 0x03, 0x04), tableStore)
+    PNAArchitecture(config)
+      .processPacket(port(0), byteArrayOf(0xAA.toByte(), 0xBB.toByte()), tableStore)
 
     val results =
       tableStore.readCounterEntries(
@@ -416,7 +451,7 @@ class PNAArchitectureTest {
     // This should hit the MAX_RECIRCULATIONS guard.
     val config = pnaConfig(mainControlStmts = listOf(recirculate()))
     try {
-      PNAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), TableStore())
+      PNAArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), TableStore())
       fail("expected recirculation depth exceeded")
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("recirculation depth exceeded"))
@@ -426,7 +461,7 @@ class PNAArchitectureTest {
   @Test
   fun `assertion failure drops packet`() {
     val config = pnaConfig(mainControlStmts = listOf(externCall("assert", boolLit(false))))
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -447,7 +482,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), store)
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -462,7 +497,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 7))
 
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0xBB.toByte()), store)
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0xBB.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -500,7 +535,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x11), store)
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x11), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -515,7 +550,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -526,7 +561,7 @@ class PNAArchitectureTest {
   @Test
   fun `mirror_packet with unknown session silently ignores mirror`() {
     val config = pnaConfig(mainControlStmts = listOf(sendToPort(2), mirrorPacket(0, 999)))
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -539,7 +574,7 @@ class PNAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5, 1 to 6, 2 to 7))
 
-    val result = PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
     val outputs = result.possibleOutcomes.single()
 
     // Original + 3 mirror replicas = 4 outputs.
@@ -561,7 +596,7 @@ class PNAArchitectureTest {
     writeCloneSession(store, 100, listOf(0 to 5))
 
     try {
-      PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+      PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
       fail("expected recirculation depth exceeded")
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("recirculation depth exceeded"))
@@ -576,7 +611,7 @@ class PNAArchitectureTest {
   fun `drop_packet in pre_control is rejected`() {
     val config = pnaConfig(preControlStmts = listOf(dropPacket()))
     try {
-      PNAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+      PNAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
       fail("expected drop_packet to be rejected in pre_control")
     } catch (e: IllegalArgumentException) {
       assertTrue(e.message!!.contains("main_control"))

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -69,7 +69,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   )
 
   override fun processPacket(
-    ingressPort: UInt,
+    ingressPort: DataplanePort,
     packet: PacketBits,
     tableStore: TableStore,
   ): PipelineResult {
@@ -103,7 +103,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   private fun processPacketRecursive(
     pipeline: PipelineConfig,
     packet: PacketBits,
-    ingressPort: UInt,
+    ingressPort: DataplanePort,
     packetPath: String,
     depth: Int,
     selectorMembers: Map<String, Int> = emptyMap(),
@@ -228,7 +228,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   private fun runIngressPipeline(
     pipeline: PipelineConfig,
     packet: PacketBits,
-    ingressPort: UInt,
+    ingressPort: DataplanePort,
     packetPath: String,
     selectorMembers: Map<String, Int> = emptyMap(),
   ): IngressResult {
@@ -402,7 +402,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           processPacketRecursive(
             state.pipeline,
             PacketBits.ofBytes(core.deparsedBytes),
-            PSA_PORT_RECIRCULATE_UINT,
+            PSA_PORT_RECIRCULATE,
             PACKET_PATH_RECIRCULATE,
             depth = depth + 1,
           )
@@ -593,15 +593,15 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
   private fun initIngressMetadata(
     values: Map<String, Value>,
-    ingressPort: UInt,
+    ingressPort: DataplanePort,
     packetPath: String,
   ) {
     (values["psa_ingress_parser_input_metadata_t"] as? StructVal)?.let {
-      it.setBitField("ingress_port", ingressPort.toLong())
+      it.setBitField("ingress_port", ingressPort.unsignedLong)
       it.fields["packet_path"] = EnumVal(packetPath)
     }
     (values["psa_ingress_input_metadata_t"] as? StructVal)?.let {
-      it.setBitField("ingress_port", ingressPort.toLong())
+      it.setBitField("ingress_port", ingressPort.unsignedLong)
       it.fields["packet_path"] = EnumVal(packetPath)
       it.fields["parser_error"] = ErrorVal.NO_ERROR
     }
@@ -729,6 +729,6 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
 
     /** PSA_PORT_RECIRCULATE (psa.p4: `const PortId_t PSA_PORT_RECIRCULATE = 32w0xfffffffa`). */
     const val PSA_PORT_RECIRCULATE_LONG = 0xFFFFFFFAL
-    val PSA_PORT_RECIRCULATE_UINT = PSA_PORT_RECIRCULATE_LONG.toUInt()
+    val PSA_PORT_RECIRCULATE = DataplanePort.fromUnsignedLong(PSA_PORT_RECIRCULATE_LONG)
   }
 }

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -50,6 +50,8 @@ class PSAArchitectureTest {
   // Helpers: minimal PSA config construction
   // ---------------------------------------------------------------------------
 
+  private fun port(value: Long): DataplanePort = DataplanePort.fromUnsignedLong(value)
+
   private fun field(name: String, width: Int): FieldDecl =
     FieldDecl.newBuilder().setName(name).setType(bitType(width)).build()
 
@@ -346,7 +348,7 @@ class PSAArchitectureTest {
   @Test
   fun `PSA drops by default without send_to_port`() {
     val config = psaConfig()
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -357,7 +359,7 @@ class PSAArchitectureTest {
   fun `send_to_port forwards packet`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(5)))
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = PSAArchitecture(config).processPacket(0u, payload, TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -366,9 +368,30 @@ class PSAArchitectureTest {
   }
 
   @Test
+  fun `uint32 ingress port with high bit set reaches PSA metadata unsigned`() {
+    val highBitPort = 0xFFFF_FFFEL
+    val isHighBitIngressPort = eq(fieldAccess("istd", "ingress_port"), bit(highBitPort, 32))
+    val config =
+      psaConfig(
+        ingressStmts =
+          listOf(ifStmt(condition = isHighBitIngressPort, thenStmts = listOf(sendToPort(9))))
+      )
+    val result =
+      PSAArchitecture(config).processPacket(port(highBitPort), byteArrayOf(0x01), TableStore())
+    val outputs = result.possibleOutcomes.single()
+
+    assertEquals(1, outputs.size)
+    assertEquals(9, outputs[0].dataplaneEgressPort)
+    assertEquals(
+      DataplanePort.fromUnsignedLong(highBitPort).protoValue,
+      result.trace.eventsList.first { it.hasPacketIngress() }.packetIngress.dataplaneIngressPort,
+    )
+  }
+
+  @Test
   fun `trace has enter-exit pairs for all 6 PSA stages`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(1)))
-    val result = PSAArchitecture(config).processPacket(7u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(7), byteArrayOf(0x01), TableStore())
     val events = result.trace.eventsList.filter { it.hasPacketIngress() || it.hasPipelineStage() }
 
     // First event: packet ingress.
@@ -416,7 +439,7 @@ class PSAArchitectureTest {
           )
       )
     val tableStore = TableStore()
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     // Packet should forward (register write doesn't affect drop).
     val outputs = result.possibleOutcomes.single()
@@ -443,7 +466,7 @@ class PSAArchitectureTest {
             sendToPort(1),
           )
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     // Should not crash — the read returns a default zero value.
     val outputs = result.possibleOutcomes.single()
@@ -457,7 +480,7 @@ class PSAArchitectureTest {
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 5, 1 to 6, 2 to 7))
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = PSAArchitecture(config).processPacket(0u, payload, tableStore)
+    val result = PSAArchitecture(config).processPacket(port(0), payload, tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(3, outputs.size)
@@ -476,7 +499,7 @@ class PSAArchitectureTest {
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 1 to 3))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
@@ -489,7 +512,7 @@ class PSAArchitectureTest {
   fun `multicast with unknown group drops packet`() {
     // multicast(group=99) but no group 99 is configured — should drop.
     val config = psaConfig(ingressStmts = listOf(multicast(99)))
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -579,7 +602,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(hashGetHash1Arg("h_0", 0x456, 12), sendToPort(1)),
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -593,8 +616,8 @@ class PSAArchitectureTest {
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
     // Run twice — should get the same result (deterministic hash).
-    val result1 = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
-    val result2 = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result1 = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
+    val result2 = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val out1 = result1.possibleOutcomes.single()
     val out2 = result2.possibleOutcomes.single()
     assertEquals(out1[0].payload, out2[0].payload)
@@ -695,7 +718,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(hashGetHash1ArgBareBit("h_0", 0xAABBCCDD, 32), sendToPort(1)),
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -710,7 +733,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(hashGetHash1ArgBareBit("h_0", 0xAABBCCDD, 32), sendToPort(1)),
         ingressExterns = listOf(hashInstance("h_0", "IDENTITY")),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -723,7 +746,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(hashGetHash3Arg("h_0", 0, 0x456, 12, 1000, 16), sendToPort(1)),
         ingressExterns = listOf(hashInstance("h_0", "CRC16")),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -737,7 +760,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(randomRead("rng_0", 16), sendToPort(1)),
         ingressExterns = listOf(randomInstance("rng_0", 0, 100)),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -751,7 +774,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(digestPack("digest_0", 0xBEEF, 16), sendToPort(1)),
         ingressExterns = listOf(digestInstance("digest_0")),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -764,7 +787,7 @@ class PSAArchitectureTest {
         ingressStmts = listOf(meterExecute("meter0", 1), sendToPort(1)),
         ingressExterns = listOf(meterInstance("meter0")),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -832,7 +855,7 @@ class PSAArchitectureTest {
           ),
         ingressExterns = listOf(checksumInstance("ck_0")),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }
@@ -896,7 +919,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -914,7 +937,7 @@ class PSAArchitectureTest {
     // The first 10 bits are packet data; the final 14 bits are transport padding.
     val packet = PacketBits.ofPaddedBytes(byteArrayOf(0xAB.toByte(), 0xC0.toByte(), 0x00), 10)
 
-    val result = PSAArchitecture(config).processPacket(0u, packet, store)
+    val result = PSAArchitecture(config).processPacket(port(0), packet, store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -930,7 +953,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 7))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xBB.toByte()), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0xBB.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     // Original dropped, clone emitted.
@@ -944,7 +967,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -958,7 +981,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 5, 1 to 6, 2 to 7))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
     val outputs = result.possibleOutcomes.single()
 
     // Original + 3 clones = 4 outputs.
@@ -975,7 +998,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 200, listOf(0 to 8))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xCC.toByte()), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0xCC.toByte()), store)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -997,7 +1020,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 200, listOf(0 to 9))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xDD.toByte()), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0xDD.toByte()), store)
 
     // Clone fork exists even though original drops — E2E clone is processed independently.
     assertTrue(result.trace.hasForkOutcome())
@@ -1011,7 +1034,7 @@ class PSAArchitectureTest {
   @Test
   fun `E2E clone with unknown session silently drops clone`() {
     val config = psaConfig(ingressStmts = listOf(sendToPort(2)), egressStmts = cloneStmts(999))
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // No clone session 999 → clone silently ignored, original output normally.
@@ -1025,7 +1048,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 200, listOf(0 to 8))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     // E2E clone fork is in the egress subtree, flattened into the top-level trace since
     // there's no I2E clone.
@@ -1039,7 +1062,7 @@ class PSAArchitectureTest {
   @Test
   fun `I2E clone with unknown session silently drops clone`() {
     val config = psaConfig(ingressStmts = cloneStmts(999) + listOf(sendToPort(2)))
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // No clone session 999 → clone silently ignored, original output normally.
@@ -1054,7 +1077,7 @@ class PSAArchitectureTest {
     // PSA_PORT_RECIRCULATE = 32w0xfffffffa (psa.p4).
     val config = psaConfig(ingressStmts = listOf(sendToPort(0xFFFFFFFAL)))
     try {
-      PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+      PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
       fail("expected recirculation depth exception")
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("PSA recirculation depth exceeded"))
@@ -1094,7 +1117,8 @@ class PSAArchitectureTest {
             )
           )
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), TableStore())
+    val result =
+      PSAArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // Packet recirculates once, then forwards on port 5.
@@ -1110,7 +1134,7 @@ class PSAArchitectureTest {
   fun `egress drop without clone produces drop trace`() {
     // Egress drops the original packet, no clone — pure egress drop path.
     val config = psaConfig(ingressStmts = listOf(sendToPort(2)), egressStmts = listOf(egressDrop()))
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1122,7 +1146,7 @@ class PSAArchitectureTest {
     // send_to_port sets drop=false, then ingress_drop sets drop=true — last writer wins.
     val config =
       psaConfig(ingressStmts = listOf(sendToPort(2), externCall("ingress_drop", nameRef("ostd"))))
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1133,7 +1157,7 @@ class PSAArchitectureTest {
     // Set clone=true but leave clone_session_id at default (0). No session 0 exists.
     val config =
       psaConfig(ingressStmts = listOf(assignField("ostd", "clone", boolLit(true)), sendToPort(2)))
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // No clone session 0 → clone silently ignored, original output normally.
@@ -1164,7 +1188,8 @@ class PSAArchitectureTest {
             )
           )
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), TableStore())
+    val result =
+      PSAArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1190,7 +1215,8 @@ class PSAArchitectureTest {
             )
           )
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0xBB.toByte()), TableStore())
+    val result =
+      PSAArchitecture(config).processPacket(port(0), byteArrayOf(0xBB.toByte()), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     // Resubmitted packet exits on port 1 with original bytes.
@@ -1203,7 +1229,7 @@ class PSAArchitectureTest {
     // PSA spec §6.2: drop has highest priority. resubmit=true with drop=true → dropped.
     val config =
       psaConfig(ingressStmts = listOf(resubmitStmt())) // drop=true by default, resubmit=true
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1227,7 +1253,7 @@ class PSAArchitectureTest {
     val store = TableStore()
     writeCloneSession(store, 100, listOf(0 to 9))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
     val outputs = result.possibleOutcomes.single()
 
     // Resubmit wins: packet loops back, then exits on port 5. No clone on port 9.
@@ -1241,7 +1267,7 @@ class PSAArchitectureTest {
     // Unconditional resubmit causes infinite loop — simulator must enforce depth limit.
     val config = psaConfig(ingressStmts = listOf(resubmitStmt(), sendToPort(1)))
     try {
-      PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+      PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
       fail("expected recirculation depth exception")
     } catch (e: IllegalStateException) {
       assertTrue(e.message!!.contains("PSA recirculation depth exceeded"))
@@ -1455,7 +1481,7 @@ class PSAArchitectureTest {
     writeActionProfileGroup(store, groupId = 1, memberIds = listOf(0, 1))
     writeGroupTableEntry(store, keyValue = 0x0A, groupId = 1)
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     // Should produce an ACTION_SELECTOR fork with 2 member branches.
     assertTrue("expected fork outcome", result.trace.hasForkOutcome())
@@ -1477,7 +1503,7 @@ class PSAArchitectureTest {
     val config = psaConfigWithTable(postTableStmts = emptyList())
     val store = storeWithActionProfile()
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     // No fork — table miss falls through to default action, packet dropped by PSA default.
     assertTrue("expected drop (no fork)", result.trace.hasPacketOutcome())
@@ -1492,7 +1518,7 @@ class PSAArchitectureTest {
     writeActionProfileGroup(store, groupId = 1, memberIds = listOf(0))
     writeGroupTableEntry(store, keyValue = 0x0A, groupId = 1)
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     assertTrue("expected fork outcome", result.trace.hasForkOutcome())
     assertEquals(ForkReason.ACTION_SELECTOR, result.trace.forkOutcome.reason)
@@ -1516,7 +1542,7 @@ class PSAArchitectureTest {
     writeActionProfileGroup(store, groupId = 1, memberIds = listOf(0, 1))
     writeGroupTableEntry(store, keyValue = 0x0A, groupId = 1)
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     // Egress fork: ACTION_SELECTOR with 2 member branches.
     assertTrue("expected fork outcome", result.trace.hasForkOutcome())
@@ -1543,7 +1569,7 @@ class PSAArchitectureTest {
     writeGroupTableEntry(store, keyValue = 0x0A, groupId = 1)
     writeCloneSession(store, 100, listOf(0 to 5))
 
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), store)
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), store)
 
     // Top-level fork is CLONE (I2E clone) — parallel.
     assertTrue("expected clone fork", result.trace.hasForkOutcome())
@@ -1584,7 +1610,7 @@ class PSAArchitectureTest {
           ),
         ingressExterns = listOf(checksumInstance("ck_0")),
       )
-    val result = PSAArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = PSAArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
   }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -79,6 +79,10 @@ class Simulator : TableDataReader {
    * @throws IllegalArgumentException if the architecture is unsupported.
    */
   fun loadPipeline(config: PipelineConfig, dropPortOverride: Int? = null) {
+    loadPipeline(config, dropPortOverride?.let(DataplanePort::fromProto))
+  }
+
+  fun loadPipeline(config: PipelineConfig, dropPortOverride: DataplanePort?) {
     val tableStore = TableStore()
     tableStore.loadMappings(config.p4Info, config.device)
     val behavioral = config.device.behavioral
@@ -102,6 +106,10 @@ class Simulator : TableDataReader {
    * **Concurrency:** same as [loadPipeline] — single-writer.
    */
   fun loadPipelinePreservingEntries(config: PipelineConfig, dropPortOverride: Int? = null) {
+    loadPipelinePreservingEntries(config, dropPortOverride?.let(DataplanePort::fromProto))
+  }
+
+  fun loadPipelinePreservingEntries(config: PipelineConfig, dropPortOverride: DataplanePort?) {
     val old = loaded()
     val oldSnapshot = old.tableStore.snapshot()
     val oldAliasByName = old.tableStore.tableAliasByName
@@ -121,9 +129,16 @@ class Simulator : TableDataReader {
    * @throws IllegalStateException if no pipeline is loaded.
    */
   fun processPacket(ingressPort: Int, payload: ByteArray): ProcessPacketResult =
+    processPacket(DataplanePort.fromProto(ingressPort), PacketBits.ofBytes(payload))
+
+  fun processPacket(ingressPort: DataplanePort, payload: ByteArray): ProcessPacketResult =
     processPacket(ingressPort, PacketBits.ofBytes(payload))
 
   fun processPacket(ingressPort: Int, packet: PacketBits): ProcessPacketResult {
+    return processPacket(DataplanePort.fromProto(ingressPort), packet)
+  }
+
+  fun processPacket(ingressPort: DataplanePort, packet: PacketBits): ProcessPacketResult {
     val loaded = loaded()
     // Pin the forwarding snapshot before processing so the reproducer's entity extraction
     // uses the exact same state the packet saw — no race with concurrent publishSnapshot().
@@ -132,7 +147,7 @@ class Simulator : TableDataReader {
     val captured =
       loaded.tableStore.captureRegisterSeeds {
         loaded.architecture.processPacket(
-          ingressPort = ingressPort.toUInt(),
+          ingressPort = ingressPort,
           packet = packet,
           tableStore = loaded.tableStore,
         )

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -62,9 +62,11 @@ internal fun buildOutputTrace(events: List<TraceEvent>, port: Int, payload: Byte
 }
 
 /** Creates a [TraceEvent] recording the packet's ingress port. */
-internal fun packetIngressEvent(ingressPort: UInt): TraceEvent =
+internal fun packetIngressEvent(ingressPort: DataplanePort): TraceEvent =
   TraceEvent.newBuilder()
-    .setPacketIngress(PacketIngressEvent.newBuilder().setDataplaneIngressPort(ingressPort.toInt()))
+    .setPacketIngress(
+      PacketIngressEvent.newBuilder().setDataplaneIngressPort(ingressPort.protoValue)
+    )
     .build()
 
 /** Creates a [TraceEvent] marking the entry/exit of a pipeline stage. */

--- a/simulator/V1ModelArchitecture.kt
+++ b/simulator/V1ModelArchitecture.kt
@@ -70,9 +70,8 @@ class V1ModelArchitecture(
    * Override for the drop port. When null (default), derived from `standard_metadata` port width:
    * `2^N - 1` (511 for 9-bit ports). Applied in [PipelineState] and in the `mark_to_drop` extern.
    */
-  private val dropPortOverride: Int? = null,
+  private val dropPortOverride: DataplanePort? = null,
 ) : Architecture {
-
   // Pipeline-invariant state derived from [config], built once per loaded pipeline. Immutable
   // after publication, so safe to read concurrently from any number of [processPacket] threads
   // without synchronization.
@@ -80,7 +79,7 @@ class V1ModelArchitecture(
 
   /** Invariant inputs to the pipeline, shared across fork re-executions. */
   private data class PipelineContext(
-    val ingressPort: UInt,
+    val ingressPort: DataplanePort,
     val packet: PacketBits,
     val config: BehavioralConfig,
     val tableStore: TableStore,
@@ -118,7 +117,7 @@ class V1ModelArchitecture(
   }
 
   override fun processPacket(
-    ingressPort: UInt,
+    ingressPort: DataplanePort,
     packet: PacketBits,
     tableStore: TableStore,
   ): PipelineResult {
@@ -568,7 +567,7 @@ class V1ModelArchitecture(
     check("packet_length" in standardMetadata.fields) {
       "$standardMetaTypeName has no packet_length"
     }
-    standardMetadata.setBitField("ingress_port", ctx.ingressPort.toLong())
+    standardMetadata.setBitField("ingress_port", ctx.ingressPort.unsignedLong)
     standardMetadata.setBitField("packet_length", ctx.packet.packetByteLength.toLong())
     standardMetadata.fields["parser_error"] = ErrorVal.NO_ERROR
     setTimestampField(
@@ -621,7 +620,7 @@ class V1ModelArchitecture(
     existingPendingOps: V1ModelPendingOps? = null,
   ): PipelineState {
     val portBits = standardMetadata.bitWidth("ingress_port")
-    val dropPort = dropPortOverride?.toLong() ?: ((1L shl portBits) - 1)
+    val dropPort = dropPortOverride?.unsignedLong ?: ((1L shl portBits) - 1)
 
     val pendingOps = existingPendingOps ?: V1ModelPendingOps()
     val interpreter =
@@ -675,7 +674,7 @@ class V1ModelArchitecture(
         s,
         s.ingressControls,
         duringIngress = true,
-        dataplanePort = ctx.ingressPort.toInt(),
+        dataplanePort = ctx.ingressPort.protoValue,
       )
 
       // --- Ingress→egress boundary (traffic manager) ---

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -48,6 +48,8 @@ class V1ModelArchitectureTest {
   // Helpers: minimal v1model config construction
   // ---------------------------------------------------------------------------
 
+  private fun port(value: Long): DataplanePort = DataplanePort.fromUnsignedLong(value)
+
   private fun param(name: String, typeName: String): ParamDecl =
     ParamDecl.newBuilder().setName(name).setType(namedType(typeName)).build()
 
@@ -350,7 +352,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
         ifFieldEquals("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS, markToDrop),
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     val branchEvents = result.trace.eventsList.filter { it.hasBranch() }
     val egressSpecBranch = branchEvents.first { it.branch.taken }
@@ -364,7 +366,7 @@ class V1ModelArchitectureTest {
     // the assigned value.
     val config =
       v1modelConfig(assignField("sm", "egress_spec", 42, V1ModelArchitecture.DEFAULT_PORT_BITS))
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     val assignEvents = result.trace.eventsList.filter { it.hasAssignment() }
     assertTrue(assignEvents.isNotEmpty())
@@ -379,7 +381,7 @@ class V1ModelArchitectureTest {
       v1modelConfig(assignField("sm", "egress_spec", 0, V1ModelArchitecture.DEFAULT_PORT_BITS))
     val zeroAssign =
       V1ModelArchitecture(configZero)
-        .processPacket(0u, byteArrayOf(0x01), TableStore())
+        .processPacket(port(0), byteArrayOf(0x01), TableStore())
         .trace
         .eventsList
         .first { it.hasAssignment() && it.assignment.target == "sm.egress_spec" }
@@ -390,7 +392,7 @@ class V1ModelArchitectureTest {
       v1modelConfig(assignField("sm", "egress_spec", 9, V1ModelArchitecture.DEFAULT_PORT_BITS))
     val nineAssign =
       V1ModelArchitecture(configNine)
-        .processPacket(0u, byteArrayOf(0x01), TableStore())
+        .processPacket(port(0), byteArrayOf(0x01), TableStore())
         .trace
         .eventsList
         .first { it.hasAssignment() && it.assignment.target == "sm.egress_spec" }
@@ -401,7 +403,7 @@ class V1ModelArchitectureTest {
       v1modelConfig(assignField("sm", "egress_spec", 10, V1ModelArchitecture.DEFAULT_PORT_BITS))
     val tenAssign =
       V1ModelArchitecture(configTen)
-        .processPacket(0u, byteArrayOf(0x01), TableStore())
+        .processPacket(port(0), byteArrayOf(0x01), TableStore())
         .trace
         .eventsList
         .first { it.hasAssignment() && it.assignment.target == "sm.egress_spec" }
@@ -412,7 +414,7 @@ class V1ModelArchitectureTest {
       v1modelConfig(assignField("sm", "egress_spec", 510, V1ModelArchitecture.DEFAULT_PORT_BITS))
     val assign510 =
       V1ModelArchitecture(config510)
-        .processPacket(0u, byteArrayOf(0x01), TableStore())
+        .processPacket(port(0), byteArrayOf(0x01), TableStore())
         .trace
         .eventsList
         .first { it.hasAssignment() && it.assignment.target == "sm.egress_spec" }
@@ -423,7 +425,7 @@ class V1ModelArchitectureTest {
   fun `table lookup trace events include key variable values`() {
     val config =
       v1modelConfig(assignField("sm", "egress_spec", 3, V1ModelArchitecture.DEFAULT_PORT_BITS))
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     // The ingress port is a table key in some pipelines. For our minimal config,
     // there are no tables — but we can verify the mechanism doesn't crash.
@@ -438,7 +440,7 @@ class V1ModelArchitectureTest {
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -454,7 +456,7 @@ class V1ModelArchitectureTest {
     val config =
       v1modelConfig(assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS))
     val payload = byteArrayOf(0x01, 0x02, 0x03)
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -470,7 +472,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
     val payload = byteArrayOf(0x01, 0x02, 0x03, 0x04)
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -486,7 +488,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
     val payload = byteArrayOf(0x01, 0x02, 0x03)
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -502,7 +504,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
     val payload = byteArrayOf(0x01, 0x02)
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -519,7 +521,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
     val payload = byteArrayOf(0x01, 0x02, 0x03, 0x04)
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -536,7 +538,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
     val payload = byteArrayOf(0x01, 0x02, 0x03, 0x04)
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -555,7 +557,7 @@ class V1ModelArchitectureTest {
           V1ModelArchitecture.DEFAULT_PORT_BITS,
         )
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -574,7 +576,7 @@ class V1ModelArchitectureTest {
           V1ModelArchitecture.DEFAULT_PORT_BITS,
         )
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     val stageNames =
       result.trace.eventsList.filter { it.hasPipelineStage() }.map { it.pipelineStage.stageName }
@@ -604,7 +606,7 @@ class V1ModelArchitectureTest {
             assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
           ),
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -664,7 +666,7 @@ class V1ModelArchitectureTest {
     )
     tableStore.publishSnapshot()
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -688,7 +690,7 @@ class V1ModelArchitectureTest {
             ),
           ),
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -702,7 +704,7 @@ class V1ModelArchitectureTest {
         externCall("digest", bit(0, 32), bit(0xBEEFL, 16)),
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -715,7 +717,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.MULTICAST, result.trace.forkOutcome.reason)
@@ -734,7 +736,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
     val payload = byteArrayOf(0xAA.toByte())
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -762,7 +764,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7, usePortBytes = true)
 
     val result =
-      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+      V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -798,7 +800,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7, instance = 42)
 
     val result =
-      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+      V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -820,7 +822,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 510, usePortBytes = true)
 
     val result =
-      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+      V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -838,7 +840,7 @@ class V1ModelArchitectureTest {
       usePortBytes = true,
     )
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -858,7 +860,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 8)
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -902,7 +904,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 8, instance = 7)
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -922,7 +924,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, replicas = listOf(7 to 10, 8 to 20))
 
     val result =
-      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+      V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -959,7 +961,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, replicas = listOf(5 to 1, 6 to 2))
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -998,7 +1000,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, replicas = listOf(7 to 0, 8 to 10))
 
     val result =
-      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+      V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -1031,7 +1033,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, replicas = listOf(7 to 1, 8 to 2))
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(3, outputs.size)
@@ -1051,7 +1053,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7, instance = 42)
 
     val result =
-      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+      V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
     val cloneEvent = result.trace.eventsList.first { it.hasCloneSessionLookup() }.cloneSessionLookup
 
     assertTrue(cloneEvent.sessionFound)
@@ -1072,7 +1074,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, replicas = listOf(7 to 10, 8 to 20))
 
     val result =
-      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+      V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
     val cloneEvent = result.trace.eventsList.first { it.hasCloneSessionLookup() }.cloneSessionLookup
 
     assertTrue(cloneEvent.sessionFound)
@@ -1090,7 +1092,7 @@ class V1ModelArchitectureTest {
         ifFieldEquals("sm", "instance_type", 0, 32, externCall("resubmit", intArg(0, 8)))
       )
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
@@ -1113,7 +1115,7 @@ class V1ModelArchitectureTest {
           ),
       )
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
@@ -1132,7 +1134,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 2, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertFalse(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -1150,7 +1152,7 @@ class V1ModelArchitectureTest {
         egressStmts = listOf(externCall("clone", enumArg("E2E"), intArg(99, 32))),
       )
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertFalse(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -1170,7 +1172,7 @@ class V1ModelArchitectureTest {
 
     val payload =
       byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte())
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -1192,7 +1194,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 8, packetLengthBytes = 2)
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte())
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -1212,7 +1214,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7, packetLengthBytes = 0)
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte())
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
@@ -1231,7 +1233,7 @@ class V1ModelArchitectureTest {
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7, packetLengthBytes = 100)
 
     val payload = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-    val result = V1ModelArchitecture(config).processPacket(0u, payload, tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), payload, tableStore)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
@@ -1247,7 +1249,7 @@ class V1ModelArchitectureTest {
         assignField("sm", "egress_spec", 5, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     // No fork — falls through to unicast path.
     val outputs = result.possibleOutcomes.single()
@@ -1273,7 +1275,7 @@ class V1ModelArchitectureTest {
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))
 
     val result =
-      V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0xAA.toByte()), tableStore)
+      V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0xAA.toByte()), tableStore)
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(2, outputs.size)
@@ -1289,7 +1291,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -1323,7 +1325,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 8)
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -1344,7 +1346,7 @@ class V1ModelArchitectureTest {
   fun `trace starts with packet ingress and has enter-exit pairs for all stages`() {
     val config =
       v1modelConfig(assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS))
-    val result = V1ModelArchitecture(config).processPacket(7u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(7), byteArrayOf(0x01), TableStore())
     val events = stageEvents(result.trace)
 
     // First event: packet ingress with correct port.
@@ -1381,6 +1383,41 @@ class V1ModelArchitectureTest {
   }
 
   @Test
+  fun `uint32 ingress port with high bit set reaches v1model metadata unsigned`() {
+    val highBitPort = 0xFFFF_FFFEL
+    val portBits = Int.SIZE_BITS
+    val config =
+      widePortConfig(
+        portBits,
+        ifFieldEquals(
+          "sm",
+          "ingress_port",
+          highBitPort,
+          portBits,
+          assignField("sm", "egress_spec", 9, portBits),
+        ),
+      )
+    val result =
+      V1ModelArchitecture(config).processPacket(port(highBitPort), byteArrayOf(0x01), TableStore())
+    val outputs = result.possibleOutcomes.single()
+    val events = stageEvents(result.trace)
+
+    assertEquals(1, outputs.size)
+    assertEquals(9, outputs[0].dataplaneEgressPort)
+    assertEquals(
+      DataplanePort.fromUnsignedLong(highBitPort).protoValue,
+      events[0].packetIngress.dataplaneIngressPort,
+    )
+    assertEquals(
+      DataplanePort.fromUnsignedLong(highBitPort).protoValue,
+      events
+        .first { it.hasPipelineStage() && it.pipelineStage.stageName == "verify_checksum" }
+        .pipelineStage
+        .dataplanePort,
+    )
+  }
+
+  @Test
   fun `parser exit emits EXIT event before drop`() {
     // Parser with an exit statement — triggers ExitException in the parser.
     val exitParser =
@@ -1396,7 +1433,7 @@ class V1ModelArchitectureTest {
         .build()
 
     val config = v1modelConfig(parser = exitParser)
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     // Should be a drop.
     assertTrue(result.trace.hasPacketOutcome())
@@ -1443,7 +1480,7 @@ class V1ModelArchitectureTest {
     val portBits = 16
     val largePort = 1000L // beyond bit<9> range
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", largePort, portBits))
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1455,7 +1492,7 @@ class V1ModelArchitectureTest {
     val portBits = 16
     val dropPort = (1L shl portBits) - 1 // 65535, not 511
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", dropPort, portBits))
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1466,7 +1503,7 @@ class V1ModelArchitectureTest {
     // Port 511 is NOT the drop port when port width is 16 bits — it's a valid port.
     val portBits = 16
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", 511, portBits))
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1481,7 +1518,7 @@ class V1ModelArchitectureTest {
     val portBits = 16
     val markToDrop = externCall("mark_to_drop", nameRef("sm"))
     val config = widePortConfig(portBits, markToDrop)
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1492,7 +1529,7 @@ class V1ModelArchitectureTest {
     val portBits = 32
     val largePort = 100_000L
     val config = widePortConfig(portBits, assignField("sm", "egress_spec", largePort, portBits))
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1546,7 +1583,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -1592,7 +1629,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 8)
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.CLONE, result.trace.forkOutcome.reason)
@@ -1635,7 +1672,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(2, outputs.size)
@@ -1680,7 +1717,7 @@ class V1ModelArchitectureTest {
         metaTypeDecl = metaTypeWithFieldList,
       )
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RESUBMIT, result.trace.forkOutcome.reason)
@@ -1733,7 +1770,7 @@ class V1ModelArchitectureTest {
         metaTypeDecl = metaTypeWithFieldList,
       )
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasForkOutcome())
     assertEquals(ForkReason.RECIRCULATE, result.trace.forkOutcome.reason)
@@ -1778,7 +1815,7 @@ class V1ModelArchitectureTest {
     val tableStore = TableStore()
     writeCloneSession(tableStore, sessionId = 1, egressPort = 7)
 
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), tableStore)
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), tableStore)
 
     assertTrue(result.trace.hasForkOutcome())
     val outputs = result.possibleOutcomes.single()
@@ -1797,7 +1834,7 @@ class V1ModelArchitectureTest {
         externCall("assert", boolLit(true)),
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1809,7 +1846,7 @@ class V1ModelArchitectureTest {
   @Test
   fun `assert false drops packet with ASSERTION_FAILURE reason`() {
     val config = v1modelConfig(externCall("assert", boolLit(false)))
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1821,7 +1858,7 @@ class V1ModelArchitectureTest {
   @Test
   fun `assume false drops packet with ASSERTION_FAILURE reason`() {
     val config = v1modelConfig(externCall("assume", boolLit(false)))
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1839,7 +1876,7 @@ class V1ModelArchitectureTest {
         externCall("log_msg", stringLit("hello world")),
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1855,7 +1892,7 @@ class V1ModelArchitectureTest {
         externCall("log_msg", stringLit("value = {}"), bit(42, 8)),
         assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS),
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
     val outputs = result.possibleOutcomes.single()
 
     assertEquals(1, outputs.size)
@@ -1872,7 +1909,7 @@ class V1ModelArchitectureTest {
           listOf(assignField("sm", "egress_spec", 1, V1ModelArchitecture.DEFAULT_PORT_BITS)),
         egressStmts = listOf(externCall("assert", boolLit(false))),
       )
-    val result = V1ModelArchitecture(config).processPacket(0u, byteArrayOf(0x01), TableStore())
+    val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1889,8 +1926,8 @@ class V1ModelArchitectureTest {
     // Sending to port 42 should now be a drop.
     val config = v1modelConfig(assignField("sm", "egress_spec", 42, DEFAULT_PORT_BITS))
     val result =
-      V1ModelArchitecture(config, dropPortOverride = 42)
-        .processPacket(0u, byteArrayOf(0x01), TableStore())
+      V1ModelArchitecture(config, dropPortOverride = DataplanePort.fromUnsignedLong(42))
+        .processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1902,8 +1939,8 @@ class V1ModelArchitectureTest {
     val config =
       v1modelConfig(assignField("sm", "egress_spec", DEFAULT_DROP_PORT.toLong(), DEFAULT_PORT_BITS))
     val result =
-      V1ModelArchitecture(config, dropPortOverride = 42)
-        .processPacket(0u, byteArrayOf(0x01), TableStore())
+      V1ModelArchitecture(config, dropPortOverride = DataplanePort.fromUnsignedLong(42))
+        .processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     val outputs = result.possibleOutcomes.single()
     assertEquals(1, outputs.size)
@@ -1915,8 +1952,8 @@ class V1ModelArchitectureTest {
     // mark_to_drop should set egress_spec to the override value, not the default.
     val config = v1modelConfig(externCall("mark_to_drop", nameRef("sm")))
     val result =
-      V1ModelArchitecture(config, dropPortOverride = 42)
-        .processPacket(0u, byteArrayOf(0x01), TableStore())
+      V1ModelArchitecture(config, dropPortOverride = DataplanePort.fromUnsignedLong(42))
+        .processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())
@@ -1929,7 +1966,7 @@ class V1ModelArchitectureTest {
       v1modelConfig(assignField("sm", "egress_spec", DEFAULT_DROP_PORT.toLong(), DEFAULT_PORT_BITS))
     val result =
       V1ModelArchitecture(config, dropPortOverride = null)
-        .processPacket(0u, byteArrayOf(0x01), TableStore())
+        .processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasPacketOutcome())
     assertTrue(result.trace.packetOutcome.hasDrop())


### PR DESCRIPTION
Fixes #783.

This replaces the signed `Int` interpretation of dataplane ports at the gRPC/simulator boundary with a `DataplanePort` domain type. The type preserves the proto `uint32` bit pattern, exposes explicit unsigned views for P4Runtime translation and architecture execution, and keeps wire serialization at the generated-proto edge.

Root cause: Java/Kotlin expose proto `uint32` fields as `Int`, so a valid 32-bit port like `0xffff_fffe` arrived as `-2`. Reverse translation then called the minimum-width unsigned encoder with that signed value, throwing during `SubscribeResults` enrichment and closing the stream as a generic `UNKNOWN`.

The fix threads `DataplanePort` through packet injection, subscription fanout, CPU/drop port resolution, PacketIn filtering, trace enrichment, and PRE replica port translation. Reverse translation now canonicalizes dataplane bytes instead of reinterpreting high-bit values as signed integers. `SubscribeResults` also wraps enrichment failures as `INTERNAL` instead of surfacing a raw unknown status.

Validation:
- `bazel test //grpc:TypeTranslatorTest //grpc:PacketHeaderCodecTest //grpc:DataplaneServiceTest //grpc:TraceEnricherTest`
- `bazel test //grpc/... //simulator:SimulatorTest //simulator:V1ModelArchitectureTest --test_tag_filters=-heavy`
- `./tools/format.sh`
- `./tools/lint.sh`