### PR TITLE
Require exact control-plane bindings

### DIFF
--- a/grpc/GoldenErrorTest.kt
+++ b/grpc/GoldenErrorTest.kt
@@ -1233,7 +1233,20 @@ class GoldenErrorTest(private val testName: String) {
             )
         )
         .build()
-    val patched = config.toBuilder().setP4Info(patchedP4Info).build()
+    val patchedDevice =
+      config.device
+        .toBuilder()
+        .setControlPlaneBindings(
+          config.device.controlPlaneBindings
+            .toBuilder()
+            .addActions(
+              fourward.ControlPlaneBinding.newBuilder()
+                .setP4InfoName("fake_action")
+                .setSimulatorName("fake_action")
+            )
+        )
+        .build()
+    val patched = config.toBuilder().setP4Info(patchedP4Info).setDevice(patchedDevice).build()
     harness.loadPipeline(patched)
     val table = patched.p4Info.tablesList.first()
     val entity =
@@ -1478,7 +1491,20 @@ class GoldenErrorTest(private val testName: String) {
             ),
         )
         .build()
-    val patched = config.toBuilder().setP4Info(patchedP4Info).build()
+    val patchedDevice =
+      config.device
+        .toBuilder()
+        .setControlPlaneBindings(
+          config.device.controlPlaneBindings
+            .toBuilder()
+            .addActions(
+              fourward.ControlPlaneBinding.newBuilder()
+                .setP4InfoName("set_multicast")
+                .setSimulatorName("set_multicast")
+            )
+        )
+        .build()
+    val patched = config.toBuilder().setP4Info(patchedP4Info).setDevice(patchedDevice).build()
     harness.loadPipeline(patched)
     // INSERT with a multicast group ID that doesn't exist in the PRE.
     val entity =

--- a/grpc/P4RuntimeConformanceTest.kt
+++ b/grpc/P4RuntimeConformanceTest.kt
@@ -623,13 +623,24 @@ class P4RuntimeConformanceTest {
   // =========================================================================
 
   /**
-   * Builds a synthetic multi-table config by injecting additional tables with ternary, LPM, range,
-   * and optional match types into the basic_table p4info.
+   * Builds a synthetic multi-table config by injecting additional ternary and LPM tables into the
+   * basic_table pipeline.
    */
   private fun loadMultiTableConfig(): PipelineConfig {
     val base = loadBasicTableConfig()
     val dropId = FourwardTestHarness.findAction(base, "drop").preamble.id
     val p4InfoBuilder = base.p4Info.toBuilder()
+    val deviceBuilder = base.device.toBuilder()
+    val behavioralBuilder = base.device.behavioral.toBuilder()
+    val bindingsBuilder = base.device.controlPlaneBindings.toBuilder()
+
+    fun addSyntheticTableBinding(name: String) {
+      behavioralBuilder.addTables(fourward.TableBehavior.newBuilder().setName(name))
+      bindingsBuilder.addTables(
+        fourward.ControlPlaneBinding.newBuilder().setP4InfoName(name).setSimulatorName(name)
+      )
+    }
+
     // Add a ternary table.
     p4InfoBuilder.addTables(
       p4.config.v1.P4InfoOuterClass.Table.newBuilder()
@@ -648,6 +659,7 @@ class P4RuntimeConformanceTest {
         )
         .addActionRefs(p4.config.v1.P4InfoOuterClass.ActionRef.newBuilder().setId(dropId))
     )
+    addSyntheticTableBinding("ternary_table")
     // Add an LPM table.
     p4InfoBuilder.addTables(
       p4.config.v1.P4InfoOuterClass.Table.newBuilder()
@@ -666,7 +678,15 @@ class P4RuntimeConformanceTest {
         )
         .addActionRefs(p4.config.v1.P4InfoOuterClass.ActionRef.newBuilder().setId(dropId))
     )
-    return base.toBuilder().setP4Info(p4InfoBuilder).build()
+    addSyntheticTableBinding("lpm_table")
+
+    return base
+      .toBuilder()
+      .setP4Info(p4InfoBuilder)
+      .setDevice(
+        deviceBuilder.setBehavioral(behavioralBuilder).setControlPlaneBindings(bindingsBuilder)
+      )
+      .build()
   }
 
   @Test

--- a/p4c_backend/BUILD.bazel
+++ b/p4c_backend/BUILD.bazel
@@ -43,11 +43,14 @@ cc_library(
     deps = [
         ":options",
         "//simulator:ir_cc_proto",
+        "@abseil-cpp//absl/container:btree",
+        "@abseil-cpp//absl/container:flat_hash_map",
         "@p4c//:ir_frontend_midend_control_plane",
         "@p4c//:lib",
         "@p4c//:p4c_backends_common_lib",
         "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
         "@protobuf",
+        "@protobuf//src/google/protobuf/io",
     ],
 )
 

--- a/p4c_backend/backend.cpp
+++ b/p4c_backend/backend.cpp
@@ -16,19 +16,81 @@
 
 #include "p4c_backend/backend.h"
 
+#include <algorithm>
 #include <array>
+#include <cstdint>
 #include <fstream>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "absl/container/btree_map.h"
+#include "absl/container/flat_hash_map.h"
 #include "frontends/p4/coreLibrary.h"
 #include "frontends/p4/enumInstance.h"
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl_lite.h"
 #include "google/protobuf/text_format.h"
 #include "lib/error.h"
 #include "lib/log.h"
 
 namespace P4::FourWard {
+
+// Bindings are emitted via IR traversal order, which is non-deterministic when
+// nodes are stored in hash maps. Sort before writing so two invocations on the
+// same source produce identical bytes.
+static void sortBindings(
+    google::protobuf::RepeatedPtrField<fourward::ControlPlaneBinding>*
+        bindings) {
+  std::vector<fourward::ControlPlaneBinding> sorted(bindings->begin(),
+                                                    bindings->end());
+  std::sort(sorted.begin(), sorted.end(),
+            [](const fourward::ControlPlaneBinding& a,
+               const fourward::ControlPlaneBinding& b) {
+              if (a.p4info_name() != b.p4info_name())
+                return a.p4info_name() < b.p4info_name();
+              return a.simulator_name() < b.simulator_name();
+            });
+  bindings->Clear();
+  for (const auto& binding : sorted) *bindings->Add() = binding;
+}
+
+static fourward::PipelineConfig canonicalPipelineConfig(
+    fourward::PipelineConfig config) {
+  auto* b = config.mutable_device()->mutable_control_plane_bindings();
+  sortBindings(b->mutable_tables());
+  sortBindings(b->mutable_actions());
+  sortBindings(b->mutable_externs());
+  return config;
+}
+
+static void addBinding(
+    google::protobuf::RepeatedPtrField<fourward::ControlPlaneBinding>* bindings,
+    const std::string& p4infoName, const std::string& simulatorName) {
+  for (const auto& binding : *bindings) {
+    if (binding.p4info_name() == p4infoName) {
+      if (binding.simulator_name() != simulatorName) {
+        // clang-format off
+        BUG("conflicting 4ward control-plane binding for %1%: %2% vs %3%",
+            p4infoName, binding.simulator_name(), simulatorName);
+        // clang-format on
+      }
+      return;
+    }
+  }
+  auto* binding = bindings->Add();
+  binding->set_p4info_name(p4infoName);
+  binding->set_simulator_name(simulatorName);
+}
+
+static std::string stripLeadingDot(std::string name) {
+  if (!name.empty() && name[0] == '.') return name.substr(1);
+  return name;
+}
+
+static std::string p4RuntimeName(const IR::P4Action& action) {
+  return stripLeadingDot(std::string(action.controlPlaneName().c_str()));
+}
 
 // =============================================================================
 // Type emission
@@ -101,9 +163,11 @@ fourward::Type FourWardBackend::emitType(const IR::Type* type) {
 // =============================================================================
 
 // Returns true if `expr` is a PathExpression referring to a P4Table, and if so
-// sets `*tableName` to the table's original (pre-midend-rename) name.
+// sets `*tableName` to the table's original (pre-midend-rename) name and
+// `*table` to the resolved IR table.
 static bool isTableApply(const IR::Expression* expr, const ReferenceMap& refMap,
-                         std::string* tableName) {
+                         std::string* tableName,
+                         const IR::P4Table** table = nullptr) {
   const auto* mc = expr->to<IR::MethodCallExpression>();
   if (mc == nullptr) return false;
   const auto* mem = mc->method->to<IR::Member>();
@@ -112,8 +176,9 @@ static bool isTableApply(const IR::Expression* expr, const ReferenceMap& refMap,
   if (pe == nullptr) return false;
   const auto* decl = refMap.getDeclaration(pe->path);
   if (decl == nullptr || !decl->is<IR::P4Table>()) return false;
-  if (tableName != nullptr)
-    *tableName = decl->to<IR::P4Table>()->name.originalName.c_str();
+  const auto* tableDecl = decl->to<IR::P4Table>();
+  if (tableName != nullptr) *tableName = tableDecl->name.originalName.c_str();
+  if (table != nullptr) *table = tableDecl;
   return true;
 }
 
@@ -432,6 +497,20 @@ fourward::Stmt FourWardBackend::emitStmt(const IR::StatOrDecl* node) {
       // Action_run switch on a table apply result.
       auto* s = out.mutable_switch_stmt();
       *s->mutable_subject() = emitExpr(sw->expression);
+      const IR::P4Table* switchTable = nullptr;
+      if (const auto* member = sw->expression->to<IR::Member>()) {
+        if (member->member == "action_run") {
+          isTableApply(member->expr, refMap_, nullptr, &switchTable);
+        }
+      }
+      const p4::config::v1::Table* p4Table =
+          switchTable != nullptr ? findP4InfoTable(switchTable) : nullptr;
+      if (p4Table == nullptr) {
+        // clang-format off
+        BUG("action_run switch is not attached to a known p4info table: %1%",
+            sw->expression);
+        // clang-format on
+      }
       for (const auto* c : sw->cases) {
         if (c->label->is<IR::DefaultExpression>()) {
           if (const auto* b = c->statement->to<IR::BlockStatement>()) {
@@ -440,9 +519,24 @@ fourward::Stmt FourWardBackend::emitStmt(const IR::StatOrDecl* node) {
         } else {
           auto* sc = s->add_cases();
           if (const auto* pe = c->label->to<IR::PathExpression>()) {
-            // Use the original (pre-rename) action name to match p4info
-            // aliases.
-            sc->set_action_name(pe->path->name.originalName.c_str());
+            const auto* declaration = refMap_.getDeclaration(pe->path, false);
+            const auto* actionDecl = declaration != nullptr
+                                         ? declaration->to<IR::P4Action>()
+                                         : nullptr;
+            if (actionDecl == nullptr) {
+              // clang-format off
+              BUG("action_run case %1% does not resolve to a P4 action",
+                  pe->path->name.originalName);
+              // clang-format on
+            }
+            const auto* p4Action = findP4InfoActionRef(*p4Table, *actionDecl);
+            if (p4Action == nullptr) {
+              // clang-format off
+              BUG("no p4info action found for action_run case %1% in %2%",
+                  p4RuntimeName(*actionDecl), p4Table->preamble().name());
+              // clang-format on
+            }
+            sc->set_action_name(p4Action->preamble().name());
           }
           if (c->statement != nullptr) {
             if (const auto* b = c->statement->to<IR::BlockStatement>()) {
@@ -784,6 +878,23 @@ void FourWardBackend::emitControl(const IR::P4Control* control) {
           ei->set_type_name(base->path->name.name.c_str());
         }
       }
+      const std::array<std::string, 3> candidates = {
+          controlName_ + "." + std::string(inst->name.originalName.c_str()),
+          std::string(inst->name.originalName.c_str()),
+          stripLeadingDot(std::string(inst->externalName().c_str())),
+      };
+      for (const auto& counter : pipelineConfig_.p4info().counters()) {
+        for (const auto& candidate : candidates) {
+          if (counter.preamble().name() == candidate ||
+              counter.preamble().alias() == candidate) {
+            addBinding(pipelineConfig_.mutable_device()
+                           ->mutable_control_plane_bindings()
+                           ->mutable_externs(),
+                       counter.preamble().name(), inst->name.name.c_str());
+            break;
+          }
+        }
+      }
       for (const auto* arg : *inst->arguments) {
         *ei->add_constructor_args() = emitExpr(arg->expression);
       }
@@ -797,8 +908,15 @@ void FourWardBackend::emitControl(const IR::P4Control* control) {
 
 void FourWardBackend::emitAction(const IR::P4Action* action,
                                  fourward::ActionDecl* out) {
-  // Use the original (pre-midend) name as the canonical key so it matches the
-  // p4info alias and allows table-dispatch lookups to succeed.
+  if (const auto* p4Action = findP4InfoAction(*action); p4Action != nullptr) {
+    addBinding(pipelineConfig_.mutable_device()
+                   ->mutable_control_plane_bindings()
+                   ->mutable_actions(),
+               p4Action->preamble().name(), p4Action->preamble().name());
+  }
+
+  // Keep the original source name for direct references. Table dispatch uses
+  // TableBehavior.action_overrides for per-table midend specializations.
   out->set_name(action->name.originalName.c_str());
   // If the midend renamed this action (e.g. "do_thing" → "do_thing_1"), also
   // record the current name so the interpreter can resolve direct call sites
@@ -816,70 +934,136 @@ void FourWardBackend::emitAction(const IR::P4Action* action,
   }
 }
 
+const p4::config::v1::Table* FourWardBackend::findP4InfoTable(
+    const IR::P4Table* table) const {
+  const std::string tableName = table->name.originalName.c_str();
+  const std::array<std::string, 2> candidates = {
+      controlName_ + "." + tableName,
+      stripLeadingDot(std::string(table->externalName().c_str())),
+  };
+  for (const auto& p4Table : pipelineConfig_.p4info().tables()) {
+    for (const auto& candidate : candidates) {
+      if (p4Table.preamble().name() == candidate) return &p4Table;
+    }
+  }
+  return nullptr;
+}
+
+const p4::config::v1::Action* FourWardBackend::findP4InfoAction(
+    const IR::P4Action& action) const {
+  const std::string actionName = p4RuntimeName(action);
+  for (const auto& p4Action : pipelineConfig_.p4info().actions()) {
+    if (p4Action.preamble().name() == actionName) return &p4Action;
+  }
+  return nullptr;
+}
+
+const IR::P4Action* FourWardBackend::resolveActionListElement(
+    const IR::ActionListElement* actionListElement) const {
+  const auto* declaration =
+      refMap_.getDeclaration(actionListElement->getPath(), false);
+  if (declaration == nullptr) return nullptr;
+  return declaration->to<IR::P4Action>();
+}
+
+const p4::config::v1::Action* FourWardBackend::findP4InfoActionRef(
+    const p4::config::v1::Table& table, const IR::P4Action& action) const {
+  absl::flat_hash_map<uint32_t, const p4::config::v1::Action*> actionById;
+  for (const auto& action : pipelineConfig_.p4info().actions()) {
+    actionById[action.preamble().id()] = &action;
+  }
+
+  const std::string actionName = p4RuntimeName(action);
+  for (const auto& actionRef : table.action_refs()) {
+    const auto actionIt = actionById.find(actionRef.id());
+    if (actionIt == actionById.end()) continue;
+    const auto* candidateAction = actionIt->second;
+    if (candidateAction->preamble().name() == actionName)
+      return candidateAction;
+  }
+  return nullptr;
+}
+
 void FourWardBackend::emitTable(const IR::P4Table* table) {
   // originalName matches the p4info alias (e.g. "port_table" from
   // "MyIngress.port_table").
   const std::string tableName = table->name.originalName.c_str();
 
-  // Look up the p4info table by qualified name to retrieve match field IDs.
-  // Try multiple strategies: (1) controlName.originalName for simple tables,
-  // (2) externalName() for tables from inlined sub-controls (where p4info uses
-  // dot-separated hierarchy like "ingress.c.t" but originalName has underscores
-  // like "c_t").
-  const p4::config::v1::Table* p4Table = nullptr;
-  {
-    std::array<std::string, 2> candidates = {
-        controlName_ + "." + tableName,
-        std::string(table->externalName().c_str()),
-    };
-    // externalName() may have a leading dot for fully-qualified names.
-    for (auto& c : candidates) {
-      if (!c.empty() && c[0] == '.') c = c.substr(1);
-    }
-    for (const auto& t : pipelineConfig_.p4info().tables()) {
-      for (const auto& c : candidates) {
-        if (t.preamble().name() == c) {
-          p4Table = &t;
-          break;
-        }
-      }
-      if (p4Table != nullptr) break;
-    }
-  }
+  const p4::config::v1::Table* p4Table = findP4InfoTable(table);
   if (p4Table == nullptr) {
     // clang-format off
-    LOG1("WARNING: no p4info table found for " << tableName << "; skipping emitTable");
+    BUG("no p4info table found for %1%", tableName);
     // clang-format on
-    return;
   }
 
   auto* tb = behavioral_->add_tables();
   tb->set_name(tableName);
+  addBinding(pipelineConfig_.mutable_device()
+                 ->mutable_control_plane_bindings()
+                 ->mutable_tables(),
+             p4Table->preamble().name(), tableName);
 
   // Emit one TableKey per match field. The field_name is the p4info match
   // field ID as a string; this is what TableStore.lookup compares against
   // FieldMatch.fieldId from P4Runtime write requests.
   const IR::Key* key = table->getKey();
-  if (key == nullptr) return;
-  int keyIdx = 0;
-  for (const auto* keyElem : key->keyElements) {
-    if (keyIdx >= p4Table->match_fields_size()) break;
-    auto* tk = tb->add_keys();
-    tk->set_field_name(std::to_string(p4Table->match_fields(keyIdx).id()));
-    *tk->mutable_expr() = emitExpr(keyElem->expression);
-    ++keyIdx;
+  if (key != nullptr) {
+    int keyIdx = 0;
+    for (const auto* keyElem : key->keyElements) {
+      if (keyIdx >= p4Table->match_fields_size()) break;
+      auto* tk = tb->add_keys();
+      tk->set_field_name(std::to_string(p4Table->match_fields(keyIdx).id()));
+      *tk->mutable_expr() = emitExpr(keyElem->expression);
+      ++keyIdx;
+    }
   }
 
-  // Record per-table action specializations so the interpreter can resolve
-  // the correct midend copy when the p4info returns a single original name.
+  // Record per-table action specializations so the interpreter resolves each
+  // P4Info action ID through this table's executable midend action name. Some
+  // architectures add IR-only helper actions to the table action list; those
+  // are intentionally outside p4info.table.action_refs and therefore outside
+  // the control-plane binding contract.
   const auto* actionList = table->getActionList();
   if (actionList != nullptr) {
-    for (const auto* ale : actionList->actionList) {
-      auto id = ale->getName();
-      if (id.name != id.originalName) {
-        (*tb->mutable_action_overrides())[id.originalName.c_str()] =
-            id.name.c_str();
+    absl::flat_hash_map<uint32_t, const p4::config::v1::Action*> actionById;
+    for (const auto& action : pipelineConfig_.p4info().actions()) {
+      actionById[action.preamble().id()] = &action;
+    }
+
+    absl::btree_map<std::string, std::string> actionOverrides;
+    for (const auto& actionRef : p4Table->action_refs()) {
+      const auto actionIt = actionById.find(actionRef.id());
+      if (actionIt == actionById.end()) {
+        // clang-format off
+        BUG("p4info table %1% references unknown action id %2%",
+            p4Table->preamble().name(), actionRef.id());
+        // clang-format on
       }
+      const auto* p4Action = actionIt->second;
+      std::string executableName;
+      for (const auto* ale : actionList->actionList) {
+        const auto* actionDecl = resolveActionListElement(ale);
+        if (actionDecl == nullptr) {
+          // clang-format off
+          BUG("table action list entry %1% does not resolve to a P4 action",
+              ale);
+          // clang-format on
+        }
+        if (p4Action->preamble().name() == p4RuntimeName(*actionDecl)) {
+          executableName = ale->getName().name.c_str();
+          break;
+        }
+      }
+      if (executableName.empty()) {
+        // clang-format off
+        BUG("no executable table action found for p4info action %1% in %2%",
+            p4Action->preamble().name(), p4Table->preamble().name());
+        // clang-format on
+      }
+      actionOverrides[p4Action->preamble().name()] = executableName;
+    }
+    for (const auto& [p4infoName, executableName] : actionOverrides) {
+      (*tb->mutable_action_overrides())[p4infoName] = executableName;
     }
   }
 }
@@ -1034,6 +1218,15 @@ namespace {
 // time we reach `writeProto` the suffix is guaranteed to be one of the two.
 bool isBinary(const std::string& path) { return path.ends_with(".binpb"); }
 
+bool serialiseDeterministic(const google::protobuf::Message& msg,
+                            std::string* out) {
+  out->clear();
+  google::protobuf::io::StringOutputStream stream(out);
+  google::protobuf::io::CodedOutputStream coded(&stream);
+  coded.SetSerializationDeterministic(true);
+  return msg.SerializeToCodedStream(&coded) && !coded.HadError();
+}
+
 bool writeProto(const google::protobuf::Message& msg, const std::string& path,
                 const char* protoFile, const char* protoMessage) {
   // Serialise into a string in full, then write the bytes all at once. Avoids
@@ -1045,7 +1238,7 @@ bool writeProto(const google::protobuf::Message& msg, const std::string& path,
   // google3 as 201-byte truncated files for ~130 KB DeviceConfigs.
   std::string serialised;
   if (isBinary(path)) {
-    if (!msg.SerializeToString(&serialised)) {
+    if (!serialiseDeterministic(msg, &serialised)) {
       ::P4::error("4ward: failed to serialise %1% to '%2%'", protoMessage,
                   path);
       return false;
@@ -1086,30 +1279,39 @@ bool writeProto(const google::protobuf::Message& msg, const std::string& path,
 }  // namespace
 
 bool FourWardBackend::writeOutputs() const {
+  const fourward::PipelineConfig outputConfig =
+      canonicalPipelineConfig(pipelineConfig_);
   if (options_.outputFile.has_value()) {
     if (options_.format == FourWardOptions::Format::kP4runtime) {
       p4::v1::ForwardingPipelineConfig fpc;
-      *fpc.mutable_p4info() = pipelineConfig_.p4info();
-      fpc.set_p4_device_config(pipelineConfig_.device().SerializeAsString());
+      *fpc.mutable_p4info() = outputConfig.p4info();
+      std::string deviceConfig;
+      if (!serialiseDeterministic(outputConfig.device(), &deviceConfig)) {
+        ::P4::error("4ward: failed to serialise fourward.DeviceConfig");
+        return false;
+      }
+      fpc.set_p4_device_config(deviceConfig);
       if (!writeProto(fpc, *options_.outputFile,
                       "@p4runtime//p4/v1/p4runtime.proto",
                       "p4.v1.ForwardingPipelineConfig")) {
         return false;
       }
-    } else if (!writeProto(pipelineConfig_, *options_.outputFile,
-                           "@fourward//simulator/ir.proto",
-                           "fourward.PipelineConfig")) {
-      return false;
+    } else {
+      if (!writeProto(outputConfig, *options_.outputFile,
+                      "@fourward//simulator/ir.proto",
+                      "fourward.PipelineConfig")) {
+        return false;
+      }
     }
   }
   if (options_.outP4Info.has_value() &&
-      !writeProto(pipelineConfig_.p4info(), *options_.outP4Info,
+      !writeProto(outputConfig.p4info(), *options_.outP4Info,
                   "@p4runtime//p4/config/v1/p4info.proto",
                   "p4.config.v1.P4Info")) {
     return false;
   }
   if (options_.outP4DeviceConfig.has_value() &&
-      !writeProto(pipelineConfig_.device(), *options_.outP4DeviceConfig,
+      !writeProto(outputConfig.device(), *options_.outP4DeviceConfig,
                   "@fourward//simulator/ir.proto", "fourward.DeviceConfig")) {
     return false;
   }

--- a/p4c_backend/backend.h
+++ b/p4c_backend/backend.h
@@ -80,6 +80,13 @@ class FourWardBackend : public Inspector {
   void emitAction(const IR::P4Action* action, fourward::ActionDecl* out);
   void emitTable(const IR::P4Table* table);
   void emitArchitecture(const IR::ToplevelBlock* toplevel);
+  const p4::config::v1::Table* findP4InfoTable(const IR::P4Table* table) const;
+  const p4::config::v1::Action* findP4InfoAction(
+      const IR::P4Action& action) const;
+  const IR::P4Action* resolveActionListElement(
+      const IR::ActionListElement* actionListElement) const;
+  const p4::config::v1::Action* findP4InfoActionRef(
+      const p4::config::v1::Table& table, const IR::P4Action& action) const;
 
   // IR-to-proto converters. These are member functions so they can access
   // refMap_ (needed to resolve PathExpression declarations for table apply

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -226,6 +226,19 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "TableStoreBindingsTest",
+    srcs = ["TableStoreBindingsTest.kt"],
+    test_class = "fourward.simulator.TableStoreBindingsTest",
+    deps = [
+        ":ir_java_proto",
+        ":p4info_java_proto",
+        ":p4runtime_java_proto",
+        ":simulator",
+        "@fourward_maven//:junit_junit",
+    ],
+)
+
+kt_jvm_test(
     name = "DirectResourceUsageTest",
     srcs = ["DirectResourceUsageTest.kt"],
     test_class = "fourward.simulator.DirectResourceUsageTest",

--- a/simulator/DirectResourceUsageTest.kt
+++ b/simulator/DirectResourceUsageTest.kt
@@ -5,6 +5,8 @@ import fourward.ActionDecl
 import fourward.Architecture
 import fourward.BehavioralConfig
 import fourward.ControlDecl
+import fourward.ControlPlaneBinding
+import fourward.ControlPlaneBindings
 import fourward.DeviceConfig
 import fourward.Expr
 import fourward.ExternInstanceDecl
@@ -321,7 +323,7 @@ class DirectResourceUsageTest {
   }
 
   @Test
-  fun `suffix match does not cross-contaminate counters on different tables`() {
+  fun `explicit bindings keep direct counters on different tables isolated`() {
     val tableAId = 1
     val tableBId = 2
     val store = TableStore()
@@ -331,7 +333,10 @@ class DirectResourceUsageTest {
           .addTables(
             P4InfoOuterClass.Table.newBuilder()
               .setPreamble(
-                P4InfoOuterClass.Preamble.newBuilder().setId(tableAId).setAlias("tableA")
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(tableAId)
+                  .setName("tableA")
+                  .setAlias("tableA")
               )
               .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_10_ID))
               .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_20_ID))
@@ -339,7 +344,10 @@ class DirectResourceUsageTest {
           .addTables(
             P4InfoOuterClass.Table.newBuilder()
               .setPreamble(
-                P4InfoOuterClass.Preamble.newBuilder().setId(tableBId).setAlias("tableB")
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(tableBId)
+                  .setName("tableB")
+                  .setAlias("tableB")
               )
               .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_10_ID))
               .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_20_ID))
@@ -371,8 +379,8 @@ class DirectResourceUsageTest {
         DeviceConfig.newBuilder()
           .setBehavioral(
             BehavioralConfig.newBuilder()
-              .addTables(TableBehavior.newBuilder().setName("tableA"))
-              .addTables(TableBehavior.newBuilder().setName("tableB"))
+              .addTables(tableBehavior("tableA"))
+              .addTables(tableBehavior("tableB"))
               .addActions(
                 ActionDecl.newBuilder()
                   .setName("action10")
@@ -398,6 +406,7 @@ class DirectResourceUsageTest {
                   )
               )
           )
+          .setControlPlaneBindings(controlPlaneBindings("tableA", "tableB"))
           .build(),
     )
 
@@ -548,17 +557,18 @@ class DirectResourceUsageTest {
       .setBehavioral(
         BehavioralConfig.newBuilder()
           .setArchitecture(Architecture.newBuilder().setName("v1model"))
-          .addTables(TableBehavior.newBuilder().setName(TABLE_NAME))
+          .addTables(tableBehavior(TABLE_NAME))
           .addActions(ActionDecl.newBuilder().setName("action10"))
           .addActions(ActionDecl.newBuilder().setName("action20"))
       )
+      .setControlPlaneBindings(controlPlaneBindings(TABLE_NAME))
       .build()
 
   private fun deviceWithDirectCounterAction(counterInstanceName: String = "dc"): DeviceConfig =
     DeviceConfig.newBuilder()
       .setBehavioral(
         BehavioralConfig.newBuilder()
-          .addTables(TableBehavior.newBuilder().setName(TABLE_NAME))
+          .addTables(tableBehavior(TABLE_NAME))
           .addActions(
             ActionDecl.newBuilder()
               .setName("action10")
@@ -575,13 +585,14 @@ class DirectResourceUsageTest {
               )
           )
       )
+      .setControlPlaneBindings(controlPlaneBindings(TABLE_NAME))
       .build()
 
   private fun deviceWithDirectMeterAction(): DeviceConfig =
     DeviceConfig.newBuilder()
       .setBehavioral(
         BehavioralConfig.newBuilder()
-          .addTables(TableBehavior.newBuilder().setName(TABLE_NAME))
+          .addTables(tableBehavior(TABLE_NAME))
           .addActions(
             ActionDecl.newBuilder()
               .setName("action10")
@@ -589,6 +600,27 @@ class DirectResourceUsageTest {
           )
           .addActions(ActionDecl.newBuilder().setName("action20"))
       )
+      .setControlPlaneBindings(controlPlaneBindings(TABLE_NAME))
+      .build()
+
+  private fun tableBehavior(name: String): TableBehavior =
+    TableBehavior.newBuilder()
+      .setName(name)
+      .putActionOverrides("action10", "action10")
+      .putActionOverrides("action20", "action20")
+      .build()
+
+  private fun controlPlaneBindings(vararg tableNames: String): ControlPlaneBindings =
+    ControlPlaneBindings.newBuilder()
+      .addAllTables(tableNames.map { binding(it, it) })
+      .addActions(binding("action10", "action10"))
+      .addActions(binding("action20", "action20"))
+      .build()
+
+  private fun binding(p4infoName: String, simulatorName: String): ControlPlaneBinding =
+    ControlPlaneBinding.newBuilder()
+      .setP4InfoName(p4infoName)
+      .setSimulatorName(simulatorName)
       .build()
 
   private fun directResourceCall(instance: String, externType: String, method: String): Stmt =
@@ -683,7 +715,12 @@ class DirectResourceUsageTest {
     P4InfoOuterClass.P4Info.newBuilder()
       .addTables(
         P4InfoOuterClass.Table.newBuilder()
-          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(TABLE_ID).setAlias(TABLE_NAME))
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder()
+              .setId(TABLE_ID)
+              .setName(TABLE_NAME)
+              .setAlias(TABLE_NAME)
+          )
           .setImplementationId(implementationId)
           .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_10_ID))
           .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(ACTION_20_ID))
@@ -693,7 +730,7 @@ class DirectResourceUsageTest {
 
   private fun action(id: Int, name: String): P4InfoOuterClass.Action =
     P4InfoOuterClass.Action.newBuilder()
-      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setAlias(name))
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName(name).setAlias(name))
       .build()
 
   companion object {

--- a/simulator/InterpreterControlTest.kt
+++ b/simulator/InterpreterControlTest.kt
@@ -428,6 +428,81 @@ class InterpreterControlTest {
     assertEquals(BitVal(2, 8), env.lookup("x"))
   }
 
+  @Test
+  fun `table miss default action side effects are visible to later statements`() {
+    val ts =
+      TableStore().also {
+        it.setDefaultAction("route", "drop")
+        it.publishSnapshot()
+      }
+    val applyRoute =
+      Stmt.newBuilder()
+        .setAssignment(
+          AssignmentStmt.newBuilder()
+            .setLhs(
+              fieldAccess(nameRef("meta"), "route_hit", Type.newBuilder().setBoolean(true).build())
+            )
+            .setRhs(
+              Expr.newBuilder()
+                .setTableApply(
+                  TableApplyExpr.newBuilder()
+                    .setTableName("route")
+                    .setAccessKind(TableApplyExpr.AccessKind.HIT)
+                )
+                .setType(Type.newBuilder().setBoolean(true))
+            )
+        )
+        .build()
+    val config =
+      BehavioralConfig.newBuilder()
+        .addTables(TableBehavior.newBuilder().setName("route"))
+        .addTables(TableBehavior.newBuilder().setName("resolution"))
+        .addActions(
+          ActionDecl.newBuilder()
+            .setName("drop")
+            .addBody(
+              assign(
+                fieldAccess(nameRef("meta"), "drop", Type.newBuilder().setBoolean(true).build()),
+                boolLit(true),
+              )
+            )
+        )
+        .addActions(ActionDecl.newBuilder().setName("NoAction"))
+        .addControls(
+          ControlDecl.newBuilder()
+            .setName("MyControl")
+            .addApplyBody(applyRoute)
+            .addApplyBody(
+              ifStmt(
+                fieldAccess(nameRef("meta"), "drop", Type.newBuilder().setBoolean(true).build()),
+                thenStmts = emptyList(),
+                elseStmts =
+                  listOf(
+                    Stmt.newBuilder()
+                      .setMethodCall(
+                        MethodCallStmt.newBuilder()
+                          .setCall(
+                            Expr.newBuilder()
+                              .setTableApply(TableApplyExpr.newBuilder().setTableName("resolution"))
+                          )
+                      )
+                      .build()
+                  ),
+              )
+            )
+        )
+        .build()
+    val env = emptyEnv
+    env.define(
+      "meta",
+      StructVal("meta_t", mutableMapOf("drop" to BoolVal(false), "route_hit" to BoolVal(true))),
+    )
+    interp(config, ts).runControl("MyControl", env)
+    val meta = env.lookup("meta") as StructVal
+    assertEquals(BoolVal(true), meta.fields["drop"])
+    assertEquals(BoolVal(false), meta.fields["route_hit"])
+  }
+
   // ---------------------------------------------------------------------------
   // Per-table action override resolution
   // ---------------------------------------------------------------------------

--- a/simulator/PNAArchitecture.kt
+++ b/simulator/PNAArchitecture.kt
@@ -372,7 +372,7 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     val missCtx = eval.lastTableMiss() ?: error("add_entry called but no table miss has occurred")
     val actionAlias = (eval.evalArg(0) as StringVal).value
     val actionName =
-      pipeline.tableStore.resolveActionByAlias(actionAlias)
+      pipeline.tableStore.resolveActionForTable(missCtx.tableName, actionAlias)
         ?: error("add_entry: unknown action '$actionAlias'")
 
     // The action_params argument (arg 1) is either a single value (one-param actions)
@@ -446,8 +446,8 @@ class PNAArchitecture(private val config: BehavioralConfig) : Architecture {
     /**
      * Maps PNA_HashAlgorithm_t enum members to the internal algorithm names used by Hash.kt.
      *
-     * PNA's hash algorithm enum has the same values as PSA's, plus TARGET_DEFAULT which we map to
-     * identity as a safe fallback.
+     * PNA's hash algorithm enum has the same values as PSA's, plus TARGET_DEFAULT. The simulator
+     * treats TARGET_DEFAULT as identity because it has no target-specific hash pipeline.
      */
     val PNA_HASH_ALGORITHMS =
       mapOf(

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -18,6 +18,8 @@ import fourward.ActionDecl
 import fourward.Architecture
 import fourward.BehavioralConfig
 import fourward.ControlDecl
+import fourward.ControlPlaneBinding
+import fourward.ControlPlaneBindings
 import fourward.DeviceConfig
 import fourward.ParamDecl
 import fourward.ParserDecl
@@ -38,9 +40,9 @@ import p4.config.v1.P4InfoOuterClass
 /**
  * Unit tests for [Simulator] — name resolution, default action handling, and error responses.
  *
- * These test the Simulator's pipeline-loading logic (p4info alias→behavioral name resolution) which
- * is a common source of bugs: p4info aliases don't always match behavioral IR names due to control
- * inlining (e.g. p4info alias "t" vs behavioral "c_t").
+ * These test the Simulator's pipeline-loading logic. Compiled behavioral configs use explicit
+ * p4info-to-runtime bindings because p4info aliases don't always match behavioral IR names due to
+ * control inlining.
  */
 class SimulatorTest {
 
@@ -67,10 +69,27 @@ class SimulatorTest {
         .addStages(PipelineStage.newBuilder().setKind(StageKind.CONTROL).setBlockName("eg"))
         .addStages(PipelineStage.newBuilder().setKind(StageKind.DEPARSER).setBlockName("dep"))
         .build()
+    val tableBindings =
+      p4infoTables.zip(behavioralTableNames).map { (table, runtimeName) ->
+        binding(table.preamble.name, runtimeName)
+      }
+    val actionBindings =
+      p4infoActions.map { action -> binding(action.preamble.name, action.preamble.name) }
+    val actionOverrideTargets =
+      p4infoActions.zip(behavioralActionNames).associate { (action, runtimeName) ->
+        action.preamble.name to runtimeName
+      }
     val behavioral =
       BehavioralConfig.newBuilder()
         .setArchitecture(arch)
-        .addAllTables(behavioralTableNames.map { TableBehavior.newBuilder().setName(it).build() })
+        .addAllTables(
+          behavioralTableNames.map { tableName ->
+            TableBehavior.newBuilder()
+              .setName(tableName)
+              .putAllActionOverrides(actionOverrideTargets)
+              .build()
+          }
+        )
         .addAllActions(behavioralActionNames.map { ActionDecl.newBuilder().setName(it).build() })
         .build()
     val p4info =
@@ -79,19 +98,33 @@ class SimulatorTest {
         .addAllActions(p4infoActions)
         .build()
     return PipelineConfig.newBuilder()
-      .setDevice(DeviceConfig.newBuilder().setBehavioral(behavioral))
+      .setDevice(
+        DeviceConfig.newBuilder()
+          .setBehavioral(behavioral)
+          .setControlPlaneBindings(
+            ControlPlaneBindings.newBuilder()
+              .addAllTables(tableBindings)
+              .addAllActions(actionBindings)
+          )
+      )
       .setP4Info(p4info)
       .build()
   }
 
+  private fun binding(p4infoName: String, simulatorName: String): ControlPlaneBinding =
+    ControlPlaneBinding.newBuilder()
+      .setP4InfoName(p4infoName)
+      .setSimulatorName(simulatorName)
+      .build()
+
   private fun p4infoTable(id: Int, alias: String): P4InfoOuterClass.Table =
     P4InfoOuterClass.Table.newBuilder()
-      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setAlias(alias))
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName(alias).setAlias(alias))
       .build()
 
   private fun p4infoAction(id: Int, alias: String): P4InfoOuterClass.Action =
     P4InfoOuterClass.Action.newBuilder()
-      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setAlias(alias))
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName(alias).setAlias(alias))
       .build()
 
   @Test
@@ -109,10 +142,7 @@ class SimulatorTest {
   }
 
   @Test
-  fun `load pipeline resolves alias via suffix fallback`() {
-    // p4info alias "t" should match behavioral "c_t" via endsWith("_t").
-    // We verify this indirectly: if resolution failed, the table store would
-    // use the wrong key and a subsequent packet wouldn't find the table.
+  fun `load pipeline succeeds with distinct p4info and behavioral names`() {
     val config =
       pipelineConfig(
         p4infoTables = listOf(p4infoTable(1, "t")),

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -306,6 +306,19 @@ class TableStore : TableDataReader {
     val idByName: Map<String, Int>,
   )
 
+  private data class ControlPlaneNameIndex(
+    val tableNameById: Map<Int, String>,
+    val tableAliasByName: Map<String, String>,
+    val tableNameByAlias: Map<String, String>,
+    val actionNameById: Map<Int, String>,
+    val actionAliasByName: Map<String, String>,
+    val actionIdByName: Map<String, Int>,
+    val tableIdByName: Map<String, Int>,
+    val actionParamInfo: Map<String, List<P4InfoOuterClass.Action.Param>>,
+    val tableMatchFields: Map<String, List<P4InfoOuterClass.MatchField>>,
+    val counterMappings: CounterMappings,
+  )
+
   internal data class StatefulExternCheckpoint(
     val directCounters: Map<TableEntry, LongArray>,
     val indirectCounters: Map<Int, Map<Int, LongArray>>,
@@ -443,7 +456,7 @@ class TableStore : TableDataReader {
   fun populatedTableAliases(): Set<String> =
     writeState.tables.entries
       .filter { (_, entries) -> entries.isNotEmpty() }
-      .mapNotNull { (behavioralName, _) -> tableAliasByName[behavioralName] }
+      .mapNotNull { (simulatorName, _) -> tableAliasByName[simulatorName] }
       .toSet()
 
   /**
@@ -502,6 +515,7 @@ class TableStore : TableDataReader {
   private var directCounterActionsByTable: Map<String, Set<String>> = emptyMap()
   private var directMeterActionsByTable: Map<String, Set<String>> = emptyMap()
   private var tableActionOverrides: Map<String, Map<String, String>> = emptyMap()
+  private var tableLocalActionNames: Map<String, Map<String, String>> = emptyMap()
   private var initialDefaultActions: Map<String, DefaultAction> = emptyMap()
 
   // For unit tests: makes lookup() return hit=true with this action rather than searching entries.
@@ -559,9 +573,9 @@ class TableStore : TableDataReader {
   /**
    * Initialises the store for a loaded pipeline and clears all mutable state.
    *
-   * Resolves p4info IDs to behavioral IR names (which may differ from p4info aliases for inlined
-   * controls — e.g. behavioral "c_t" vs p4info alias "t"). When [device] has no behavioral config,
-   * p4info aliases are used directly (convenient for tests).
+   * Resolves p4info IDs to behavioral IR names. Compiled behavioral configs must carry explicit
+   * compiler-emitted bindings; P4Info-only tests use p4info aliases directly because there is no
+   * behavioral symbol space.
    *
    * Also installs default actions and static table entries from [p4info] and [device].
    *
@@ -571,85 +585,25 @@ class TableStore : TableDataReader {
     p4info: P4InfoOuterClass.P4Info = P4InfoOuterClass.P4Info.getDefaultInstance(),
     device: DeviceConfig = DeviceConfig.getDefaultInstance(),
   ) {
-    // Extract behavioral names from the IR. The behavioral IR uses its own table/action
-    // names (e.g. inlined "c_t" vs p4info alias "t"). When the device config is empty
-    // (e.g. unit tests), resolveName falls through to the p4info alias itself.
     val behavioral = device.behavioral
-    val behavioralTableNames = behavioral.tablesList.map { it.name }
-    val behavioralActionNames =
-      (behavioral.actionsList + behavioral.controlsList.flatMap { it.localActionsList }).flatMap {
-        action ->
-        listOfNotNull(action.name, action.currentName.ifEmpty { null })
-      }
-
-    fun resolveName(alias: String, candidates: List<String>): String {
-      // p4info aliases use dots for nested controls (e.g. "ct.ipv4_da"), while
-      // the behavioral IR uses underscores (e.g. "ct_ipv4_da"). When two tables
-      // share a short name, p4c disambiguates with a control prefix
-      // (e.g. "MainControlImpl.ipv4_da" for behavioral "ipv4_da"). Try multiple
-      // forms to handle all cases.
-      val underscored = alias.replace('.', '_')
-      val afterFirstDot = if ('.' in alias) alias.substringAfter('.') else null
-      val afterFirstDotUnderscored = afterFirstDot?.replace('.', '_')
-      return candidates.find { it == alias }
-        ?: candidates.find { it.endsWith("_$alias") }
-        ?: candidates.find { it == underscored }
-        ?: candidates.find { it.endsWith("_$underscored") }
-        ?: afterFirstDotUnderscored?.let { suffix ->
-          candidates.find { it == suffix } ?: candidates.find { it.endsWith("_$suffix") }
-        }
-        ?: alias
-    }
-
-    // Build both forward (id → behavioral name) and reverse (behavioral name → alias) maps
-    // in a single pass per list.
-    val tableById = mutableMapOf<Int, String>()
-    val tableByName = mutableMapOf<String, String>()
-    for (table in p4info.tablesList) {
-      val alias = table.preamble.alias.ifEmpty { table.preamble.name }
-      val behavioral = resolveName(alias, behavioralTableNames)
-      tableById[table.preamble.id] = behavioral
-      tableByName[behavioral] = alias
-    }
-    this.tableNameById = tableById
-    this.tableAliasByName = tableByName
-    this.tableNameByAlias = tableByName.entries.associate { (name, alias) -> alias to name }
-
-    val actionById = mutableMapOf<Int, String>()
-    val actionByName = mutableMapOf<String, String>()
-    for (action in p4info.actionsList) {
-      val alias = action.preamble.alias.ifEmpty { action.preamble.name }
-      val behavioral = resolveName(alias, behavioralActionNames)
-      actionById[action.preamble.id] = behavioral
-      actionByName[behavioral] = alias
-    }
-    this.actionNameById = actionById
-    this.actionAliasByName = actionByName
-    this.actionIdByName = actionById.entries.associate { (id, name) -> name to id }
-    this.tableIdByName = tableById.entries.associate { (id, name) -> name to id }
-    this.actionParamInfo =
-      p4info.actionsList
-        .mapNotNull { action ->
-          val name = actionById[action.preamble.id] ?: return@mapNotNull null
-          name to action.paramsList
-        }
-        .toMap()
-    this.tableMatchFields =
-      p4info.tablesList
-        .mapNotNull { table ->
-          val name = tableById[table.preamble.id] ?: return@mapNotNull null
-          name to table.matchFieldsList
-        }
-        .toMap()
+    val nameIndex = buildControlPlaneNameIndex(p4info, device)
+    this.tableNameById = nameIndex.tableNameById
+    this.tableAliasByName = nameIndex.tableAliasByName
+    this.tableNameByAlias = nameIndex.tableNameByAlias
+    this.actionNameById = nameIndex.actionNameById
+    this.actionAliasByName = nameIndex.actionAliasByName
+    this.actionIdByName = nameIndex.actionIdByName
+    this.tableIdByName = nameIndex.tableIdByName
+    this.actionParamInfo = nameIndex.actionParamInfo
+    this.tableMatchFields = nameIndex.tableMatchFields
     this.registerInfoById =
       p4info.registersList.associate { reg ->
         val bitwidth = reg.typeSpec.bitstring.bit.bitwidth
         reg.preamble.id to RegisterInfo(reg.preamble.name, bitwidth, reg.size)
       }
     this.registerInfoByName = registerInfoById.entries.associate { it.value.name to it.toPair() }
-    val counterMappings = buildCounterMappings(p4info, behavioral, ::resolveName)
-    this.counterInfoById = counterMappings.infoById
-    this.counterIdByName = counterMappings.idByName
+    this.counterInfoById = nameIndex.counterMappings.infoById
+    this.counterIdByName = nameIndex.counterMappings.idByName
     this.meterInfoById =
       p4info.metersList.associate { it.preamble.id to IndexedExternInfo(it.size.toInt()) }
     this.valueSetInfoById =
@@ -662,6 +616,7 @@ class TableStore : TableDataReader {
     this.directMeterTables =
       p4info.directMetersList.mapNotNull { tableNameById[it.directTableId] }.toSet()
     tableActionOverrides = behavioral.tablesList.associate { it.name to it.actionOverridesMap }
+    tableLocalActionNames = buildTableLocalActionNames(p4info)
     val directResourceActions =
       deriveDirectResourceActions(
         behavioral,
@@ -747,27 +702,175 @@ class TableStore : TableDataReader {
     publishSnapshot()
   }
 
+  private fun buildControlPlaneNameIndex(
+    p4info: P4InfoOuterClass.P4Info,
+    device: DeviceConfig,
+  ): ControlPlaneNameIndex {
+    val behavioral = device.behavioral
+    val behavioralTableNames = behavioral.tablesList.map { it.name }.toSet()
+    val behavioralActionNames =
+      (behavioral.actionsList + behavioral.controlsList.flatMap { it.localActionsList })
+        .flatMap { action -> listOfNotNull(action.name, action.currentName.ifEmpty { null }) }
+        .toSet()
+
+    val tableBindings = bindingMap("table", device.controlPlaneBindings.tablesList)
+    val actionBindings = bindingMap("action", device.controlPlaneBindings.actionsList)
+    val externBindings = bindingMap("extern", device.controlPlaneBindings.externsList)
+
+    val tableById = mutableMapOf<Int, String>()
+    val tableByName = mutableMapOf<String, String>()
+    val requireTableBindings = behavioralTableNames.isNotEmpty()
+    for (table in p4info.tablesList) {
+      val alias = table.preamble.alias.ifEmpty { table.preamble.name }
+      val runtimeName =
+        if (requireTableBindings) requireBinding("table", table.preamble.name, tableBindings)
+        else alias
+      if (requireTableBindings) {
+        require(runtimeName in behavioralTableNames) {
+          "table binding for '${table.preamble.name}' points to unknown behavioral table " +
+            "'$runtimeName'"
+        }
+      }
+      tableById[table.preamble.id] = runtimeName
+      tableByName[runtimeName] = alias
+    }
+
+    val actionById = mutableMapOf<Int, String>()
+    val actionByName = mutableMapOf<String, String>()
+    val requireActionBindings = behavioralActionNames.isNotEmpty()
+    for (action in p4info.actionsList) {
+      val alias = action.preamble.alias.ifEmpty { action.preamble.name }
+      val runtimeName =
+        if (requireActionBindings) requireBinding("action", action.preamble.name, actionBindings)
+        else alias
+      if (requireActionBindings) {
+        require(runtimeName == action.preamble.name || runtimeName in behavioralActionNames) {
+          "action binding for '${action.preamble.name}' points to unknown simulator action " +
+            "'$runtimeName'"
+        }
+      }
+      actionById[action.preamble.id] = runtimeName
+      actionByName[runtimeName] = alias
+    }
+
+    return ControlPlaneNameIndex(
+      tableNameById = tableById,
+      tableAliasByName = tableByName,
+      tableNameByAlias = tableByName.entries.associate { (name, alias) -> alias to name },
+      actionNameById = actionById,
+      actionAliasByName = actionByName,
+      actionIdByName = actionById.entries.associate { (id, name) -> name to id },
+      tableIdByName = tableById.entries.associate { (id, name) -> name to id },
+      actionParamInfo =
+        p4info.actionsList
+          .mapNotNull { action ->
+            val name = actionById[action.preamble.id] ?: return@mapNotNull null
+            name to action.paramsList
+          }
+          .toMap(),
+      tableMatchFields =
+        p4info.tablesList
+          .mapNotNull { table ->
+            val name = tableById[table.preamble.id] ?: return@mapNotNull null
+            name to table.matchFieldsList
+          }
+          .toMap(),
+      counterMappings = buildCounterMappings(p4info, behavioral, externBindings),
+    )
+  }
+
+  private fun bindingMap(
+    kind: String,
+    bindings: List<fourward.ControlPlaneBinding>,
+  ): Map<String, String> {
+    val result = mutableMapOf<String, String>()
+    for (binding in bindings) {
+      require(binding.p4InfoName.isNotEmpty()) { "$kind binding has empty p4info_name" }
+      require(binding.simulatorName.isNotEmpty()) { "$kind binding has empty simulator_name" }
+      val previous = result.put(binding.p4InfoName, binding.simulatorName)
+      require(previous == null || previous == binding.simulatorName) {
+        "conflicting $kind binding for '${binding.p4InfoName}': " +
+          "'$previous' vs '${binding.simulatorName}'"
+      }
+    }
+    return result
+  }
+
+  private fun requireBinding(
+    kind: String,
+    p4infoName: String,
+    bindings: Map<String, String>,
+  ): String =
+    bindings[p4infoName]
+      ?: error(
+        "compiled behavioral config is missing $kind binding for '$p4infoName'; " +
+          "recompile with the current p4c-4ward"
+      )
+
   private fun buildCounterMappings(
     p4info: P4InfoOuterClass.P4Info,
     behavioral: BehavioralConfig,
-    resolveName: (String, List<String>) -> String,
+    externBindings: Map<String, String>,
   ): CounterMappings {
     val externInstanceNames =
       (behavioral.parsersList.flatMap { it.externInstancesList } +
           behavioral.controlsList.flatMap { it.externInstancesList })
         .map { it.name }
+    val requireExternBindings = externInstanceNames.isNotEmpty()
     val countersById = mutableMapOf<Int, IndexedExternInfo>()
     val countersByName = mutableMapOf<String, Int>()
     for (counter in p4info.countersList) {
       val alias = counter.preamble.alias.ifEmpty { counter.preamble.name }
-      val behavioralName = resolveName(alias, externInstanceNames)
+      val runtimeName =
+        if (requireExternBindings) {
+          externBindings[counter.preamble.name]
+            ?: error(
+              "compiled behavioral config is missing extern binding for " +
+                "'${counter.preamble.name}'; recompile with the current p4c-4ward"
+            )
+        } else alias
+      if (requireExternBindings) {
+        require(runtimeName in externInstanceNames) {
+          "extern binding for '${counter.preamble.name}' points to unknown behavioral extern " +
+            "'$runtimeName'"
+        }
+      }
       countersById[counter.preamble.id] = IndexedExternInfo(counter.size.toInt())
-      countersByName[behavioralName] = counter.preamble.id
+      countersByName[runtimeName] = counter.preamble.id
       countersByName[alias] = counter.preamble.id
       if (counter.preamble.name.isNotEmpty())
         countersByName[counter.preamble.name] = counter.preamble.id
     }
     return CounterMappings(countersById, countersByName)
+  }
+
+  private fun buildTableLocalActionNames(
+    p4info: P4InfoOuterClass.P4Info
+  ): Map<String, Map<String, String>> {
+    val actionById = p4info.actionsList.associateBy { it.preamble.id }
+    return p4info.tablesList
+      .mapNotNull { table ->
+        val tableName = tableNameById[table.preamble.id] ?: return@mapNotNull null
+        val namespace = table.preamble.name.substringBeforeLast('.', missingDelimiterValue = "")
+        val localNames = mutableMapOf<String, String>()
+        for (actionRef in table.actionRefsList) {
+          val action = actionById[actionRef.id] ?: continue
+          val actionName = actionNameById[actionRef.id] ?: continue
+          val localName =
+            if (namespace.isNotEmpty() && action.preamble.name.startsWith("$namespace.")) {
+              action.preamble.name.removePrefix("$namespace.")
+            } else {
+              action.preamble.name
+            }
+          val previous = localNames.put(localName, actionName)
+          require(previous == null || previous == actionName) {
+            "table '$tableName' has ambiguous local action name '$localName': " +
+              "'$previous' and '$actionName'"
+          }
+        }
+        tableName to localNames
+      }
+      .toMap()
   }
 
   fun setDefaultAction(
@@ -913,10 +1016,10 @@ class TableStore : TableDataReader {
     displayName: String,
     snapshot: ForwardingSnapshot,
   ): P4RuntimeOuterClass.Entity? {
-    val behavioralName = tableNameByAlias[displayName] ?: displayName
-    if (behavioralName !in snapshot.modifiedDefaults) return null
-    val default = snapshot.defaultActions[behavioralName] ?: return null
-    val tableId = tableIdByName[behavioralName] ?: return null
+    val simulatorName = tableNameByAlias[displayName] ?: displayName
+    if (simulatorName !in snapshot.modifiedDefaults) return null
+    val default = snapshot.defaultActions[simulatorName] ?: return null
+    val tableId = tableIdByName[simulatorName] ?: return null
     val actionId = actionIdByName[default.name] ?: return null
     return P4RuntimeOuterClass.Entity.newBuilder()
       .setTableEntry(
@@ -2033,37 +2136,32 @@ class TableStore : TableDataReader {
           })})"
       )
 
-  /** Resolves an action name (alias or behavioral) to its behavioral name. */
-  fun resolveActionByAlias(name: String): String? {
+  /** Resolves a table-scoped action name to the runtime action key for [tableName]. */
+  fun resolveActionForTable(tableName: String, name: String): String? {
     if (name in actionIdByName) return name
-    // Exact alias match.
-    actionAliasByName.entries
-      .find { it.value == name }
+    tableActionOverrides[tableName]
+      ?.entries
+      ?.find { it.value == name }
       ?.let {
         return it.key
       }
-    // Fuzzy match: nested controls use underscored behavioral names for dotted aliases.
-    val candidates = actionIdByName.keys.toList()
-    val underscored = name.replace('.', '_')
-    candidates
-      .find { it.endsWith("_$name") || it.endsWith("_$underscored") }
-      ?.let {
-        return it
-      }
+    tableLocalActionNames[tableName]?.get(name)?.let {
+      return it
+    }
     return null
   }
 
-  /** Returns the short p4info alias for a behavioral action name, or the name itself if unknown. */
-  fun actionDisplayName(behavioralName: String): String =
-    actionAliasByName[behavioralName] ?: behavioralName
+  /** Returns the short p4info alias for a simulator action name, or the name itself if unknown. */
+  fun actionDisplayName(simulatorName: String): String =
+    actionAliasByName[simulatorName] ?: simulatorName
 
-  /** Returns the short p4info alias for a behavioral table name, or the name itself if unknown. */
-  fun tableDisplayName(behavioralName: String): String =
-    tableAliasByName[behavioralName] ?: behavioralName
+  /** Returns the short p4info alias for a simulator table name, or the name itself if unknown. */
+  fun tableDisplayName(simulatorName: String): String =
+    tableAliasByName[simulatorName] ?: simulatorName
 
-  /** Returns the short p4info alias for a behavioral name (table or action), or the name itself. */
-  fun displayName(behavioralName: String): String =
-    tableAliasByName[behavioralName] ?: actionAliasByName[behavioralName] ?: behavioralName
+  /** Returns the short p4info alias for a simulator name (table or action), or the name itself. */
+  fun displayName(simulatorName: String): String =
+    tableAliasByName[simulatorName] ?: actionAliasByName[simulatorName] ?: simulatorName
 
   /**
    * Scores an entry against [keyByFieldId]. Returns null if the entry does not match. Returns a

--- a/simulator/TableStoreBindingsTest.kt
+++ b/simulator/TableStoreBindingsTest.kt
@@ -1,0 +1,378 @@
+package fourward.simulator
+
+import fourward.ActionDecl
+import fourward.BehavioralConfig
+import fourward.ControlDecl
+import fourward.ControlPlaneBinding
+import fourward.ControlPlaneBindings
+import fourward.DeviceConfig
+import fourward.ExternInstanceDecl
+import fourward.TableBehavior
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import p4.config.v1.P4InfoOuterClass
+import p4.v1.P4RuntimeOuterClass
+
+class TableStoreBindingsTest {
+  @Test
+  fun `loadMappings uses explicit bindings for compiled behavioral names`() {
+    val nestedTableId = 3
+    val nestedActionId = 30
+    val p4info =
+      buildP4Info(
+        tables =
+          listOf(
+            P4InfoOuterClass.Table.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(nestedTableId)
+                  .setName("ingress.inner.myTable")
+                  .setAlias("inner.myTable")
+              )
+              .setConstDefaultActionId(nestedActionId)
+              .build()
+          ),
+        actions =
+          listOf(
+            P4InfoOuterClass.Action.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(nestedActionId)
+                  .setName("ingress.inner.myAction")
+                  .setAlias("inner.myAction")
+              )
+              .build()
+          ),
+      )
+    val device =
+      DeviceConfig.newBuilder()
+        .setBehavioral(
+          BehavioralConfig.newBuilder()
+            .addTables(
+              TableBehavior.newBuilder()
+                .setName("inner_myTable")
+                .putActionOverrides("ingress.inner.myAction", "inner_myAction")
+            )
+            .addActions(ActionDecl.newBuilder().setName("inner_myAction"))
+        )
+        .setControlPlaneBindings(
+          ControlPlaneBindings.newBuilder()
+            .addTables(binding("ingress.inner.myTable", "inner_myTable"))
+            .addActions(binding("ingress.inner.myAction", "ingress.inner.myAction"))
+        )
+        .build()
+    val store = TableStore()
+    store.loadMappings(p4info = p4info, device = device)
+
+    val result = store.lookup("inner_myTable", emptyList())
+    assertEquals("ingress.inner.myAction", result.actionName)
+  }
+
+  @Test
+  fun `resolveActionForTable accepts source action name in table namespace`() {
+    val tableId = 3
+    val hitActionId = 30
+    val missActionId = 31
+    val p4info =
+      buildP4Info(
+        tables =
+          listOf(
+            P4InfoOuterClass.Table.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(tableId)
+                  .setName("MainControlImpl.outbound.conntrack.ct_tcp_table")
+                  .setAlias("outbound.conntrack.ct_tcp_table")
+              )
+              .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(hitActionId))
+              .addActionRefs(P4InfoOuterClass.ActionRef.newBuilder().setId(missActionId))
+              .build()
+          ),
+        actions =
+          listOf(
+            P4InfoOuterClass.Action.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(hitActionId)
+                  .setName("MainControlImpl.outbound.conntrack.ct_tcp_table_hit")
+                  .setAlias("outbound.conntrack.ct_tcp_table_hit")
+              )
+              .build(),
+            P4InfoOuterClass.Action.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(missActionId)
+                  .setName("MainControlImpl.outbound.conntrack.ct_tcp_table_miss")
+                  .setAlias("outbound.conntrack.ct_tcp_table_miss")
+              )
+              .build(),
+          ),
+      )
+    val device =
+      DeviceConfig.newBuilder()
+        .setBehavioral(
+          BehavioralConfig.newBuilder()
+            .addTables(
+              TableBehavior.newBuilder()
+                .setName("outbound_conntrack_ct_tcp_table")
+                .putActionOverrides(
+                  "MainControlImpl.outbound.conntrack.ct_tcp_table_hit",
+                  "outbound_conntrack_ct_tcp_table_hit_0",
+                )
+                .putActionOverrides(
+                  "MainControlImpl.outbound.conntrack.ct_tcp_table_miss",
+                  "outbound_conntrack_ct_tcp_table_miss_0",
+                )
+            )
+            .addActions(ActionDecl.newBuilder().setName("outbound_conntrack_ct_tcp_table_hit_0"))
+            .addActions(ActionDecl.newBuilder().setName("outbound_conntrack_ct_tcp_table_miss_0"))
+        )
+        .setControlPlaneBindings(
+          ControlPlaneBindings.newBuilder()
+            .addTables(
+              binding(
+                "MainControlImpl.outbound.conntrack.ct_tcp_table",
+                "outbound_conntrack_ct_tcp_table",
+              )
+            )
+            .addActions(
+              binding(
+                "MainControlImpl.outbound.conntrack.ct_tcp_table_hit",
+                "MainControlImpl.outbound.conntrack.ct_tcp_table_hit",
+              )
+            )
+            .addActions(
+              binding(
+                "MainControlImpl.outbound.conntrack.ct_tcp_table_miss",
+                "MainControlImpl.outbound.conntrack.ct_tcp_table_miss",
+              )
+            )
+        )
+        .build()
+    val store = TableStore()
+    store.loadMappings(p4info = p4info, device = device)
+
+    assertEquals(
+      "MainControlImpl.outbound.conntrack.ct_tcp_table_hit",
+      store.resolveActionForTable("outbound_conntrack_ct_tcp_table", "ct_tcp_table_hit"),
+    )
+  }
+
+  @Test
+  fun `loadMappings rejects compiled behavioral config without table binding`() {
+    val p4info =
+      buildP4Info(
+        tables =
+          listOf(
+            P4InfoOuterClass.Table.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(4)
+                  .setName("ingress.inner.myTable")
+                  .setAlias("inner.myTable")
+              )
+              .build()
+          )
+      )
+    val device =
+      DeviceConfig.newBuilder()
+        .setBehavioral(
+          BehavioralConfig.newBuilder()
+            .addTables(TableBehavior.newBuilder().setName("inner_myTable"))
+        )
+        .build()
+    val store = TableStore()
+
+    val thrown =
+      try {
+        store.loadMappings(p4info = p4info, device = device)
+        null
+      } catch (e: IllegalStateException) {
+        e
+      }
+
+    assertNotNull(thrown)
+    assertEquals(
+      "compiled behavioral config is missing table binding for 'ingress.inner.myTable'; " +
+        "recompile with the current p4c-4ward",
+      thrown!!.message,
+    )
+  }
+
+  @Test
+  fun `loadMappings keeps duplicate action aliases distinct through explicit bindings`() {
+    val routeDropId = 30
+    val aclDropId = 31
+    val p4info =
+      buildP4Info(
+        tables =
+          listOf(
+            P4InfoOuterClass.Table.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(3)
+                  .setName("ingress.routing_lookup.ipv4_table")
+                  .setAlias("ipv4_table")
+              )
+              .setConstDefaultActionId(routeDropId)
+              .build()
+          ),
+        actions =
+          listOf(
+            P4InfoOuterClass.Action.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(routeDropId)
+                  .setName("ingress.routing_lookup.drop")
+                  .setAlias("drop")
+              )
+              .build(),
+            P4InfoOuterClass.Action.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(aclDropId)
+                  .setName("ingress.acl.drop")
+                  .setAlias("drop")
+              )
+              .build(),
+          ),
+      )
+    val device =
+      DeviceConfig.newBuilder()
+        .setBehavioral(
+          BehavioralConfig.newBuilder()
+            .addTables(
+              TableBehavior.newBuilder()
+                .setName("routing_lookup_ipv4_table")
+                .putActionOverrides("ingress.routing_lookup.drop", "routing_lookup_drop")
+            )
+            .addActions(ActionDecl.newBuilder().setName("routing_lookup_drop"))
+            .addActions(ActionDecl.newBuilder().setName("acl_drop"))
+        )
+        .setControlPlaneBindings(
+          ControlPlaneBindings.newBuilder()
+            .addTables(binding("ingress.routing_lookup.ipv4_table", "routing_lookup_ipv4_table"))
+            .addActions(binding("ingress.routing_lookup.drop", "ingress.routing_lookup.drop"))
+            .addActions(binding("ingress.acl.drop", "ingress.acl.drop"))
+        )
+        .build()
+    val store = TableStore()
+    store.loadMappings(p4info = p4info, device = device)
+
+    val result = store.lookup("routing_lookup_ipv4_table", emptyList())
+    assertEquals("ingress.routing_lookup.drop", result.actionName)
+  }
+
+  @Test
+  fun `loadMappings rejects action binding to unknown simulator action`() {
+    val p4info =
+      buildP4Info(
+        actions =
+          listOf(
+            P4InfoOuterClass.Action.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(30)
+                  .setName("ingress.inner.myAction")
+                  .setAlias("inner.myAction")
+              )
+              .build()
+          )
+      )
+    val device =
+      DeviceConfig.newBuilder()
+        .setBehavioral(
+          BehavioralConfig.newBuilder().addActions(ActionDecl.newBuilder().setName("known_action"))
+        )
+        .setControlPlaneBindings(
+          ControlPlaneBindings.newBuilder()
+            .addActions(binding("ingress.inner.myAction", "missing_action"))
+        )
+        .build()
+    val store = TableStore()
+
+    val thrown =
+      try {
+        store.loadMappings(p4info = p4info, device = device)
+        null
+      } catch (e: IllegalArgumentException) {
+        e
+      }
+
+    assertNotNull(thrown)
+    assertEquals(
+      "action binding for 'ingress.inner.myAction' points to unknown simulator action " +
+        "'missing_action'",
+      thrown!!.message,
+    )
+  }
+
+  @Test
+  fun `loadMappings uses explicit bindings for compiled counter extern names`() {
+    val counterId = 5
+    val p4info =
+      buildP4Info(
+        counters =
+          listOf(
+            P4InfoOuterClass.Counter.newBuilder()
+              .setPreamble(
+                P4InfoOuterClass.Preamble.newBuilder()
+                  .setId(counterId)
+                  .setName("ingress.inner.pktCounter")
+                  .setAlias("inner.pktCounter")
+              )
+              .setSize(4)
+              .build()
+          )
+      )
+    val device =
+      DeviceConfig.newBuilder()
+        .setBehavioral(
+          BehavioralConfig.newBuilder()
+            .addControls(
+              ControlDecl.newBuilder()
+                .addExternInstances(
+                  ExternInstanceDecl.newBuilder().setTypeName("Counter").setName("inner_pktCounter")
+                )
+            )
+        )
+        .setControlPlaneBindings(
+          ControlPlaneBindings.newBuilder()
+            .addExterns(binding("ingress.inner.pktCounter", "inner_pktCounter"))
+        )
+        .build()
+    val store = TableStore()
+    store.loadMappings(p4info = p4info, device = device)
+
+    store.counterIncrement("inner_pktCounter", index = 2, byteCount = 9)
+
+    val results =
+      store.readCounterEntries(
+        P4RuntimeOuterClass.CounterEntry.newBuilder()
+          .setCounterId(counterId)
+          .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(2))
+          .build()
+      )
+    assertEquals(1, results.size)
+    assertEquals(1, results[0].counterEntry.data.packetCount)
+    assertEquals(9, results[0].counterEntry.data.byteCount)
+  }
+
+  private fun buildP4Info(
+    tables: List<P4InfoOuterClass.Table> = emptyList(),
+    actions: List<P4InfoOuterClass.Action> = emptyList(),
+    counters: List<P4InfoOuterClass.Counter> = emptyList(),
+  ): P4InfoOuterClass.P4Info =
+    P4InfoOuterClass.P4Info.newBuilder()
+      .addAllTables(tables)
+      .addAllActions(actions)
+      .addAllCounters(counters)
+      .build()
+
+  private fun binding(p4infoName: String, simulatorName: String): ControlPlaneBinding =
+    ControlPlaneBinding.newBuilder()
+      .setP4InfoName(p4infoName)
+      .setSimulatorName(simulatorName)
+      .build()
+}

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -89,7 +89,7 @@ class TableStoreTest {
     constDefaultActionId: Int = 0,
   ): P4InfoOuterClass.Table =
     P4InfoOuterClass.Table.newBuilder()
-      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setAlias(name))
+      .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setName(name).setAlias(name))
       .setSize(size)
       .setImplementationId(implementationId)
       .setConstDefaultActionId(constDefaultActionId)
@@ -247,9 +247,24 @@ class TableStoreTest {
     DeviceConfig.newBuilder()
       .setBehavioral(
         BehavioralConfig.newBuilder()
-          .addTables(TableBehavior.newBuilder().setName(TABLE_NAME))
+          .addTables(
+            TableBehavior.newBuilder()
+              .setName(TABLE_NAME)
+              .putAllActionOverrides(ACTION_IDS.associate { "action$it" to "action$it" })
+          )
           .addAllActions(actions.toList())
       )
+      .setControlPlaneBindings(
+        fourward.ControlPlaneBindings.newBuilder()
+          .addTables(binding(TABLE_NAME, TABLE_NAME))
+          .addAllActions(ACTION_IDS.map { binding("action$it", "action$it") })
+      )
+      .build()
+
+  private fun binding(p4infoName: String, simulatorName: String): fourward.ControlPlaneBinding =
+    fourward.ControlPlaneBinding.newBuilder()
+      .setP4InfoName(p4infoName)
+      .setSimulatorName(simulatorName)
       .build()
 
   private fun write(entry: TableEntry) {
@@ -1232,147 +1247,6 @@ class TableStoreTest {
     store.loadMappings(p4info = BASE_P4INFO)
 
     assertEquals("NoAction", store.lookup(TABLE_NAME, emptyList()).actionName)
-  }
-
-  // ---------------------------------------------------------------------------
-  // Dotted alias resolution for nested controls
-  // ---------------------------------------------------------------------------
-
-  @Test
-  fun `loadMappings resolves dotted aliases to underscored behavioral names`() {
-    // Simulate inlined nested controls: p4info uses dotted aliases (e.g. "ct.t"),
-    // while behavioral IR uses underscored names (e.g. "ct_t").
-    val nestedTableId = 3
-    val nestedActionId = 30
-    val p4info =
-      buildP4Info(
-        tables =
-          listOf(
-            P4InfoOuterClass.Table.newBuilder()
-              .setPreamble(
-                P4InfoOuterClass.Preamble.newBuilder()
-                  .setId(nestedTableId)
-                  .setAlias("inner.myTable")
-              )
-              .setConstDefaultActionId(nestedActionId)
-              .build()
-          ),
-        actions =
-          listOf(
-            P4InfoOuterClass.Action.newBuilder()
-              .setPreamble(
-                P4InfoOuterClass.Preamble.newBuilder()
-                  .setId(nestedActionId)
-                  .setAlias("inner.myAction")
-              )
-              .build()
-          ),
-      )
-    val device =
-      fourward.DeviceConfig.newBuilder()
-        .setBehavioral(
-          fourward.BehavioralConfig.newBuilder()
-            .addTables(fourward.TableBehavior.newBuilder().setName("inner_myTable"))
-            .addActions(fourward.ActionDecl.newBuilder().setName("inner_myAction"))
-        )
-        .build()
-    val s = TableStore()
-    s.loadMappings(p4info = p4info, device = device)
-    // The dotted alias "inner.myTable" should resolve to behavioral "inner_myTable",
-    // and the default action "inner.myAction" should resolve to "inner_myAction".
-    val result = s.lookup("inner_myTable", emptyList())
-    assertEquals("inner_myAction", result.actionName)
-  }
-
-  @Test
-  fun `loadMappings resolves control-prefixed aliases to short behavioral names`() {
-    // When two tables share a short name, p4c disambiguates with the control prefix
-    // (e.g. alias "MainControl.t" for behavioral name "t").
-    val tableId = 4
-    val actionId = 40
-    val p4info =
-      buildP4Info(
-        tables =
-          listOf(
-            P4InfoOuterClass.Table.newBuilder()
-              .setPreamble(
-                P4InfoOuterClass.Preamble.newBuilder()
-                  .setId(tableId)
-                  .setAlias("MainControl.myTable")
-              )
-              .setConstDefaultActionId(actionId)
-              .build()
-          ),
-        actions =
-          listOf(
-            P4InfoOuterClass.Action.newBuilder()
-              .setPreamble(
-                P4InfoOuterClass.Preamble.newBuilder()
-                  .setId(actionId)
-                  .setAlias("MainControl.myAction")
-              )
-              .build()
-          ),
-      )
-    val device =
-      fourward.DeviceConfig.newBuilder()
-        .setBehavioral(
-          fourward.BehavioralConfig.newBuilder()
-            .addTables(fourward.TableBehavior.newBuilder().setName("myTable"))
-            .addActions(fourward.ActionDecl.newBuilder().setName("myAction"))
-        )
-        .build()
-    val s = TableStore()
-    s.loadMappings(p4info = p4info, device = device)
-    // "MainControl.myTable" should resolve to "myTable" by stripping the control prefix.
-    val result = s.lookup("myTable", emptyList())
-    assertEquals("myAction", result.actionName)
-  }
-
-  @Test
-  fun `loadMappings resolves dotted counter aliases to underscored extern names`() {
-    val counterId = 5
-    val p4info =
-      buildP4Info(
-        counters =
-          listOf(
-            P4InfoOuterClass.Counter.newBuilder()
-              .setPreamble(
-                P4InfoOuterClass.Preamble.newBuilder().setId(counterId).setAlias("inner.pktCounter")
-              )
-              .setSize(4)
-              .build()
-          )
-      )
-    val device =
-      fourward.DeviceConfig.newBuilder()
-        .setBehavioral(
-          fourward.BehavioralConfig.newBuilder()
-            .addControls(
-              fourward.ControlDecl.newBuilder()
-                .addExternInstances(
-                  fourward.ExternInstanceDecl.newBuilder()
-                    .setTypeName("Counter")
-                    .setName("inner_pktCounter")
-                )
-            )
-        )
-        .build()
-    val s = TableStore()
-    s.loadMappings(p4info = p4info, device = device)
-
-    s.counterIncrement("inner_pktCounter", index = 2, byteCount = 9)
-
-    val results =
-      s.readCounterEntries(
-        P4RuntimeOuterClass.CounterEntry.newBuilder()
-          .setCounterId(counterId)
-          .setIndex(P4RuntimeOuterClass.Index.newBuilder().setIndex(2))
-          .build()
-      )
-    assertEquals(1, results.size)
-    assertEquals(1, results[0].counterEntry.data.packetCount)
-    assertEquals(9, results[0].counterEntry.data.byteCount)
   }
 
   // ---------------------------------------------------------------------------
@@ -3463,7 +3337,12 @@ class TableStoreTest {
     private val ACTION_LIST: List<P4InfoOuterClass.Action> =
       ACTION_IDS.map { id ->
         P4InfoOuterClass.Action.newBuilder()
-          .setPreamble(P4InfoOuterClass.Preamble.newBuilder().setId(id).setAlias("action$id"))
+          .setPreamble(
+            P4InfoOuterClass.Preamble.newBuilder()
+              .setId(id)
+              .setName("action$id")
+              .setAlias("action$id")
+          )
           .build()
       }
 
@@ -3473,7 +3352,10 @@ class TableStoreTest {
         .addTables(
           P4InfoOuterClass.Table.newBuilder()
             .setPreamble(
-              P4InfoOuterClass.Preamble.newBuilder().setId(TABLE_ID).setAlias(TABLE_NAME)
+              P4InfoOuterClass.Preamble.newBuilder()
+                .setId(TABLE_ID)
+                .setName(TABLE_NAME)
+                .setAlias(TABLE_NAME)
             )
         )
         .addAllActions(ACTION_LIST)

--- a/simulator/ir.proto
+++ b/simulator/ir.proto
@@ -62,6 +62,12 @@ message DeviceConfig {
   // Type translation mappings for @p4runtime_translation-annotated types.
   // Keyed by URI. When absent for a translated type, auto-allocation is used.
   repeated TypeTranslation translations = 3;
+
+  // Exact names that connect p4info's control-plane surface to this
+  // behavioral IR. The p4c backend emits these while both symbol spaces are in
+  // scope; the simulator treats them as required whenever a compiled
+  // behavioral config contains the corresponding kind of symbol.
+  ControlPlaneBindings control_plane_bindings = 4;
 }
 
 // Behavioral IR: the execution semantics of a compiled P4 program.
@@ -75,6 +81,24 @@ message BehavioralConfig {
   // Supplements p4info's table descriptions with key expressions to evaluate.
   // One entry per table; name matches p4info table preamble name.
   repeated TableBehavior tables = 6;
+}
+
+message ControlPlaneBindings {
+  repeated ControlPlaneBinding tables = 1;
+  repeated ControlPlaneBinding actions = 2;
+  repeated ControlPlaneBinding externs = 3;
+}
+
+message ControlPlaneBinding {
+  // Fully qualified p4info preamble.name, e.g.
+  // "ingress.routing_lookup.ipv4_table".
+  string p4info_name = 1;
+
+  // The runtime name consumed by the simulator. For tables and externs this is
+  // the IR declaration name. For actions this is the fully qualified p4info
+  // action name; TableBehavior.action_overrides resolves it to the executable
+  // midend action copy for each table.
+  string simulator_name = 2;
 }
 
 // =============================================================================
@@ -379,20 +403,22 @@ message ExternInstanceDecl {
 }
 
 message ActionDecl {
-  // Semantic name: matches the p4info alias and originalName (used for table
-  // dispatch).
+  // Source-level action name from p4c's originalName. The interpreter indexes
+  // actions under this name and current_name; table dispatch uses
+  // TableBehavior.action_overrides to select one of those executable names from
+  // the fully qualified p4info action name.
   string name = 1;
   repeated ParamDecl params = 2;
   repeated Stmt body = 3;
   // Post-midend name if renamed (e.g. "do_thing_1" when "do_thing" was
   // duplicated). Populated only when different from name. The interpreter
-  // indexes actions under both name and current_name so both table dispatch and
-  // inline calls resolve.
+  // indexes actions under both name and current_name so table dispatch and
+  // inline calls can resolve to the executable body p4c selected.
   string current_name = 4;
 }
 
 // Supplements the p4info table description with key expressions.
-// Name must match p4info table.preamble.name.
+// Name is the behavioral table name used by the interpreter.
 message TableBehavior {
   string name = 1;
 
@@ -400,10 +426,10 @@ message TableBehavior {
   // expression to produce the lookup key.
   repeated TableKey keys = 2;
 
-  // Maps original action name → midend-specialized name for this table.
-  // When p4c duplicates an action for per-table specialization (e.g.
-  // "setbyte" → "setbyte_1"), the p4info still uses the single original
-  // action ID. This map lets the interpreter resolve the correct copy.
+  // Maps fully qualified p4info action name → executable behavioral action name
+  // for this table. This is intentionally table-scoped: the same p4info alias
+  // can appear in multiple controls, and the midend can also duplicate an
+  // action for per-table specialization.
   map<string, string> action_overrides = 3;
 }
 


### PR DESCRIPTION
## Summary

Fixes the issue-787 root cause by replacing simulator-side fuzzy P4Info alias resolution with compiler-emitted exact control-plane bindings.

The p4c backend now emits explicit P4Info-to-behavioral bindings for tables, actions, and externs while both symbol spaces are available. The simulator requires those bindings for compiled behavioral configs and fails loudly if an old config is loaded without them.

## Root Cause

The simulator resolved P4Info aliases such as `drop` by suffix matching against behavioral action names. In the SAI pipeline, `ingress.routing_lookup.drop` could resolve to the ACL `acl_drop` action because multiple actions shared the short alias `drop`. That meant the routing table miss default action did not execute `mark_to_drop`, so later forwarding state could still produce forwarded outcomes.

## Changes

- Add `DeviceConfig.control_plane_bindings` to `ir.proto`.
- Emit exact bindings from the p4c backend.
- Make `TableStore.loadMappings` require bindings for compiled behavioral configs.
- Resolve table actions through fully qualified P4Info action names and table-local executable action overrides.
- Remove the fuzzy/suffix control-plane resolver path.
- Add focused binding tests, including duplicate `drop` aliases.

## Validation

- `bazel test //simulator/...`
- `bazel build //p4c_backend:p4c-4ward //e2e_tests/sai_p4:sai_middleblock`
- `./tools/format.sh`
- `./tools/lint.sh`

Verified the generated SAI middleblock maps `ingress.routing_lookup.drop` to `routing_lookup_drop_0` for `routing_lookup_ipv4_table`.

Fixes #787
