### PR TITLE
Support many logical devices in one 4ward server

### DIFF
--- a/designs/multi_device_server.md
+++ b/designs/multi_device_server.md
@@ -1,6 +1,10 @@
 # Multi-Device Server
 
-**Status: proposed**
+**Status: implemented in PR #788**
+
+Revision note: PR #788 implements the first version of this design. It keeps
+per-device state independent, adds the management API, routes P4Runtime by
+`device_id`, and keeps single-device use on the default device.
 
 ## Problem
 
@@ -28,16 +32,28 @@ roughly 1k-10k entries per device and 100-200 GB of memory available.
 
 6. **Simplicity.** Keep the design as simple as the requirements allow.
 
-## Assumptions to validate
+## Scale Validation
 
-Implementation should measure these early:
+PR #788 validated the main scale assumptions with `MultiDeviceScaleBenchmark`.
+
+| Workload | Result |
+|----------|--------|
+| 10k devices, SAI middleblock loaded, no table entries | Passed; 8.3 GiB incremental heap, about 0.88 MiB/device. |
+| 1k devices, SAI middleblock loaded, 1k IPv6 routes/device | Passed; 1.2 GiB incremental heap, about 1.3 MiB/device. |
+| 1k devices, SAI middleblock loaded, 10k IPv6 routes/device | Passed; 4.9 GiB incremental heap, about 5.3 MiB/device. |
+
+These measurements support the first target and the 10k mostly-idle stretch
+target. The benchmark uses real P4Runtime writes against SAI P4 and installs
+IPv6 LPM route entries plus the prerequisite SAI objects required by
+`@refers_to`. We did not run the full extrapolated 10k devices x 10k routes
+case because it would install 100 million entries; the measured heap/device
+stays well inside the 100-200 GB memory target, while write throughput is the
+practical caveat.
+
+Remaining design assumptions:
 
 - The naive design, N independent 4ward processes with one JVM each, does not
   meet the target workload.
-- One JVM and one gRPC server remove enough fixed overhead to make the first
-  target practical before any state-sharing optimization.
-- 10k mostly idle devices fit in 100-200 GB when each device owns independent
-  runtime state and 1k-10k table entries.
 - Contiguous device IDs are natural for the target network-emulation workflow.
 - Most multi-device runs use homogeneous server-level options. Per-device CPU
   port, drop port, or validation settings are not needed in the first API.
@@ -220,10 +236,15 @@ An ergonomic wrapper mirrors the gRPC API:
 ```cc
 class ManagementClient {
  public:
+  struct DeviceRange {
+    uint64_t first_device_id;
+    uint32_t count;
+  };
+
   explicit ManagementClient(const FourwardServer& server);
 
-  absl::Status CreateDevices(uint64_t first_device_id, uint32_t count);
-  absl::Status DeleteDevices(uint64_t first_device_id, uint32_t count);
+  absl::Status CreateDevices(DeviceRange devices);
+  absl::Status DeleteDevices(DeviceRange devices);
   absl::StatusOr<std::vector<uint64_t>> ListDevices();
 };
 ```
@@ -269,7 +290,8 @@ Tests should cover the design contracts, not every implementation detail:
 - P4Runtime routing and error behavior by `device_id`
 - Dataplane default-device and explicit-device routing
 - deletion behavior for active and future streams
-- a scale smoke test that creates and lists 10k empty devices in one RPC
+- a scale benchmark that creates 10k devices and installs SAI IPv6 route entries
+  through P4Runtime
 
 ## Future work
 
@@ -283,5 +305,3 @@ Other possible extensions:
 - arbitrary repeated device IDs for sparse bulk operations
 - per-device creation options
 - paginated or range-compressed `ListDevices`
-- a benchmark that reports heap per empty device and heap per programmed table
-  entry

--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -32,6 +32,8 @@ cc_library(
         ":output_capture",
         "//grpc:dataplane_cc_grpc",
         "//grpc:dataplane_cc_proto",
+        "//grpc:management_cc_grpc",
+        "//grpc:management_cc_proto",
         "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/status",
@@ -43,6 +45,22 @@ cc_library(
         "@grpc//:grpc++",
         "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
         "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+    ],
+)
+
+cc_library(
+    name = "management_client",
+    srcs = ["management_client.cc"],
+    hdrs = ["management_client.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":fourward_server",
+        "//grpc:management_cc_grpc",
+        "//grpc:management_cc_proto",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/time",
+        "@grpc//:grpc++",
     ],
 )
 
@@ -106,6 +124,20 @@ cc_test(
 )
 
 cc_test(
+    name = "management_client_test",
+    srcs = ["management_client_test.cc"],
+    deps = [
+        ":fourward_server",
+        ":management_client",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/time",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "dataplane_client_e2e_test",
     srcs = ["dataplane_client_e2e_test.cc"],
     data = [
@@ -120,6 +152,7 @@ cc_test(
         ":dataplane_client",
         ":dataplane_matchers",
         ":fourward_server",
+        ":management_client",
         "//grpc:dataplane_cc_proto",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",

--- a/fourward_cc/dataplane_client.cc
+++ b/fourward_cc/dataplane_client.cc
@@ -41,18 +41,20 @@ std::chrono::system_clock::time_point AbsoluteDeadline(
       std::chrono::system_clock::now() + absl::ToChronoNanoseconds(relative));
 }
 
-InjectPacketRequest MakeRequest(DataplanePort ingress_port,
+InjectPacketRequest MakeRequest(uint64_t device_id, DataplanePort ingress_port,
                                 std::string_view payload, Tag tag) {
   InjectPacketRequest req;
+  req.set_device_id(device_id);
   req.set_dataplane_ingress_port(ingress_port.port);
   req.set_payload(payload.data(), payload.size());
   req.set_tag(tag.value);
   return req;
 }
 
-InjectPacketRequest MakeRequest(P4RuntimePort ingress_port,
+InjectPacketRequest MakeRequest(uint64_t device_id, P4RuntimePort ingress_port,
                                 std::string_view payload, Tag tag) {
   InjectPacketRequest req;
+  req.set_device_id(device_id);
   req.set_p4rt_ingress_port(std::move(ingress_port.port));
   req.set_payload(payload.data(), payload.size());
   req.set_tag(tag.value);
@@ -65,11 +67,24 @@ InjectPacketRequest MakeRequest(P4RuntimePort ingress_port,
 
 DataplaneClient::DataplaneClient(const FourwardServer &server,
                                  absl::Duration default_timeout)
-    : DataplaneClient(server.NewDataplaneStub(), default_timeout) {}
+    : DataplaneClient(server.NewDataplaneStub(), server.DeviceId(),
+                      default_timeout) {}
+
+DataplaneClient::DataplaneClient(const FourwardServer &server,
+                                 uint64_t device_id,
+                                 absl::Duration default_timeout)
+    : DataplaneClient(server.NewDataplaneStub(), device_id, default_timeout) {}
 
 DataplaneClient::DataplaneClient(std::unique_ptr<Dataplane::Stub> stub,
                                  absl::Duration default_timeout)
-    : stub_(std::move(stub)), default_timeout_(default_timeout) {}
+    : DataplaneClient(std::move(stub), 0, default_timeout) {}
+
+DataplaneClient::DataplaneClient(std::unique_ptr<Dataplane::Stub> stub,
+                                 uint64_t device_id,
+                                 absl::Duration default_timeout)
+    : stub_(std::move(stub)),
+      device_id_(device_id),
+      default_timeout_(default_timeout) {}
 
 DataplaneClient::~DataplaneClient() = default;
 DataplaneClient::DataplaneClient(DataplaneClient &&) = default;
@@ -79,7 +94,7 @@ absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
     DataplanePort ingress_port, std::string_view payload, Tag tag) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(default_timeout_));
-  InjectPacketRequest req = MakeRequest(ingress_port, payload, tag);
+  InjectPacketRequest req = MakeRequest(device_id_, ingress_port, payload, tag);
   InjectPacketResponse resp;
   grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
@@ -90,7 +105,8 @@ absl::StatusOr<InjectPacketResponse> DataplaneClient::InjectPacket(
     P4RuntimePort ingress_port, std::string_view payload, Tag tag) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(default_timeout_));
-  InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload, tag);
+  InjectPacketRequest req =
+      MakeRequest(device_id_, std::move(ingress_port), payload, tag);
   InjectPacketResponse resp;
   grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
@@ -101,7 +117,7 @@ absl::StatusOr<Reproducer> DataplaneClient::GetReproducer(
     DataplanePort ingress_port, std::string_view payload, Tag tag) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(default_timeout_));
-  InjectPacketRequest req = MakeRequest(ingress_port, payload, tag);
+  InjectPacketRequest req = MakeRequest(device_id_, ingress_port, payload, tag);
   Reproducer resp;
   grpc::Status status = stub_->GetReproducer(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
@@ -112,7 +128,8 @@ absl::StatusOr<Reproducer> DataplaneClient::GetReproducer(
     P4RuntimePort ingress_port, std::string_view payload, Tag tag) {
   grpc::ClientContext ctx;
   ctx.set_deadline(AbsoluteDeadline(default_timeout_));
-  InjectPacketRequest req = MakeRequest(std::move(ingress_port), payload, tag);
+  InjectPacketRequest req =
+      MakeRequest(device_id_, std::move(ingress_port), payload, tag);
   Reproducer resp;
   grpc::Status status = stub_->GetReproducer(&ctx, req, &resp);
   if (!status.ok()) return ToAbsl(status);
@@ -124,11 +141,24 @@ absl::StatusOr<Reproducer> DataplaneClient::GetReproducer(
 class PacketWriter::Impl {
  public:
   static std::unique_ptr<Impl> Create(
-      Dataplane::Stub *stub, std::unique_ptr<grpc::ClientContext> context) {
+      Dataplane::Stub *stub, uint64_t device_id,
+      std::unique_ptr<grpc::ClientContext> context) {
     std::unique_ptr<Impl> impl(new Impl);
+    impl->device_id_ = device_id;
     impl->context_ = std::move(context);
     impl->writer_ = stub->InjectPackets(impl->context_.get(), &impl->response_);
     return impl;
+  }
+
+  absl::Status Inject(DataplanePort ingress_port, std::string_view payload,
+                      Tag tag) {
+    return Inject(MakeRequest(device_id_, ingress_port, payload, tag));
+  }
+
+  absl::Status Inject(P4RuntimePort ingress_port, std::string_view payload,
+                      Tag tag) {
+    return Inject(
+        MakeRequest(device_id_, std::move(ingress_port), payload, tag));
   }
 
   absl::Status Inject(InjectPacketRequest req) {
@@ -165,6 +195,7 @@ class PacketWriter::Impl {
   std::unique_ptr<grpc::ClientContext> context_;
   InjectPacketsResponse response_;
   std::unique_ptr<grpc::ClientWriter<InjectPacketRequest>> writer_;
+  uint64_t device_id_ = 0;
   bool finished_ = false;
   int count_ = 0;
   absl::Status finished_status_;
@@ -178,8 +209,8 @@ PacketWriter DataplaneClient::InjectPackets(
   if (total_timeout.has_value()) {
     context->set_deadline(AbsoluteDeadline(*total_timeout));
   }
-  return PacketWriter(
-      PacketWriter::Impl::Create(stub_.get(), std::move(context)));
+  return PacketWriter(PacketWriter::Impl::Create(stub_.get(), device_id_,
+                                                 std::move(context)));
 }
 
 PacketWriter::~PacketWriter() {
@@ -192,12 +223,12 @@ PacketWriter::PacketWriter(std::unique_ptr<Impl> impl)
 
 absl::Status PacketWriter::Inject(DataplanePort ingress_port,
                                   std::string_view payload, Tag tag) {
-  return impl_->Inject(MakeRequest(ingress_port, payload, tag));
+  return impl_->Inject(ingress_port, payload, tag);
 }
 
 absl::Status PacketWriter::Inject(P4RuntimePort ingress_port,
                                   std::string_view payload, Tag tag) {
-  return impl_->Inject(MakeRequest(std::move(ingress_port), payload, tag));
+  return impl_->Inject(std::move(ingress_port), payload, tag);
 }
 
 absl::StatusOr<int> PacketWriter::Finish() { return impl_->Finish(); }
@@ -207,7 +238,8 @@ absl::StatusOr<int> PacketWriter::Finish() { return impl_->Finish(); }
 class ResultStream::Impl {
  public:
   static absl::StatusOr<std::unique_ptr<Impl>> Create(
-      Dataplane::Stub *stub, absl::Duration startup_timeout);
+      Dataplane::Stub *stub, uint64_t device_id,
+      absl::Duration startup_timeout);
 
   ~Impl();
 
@@ -242,10 +274,12 @@ class ResultStream::Impl {
 };
 
 absl::StatusOr<std::unique_ptr<ResultStream::Impl>> ResultStream::Impl::Create(
-    Dataplane::Stub *stub, absl::Duration startup_timeout) {
+    Dataplane::Stub *stub, uint64_t device_id,
+    absl::Duration startup_timeout) {
   std::unique_ptr<Impl> impl(new Impl);
   impl->context_ = std::make_unique<grpc::ClientContext>();
   SubscribeResultsRequest req;
+  req.set_device_id(device_id);
   impl->reader_ = stub->SubscribeResults(impl->context_.get(), req);
 
   Impl *raw = impl.get();
@@ -344,7 +378,7 @@ absl::StatusOr<ProcessPacketResult> ResultStream::Next(absl::Duration timeout) {
 absl::StatusOr<ResultStream> DataplaneClient::SubscribeResults(
     std::optional<absl::Duration> startup_timeout) {
   absl::StatusOr<std::unique_ptr<ResultStream::Impl>> impl =
-      ResultStream::Impl::Create(stub_.get(),
+      ResultStream::Impl::Create(stub_.get(), device_id_,
                                  startup_timeout.value_or(default_timeout_));
   if (!impl.ok()) return impl.status();
   return ResultStream(*std::move(impl));

--- a/fourward_cc/dataplane_client.h
+++ b/fourward_cc/dataplane_client.h
@@ -116,8 +116,18 @@ class DataplaneClient {
  public:
   explicit DataplaneClient(const FourwardServer &server,
                            absl::Duration default_timeout = absl::Seconds(10));
+  // Scopes 4ward-native dataplane RPCs to `device_id`. Single-device callers
+  // should use the constructor above, which targets the server's default
+  // device. Pass an explicit ID only after creating extra devices with
+  // ManagementClient.
+  DataplaneClient(const FourwardServer &server, uint64_t device_id,
+                  absl::Duration default_timeout = absl::Seconds(10));
   explicit DataplaneClient(std::unique_ptr<Dataplane::Stub> stub,
                            absl::Duration default_timeout = absl::Seconds(10));
+  // Same device-scoping behavior for callers that provide their own
+  // channel/stub.
+  DataplaneClient(std::unique_ptr<Dataplane::Stub> stub, uint64_t device_id,
+                  absl::Duration default_timeout = absl::Seconds(10));
 
   ~DataplaneClient();
   DataplaneClient(DataplaneClient &&);
@@ -157,6 +167,7 @@ class DataplaneClient {
 
  private:
   std::unique_ptr<Dataplane::Stub> stub_;
+  uint64_t device_id_ = 0;
   absl::Duration default_timeout_;
 };
 

--- a/fourward_cc/dataplane_client_e2e_test.cc
+++ b/fourward_cc/dataplane_client_e2e_test.cc
@@ -20,14 +20,15 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
+#include "fourward_cc/dataplane_matchers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "grpc/dataplane.pb.h"
 #include "grpcpp/client_context.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
-#include "grpc/dataplane.pb.h"
-#include "fourward_cc/dataplane_matchers.h"
 #include "fourward_cc/fourward_server.h"
+#include "fourward_cc/management_client.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
 #ifndef PASSTHROUGH_PIPELINE_RLOCATION
@@ -72,10 +73,10 @@ absl::StatusOr<std::string> ReadRunfile(const std::string& rlocation) {
                      std::istreambuf_iterator<char>());
 }
 
-absl::Status EstablishMasterArbitration(const FourwardServer& server,
+absl::Status EstablishMasterArbitration(uint64_t device_id,
                                         P4RuntimeStream* stream) {
   p4::v1::StreamMessageRequest arbitration;
-  arbitration.mutable_arbitration()->set_device_id(server.DeviceId());
+  arbitration.mutable_arbitration()->set_device_id(device_id);
   arbitration.mutable_arbitration()->mutable_election_id()->set_low(1);
   if (!stream->Write(arbitration)) {
     return absl::InternalError("failed to write arbitration request");
@@ -91,18 +92,19 @@ absl::Status EstablishMasterArbitration(const FourwardServer& server,
 // Pushes a ForwardingPipelineConfig to the server via the P4Runtime API.
 // Handles the arbitration handshake.
 absl::Status PushPipeline(const FourwardServer& server,
-                          const p4::v1::ForwardingPipelineConfig& config) {
+                          const p4::v1::ForwardingPipelineConfig& config,
+                          uint64_t device_id) {
   auto stub = server.NewP4RuntimeStub();
 
   grpc::ClientContext stream_ctx;
   auto stream = stub->StreamChannel(&stream_ctx);
-  absl::Status arbitration = EstablishMasterArbitration(server, stream.get());
+  absl::Status arbitration = EstablishMasterArbitration(device_id, stream.get());
   if (!arbitration.ok()) return arbitration;
 
   // Push pipeline.
   grpc::ClientContext set_ctx;
   p4::v1::SetForwardingPipelineConfigRequest req;
-  req.set_device_id(server.DeviceId());
+  req.set_device_id(device_id);
   req.mutable_election_id()->set_low(1);
   req.set_action(
       p4::v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT);
@@ -114,6 +116,11 @@ absl::Status PushPipeline(const FourwardServer& server,
 
   stream_ctx.TryCancel();
   return absl::OkStatus();
+}
+
+absl::Status PushPipeline(const FourwardServer& server,
+                          const p4::v1::ForwardingPipelineConfig& config) {
+  return PushPipeline(server, config, server.DeviceId());
 }
 
 const p4::config::v1::Table* FindTable(const p4::config::v1::P4Info& p4info,
@@ -187,7 +194,8 @@ absl::Status WriteInsert(const FourwardServer& server,
 
   grpc::ClientContext stream_ctx;
   auto stream = stub->StreamChannel(&stream_ctx);
-  absl::Status arbitration = EstablishMasterArbitration(server, stream.get());
+  absl::Status arbitration =
+      EstablishMasterArbitration(server.DeviceId(), stream.get());
   if (!arbitration.ok()) return arbitration;
 
   p4::v1::WriteRequest req;
@@ -243,7 +251,8 @@ absl::Status SendPacketOut(const FourwardServer& server,
   grpc::ClientContext ctx;
   auto stream = stub->StreamChannel(&ctx);
 
-  absl::Status arbitration = EstablishMasterArbitration(server, stream.get());
+  absl::Status arbitration =
+      EstablishMasterArbitration(server.DeviceId(), stream.get());
   if (!arbitration.ok()) return arbitration;
 
   p4::v1::StreamMessageRequest request;
@@ -384,6 +393,36 @@ TEST_F(DataplaneClientE2ETest, InjectPacketsBurstCanBeDrainedAfterInjection) {
     ASSERT_TRUE(result.ok()) << "result " << i << ": " << result.status();
     EXPECT_THAT(*result, ForwardsTo(1));
   }
+}
+
+TEST_F(DataplaneClientE2ETest, ExplicitDeviceIdScopesStreamingDataplaneRpc) {
+  constexpr uint64_t kSecondDeviceId = 2;
+  ManagementClient management(*server_);
+  ASSERT_TRUE(
+      management.CreateDevices({.first_device_id = kSecondDeviceId, .count = 1}).ok());
+
+  absl::StatusOr<std::string> binpb =
+      ReadRunfile(PASSTHROUGH_PIPELINE_RLOCATION);
+  ASSERT_TRUE(binpb.ok()) << binpb.status();
+  p4::v1::ForwardingPipelineConfig config;
+  ASSERT_TRUE(config.ParseFromString(*binpb))
+      << "failed to parse ForwardingPipelineConfig";
+  ASSERT_TRUE(PushPipeline(*server_, config, kSecondDeviceId).ok());
+
+  DataplaneClient client(*server_, kSecondDeviceId);
+  absl::StatusOr<ResultStream> stream = client.SubscribeResults();
+  ASSERT_TRUE(stream.ok()) << stream.status();
+
+  PacketWriter writer = client.InjectPackets();
+  ASSERT_TRUE(writer.Inject(DataplanePort{7}, MakeEthernetFrame()).ok());
+  absl::StatusOr<int> count = writer.Finish();
+  ASSERT_TRUE(count.ok()) << count.status();
+  ASSERT_EQ(*count, 1);
+
+  absl::StatusOr<ProcessPacketResult> result = stream->Next();
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_THAT(*result, ForwardsTo(1));
+  EXPECT_THAT(*result, HasIngress(7));
 }
 
 TEST_F(DataplaneClientE2ETest,

--- a/fourward_cc/fourward_server.h
+++ b/fourward_cc/fourward_server.h
@@ -40,6 +40,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
 #include "grpc/dataplane.grpc.pb.h"
+#include "grpc/management.grpc.pb.h"
 #include "grpcpp/channel.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 
@@ -88,7 +89,9 @@ struct CpuPort {
 };
 
 struct FourwardServerOptions {
-  // P4Runtime device ID exposed by the server (the `--device-id` flag).
+  // Default P4Runtime device ID exposed by the server (the `--device-id` flag).
+  // Leave this at 1 for ordinary single-device tests. Multi-device tests create
+  // additional device IDs through ManagementClient.
   uint64_t device_id = 1;
 
   // TCP port the server binds on. If unset, the kernel assigns an ephemeral
@@ -157,6 +160,10 @@ class FourwardServer {
   std::unique_ptr<fourward::Dataplane::Stub> NewDataplaneStub() const {
     return fourward::Dataplane::NewStub(channel_);
   }
+  std::unique_ptr<fourward::FourwardManagement::Stub> NewManagementStub()
+      const {
+    return fourward::FourwardManagement::NewStub(channel_);
+  }
 
   // Address suitable for grpc::CreateChannel, e.g. "localhost:42517".
   std::string Address() const { return absl::StrCat("localhost:", port_); }
@@ -164,7 +171,9 @@ class FourwardServer {
   // TCP port the server is listening on.
   int Port() const { return port_; }
 
-  // P4Runtime device ID exposed by the server.
+  // Default P4Runtime device ID exposed by the server. Single-device callers
+  // should use this value for P4Runtime requests and otherwise ignore device
+  // lifecycle APIs.
   uint64_t DeviceId() const { return device_id_; }
 
   // Escape hatches. Not needed to drive the server — reach for these when

--- a/fourward_cc/management_client.cc
+++ b/fourward_cc/management_client.cc
@@ -1,0 +1,74 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fourward_cc/management_client.h"
+
+#include <chrono>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "grpc/management.pb.h"
+#include "grpcpp/client_context.h"
+#include "grpcpp/support/status.h"
+
+namespace fourward {
+namespace {
+
+absl::Status ToAbsl(const grpc::Status& s) {
+  if (s.ok()) return absl::OkStatus();
+  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
+                      s.error_message());
+}
+
+std::chrono::system_clock::time_point AbsoluteDeadline(
+    absl::Duration relative) {
+  return std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+      std::chrono::system_clock::now() + absl::ToChronoNanoseconds(relative));
+}
+
+}  // namespace
+
+ManagementClient::ManagementClient(const FourwardServer& server,
+                                   absl::Duration default_timeout)
+    : ManagementClient(server.NewManagementStub(), default_timeout) {}
+
+ManagementClient::ManagementClient(
+    std::unique_ptr<FourwardManagement::Stub> stub,
+    absl::Duration default_timeout)
+    : stub_(std::move(stub)), default_timeout_(default_timeout) {}
+
+absl::Status ManagementClient::CreateDevices(DeviceRange devices) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  CreateDevicesRequest req;
+  req.set_first_device_id(devices.first_device_id);
+  req.set_count(devices.count);
+  CreateDevicesResponse resp;
+  return ToAbsl(stub_->CreateDevices(&ctx, req, &resp));
+}
+
+absl::Status ManagementClient::DeleteDevices(DeviceRange devices) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  DeleteDevicesRequest req;
+  req.set_first_device_id(devices.first_device_id);
+  req.set_count(devices.count);
+  DeleteDevicesResponse resp;
+  return ToAbsl(stub_->DeleteDevices(&ctx, req, &resp));
+}
+
+absl::StatusOr<std::vector<uint64_t>> ManagementClient::ListDevices() {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  ListDevicesRequest req;
+  ListDevicesResponse resp;
+  grpc::Status status = stub_->ListDevices(&ctx, req, &resp);
+  if (!status.ok()) return ToAbsl(status);
+  return std::vector<uint64_t>(resp.device_ids().begin(), resp.device_ids().end());
+}
+
+}  // namespace fourward

--- a/fourward_cc/management_client.h
+++ b/fourward_cc/management_client.h
@@ -1,0 +1,57 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FOURWARD_CC_MANAGEMENT_CLIENT_H_
+#define FOURWARD_CC_MANAGEMENT_CLIENT_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "fourward_cc/fourward_server.h"
+#include "grpc/management.grpc.pb.h"
+
+namespace fourward {
+
+// C++ wrapper for the 4ward management gRPC service.
+//
+// Most tests never need this: FourwardServer starts one default device. Use
+// ManagementClient only when one server should host multiple logical devices,
+// each addressed by the P4Runtime `device_id` field. This is useful for
+// network-scale tests where one 4ward process emulates many independent
+// switches.
+class ManagementClient {
+ public:
+  struct DeviceRange {
+    // First nonzero logical device ID in the contiguous range.
+    uint64_t first_device_id;
+    // Number of contiguous device IDs in the range.
+    uint32_t count;
+  };
+
+  explicit ManagementClient(const FourwardServer& server,
+                            absl::Duration default_timeout = absl::Seconds(10));
+  explicit ManagementClient(std::unique_ptr<FourwardManagement::Stub> stub,
+                            absl::Duration default_timeout = absl::Seconds(10));
+
+  // Create/delete contiguous logical devices. Prefer designated initializers so
+  // call sites spell out the range semantics:
+  //   client.CreateDevices({.first_device_id = 2, .count = 100});
+  absl::Status CreateDevices(DeviceRange devices);
+  absl::Status DeleteDevices(DeviceRange devices);
+
+  // Returns the currently live logical device IDs, including the default
+  // device.
+  absl::StatusOr<std::vector<uint64_t>> ListDevices();
+
+ private:
+  std::unique_ptr<FourwardManagement::Stub> stub_;
+  absl::Duration default_timeout_;
+};
+
+}  // namespace fourward
+
+#endif  // FOURWARD_CC_MANAGEMENT_CLIENT_H_

--- a/fourward_cc/management_client_test.cc
+++ b/fourward_cc/management_client_test.cc
@@ -1,0 +1,67 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fourward_cc/management_client.h"
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "fourward_cc/fourward_server.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace fourward {
+namespace {
+
+using ::testing::ElementsAre;
+
+class ManagementClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    absl::StatusOr<FourwardServer> s = FourwardServer::Start();
+    ASSERT_TRUE(s.ok()) << s.status();
+    server_ = std::make_unique<FourwardServer>(*std::move(s));
+  }
+
+  std::unique_ptr<FourwardServer> server_;
+};
+
+TEST_F(ManagementClientTest, ListsDefaultDevice) {
+  ManagementClient client(*server_);
+
+  absl::StatusOr<std::vector<uint64_t>> devices = client.ListDevices();
+  ASSERT_TRUE(devices.ok()) << devices.status();
+  EXPECT_THAT(*devices, ElementsAre(server_->DeviceId()));
+}
+
+TEST_F(ManagementClientTest, CreatesAndDeletesContiguousDevices) {
+  ManagementClient client(*server_);
+
+  EXPECT_TRUE(client.CreateDevices({.first_device_id = 2, .count = 3}).ok());
+  absl::StatusOr<std::vector<uint64_t>> created = client.ListDevices();
+  ASSERT_TRUE(created.ok()) << created.status();
+  EXPECT_THAT(*created, ElementsAre(1, 2, 3, 4));
+
+  absl::Status duplicate = client.CreateDevices({.first_device_id = 3, .count = 1});
+  EXPECT_EQ(duplicate.code(), absl::StatusCode::kAlreadyExists) << duplicate;
+
+  EXPECT_TRUE(client.DeleteDevices({.first_device_id = 2, .count = 2}).ok());
+  absl::StatusOr<std::vector<uint64_t>> remaining = client.ListDevices();
+  ASSERT_TRUE(remaining.ok()) << remaining.status();
+  EXPECT_THAT(*remaining, ElementsAre(1, 4));
+}
+
+TEST_F(ManagementClientTest, RejectsDeviceIdZero) {
+  ManagementClient client(*server_);
+
+  absl::Status status = client.CreateDevices({.first_device_id = 0, .count = 1});
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument) << status;
+}
+
+}  // namespace
+}  // namespace fourward

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -69,6 +69,51 @@ kt_jvm_grpc_library(
 )
 
 # =============================================================================
+# 4ward management gRPC service (logical device lifecycle)
+# =============================================================================
+
+proto_library(
+    name = "management_proto",
+    srcs = ["management.proto"],
+    visibility = ["//visibility:public"],
+)
+
+java_proto_library(
+    name = "management_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":management_proto"],
+)
+
+cc_proto_library(
+    name = "management_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":management_proto"],
+)
+
+cc_grpc_library(
+    name = "management_cc_grpc",
+    srcs = [":management_proto"],
+    features = ["-layering_check"],
+    grpc_only = True,
+    visibility = ["//visibility:public"],
+    deps = [":management_cc_proto"],
+)
+
+java_grpc_library(
+    name = "management_java_grpc",
+    srcs = [":management_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":management_java_proto"],
+)
+
+kt_jvm_grpc_library(
+    name = "management_kt_grpc",
+    srcs = [":management_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":management_java_proto"],
+)
+
+# =============================================================================
 # P4Runtime gRPC stubs (Kotlin)
 # =============================================================================
 
@@ -108,6 +153,8 @@ kt_jvm_library(
         ":constraint_validator_java_proto",
         ":dataplane_java_proto",
         ":dataplane_kt_grpc",
+        ":management_java_proto",
+        ":management_kt_grpc",
         ":p4runtime_kt_grpc",
         "//simulator",
         "//simulator:ir_java_proto",
@@ -236,6 +283,39 @@ kt_jvm_test(
         ":p4runtime_kt_grpc",
         "//bazel:runfiles",
         "//e2e_tests:inline_p4_compiler",
+        "//simulator",
+        "//simulator:ir_java_proto",
+        "//simulator:p4data_java_proto",
+        "//simulator:p4info_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:io_grpc_grpc_api",
+        "@fourward_maven//:io_grpc_grpc_inprocess",
+        "@fourward_maven//:junit_junit",
+        "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@googleapis//google/rpc:rpc_java_proto",
+    ],
+)
+
+kt_jvm_test(
+    name = "MultiDeviceServiceTest",
+    srcs = [
+        "FourwardTestHarness.kt",
+        "MultiDeviceServiceTest.kt",
+    ],
+    data = [
+        "//e2e_tests/passthrough",
+    ],
+    test_class = "fourward.grpc.MultiDeviceServiceTest",
+    deps = [
+        ":dataplane_java_proto",
+        ":dataplane_kt_grpc",
+        ":grpc",
+        ":management_java_proto",
+        ":management_kt_grpc",
+        ":p4runtime_kt_grpc",
+        "//bazel:runfiles",
         "//simulator",
         "//simulator:ir_java_proto",
         "//simulator:p4data_java_proto",
@@ -729,6 +809,40 @@ kt_jvm_test(
         ":dataplane_java_proto",
         ":dataplane_kt_grpc",
         ":grpc",
+        ":p4runtime_kt_grpc",
+        "//bazel:runfiles",
+        "//simulator",
+        "//simulator:ir_java_proto",
+        "//simulator:p4data_java_proto",
+        "//simulator:p4info_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:io_grpc_grpc_api",
+        "@fourward_maven//:io_grpc_grpc_inprocess",
+        "@fourward_maven//:junit_junit",
+        "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@googleapis//google/rpc:rpc_java_proto",
+    ],
+)
+
+kt_jvm_test(
+    name = "MultiDeviceScaleBenchmark",
+    srcs = [
+        "FourwardTestHarness.kt",
+        "MultiDeviceScaleBenchmark.kt",
+    ],
+    data = [
+        "//e2e_tests/sai_p4:sai_middleblock",
+    ],
+    tags = ["heavy"],
+    test_class = "fourward.grpc.MultiDeviceScaleBenchmark",
+    deps = [
+        ":dataplane_java_proto",
+        ":dataplane_kt_grpc",
+        ":grpc",
+        ":management_java_proto",
+        ":management_kt_grpc",
         ":p4runtime_kt_grpc",
         "//bazel:runfiles",
         "//simulator",

--- a/grpc/DeviceContext.kt
+++ b/grpc/DeviceContext.kt
@@ -1,0 +1,56 @@
+package fourward.grpc
+
+import fourward.simulator.Simulator
+import io.grpc.Status
+import kotlinx.coroutines.sync.Mutex
+
+/** Per-device 4ward runtime state. */
+class DeviceContext(val deviceId: Long, private val settings: DeviceSettings) : AutoCloseable {
+  val simulator = Simulator()
+  private val writeMutex = Mutex()
+  val broker =
+    PacketBroker(
+      { ingressPort, packet -> simulator.processPacket(ingressPort, packet) },
+      writeMutex,
+    )
+  val p4RuntimeService =
+    P4RuntimeService(
+      simulator,
+      broker,
+      settings.constraintValidatorBinary,
+      writeMutex = writeMutex,
+      deviceId = deviceId,
+      cpuPortConfig = settings.cpuPortConfig,
+      dropPortConfig = settings.dropPortConfig,
+      disableRefersToChecking = settings.disableRefersToChecking,
+      disableP4ConstraintsChecking = settings.disableP4ConstraintsChecking,
+    )
+  val dataplaneService =
+    DataplaneService(broker) {
+      val config = simulator.pipelineConfig ?: return@DataplaneService null
+      val tableStore = simulator.tableStore ?: return@DataplaneService null
+      DataplaneService.PipelineSnapshot(
+        config,
+        tableStore,
+        p4RuntimeService.typeTranslator,
+        p4RuntimeService.packetHeaderCodec,
+      )
+    }
+
+  init {
+    broker.readAllEntities = { p4RuntimeService.readAllEntities() }
+    broker.readP4Info = { p4RuntimeService.p4Info() }
+    broker.applyUpdates = { updates -> p4RuntimeService.applyHookUpdates(updates) }
+  }
+
+  fun closeDeleted() {
+    p4RuntimeService.closeStreams(
+      Status.NOT_FOUND.withDescription("device_id $deviceId was deleted").asException()
+    )
+    close()
+  }
+
+  override fun close() {
+    p4RuntimeService.close()
+  }
+}

--- a/grpc/DeviceRegistry.kt
+++ b/grpc/DeviceRegistry.kt
@@ -1,0 +1,115 @@
+package fourward.grpc
+
+import io.grpc.Status
+import java.nio.file.Path
+
+data class DeviceSettings(
+  val constraintValidatorBinary: Path? = null,
+  val dropPortConfig: PortOverride? = null,
+  val cpuPortConfig: CpuPortConfig = CpuPortConfig.Auto,
+  val disableRefersToChecking: Boolean = false,
+  val disableP4ConstraintsChecking: Boolean = false,
+)
+
+class DeviceRegistry(
+  private val settings: DeviceSettings,
+  private val defaultDeviceId: Long = P4RuntimeService.DEFAULT_DEVICE_ID,
+  private val maxDevices: Int = DEFAULT_MAX_DEVICES,
+  private val maxDevicesPerRequest: Int = DEFAULT_MAX_DEVICES_PER_REQUEST,
+) : AutoCloseable {
+  private val devices = sortedMapOf<Long, DeviceContext>()
+
+  init {
+    require(defaultDeviceId != 0L) { "default device ID must be nonzero" }
+    devices[defaultDeviceId] = DeviceContext(defaultDeviceId, settings)
+  }
+
+  @Synchronized
+  fun get(deviceId: Long): DeviceContext {
+    requireValidDeviceId(deviceId)
+    return devices[deviceId]
+      ?: throw Status.NOT_FOUND.withDescription("unknown device_id $deviceId").asException()
+  }
+
+  fun defaultDevice(): DeviceContext = get(defaultDeviceId)
+
+  @Synchronized
+  fun createDevices(firstDeviceId: Long, count: Int) {
+    val ids = deviceIds(firstDeviceId, count)
+    val existing = ids.firstOrNull { devices.containsKey(it) }
+    if (existing != null) {
+      throw Status.ALREADY_EXISTS.withDescription("device_id $existing already exists")
+        .asException()
+    }
+    if (devices.size + ids.size > maxDevices) {
+      throw Status.RESOURCE_EXHAUSTED.withDescription(
+          "creating ${ids.size} devices would exceed max live devices $maxDevices"
+        )
+        .asException()
+    }
+    val newDevices = ids.map { id -> id to DeviceContext(id, settings) }
+    for ((id, device) in newDevices) {
+      devices[id] = device
+    }
+  }
+
+  fun deleteDevices(firstDeviceId: Long, count: Int) {
+    val removed =
+      synchronized(this) {
+        val ids = deviceIds(firstDeviceId, count)
+        val missing = ids.firstOrNull { !devices.containsKey(it) }
+        if (missing != null) {
+          throw Status.NOT_FOUND.withDescription("unknown device_id $missing").asException()
+        }
+        ids.map { devices.remove(it)!! }
+      }
+    for (device in removed) {
+      device.closeDeleted()
+    }
+  }
+
+  @Synchronized fun listDeviceIds(): List<Long> = devices.keys.toList()
+
+  override fun close() {
+    val existing =
+      synchronized(this) {
+        val snapshot = devices.values.toList()
+        devices.clear()
+        snapshot
+      }
+    for (device in existing) {
+      device.close()
+    }
+  }
+
+  private fun deviceIds(firstDeviceId: Long, count: Int): List<Long> {
+    requireValidDeviceId(firstDeviceId)
+    if (count <= 0) {
+      throw Status.INVALID_ARGUMENT.withDescription("count must be positive").asException()
+    }
+    if (count > maxDevicesPerRequest) {
+      throw Status.RESOURCE_EXHAUSTED.withDescription(
+          "count $count exceeds max devices per request $maxDevicesPerRequest"
+        )
+        .asException()
+    }
+    val first = firstDeviceId.toULong()
+    val countMinusOne = (count - 1).toUInt().toULong()
+    if (ULong.MAX_VALUE - first < countMinusOne) {
+      throw Status.INVALID_ARGUMENT.withDescription("device ID range overflows uint64")
+        .asException()
+    }
+    return List(count) { (first + it.toUInt().toULong()).toLong() }
+  }
+
+  private fun requireValidDeviceId(deviceId: Long) {
+    if (deviceId == 0L) {
+      throw Status.INVALID_ARGUMENT.withDescription("device_id must be nonzero").asException()
+    }
+  }
+
+  companion object {
+    const val DEFAULT_MAX_DEVICES = 10_000
+    const val DEFAULT_MAX_DEVICES_PER_REQUEST = 10_000
+  }
+}

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -8,7 +8,6 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.sync.Mutex
 
 /** Wraps a P4Runtime + Dataplane gRPC server backed by a 4ward [Simulator]. */
 class FourwardServer(
@@ -28,42 +27,22 @@ class FourwardServer(
    * The underlying simulator. Exposed for pre-configuration (loading pipelines, installing entries)
    * before the server starts accepting RPCs.
    */
-  val simulator = Simulator()
-  private val writeMutex = Mutex()
-  private val broker =
-    PacketBroker(
-      { ingressPort, packet -> simulator.processPacket(ingressPort, packet) },
-      writeMutex,
-    )
-  private val service =
-    P4RuntimeService(
-      simulator,
-      broker,
-      writeMutex = writeMutex,
-      deviceId = deviceId,
-      cpuPortConfig = cpuPortConfig,
-      dropPortConfig = dropPortOverride,
-      disableRefersToChecking = disableRefersToChecking,
-      disableP4ConstraintsChecking = disableP4ConstraintsChecking,
-    )
-  private val dataplaneService =
-    DataplaneService(broker) {
-      val config = simulator.pipelineConfig ?: return@DataplaneService null
-      val tableStore = simulator.tableStore ?: return@DataplaneService null
-      DataplaneService.PipelineSnapshot(
-        config,
-        tableStore,
-        service.typeTranslator,
-        service.packetHeaderCodec,
-      )
-    }
+  val simulator: Simulator
+    get() = registry.defaultDevice().simulator
 
-  init {
-    // Wire P4RuntimeService lambdas into the broker for hook support.
-    broker.readAllEntities = { service.readAllEntities() }
-    broker.readP4Info = { service.p4Info() }
-    broker.applyUpdates = { updates -> service.applyHookUpdates(updates) }
-  }
+  private val registry =
+    DeviceRegistry(
+      DeviceSettings(
+        dropPortConfig = dropPortOverride,
+        cpuPortConfig = cpuPortConfig,
+        disableRefersToChecking = disableRefersToChecking,
+        disableP4ConstraintsChecking = disableP4ConstraintsChecking,
+      ),
+      defaultDeviceId = deviceId,
+    )
+  private val p4RuntimeService = MultiDeviceP4RuntimeService(registry)
+  private val dataplaneService = MultiDeviceDataplaneService(registry, defaultDeviceId = deviceId)
+  private val managementService = ManagementService(registry)
 
   private lateinit var server: Server
 
@@ -81,8 +60,9 @@ class FourwardServer(
         .maxInboundMessageSize(inboundMessageSize)
         .permitKeepAliveWithoutCalls(permitKeepaliveWithoutCalls)
         .permitKeepAliveTime(permitKeepaliveTimeMs, TimeUnit.MILLISECONDS)
-        .addService(service)
+        .addService(p4RuntimeService)
         .addService(dataplaneService)
+        .addService(managementService)
         .build()
         .start()
     Runtime.getRuntime().addShutdownHook(Thread { stop() })
@@ -92,6 +72,8 @@ class FourwardServer(
   fun stop() {
     if (::server.isInitialized) {
       server.shutdown()
+      server.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+      registry.close()
     }
   }
 
@@ -107,6 +89,7 @@ class FourwardServer(
     const val DEFAULT_MAX_RECEIVE_MESSAGE_SIZE = -1 // unlimited
     const val DEFAULT_PERMIT_KEEPALIVE_WITHOUT_CALLS = true
     const val DEFAULT_PERMIT_KEEPALIVE_TIME_MS = 0L
+    private const val SHUTDOWN_TIMEOUT_SECONDS = 5L
   }
 }
 

--- a/grpc/ManagementService.kt
+++ b/grpc/ManagementService.kt
@@ -1,0 +1,25 @@
+package fourward.grpc
+
+import fourward.CreateDevicesRequest
+import fourward.CreateDevicesResponse
+import fourward.DeleteDevicesRequest
+import fourward.DeleteDevicesResponse
+import fourward.FourwardManagementGrpcKt
+import fourward.ListDevicesRequest
+import fourward.ListDevicesResponse
+
+class ManagementService(private val registry: DeviceRegistry) :
+  FourwardManagementGrpcKt.FourwardManagementCoroutineImplBase() {
+  override suspend fun createDevices(request: CreateDevicesRequest): CreateDevicesResponse {
+    registry.createDevices(request.firstDeviceId, request.count)
+    return CreateDevicesResponse.getDefaultInstance()
+  }
+
+  override suspend fun deleteDevices(request: DeleteDevicesRequest): DeleteDevicesResponse {
+    registry.deleteDevices(request.firstDeviceId, request.count)
+    return DeleteDevicesResponse.getDefaultInstance()
+  }
+
+  override suspend fun listDevices(request: ListDevicesRequest): ListDevicesResponse =
+    ListDevicesResponse.newBuilder().addAllDeviceIds(registry.listDeviceIds()).build()
+}

--- a/grpc/MultiDeviceDataplaneService.kt
+++ b/grpc/MultiDeviceDataplaneService.kt
@@ -1,0 +1,67 @@
+package fourward.grpc
+
+import fourward.DataplaneGrpcKt
+import fourward.InjectPacketRequest
+import fourward.InjectPacketResponse
+import fourward.InjectPacketsResponse
+import fourward.PrePacketHookInvocation
+import fourward.PrePacketHookResponse
+import fourward.Reproducer
+import fourward.SubscribeResultsRequest
+import fourward.SubscribeResultsResponse
+import io.grpc.Status
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.produceIn
+
+class MultiDeviceDataplaneService(
+  private val registry: DeviceRegistry,
+  private val defaultDeviceId: Long = P4RuntimeService.DEFAULT_DEVICE_ID,
+) : DataplaneGrpcKt.DataplaneCoroutineImplBase() {
+  override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse =
+    service(request.deviceId).injectPacket(request)
+
+  override suspend fun getReproducer(request: InjectPacketRequest): Reproducer =
+    service(request.deviceId).getReproducer(request)
+
+  override suspend fun injectPackets(requests: Flow<InjectPacketRequest>): InjectPacketsResponse =
+    coroutineScope {
+      val channel = requests.produceIn(this)
+      val first =
+        channel.receiveCatching().getOrNull()
+          ?: return@coroutineScope InjectPacketsResponse.getDefaultInstance()
+      val targetDeviceId = normalizedDeviceId(first.deviceId)
+      val guardedRequests = flow {
+        emit(first)
+        for (request in channel) {
+          val requestDeviceId = normalizedDeviceId(request.deviceId)
+          if (requestDeviceId != targetDeviceId) {
+            throw Status.INVALID_ARGUMENT.withDescription(
+                "InjectPackets stream is bound to device_id $targetDeviceId; " +
+                  "got device_id $requestDeviceId"
+              )
+              .asException()
+          }
+          emit(request)
+        }
+      }
+      registry.get(targetDeviceId).dataplaneService.injectPackets(guardedRequests)
+    }
+
+  override fun subscribeResults(request: SubscribeResultsRequest): Flow<SubscribeResultsResponse> =
+    service(request.deviceId).subscribeResults(request)
+
+  override fun registerPrePacketHook(
+    requests: Flow<PrePacketHookResponse>
+  ): Flow<PrePacketHookInvocation> =
+    // Pre-packet hooks are process-wide: this stream has no request envelope
+    // where a client could put device_id.
+    registry.defaultDevice().dataplaneService.registerPrePacketHook(requests)
+
+  private fun service(deviceId: Long): DataplaneService =
+    registry.get(normalizedDeviceId(deviceId)).dataplaneService
+
+  private fun normalizedDeviceId(deviceId: Long): Long =
+    if (deviceId == 0L) defaultDeviceId else deviceId
+}

--- a/grpc/MultiDeviceP4RuntimeService.kt
+++ b/grpc/MultiDeviceP4RuntimeService.kt
@@ -1,0 +1,101 @@
+package fourward.grpc
+
+import io.grpc.Status
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import p4.v1.P4RuntimeGrpcKt
+import p4.v1.P4RuntimeOuterClass.CapabilitiesRequest
+import p4.v1.P4RuntimeOuterClass.CapabilitiesResponse
+import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigResponse
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.ReadResponse
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigResponse
+import p4.v1.P4RuntimeOuterClass.StreamMessageRequest
+import p4.v1.P4RuntimeOuterClass.StreamMessageResponse
+import p4.v1.P4RuntimeOuterClass.WriteRequest
+import p4.v1.P4RuntimeOuterClass.WriteResponse
+
+class MultiDeviceP4RuntimeService(private val registry: DeviceRegistry) :
+  P4RuntimeGrpcKt.P4RuntimeCoroutineImplBase() {
+  override suspend fun setForwardingPipelineConfig(
+    request: SetForwardingPipelineConfigRequest
+  ): SetForwardingPipelineConfigResponse =
+    registry.get(request.deviceId).p4RuntimeService.setForwardingPipelineConfig(request)
+
+  override suspend fun write(request: WriteRequest): WriteResponse =
+    registry.get(request.deviceId).p4RuntimeService.write(request)
+
+  override fun read(request: ReadRequest): Flow<ReadResponse> =
+    registry.get(request.deviceId).p4RuntimeService.read(request)
+
+  override suspend fun getForwardingPipelineConfig(
+    request: GetForwardingPipelineConfigRequest
+  ): GetForwardingPipelineConfigResponse =
+    registry.get(request.deviceId).p4RuntimeService.getForwardingPipelineConfig(request)
+
+  override suspend fun capabilities(request: CapabilitiesRequest): CapabilitiesResponse {
+    // Capabilities are server-wide. For nonzero device_id, still validate that
+    // the addressed logical device exists.
+    if (request.deviceId != 0L) {
+      registry.get(request.deviceId)
+    }
+    return CapabilitiesResponse.newBuilder()
+      .setP4RuntimeApiVersion(P4RuntimeService.P4RUNTIME_API_VERSION)
+      .build()
+  }
+
+  override fun streamChannel(requests: Flow<StreamMessageRequest>): Flow<StreamMessageResponse> =
+    channelFlow {
+      var device: DeviceContext? = null
+      val forwarded = Channel<StreamMessageRequest>(Channel.UNLIMITED)
+      var delegateStarted = false
+
+      suspend fun bind(first: StreamMessageRequest) {
+        if (first.updateCase != StreamMessageRequest.UpdateCase.ARBITRATION) {
+          throw Status.FAILED_PRECONDITION.withDescription(
+              "first StreamChannel message must be MasterArbitrationUpdate"
+            )
+            .asException()
+        }
+        val context = registry.get(first.arbitration.deviceId)
+        device = context
+        delegateStarted = true
+        launch {
+          context.p4RuntimeService.streamChannel(forwarded.receiveAsFlow()).collect { send(it) }
+        }
+      }
+
+      try {
+        requests.collect { msg ->
+          val boundDevice = device
+          if (boundDevice == null) {
+            bind(msg)
+          } else if (
+            msg.updateCase == StreamMessageRequest.UpdateCase.ARBITRATION &&
+              msg.arbitration.deviceId != boundDevice.deviceId
+          ) {
+            throw Status.FAILED_PRECONDITION.withDescription(
+                "StreamChannel already bound to device_id ${boundDevice.deviceId}; " +
+                  "got device_id ${msg.arbitration.deviceId}"
+              )
+              .asException()
+          }
+          forwarded.send(msg)
+        }
+        if (!delegateStarted) {
+          throw Status.FAILED_PRECONDITION.withDescription(
+              "StreamChannel closed before MasterArbitrationUpdate"
+            )
+            .asException()
+        }
+      } finally {
+        forwarded.close()
+      }
+    }
+}

--- a/grpc/MultiDeviceScaleBenchmark.kt
+++ b/grpc/MultiDeviceScaleBenchmark.kt
@@ -1,0 +1,340 @@
+package fourward.grpc
+
+import com.google.protobuf.ByteString
+import fourward.CreateDevicesRequest
+import fourward.PipelineConfig
+import fourward.grpc.FourwardTestHarness.Companion.loadConfig
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import p4.config.v1.P4InfoOuterClass
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.TableEntry
+import p4.v1.P4RuntimeOuterClass.Update
+import p4.v1.P4RuntimeOuterClass.WriteRequest
+
+/**
+ * Multi-device scale benchmark.
+ *
+ * Run with:
+ * ```
+ * bazel test //grpc:MultiDeviceScaleBenchmark --test_output=streamed \
+ *   --jvmopt=-Dfourward.multidevice.devices=10000 \
+ *   --jvmopt=-Dfourward.multidevice.entriesPerDevice=1000
+ * ```
+ *
+ * The benchmark loads SAI middleblock on every device. `entriesPerDevice` installs that many IPv6
+ * route entries per device, plus the four prerequisite SAI objects needed by `@refers_to`.
+ */
+@Suppress("FunctionNaming", "MagicNumber")
+class MultiDeviceScaleBenchmark {
+  @Test
+  fun `multi-device scale benchmark`() = runBlocking {
+    val deviceCount = intProperty("fourward.multidevice.devices", default = 100)
+    val entriesPerDevice = intProperty("fourward.multidevice.entriesPerDevice", default = 0)
+    val writeBatchSize = intProperty("fourward.multidevice.writeBatchSize", default = 1_000)
+    require(deviceCount > 0) { "fourward.multidevice.devices must be positive" }
+    require(entriesPerDevice >= 0) { "fourward.multidevice.entriesPerDevice must be non-negative" }
+    require(entriesPerDevice <= MAX_IPV6_ROUTES_PER_DEVICE) {
+      "entriesPerDevice must be <= $MAX_IPV6_ROUTES_PER_DEVICE for unique IPv6 /128 routes"
+    }
+    require(writeBatchSize > 0) { "fourward.multidevice.writeBatchSize must be positive" }
+
+    val registry =
+      DeviceRegistry(DeviceSettings(), maxDevices = deviceCount, maxDevicesPerRequest = deviceCount)
+    try {
+      val management = ManagementService(registry)
+      val p4runtime = MultiDeviceP4RuntimeService(registry)
+
+      val baselineHeap = usedHeapAfterGc()
+      val createMs = elapsedMillis {
+        if (deviceCount > 1) {
+          management.createDevices(
+            CreateDevicesRequest.newBuilder().setFirstDeviceId(2).setCount(deviceCount - 1).build()
+          )
+        }
+      }
+      val idleHeap = usedHeapAfterGc()
+
+      val config = loadConfig("e2e_tests/sai_p4/sai_middleblock.txtpb")
+      val forwardingConfig =
+        ForwardingPipelineConfig.newBuilder()
+          .setP4Info(config.p4Info)
+          .setP4DeviceConfig(config.device.toByteString())
+          .build()
+      val entryBatches = saiEntries(config, entriesPerDevice).chunked(writeBatchSize)
+
+      val populateMs = elapsedMillis {
+        for (deviceId in 1L..deviceCount.toLong()) {
+          p4runtime.setForwardingPipelineConfig(
+            SetForwardingPipelineConfigRequest.newBuilder()
+              .setDeviceId(deviceId)
+              .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+              .setConfig(forwardingConfig)
+              .build()
+          )
+          for (batch in entryBatches) {
+            p4runtime.write(writeRequest(deviceId, batch))
+          }
+        }
+      }
+      val populatedHeap = usedHeapAfterGc()
+
+      println()
+      println("Multi-device scale benchmark")
+      println("pipeline: sai_middleblock")
+      println("devices: $deviceCount")
+      println("ipv6_routes/device: $entriesPerDevice")
+      println("total_table_entries/device: ${entryBatches.sumOf { it.size }}")
+      println("create_ms: $createMs")
+      println("populate_ms: $populateMs")
+      println("idle_heap_mb: ${bytesToMiB(idleHeap - baselineHeap)}")
+      println("idle_heap_bytes_per_device: ${(idleHeap - baselineHeap) / deviceCount}")
+      println("populated_heap_mb: ${bytesToMiB(populatedHeap - baselineHeap)}")
+      println("populated_heap_bytes_per_device: ${(populatedHeap - baselineHeap) / deviceCount}")
+    } finally {
+      registry.close()
+    }
+  }
+
+  private fun writeRequest(deviceId: Long, entities: List<Entity>): WriteRequest =
+    WriteRequest.newBuilder()
+      .setDeviceId(deviceId)
+      .apply {
+        for (entity in entities) {
+          addUpdates(Update.newBuilder().setType(Update.Type.INSERT).setEntity(entity))
+        }
+      }
+      .build()
+
+  private fun intProperty(name: String, default: Int): Int =
+    System.getProperty(name)?.toIntOrNull() ?: default
+
+  private suspend fun elapsedMillis(block: suspend () -> Unit): Long {
+    val start = System.nanoTime()
+    block()
+    return (System.nanoTime() - start) / 1_000_000
+  }
+
+  private fun usedHeapAfterGc(): Long {
+    repeat(3) {
+      System.gc()
+      Thread.sleep(100)
+    }
+    val runtime = Runtime.getRuntime()
+    return runtime.totalMemory() - runtime.freeMemory()
+  }
+
+  private fun bytesToMiB(bytes: Long): Long = bytes / (1024 * 1024)
+
+  private fun saiEntries(config: PipelineConfig, routeCount: Int): List<Entity> {
+    if (routeCount == 0) return emptyList()
+    return buildList {
+      add(buildVrfEntry(config))
+      add(buildRouterInterfaceEntry(config))
+      add(buildNeighborEntry(config))
+      add(buildNexthopEntry(config))
+      for (index in 0 until routeCount) {
+        add(buildIpv6RouteEntry(config, index))
+      }
+    }
+  }
+
+  private fun buildVrfEntry(config: PipelineConfig): Entity {
+    val table = findTable(config, "vrf_table")
+    val action = findAction(config, "no_action")
+    return buildEntry(table, action, matches = listOf(exactMatch(table, "vrf_id", VRF_ID)))
+  }
+
+  private fun buildRouterInterfaceEntry(config: PipelineConfig): Entity {
+    val table = findTable(config, "router_interface_table")
+    val action = findAction(config, "set_port_and_src_mac")
+    return buildEntry(
+      table,
+      action,
+      matches = listOf(exactMatch(table, "router_interface_id", ROUTER_INTERFACE_ID)),
+      params =
+        listOf(
+          stringParam(action, "port", PORT_ID),
+          bytesParam(action, "src_mac", byteArrayOf(0x00, 0x11, 0x22, 0x33, 0x44, 0x55)),
+        ),
+    )
+  }
+
+  private fun buildNeighborEntry(config: PipelineConfig): Entity {
+    val table = findTable(config, "neighbor_table")
+    val action = findAction(config, "set_dst_mac")
+    return buildEntry(
+      table,
+      action,
+      matches =
+        listOf(
+          exactMatch(table, "router_interface_id", ROUTER_INTERFACE_ID),
+          exactMatch(table, "neighbor_id", NEIGHBOR_ID),
+        ),
+      params =
+        listOf(
+          bytesParam(
+            action,
+            "dst_mac",
+            byteArrayOf(
+              0x00,
+              0xAA.toByte(),
+              0xBB.toByte(),
+              0xCC.toByte(),
+              0xDD.toByte(),
+              0xEE.toByte(),
+            ),
+          )
+        ),
+    )
+  }
+
+  private fun buildNexthopEntry(config: PipelineConfig): Entity {
+    val table = findTable(config, "nexthop_table")
+    val action = findAction(config, "set_ip_nexthop")
+    return buildEntry(
+      table,
+      action,
+      matches = listOf(exactMatch(table, "nexthop_id", NEXTHOP_ID)),
+      params =
+        listOf(
+          stringParam(action, "router_interface_id", ROUTER_INTERFACE_ID),
+          bytesParam(action, "neighbor_id", NEIGHBOR_ID),
+        ),
+    )
+  }
+
+  private fun buildIpv6RouteEntry(config: PipelineConfig, index: Int): Entity {
+    val table = findTable(config, "ipv6_table")
+    val action = findAction(config, "set_nexthop_id")
+    return buildEntry(
+      table,
+      action,
+      matches =
+        listOf(
+          exactMatch(table, "vrf_id", VRF_ID),
+          lpmMatch(table, "ipv6_dst", ipv6Address(index), prefixLen = 128),
+        ),
+      params = listOf(stringParam(action, "nexthop_id", NEXTHOP_ID)),
+    )
+  }
+
+  private fun buildEntry(
+    table: P4InfoOuterClass.Table,
+    action: P4InfoOuterClass.Action,
+    matches: List<FieldMatch>,
+    params: List<p4.v1.P4RuntimeOuterClass.Action.Param> = emptyList(),
+  ): Entity =
+    Entity.newBuilder()
+      .setTableEntry(
+        TableEntry.newBuilder()
+          .setTableId(table.preamble.id)
+          .addAllMatch(matches)
+          .setAction(
+            p4.v1.P4RuntimeOuterClass.TableAction.newBuilder()
+              .setAction(
+                p4.v1.P4RuntimeOuterClass.Action.newBuilder()
+                  .setActionId(action.preamble.id)
+                  .addAllParams(params)
+              )
+          )
+      )
+      .build()
+
+  private fun exactMatch(
+    table: P4InfoOuterClass.Table,
+    fieldName: String,
+    value: String,
+  ): FieldMatch = exactMatch(table, fieldName, value.toByteArray(Charsets.UTF_8))
+
+  private fun exactMatch(
+    table: P4InfoOuterClass.Table,
+    fieldName: String,
+    value: ByteArray,
+  ): FieldMatch =
+    FieldMatch.newBuilder()
+      .setFieldId(matchFieldId(table, fieldName))
+      .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(value)))
+      .build()
+
+  private fun lpmMatch(
+    table: P4InfoOuterClass.Table,
+    fieldName: String,
+    value: ByteArray,
+    prefixLen: Int,
+  ): FieldMatch =
+    FieldMatch.newBuilder()
+      .setFieldId(matchFieldId(table, fieldName))
+      .setLpm(
+        FieldMatch.LPM.newBuilder().setValue(ByteString.copyFrom(value)).setPrefixLen(prefixLen)
+      )
+      .build()
+
+  private fun stringParam(
+    action: P4InfoOuterClass.Action,
+    paramName: String,
+    value: String,
+  ): p4.v1.P4RuntimeOuterClass.Action.Param =
+    p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+      .setParamId(paramId(action, paramName))
+      .setValue(ByteString.copyFromUtf8(value))
+      .build()
+
+  private fun bytesParam(
+    action: P4InfoOuterClass.Action,
+    paramName: String,
+    value: ByteArray,
+  ): p4.v1.P4RuntimeOuterClass.Action.Param =
+    p4.v1.P4RuntimeOuterClass.Action.Param.newBuilder()
+      .setParamId(paramId(action, paramName))
+      .setValue(ByteString.copyFrom(value))
+      .build()
+
+  private fun findTable(config: PipelineConfig, alias: String): P4InfoOuterClass.Table =
+    config.p4Info.tablesList.find { it.preamble.alias == alias }
+      ?: error("table '$alias' not found")
+
+  private fun findAction(config: PipelineConfig, alias: String): P4InfoOuterClass.Action =
+    config.p4Info.actionsList.find { it.preamble.alias == alias }
+      ?: error("action '$alias' not found")
+
+  private fun matchFieldId(table: P4InfoOuterClass.Table, name: String): Int =
+    table.matchFieldsList.find { it.name == name }?.id
+      ?: error("match field '${table.preamble.alias}.$name' not found")
+
+  private fun paramId(action: P4InfoOuterClass.Action, name: String): Int =
+    action.paramsList.find { it.name == name }?.id
+      ?: error("action param '${action.preamble.alias}.$name' not found")
+
+  private fun ipv6Address(index: Int): ByteArray =
+    byteArrayOf(
+      0x20,
+      0x01,
+      0x0D,
+      0xB8.toByte(),
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      ((index ushr 16) and 0xFF).toByte(),
+      ((index ushr 8) and 0xFF).toByte(),
+      0,
+      (index and 0xFF).toByte(),
+    )
+
+  companion object {
+    private const val MAX_IPV6_ROUTES_PER_DEVICE = 1 shl 24
+    private const val VRF_ID = "benchmark-vrf"
+    private const val ROUTER_INTERFACE_ID = "benchmark-rif"
+    private const val NEXTHOP_ID = "benchmark-nhop"
+    private const val PORT_ID = "Ethernet0"
+    private val NEIGHBOR_ID = ByteArray(16) { if (it == 15) 1 else 0 }
+  }
+}

--- a/grpc/MultiDeviceServiceTest.kt
+++ b/grpc/MultiDeviceServiceTest.kt
@@ -1,0 +1,327 @@
+package fourward.grpc
+
+import com.google.protobuf.ByteString
+import fourward.CreateDevicesRequest
+import fourward.DataplaneGrpcKt.DataplaneCoroutineStub
+import fourward.DeleteDevicesRequest
+import fourward.FourwardManagementGrpcKt.FourwardManagementCoroutineStub
+import fourward.InjectPacketRequest
+import fourward.ListDevicesRequest
+import fourward.grpc.FourwardTestHarness.Companion.assertGrpcError
+import fourward.grpc.FourwardTestHarness.Companion.loadConfig
+import io.grpc.ManagedChannel
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import java.io.Closeable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import p4.v1.P4RuntimeGrpcKt.P4RuntimeCoroutineStub
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.GetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.MasterArbitrationUpdate
+import p4.v1.P4RuntimeOuterClass.ReadRequest
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.StreamMessageRequest
+import p4.v1.P4RuntimeOuterClass.StreamMessageResponse
+import p4.v1.P4RuntimeOuterClass.TableEntry
+import p4.v1.P4RuntimeOuterClass.Uint128
+
+class MultiDeviceServiceTest {
+  private lateinit var harness: Harness
+
+  @Before
+  fun setUp() {
+    harness = Harness()
+  }
+
+  @After
+  fun tearDown() {
+    harness.close()
+  }
+
+  @Test
+  fun `startup creates default device`() = runBlocking {
+    assertEquals(listOf(1L), harness.listDevices())
+  }
+
+  @Test
+  fun `CreateDevices creates contiguous range atomically`() = runBlocking {
+    harness.createDevices(2, 3)
+
+    assertEquals(listOf(1L, 2L, 3L, 4L), harness.listDevices())
+
+    assertGrpcError(Status.Code.ALREADY_EXISTS, "device_id 3") { harness.createDevices(3, 1) }
+    assertEquals(
+      "failed create leaves registry unchanged",
+      listOf(1L, 2L, 3L, 4L),
+      harness.listDevices(),
+    )
+  }
+
+  @Test
+  fun `DeleteDevices deletes contiguous range atomically`() = runBlocking {
+    harness.createDevices(2, 3)
+
+    assertGrpcError(Status.Code.NOT_FOUND, "device_id 5") { harness.deleteDevices(3, 3) }
+    assertEquals(
+      "failed delete leaves registry unchanged",
+      listOf(1L, 2L, 3L, 4L),
+      harness.listDevices(),
+    )
+
+    harness.deleteDevices(2, 2)
+    assertEquals(listOf(1L, 4L), harness.listDevices())
+  }
+
+  @Test
+  fun `CreateDevices enforces resource limits`() {
+    DeviceRegistry(DeviceSettings(), maxDevices = 2, maxDevicesPerRequest = 2).use { registry ->
+      assertGrpcError(Status.Code.RESOURCE_EXHAUSTED, "max live devices") {
+        registry.createDevices(2, 2)
+      }
+    }
+    DeviceRegistry(DeviceSettings(), maxDevices = 10, maxDevicesPerRequest = 1).use { registry ->
+      assertGrpcError(Status.Code.RESOURCE_EXHAUSTED, "max devices per request") {
+        registry.createDevices(2, 2)
+      }
+    }
+  }
+
+  @Test
+  fun `P4Runtime routes pipeline state by device_id`() = runBlocking {
+    val config = loadConfig("e2e_tests/passthrough/passthrough.txtpb")
+    harness.createDevices(2, 1)
+    harness.loadPipeline(deviceId = 2, config = config)
+
+    assertTrue(harness.getConfig(deviceId = 2).config.hasP4Info())
+    assertGrpcError(Status.Code.FAILED_PRECONDITION, "No pipeline loaded") {
+      harness.getConfig(deviceId = 1)
+    }
+    assertGrpcError(Status.Code.NOT_FOUND, "unknown device_id 999") {
+      harness.getConfig(deviceId = 999)
+    }
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "device_id must be nonzero") {
+      harness.getConfig(deviceId = 0)
+    }
+  }
+
+  @Test
+  fun `P4Runtime StreamChannel rejects device_id zero`() {
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "device_id must be nonzero") {
+      runBlocking { harness.streamChannel(flowOf(arbitration(deviceId = 0))).toList() }
+    }
+  }
+
+  @Test
+  fun `DeleteDevices closes active P4Runtime streams`() = runBlocking {
+    supervisorScope {
+      harness.createDevices(2, 1)
+      val requests = Channel<StreamMessageRequest>(Channel.UNLIMITED)
+      val responses = Channel<StreamMessageResponse>(Channel.UNLIMITED)
+      val collector = async {
+        try {
+          harness.streamChannel(requests.consumeAsFlow()).collect { responses.send(it) }
+        } finally {
+          responses.close()
+        }
+      }
+
+      try {
+        requests.send(arbitration(deviceId = 2))
+        assertTrue(withTimeout(STREAM_TIMEOUT_MS) { responses.receive() }.hasArbitration())
+
+        harness.deleteDevices(2, 1)
+
+        try {
+          collector.await()
+          fail("expected deleted device stream to fail")
+        } catch (e: StatusException) {
+          assertEquals(Status.Code.NOT_FOUND, e.status.code)
+          assertTrue(e.status.description!!.contains("device_id 2 was deleted"))
+        }
+      } finally {
+        requests.close()
+      }
+    }
+  }
+
+  @Test
+  fun `Dataplane device_id zero uses default device`() = runBlocking {
+    val config = loadConfig("e2e_tests/passthrough/passthrough.txtpb")
+    harness.createDevices(2, 1)
+    harness.loadPipeline(deviceId = 1, config = config)
+    val payload = byteArrayOf(0xCA.toByte(), 0xFE.toByte())
+
+    val defaulted = harness.injectPacket(deviceId = 0, ingressPort = 0, payload = payload)
+    assertEquals(ByteString.copyFrom(payload), defaulted.outputPayload())
+
+    assertGrpcError(Status.Code.INTERNAL, "InjectPacket failed") {
+      harness.injectPacket(deviceId = 2, ingressPort = 0, payload = payload)
+    }
+  }
+
+  @Test
+  fun `InjectPackets rejects mixed device streams`() = runBlocking {
+    harness.loadPipeline(
+      deviceId = 1,
+      config = loadConfig("e2e_tests/passthrough/passthrough.txtpb"),
+    )
+
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "bound to device_id 1") {
+      runBlocking {
+        harness.injectPackets(
+          flow {
+            emit(injectPacketRequest(deviceId = 0))
+            emit(injectPacketRequest(deviceId = 2))
+          }
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `Read routes by device_id`() = runBlocking {
+    val config = loadConfig("e2e_tests/passthrough/passthrough.txtpb")
+    harness.createDevices(2, 1)
+    harness.loadPipeline(deviceId = 2, config = config)
+
+    assertEquals(emptyList<Entity>(), harness.readTableEntries(deviceId = 2))
+    assertGrpcError(Status.Code.FAILED_PRECONDITION, "No pipeline loaded") {
+      harness.readTableEntries(deviceId = 1)
+    }
+  }
+
+  private fun fourward.InjectPacketResponse.outputPayload(): ByteString =
+    possibleOutcomesList.single().getPackets(0).payload
+
+  private fun arbitration(deviceId: Long): StreamMessageRequest =
+    StreamMessageRequest.newBuilder()
+      .setArbitration(
+        MasterArbitrationUpdate.newBuilder()
+          .setDeviceId(deviceId)
+          .setElectionId(Uint128.newBuilder().setLow(1))
+      )
+      .build()
+
+  private fun injectPacketRequest(deviceId: Long): InjectPacketRequest =
+    InjectPacketRequest.newBuilder()
+      .setDeviceId(deviceId)
+      .setDataplaneIngressPort(0)
+      .setPayload(ByteString.copyFrom(byteArrayOf(0xCA.toByte(), 0xFE.toByte())))
+      .build()
+
+  companion object {
+    private const val STREAM_TIMEOUT_MS = 5000L
+  }
+
+  private class Harness : Closeable {
+    private val registry = DeviceRegistry(DeviceSettings())
+    private val serverName = InProcessServerBuilder.generateName()
+    private val executor = java.util.concurrent.Executors.newCachedThreadPool()
+    private val server =
+      InProcessServerBuilder.forName(serverName)
+        .executor(executor)
+        .addService(MultiDeviceP4RuntimeService(registry))
+        .addService(MultiDeviceDataplaneService(registry))
+        .addService(ManagementService(registry))
+        .build()
+        .start()
+
+    private val channel: ManagedChannel = InProcessChannelBuilder.forName(serverName).build()
+    private val p4rt = P4RuntimeCoroutineStub(channel)
+    private val dataplane = DataplaneCoroutineStub(channel)
+    private val management = FourwardManagementCoroutineStub(channel)
+
+    suspend fun createDevices(firstDeviceId: Long, count: Int) {
+      management.createDevices(
+        CreateDevicesRequest.newBuilder().setFirstDeviceId(firstDeviceId).setCount(count).build()
+      )
+    }
+
+    suspend fun deleteDevices(firstDeviceId: Long, count: Int) {
+      management.deleteDevices(
+        DeleteDevicesRequest.newBuilder().setFirstDeviceId(firstDeviceId).setCount(count).build()
+      )
+    }
+
+    suspend fun listDevices(): List<Long> =
+      management.listDevices(ListDevicesRequest.getDefaultInstance()).deviceIdsList
+
+    suspend fun loadPipeline(deviceId: Long, config: fourward.PipelineConfig) {
+      p4rt.setForwardingPipelineConfig(
+        SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(deviceId)
+          .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+          .setConfig(
+            ForwardingPipelineConfig.newBuilder()
+              .setP4Info(config.p4Info)
+              .setP4DeviceConfig(config.device.toByteString())
+          )
+          .build()
+      )
+    }
+
+    suspend fun getConfig(deviceId: Long) =
+      p4rt.getForwardingPipelineConfig(
+        GetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(deviceId)
+          .setResponseType(GetForwardingPipelineConfigRequest.ResponseType.ALL)
+          .build()
+      )
+
+    suspend fun injectPacket(deviceId: Long, ingressPort: Int, payload: ByteArray) =
+      dataplane.injectPacket(
+        InjectPacketRequest.newBuilder()
+          .setDeviceId(deviceId)
+          .setDataplaneIngressPort(ingressPort)
+          .setPayload(ByteString.copyFrom(payload))
+          .build()
+      )
+
+    suspend fun injectPackets(requests: Flow<InjectPacketRequest>) {
+      dataplane.injectPackets(requests)
+    }
+
+    fun streamChannel(requests: Flow<StreamMessageRequest>): Flow<StreamMessageResponse> =
+      p4rt.streamChannel(requests)
+
+    suspend fun readTableEntries(deviceId: Long): List<Entity> {
+      val entities = mutableListOf<Entity>()
+      p4rt
+        .read(
+          ReadRequest.newBuilder()
+            .setDeviceId(deviceId)
+            .addEntities(Entity.newBuilder().setTableEntry(TableEntry.newBuilder().setTableId(0)))
+            .build()
+        )
+        .toList()
+        .forEach { entities.addAll(it.entitiesList) }
+      return entities
+    }
+
+    override fun close() {
+      channel.shutdownNow()
+      server.shutdownNow()
+      executor.shutdownNow()
+      registry.close()
+    }
+  }
+}

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -17,6 +17,7 @@ import io.grpc.Status
 import io.grpc.StatusException
 import java.io.Closeable
 import java.nio.file.Path
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
@@ -76,7 +77,7 @@ class P4RuntimeService(
    * with [PacketBroker] so that pre-packet hook updates are atomic with other writes.
    */
   private val writeMutex: Mutex = Mutex(),
-  private val deviceId: Long = DEFAULT_DEVICE_ID,
+  val deviceId: Long = DEFAULT_DEVICE_ID,
   private val cpuPortConfig: CpuPortConfig = CpuPortConfig.Auto,
   private val dropPortConfig: PortOverride? = null,
   private val disableRefersToChecking: Boolean = false,
@@ -129,6 +130,7 @@ class P4RuntimeService(
 
   private val arbitrationMutex = Mutex()
   private val controllers = mutableMapOf<Any, ControllerStream>()
+  private val streamClosers = CopyOnWriteArrayList<(StatusException) -> Unit>()
 
   // Per-role election state: key is role name (empty = default role).
   // Modified under arbitrationMutex, but read without it by requirePrimaryOrNoArbitration
@@ -625,6 +627,8 @@ class P4RuntimeService(
     channelFlow {
       val streamId = Any()
       val notifications = Channel<StreamMessageResponse>(Channel.UNLIMITED)
+      val streamCloser: (StatusException) -> Unit = { close(it) }
+      streamClosers.add(streamCloser)
 
       // Forward async notifications (demotion/promotion) to the stream output.
       launch { for (msg in notifications) send(msg) }
@@ -684,6 +688,7 @@ class P4RuntimeService(
           }
         }
       } finally {
+        streamClosers.remove(streamCloser)
         packetInHandle.unsubscribe()
         notifications.close()
         // Disconnect cleanup must complete even if the stream coroutine is being cancelled —
@@ -862,6 +867,7 @@ class P4RuntimeService(
     arbitration: MasterArbitrationUpdate,
     notifications: SendChannel<StreamMessageResponse>,
   ): StreamMessageResponse {
+    requireDeviceId(arbitration.deviceId)
     // P4Runtime spec §15: Role.config is target-specific policy we don't support.
     if (arbitration.role.hasConfig()) {
       throw Status.UNIMPLEMENTED.withDescription(ROLE_CONFIG_NOT_SUPPORTED).asException()
@@ -983,6 +989,9 @@ class P4RuntimeService(
 
   /** Rejects requests targeting a different device (P4Runtime spec §6.3). */
   private fun requireDeviceId(requestDeviceId: Long) {
+    if (requestDeviceId == 0L) {
+      throw Status.INVALID_ARGUMENT.withDescription("device_id must be nonzero").asException()
+    }
     if (requestDeviceId != deviceId) {
       throw Status.NOT_FOUND.withDescription(
           "unknown device_id $requestDeviceId (this device is $deviceId)"
@@ -1146,6 +1155,12 @@ class P4RuntimeService(
     savedPipeline?.constraintValidator?.close()
   }
 
+  fun closeStreams(cause: StatusException) {
+    for (closeStream in streamClosers) {
+      closeStream(cause)
+    }
+  }
+
   /**
    * Resolves a [PortOverride] to a dataplane port number. [PortOverride.Dataplane] passes through;
    * [PortOverride.P4rt] looks up the name in the port translator's explicit mappings (no
@@ -1184,7 +1199,7 @@ class P4RuntimeService(
     private const val INGRESS_PORT_METADATA_ID = 1
 
     // Matches the p4runtime proto version declared in MODULE.bazel.
-    private const val P4RUNTIME_API_VERSION = "1.5.0"
+    internal const val P4RUNTIME_API_VERSION = "1.5.0"
 
     private const val NO_PIPELINE_MESSAGE =
       "no pipeline loaded; call SetForwardingPipelineConfig first"

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -632,32 +632,32 @@ class SaiP4E2ETest {
       harness.openStream().use { session ->
         session.arbitrate()
         session.sendPacketOut(packetOut, timeoutMs = FourwardTestHarness.NO_RESPONSE_TIMEOUT_MS)
-      }
 
-      val msg = withTimeout(5000) { results.receive() }
-      assertTrue("should be a result", msg.hasResult())
-      val outputs = msg.result.possibleOutcomesList.single().packetsList
-      assertEquals(
-        "submit_to_ingress=0 should bypass ingress (ACL drop) and exit on egress_port",
-        1,
-        outputs.size,
-      )
-      assertEquals(
-        "should exit on the PacketOut's egress_port",
-        "Ethernet1",
-        outputs[0].p4RtEgressPort.toStringUtf8(),
-      )
-      val expectedPayload = packetOut.payload.toByteArray()
-      val actualPayload = outputs[0].payload.toByteArray()
-      assertEquals(
-        "PacketOut controller header bits must not leak into output payload",
-        expectedPayload.size,
-        actualPayload.size,
-      )
-      assertBytesEqual("dst_mac", UNICAST_MAC, actualPayload, 0)
-      assertBytesEqual("src_mac", SRC_MAC, actualPayload, MAC_LEN)
-      assertBytesEqual("src_ip", SRC_IP, actualPayload, SRC_IP_OFFSET)
-      assertBytesEqual("dst_ip", DST_IP, actualPayload, DST_IP_OFFSET)
+        val msg = withTimeout(5000) { results.receive() }
+        assertTrue("should be a result", msg.hasResult())
+        val outputs = msg.result.possibleOutcomesList.single().packetsList
+        assertEquals(
+          "submit_to_ingress=0 should bypass ingress (ACL drop) and exit on egress_port",
+          1,
+          outputs.size,
+        )
+        assertEquals(
+          "should exit on the PacketOut's egress_port",
+          "Ethernet1",
+          outputs[0].p4RtEgressPort.toStringUtf8(),
+        )
+        val expectedPayload = packetOut.payload.toByteArray()
+        val actualPayload = outputs[0].payload.toByteArray()
+        assertEquals(
+          "PacketOut controller header bits must not leak into output payload",
+          expectedPayload.size,
+          actualPayload.size,
+        )
+        assertBytesEqual("dst_mac", UNICAST_MAC, actualPayload, 0)
+        assertBytesEqual("src_mac", SRC_MAC, actualPayload, MAC_LEN)
+        assertBytesEqual("src_ip", SRC_IP, actualPayload, SRC_IP_OFFSET)
+        assertBytesEqual("dst_ip", DST_IP, actualPayload, DST_IP_OFFSET)
+      }
 
       job.cancel()
     }

--- a/grpc/dataplane.proto
+++ b/grpc/dataplane.proto
@@ -61,6 +61,13 @@ service Dataplane {
 message InjectPacketsResponse {}
 
 message InjectPacketRequest {
+  // 4ward logical device ID for this native dataplane request.
+  //
+  // Unlike P4Runtime control-plane RPCs, this 4ward-native API accepts
+  // unset/0 as "use the server's default device" so single-device clients do
+  // not need to know about device IDs.
+  uint64 device_id = 5;
+
   oneof ingress_port {
     // Dataplane port number (e.g. 0, 1, 510).
     uint32 dataplane_ingress_port = 1;
@@ -120,7 +127,14 @@ message ProcessPacketResult {
   repeated PacketSet possible_outcomes = 3;
 }
 
-message SubscribeResultsRequest {}
+message SubscribeResultsRequest {
+  // 4ward logical device ID for this native dataplane subscription.
+  //
+  // Unlike P4Runtime control-plane RPCs, this 4ward-native API accepts
+  // unset/0 as "use the server's default device" so single-device clients do
+  // not need to know about device IDs.
+  uint64 device_id = 1;
+}
 
 message SubscribeResultsResponse {
   oneof event {

--- a/grpc/management.proto
+++ b/grpc/management.proto
@@ -1,0 +1,47 @@
+// 4ward-native management service for logical device lifecycle.
+//
+// A normal single-device 4ward server starts with one default device and does
+// not require this API. Use this service only when one server should emulate
+// multiple independent P4Runtime devices.
+
+syntax = "proto3";
+
+package fourward;
+
+option java_package = "fourward";
+option java_outer_classname = "ManagementProto";
+option java_multiple_files = true;
+
+service FourwardManagement {
+  rpc CreateDevices(CreateDevicesRequest) returns (CreateDevicesResponse);
+  rpc DeleteDevices(DeleteDevicesRequest) returns (DeleteDevicesResponse);
+  rpc ListDevices(ListDevicesRequest) returns (ListDevicesResponse);
+}
+
+message CreateDevicesRequest {
+  // First logical device ID to create. Device IDs are the same IDs used in
+  // P4Runtime requests; they must be nonzero because P4Runtime reserves 0 as
+  // the proto3 unset value for normal control-plane RPCs.
+  uint64 first_device_id = 1;
+  // Number of contiguous device IDs to create.
+  uint32 count = 2;
+}
+
+message CreateDevicesResponse {}
+
+message DeleteDevicesRequest {
+  // First logical device ID to delete.
+  uint64 first_device_id = 1;
+  // Number of contiguous device IDs to delete.
+  uint32 count = 2;
+}
+
+message DeleteDevicesResponse {}
+
+message ListDevicesRequest {}
+
+message ListDevicesResponse {
+  // Live logical devices. Single-device users should normally see only the
+  // default device, currently 1 unless the server was started with --device-id.
+  repeated uint64 device_ids = 1;
+}

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -4,7 +4,8 @@ description: "4ward gRPC API reference: P4Runtime and Dataplane service RPCs, co
 
 # gRPC API Reference
 
-4ward exposes two gRPC services on the same port (default: **9559**).
+4ward exposes P4Runtime, dataplane, and management gRPC services on the same
+port (default: **9559**).
 
 ## Server
 
@@ -15,7 +16,7 @@ bazel run //grpc:fourward_server -- [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--port` | 9559 | gRPC listen port (use `0` to let the kernel assign an ephemeral port; pair with `--port-file` to discover it) |
-| `--device-id` | 1 | P4Runtime device ID |
+| `--device-id` | 1 | Default P4Runtime device ID. Leave this at `1` unless integrating with a controller that expects a different ID. |
 | `--drop-port` | `2^N - 1` | Override drop port (e.g., 511 for 9-bit ports) |
 | `--cpu-port` | `2^N - 2` | Override CPU port (e.g., 510 for 9-bit ports; auto-enabled when `@controller_header` is present) |
 | `--port-file` | — | After binding, atomically write the listening port to this path. File-exists ≡ ready to serve. Intended for embedders — see [Embedding in C++](embedding-cc.md). |
@@ -24,6 +25,11 @@ bazel run //grpc:fourward_server -- [flags]
 
 Standard [P4Runtime](https://p4lang.github.io/p4runtime/spec/v1.5.0/P4Runtime-Spec.html) gRPC API (reports version
 **1.5.0**). All six RPCs are implemented:
+
+Every normal P4Runtime request has a required nonzero `device_id`. In the
+usual one-device setup, use `1` (or the value passed to `--device-id`) and
+ignore device lifecycle APIs. Device IDs matter only when one 4ward server is
+hosting multiple logical devices.
 
 | RPC | Description |
 |-----|-------------|
@@ -53,6 +59,12 @@ become primary for a role. The highest `election_id` wins.
 Defined in [`dataplane.proto`]({{ config.repo_url }}/blob/main/grpc/dataplane.proto).
 For packet injection and result observation — not part of the P4Runtime spec.
 
+Native dataplane requests can target a logical 4ward device with
+`device_id`. Unset or `0` means the server's default device, which keeps
+single-device clients simple. This convention is specific to 4ward-native
+dataplane RPCs; P4Runtime control-plane RPCs still require a nonzero
+`device_id` and reject `0`.
+
 ### `InjectPacket`
 
 Inject a single packet and get the result inline.
@@ -61,6 +73,7 @@ Inject a single packet and get the result inline.
 
 ```protobuf
 message InjectPacketRequest {
+  uint64 device_id = 5;  // optional; unset/0 means the default device
   oneof ingress_port {
     uint32 dataplane_ingress_port = 1;  // e.g., 0
     bytes p4rt_ingress_port = 2;        // e.g., "Ethernet0"
@@ -121,6 +134,10 @@ Server-streaming RPC that delivers results from all packet sources
 (InjectPacket, InjectPackets, PacketOut, etc.).
 
 ```protobuf
+SubscribeResultsRequest {
+  device_id: 0  // optional; unset/0 means the default device
+}
+
 // First message confirms the subscription.
 SubscribeResultsResponse { active: {} }
 // Subsequent messages carry results.
@@ -185,6 +202,36 @@ message OutputPacket {
   bytes payload = 2;
 }
 ```
+
+## Management service
+
+Defined in [`management.proto`]({{ config.repo_url }}/blob/main/grpc/management.proto).
+Use this 4ward-native service only when one server should host multiple
+logical devices. Single-device users can ignore it: the server starts with one
+default device.
+
+This is useful for network-scale tests: a controller can manage many
+independent 4ward switches through one JVM instead of starting one 4ward process
+per switch. Each switch has separate pipeline and table state and is selected
+with the P4Runtime `device_id` field. The one-JVM-per-switch approach does not
+scale well because every switch pays fixed JVM and OS process overhead.
+
+`CreateDevices` and `DeleteDevices` operate on contiguous ranges:
+
+```protobuf
+message CreateDevicesRequest {
+  uint64 first_device_id = 1;  // must be nonzero
+  uint32 count = 2;            // number of contiguous devices
+}
+
+message DeleteDevicesRequest {
+  uint64 first_device_id = 1;
+  uint32 count = 2;
+}
+```
+
+New devices start empty. Program each device through standard P4Runtime by
+setting that device's `device_id` on `SetForwardingPipelineConfig` and `Write`.
 
 ## Data plane performance
 


### PR DESCRIPTION
Adds multi-device support behind the existing P4Runtime server so one 4ward process can host many independent logical devices routed by standard P4Runtime `device_id`.

What changed:
- Add `FourwardManagement` bulk lifecycle RPCs for contiguous device creation/deletion/listing.
- Route P4Runtime requests and streams through per-device contexts.
- Keep the common single-device path simple: server default device is still the configured device ID, and native dataplane requests can omit/0 the device ID to use that default.
- Add C++ management client wrapper and device-scoped dataplane client constructors.
- Add focused multi-device tests and a heavy scale benchmark.

Benchmark shape:
- Default benchmark pipeline is now the SAI middleblock pipeline for realistic per-device pipeline footprint.
- `-Dfourward.multidevice.pipeline=basic` remains available for synthetic entry-count sweeps.

Validation:
- `./tools/lint.sh`
- `bazel test //grpc:MultiDeviceServiceTest //fourward_cc:management_client_test //fourward_cc:dataplane_client_e2e_test --test_output=errors`
- `bazel test //grpc:all //fourward_cc:all --test_tag_filters=-heavy --test_output=errors`
- `bazel test //grpc:MultiDeviceScaleBenchmark --test_output=streamed --cache_test_results=no`
- `bazel test //grpc:MultiDeviceScaleBenchmark --test_output=streamed --cache_test_results=no --jvmopt=-Dfourward.multidevice.pipeline=sai --jvmopt=-Dfourward.multidevice.devices=1000`
- `bazel test //grpc:MultiDeviceScaleBenchmark --test_output=streamed --cache_test_results=no --jvmopt=-Dfourward.multidevice.pipeline=basic --jvmopt=-Dfourward.multidevice.devices=100 --jvmopt=-Dfourward.multidevice.entriesPerDevice=1000`

Benchmark samples:
- SAI, 100 devices: create 2 ms, populate 298 ms, ~88 MB populated heap, ~923 KB/device.
- SAI, 1k devices: create 5 ms, populate 1.38 s, ~838 MB populated heap, ~879 KB/device.
- Basic table, 100 devices × 1k entries/device: populate 945 ms, ~40 MB populated heap.
