### PR TITLE
fix PacketHeaderCodec.create bridge for high-bit uint32 CPU port overrides

### DIFF
--- a/grpc/PacketHeaderCodec.kt
+++ b/grpc/PacketHeaderCodec.kt
@@ -267,11 +267,7 @@ private constructor(
       behavioral: BehavioralConfig,
       cpuPortOverride: Int? = null,
     ): PacketHeaderCodec? =
-      createWithCpuPort(
-        p4info,
-        behavioral,
-        cpuPortOverride?.toLong()?.let(DataplanePort::fromUnsignedLong),
-      )
+      createWithCpuPort(p4info, behavioral, cpuPortOverride?.let(DataplanePort::fromProto))
 
     fun createWithCpuPort(
       p4info: P4Info,

--- a/grpc/PacketHeaderCodecTest.kt
+++ b/grpc/PacketHeaderCodecTest.kt
@@ -1032,6 +1032,21 @@ class PacketHeaderCodecTest {
     }
   }
 
+  @Test
+  @Suppress("MagicNumber")
+  fun `cpu port override accepts uint32 port with high bit set`() {
+    // Regression: the Int bridge previously used .toLong() which sign-extends a high-bit Int
+    // to a negative Long, causing fromUnsignedLong to throw. fromProto preserves the raw bits.
+    val (p4info, behavioral) = buildSaiLikeConfig()
+    val highBitPort = 0xFFFF_FFFE.toInt() // -2 as signed Int, 4294967294 as uint32
+
+    val codec = PacketHeaderCodec.create(p4info, behavioral, cpuPortOverride = highBitPort)
+
+    assertNotNull(codec)
+    assertEquals(highBitPort, codec!!.cpuPort.protoValue)
+    assertEquals(0xFFFF_FFFEL, codec.cpuPort.unsignedLong)
+  }
+
   // =========================================================================
   // CpuPortConfig.fromFlag
   // =========================================================================

--- a/simulator/DataplanePort.kt
+++ b/simulator/DataplanePort.kt
@@ -54,6 +54,7 @@ private constructor(
       return DataplanePort(parsed.toLong().toInt())
     }
 
+    /** Constructs a port from an unsigned [Long] in `0..0xFFFF_FFFF`; throws if out of range. */
     fun fromUnsignedLong(value: Long): DataplanePort {
       require(value in 0..UINT32_MASK) { "dataplane port out of uint32 range: $value" }
       return DataplanePort(value.toInt())


### PR DESCRIPTION
Follow-up to #784.

## What

The `Int` overload of `PacketHeaderCodec.create` bridged via `.toLong()` before calling `DataplanePort.fromUnsignedLong`:

```kotlin
// before
cpuPortOverride?.toLong()?.let(DataplanePort::fromUnsignedLong)
```

`.toLong()` sign-extends a negative `Int` (the Kotlin/Java representation of a `uint32 > Int.MAX_VALUE`) to a negative `Long`, which then fails `fromUnsignedLong`'s `require(value in 0..UINT32_MASK)` check. Any caller passing a high-bit uint32 CPU port through this overload would get an `IllegalArgumentException`.

## Fix

Use `fromProto` instead, which preserves the raw bit pattern without range-checking — consistent with every other `Int → DataplanePort` boundary in the codebase:

```kotlin
// after
cpuPortOverride?.let(DataplanePort::fromProto)
```

Also adds a missing KDoc to `DataplanePort.fromUnsignedLong`.

## Test

Added `cpu port override accepts uint32 port with high bit set` in `PacketHeaderCodecTest`, which would have failed before this fix.