### PR TITLE
[codex] Enable Kotlin checked return values

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,16 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_kotlin", version = "2.3.20")
 
+# WORKAROUND: rules_kotlin@2.3.20's Kotlin capability metadata knows about
+# `-Xreturn-value-checker`, but its Starlark option surface does not expose
+# an attribute for it. Keep this patch until rules_kotlin exposes the option
+# directly.
+single_version_override(
+    module_name = "rules_kotlin",
+    patch_strip = 1,
+    patches = ["//bazel:rules_kotlin_return_value_checker.patch"],
+)
+
 # `dev_dependency` so the strict-deps toolchain only activates when
 # 4ward is the root module; BCR consumers see the default rules_kotlin
 # toolchain. Same scoping as the `single_version_override` below.

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -74,7 +74,6 @@ bzl_library(
 kt_kotlinc_options(
     name = "fourward_kotlinc_options",
     warn = "error",
-    x_return_value_checker = "check",
 )
 
 define_kt_toolchain(

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -74,6 +74,7 @@ bzl_library(
 kt_kotlinc_options(
     name = "fourward_kotlinc_options",
     warn = "error",
+    x_return_value_checker = "check",
 )
 
 define_kt_toolchain(

--- a/bazel/rules_kotlin_return_value_checker.patch
+++ b/bazel/rules_kotlin_return_value_checker.patch
@@ -1,0 +1,30 @@
+diff --git a/src/main/starlark/core/options/opts.kotlinc.bzl b/src/main/starlark/core/options/opts.kotlinc.bzl
+index 7ba20530..630d012b 100644
+--- a/src/main/starlark/core/options/opts.kotlinc.bzl
++++ b/src/main/starlark/core/options/opts.kotlinc.bzl
+@@ -423,6 +423,25 @@
+             True: ["-Xreport-perf"],
+         },
+     ),
++    "x_return_value_checker": struct(
++        flag = "-Xreturn-value-checker",
++        args = dict(
++            default = "disable",
++            doc = """Set improved unused return value checker mode.
++
++Options:
++- 'disable': Disable the unused return value checker.
++- 'check': Report ignored results from marked functions.
++- 'full': Also enable automatic annotation insertion.""",
++            values = ["disable", "check", "full"],
++        ),
++        type = attr.string,
++        value_to_flag = {
++            "check": ["-Xreturn-value-checker=check"],
++            "disable": None,
++            "full": ["-Xreturn-value-checker=full"],
++        },
++    ),
+     "x_sam_conversions": struct(
+         flag = "-Xsam-conversions",
+         args = dict(

--- a/bazel/rules_kotlin_return_value_checker.patch
+++ b/bazel/rules_kotlin_return_value_checker.patch
@@ -9,7 +9,7 @@ index 7ba20530..630d012b 100644
 +    "x_return_value_checker": struct(
 +        flag = "-Xreturn-value-checker",
 +        args = dict(
-+            default = "disable",
++            default = "check",
 +            doc = """Set improved unused return value checker mode.
 +
 +Options:
@@ -21,7 +21,7 @@ index 7ba20530..630d012b 100644
 +        type = attr.string,
 +        value_to_flag = {
 +            "check": ["-Xreturn-value-checker=check"],
-+            "disable": None,
++            "disable": ["-Xreturn-value-checker=disable"],
 +            "full": ["-Xreturn-value-checker=full"],
 +        },
 +    ),

--- a/grpc/MultiDeviceServiceTest.kt
+++ b/grpc/MultiDeviceServiceTest.kt
@@ -1,3 +1,7 @@
+// See comment in GoldenErrorTest.kt — `val unused = stub.X(...)` discards must-be-used gRPC
+// return values flagged by the downstream sync's `@CheckReturnValue` lint.
+@file:Suppress("UnusedPrivateProperty")
+
 package fourward.grpc
 
 import com.google.protobuf.ByteString
@@ -266,17 +270,18 @@ class MultiDeviceServiceTest {
       management.listDevices(ListDevicesRequest.getDefaultInstance()).deviceIdsList
 
     suspend fun loadPipeline(deviceId: Long, config: fourward.PipelineConfig) {
-      p4rt.setForwardingPipelineConfig(
-        SetForwardingPipelineConfigRequest.newBuilder()
-          .setDeviceId(deviceId)
-          .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
-          .setConfig(
-            ForwardingPipelineConfig.newBuilder()
-              .setP4Info(config.p4Info)
-              .setP4DeviceConfig(config.device.toByteString())
-          )
-          .build()
-      )
+      val unused =
+        p4rt.setForwardingPipelineConfig(
+          SetForwardingPipelineConfigRequest.newBuilder()
+            .setDeviceId(deviceId)
+            .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+            .setConfig(
+              ForwardingPipelineConfig.newBuilder()
+                .setP4Info(config.p4Info)
+                .setP4DeviceConfig(config.device.toByteString())
+            )
+            .build()
+        )
     }
 
     suspend fun getConfig(deviceId: Long) =

--- a/simulator/ArchitectureHelpers.kt
+++ b/simulator/ArchitectureHelpers.kt
@@ -100,14 +100,18 @@ internal fun createDefaultValues(
   for (parser in config.parsersList) {
     for (param in parser.paramsList) {
       if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
-        values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
+        if (!values.containsKey(param.type.named)) {
+          values[param.type.named] = defaultValue(param.type.named, typesByName)
+        }
       }
     }
   }
   for (control in config.controlsList) {
     for (param in control.paramsList) {
       if (param.type.hasNamed() && param.type.named !in IO_TYPES) {
-        values.getOrPut(param.type.named) { defaultValue(param.type.named, typesByName) }
+        if (!values.containsKey(param.type.named)) {
+          values[param.type.named] = defaultValue(param.type.named, typesByName)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Enable Kotlin's checked return value mode in the root build so ignored results from must-use APIs fail in GitHub CI, matching the downstream check that reported #790.

This fixes the reported ignored `setForwardingPipelineConfig(...)` result in `MultiDeviceServiceTest` by explicitly discarding it with the existing `val unused = ...` pattern. Enabling the checker also surfaced two ignored `getOrPut` results in `ArchitectureHelpers`; those cache-population sites now use explicit `containsKey`/assignment logic instead.

`rules_kotlin@2.3.20` already knows about the Kotlin flag in capability metadata, but its Starlark option surface does not expose an attribute for it. This PR carries a small root-module patch until upstream exposes `x_return_value_checker` directly.

Fixes #790.

## Validation

- `bazel test //grpc:MultiDeviceServiceTest`
- `bazel test //... --test_tag_filters=-heavy`
- `./tools/format.sh`
- `./tools/lint.sh`