### PR TITLE
[codex] Harden pipeline output follow-up coverage

### DIFF
--- a/e2e_tests/pipeline_outputs/BUILD.bazel
+++ b/e2e_tests/pipeline_outputs/BUILD.bazel
@@ -22,6 +22,13 @@ fourward_pipeline(
     out_format = "p4runtime",
 )
 
+fourward_pipeline(
+    name = "tiny_p4runtime_repeat",
+    src = "tiny.p4",
+    out = "tiny_p4runtime.repeat.binpb",
+    out_format = "p4runtime",
+)
+
 # Standalone p4info outputs, one target per encoding.
 fourward_pipeline(
     name = "tiny_p4info_txtpb",
@@ -35,6 +42,12 @@ fourward_pipeline(
     out_p4info = "tiny.p4info.binpb",
 )
 
+fourward_pipeline(
+    name = "tiny_p4info_binpb_repeat",
+    src = "tiny.p4",
+    out_p4info = "tiny.p4info.repeat.binpb",
+)
+
 # Standalone device-config outputs, one target per encoding.
 fourward_pipeline(
     name = "tiny_device_config_txtpb",
@@ -46,6 +59,12 @@ fourward_pipeline(
     name = "tiny_device_config_binpb",
     src = "tiny.p4",
     out_p4_device_config = "tiny.device_config.binpb",
+)
+
+fourward_pipeline(
+    name = "tiny_device_config_binpb_repeat",
+    src = "tiny.p4",
+    out_p4_device_config = "tiny.device_config.repeat.binpb",
 )
 
 # All three outputs from a single action, mixing encodings to ensure per-file
@@ -65,11 +84,14 @@ kt_jvm_test(
     data = [
         ":tiny_all",
         ":tiny_device_config_binpb",
+        ":tiny_device_config_binpb_repeat",
         ":tiny_device_config_txtpb",
         ":tiny_native",
         ":tiny_p4info_binpb",
+        ":tiny_p4info_binpb_repeat",
         ":tiny_p4info_txtpb",
         ":tiny_p4runtime",
+        ":tiny_p4runtime_repeat",
         # Regression fixture for #592: large (~130 KB) binpb output that
         # exercises multi-buffer-chunk writes.
         "//e2e_tests/sai_p4:sai_middleblock",

--- a/e2e_tests/pipeline_outputs/PipelineOutputsTest.kt
+++ b/e2e_tests/pipeline_outputs/PipelineOutputsTest.kt
@@ -6,6 +6,7 @@ import fourward.PipelineConfig
 import fourward.bazel.repoRoot
 import java.nio.file.Files
 import java.nio.file.Path
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -126,7 +127,26 @@ class PipelineOutputsTest {
     assertEquals(dcStandalone, dc)
   }
 
+  @Test
+  fun `binary outputs are byte-identical across compiler invocations`() {
+    // tiny.p4 has a table with multiple actions, so the DeviceConfig contains
+    // action_overrides: a protobuf map whose wire order used to depend on hash
+    // iteration. These duplicate Bazel actions run separate p4c processes and
+    // compare the raw bytes, not just parsed proto equality.
+    assertSameBytes("p4runtime", "tiny_p4runtime.binpb", "tiny_p4runtime.repeat.binpb")
+    assertSameBytes("p4info", "tiny.p4info.binpb", "tiny.p4info.repeat.binpb")
+    assertSameBytes("device config", "tiny.device_config.binpb", "tiny.device_config.repeat.binpb")
+  }
+
   private fun runfile(name: String): Path = repoRoot.resolve("e2e_tests/pipeline_outputs/$name")
+
+  private fun assertSameBytes(label: String, expected: String, actual: String) {
+    assertArrayEquals(
+      "$label output should be deterministic",
+      Files.readAllBytes(runfile(expected)),
+      Files.readAllBytes(runfile(actual)),
+    )
+  }
 
   private fun assertHeader(path: Path, expectedMessage: String) {
     val firstTwo = Files.readAllLines(path).take(2)

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -8,6 +8,9 @@ import fourward.SubscribeResultsResponse
 import fourward.TranslationEntry
 import fourward.TypeTranslation
 import io.grpc.Status
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.launch
@@ -615,47 +618,42 @@ class SaiP4E2ETest {
       installAclEntry(findAction("acl_drop"))
 
       val stub = DataplaneCoroutineStub(harness.channel)
-      val results = Channel<SubscribeResultsResponse>(UNLIMITED)
-      val job = launch {
-        stub.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
-          results.send(it)
+      val (job, results) = subscribeAndAwaitActive(stub)
+      try {
+        val packetOut = buildCpuPacketOut(submitToIngress = false)
+
+        harness.openStream().use { session ->
+          session.arbitrate()
+          session.sendPacketOut(packetOut, timeoutMs = FourwardTestHarness.NO_RESPONSE_TIMEOUT_MS)
+
+          val msg = withTimeout(SUBSCRIBE_RESULT_TIMEOUT_MS) { results.receive() }
+          assertTrue("should be a result", msg.hasResult())
+          val outputs = msg.result.possibleOutcomesList.single().packetsList
+          assertEquals(
+            "submit_to_ingress=0 should bypass ingress (ACL drop) and exit on egress_port",
+            1,
+            outputs.size,
+          )
+          assertEquals(
+            "should exit on the PacketOut's egress_port",
+            "Ethernet1",
+            outputs[0].p4RtEgressPort.toStringUtf8(),
+          )
+          val expectedPayload = packetOut.payload.toByteArray()
+          val actualPayload = outputs[0].payload.toByteArray()
+          assertEquals(
+            "PacketOut controller header bits must not leak into output payload",
+            expectedPayload.size,
+            actualPayload.size,
+          )
+          assertBytesEqual("dst_mac", UNICAST_MAC, actualPayload, 0)
+          assertBytesEqual("src_mac", SRC_MAC, actualPayload, MAC_LEN)
+          assertBytesEqual("src_ip", SRC_IP, actualPayload, SRC_IP_OFFSET)
+          assertBytesEqual("dst_ip", DST_IP, actualPayload, DST_IP_OFFSET)
         }
+      } finally {
+        job.cancelAndJoin()
       }
-      val first = withTimeout(5000) { results.receive() }
-      assertTrue("first message should be SubscriptionActive", first.hasActive())
-      val packetOut = buildCpuPacketOut(submitToIngress = false)
-
-      harness.openStream().use { session ->
-        session.arbitrate()
-        session.sendPacketOut(packetOut, timeoutMs = FourwardTestHarness.NO_RESPONSE_TIMEOUT_MS)
-
-        val msg = withTimeout(5000) { results.receive() }
-        assertTrue("should be a result", msg.hasResult())
-        val outputs = msg.result.possibleOutcomesList.single().packetsList
-        assertEquals(
-          "submit_to_ingress=0 should bypass ingress (ACL drop) and exit on egress_port",
-          1,
-          outputs.size,
-        )
-        assertEquals(
-          "should exit on the PacketOut's egress_port",
-          "Ethernet1",
-          outputs[0].p4RtEgressPort.toStringUtf8(),
-        )
-        val expectedPayload = packetOut.payload.toByteArray()
-        val actualPayload = outputs[0].payload.toByteArray()
-        assertEquals(
-          "PacketOut controller header bits must not leak into output payload",
-          expectedPayload.size,
-          actualPayload.size,
-        )
-        assertBytesEqual("dst_mac", UNICAST_MAC, actualPayload, 0)
-        assertBytesEqual("src_mac", SRC_MAC, actualPayload, MAC_LEN)
-        assertBytesEqual("src_ip", SRC_IP, actualPayload, SRC_IP_OFFSET)
-        assertBytesEqual("dst_ip", DST_IP, actualPayload, DST_IP_OFFSET)
-      }
-
-      job.cancel()
     }
 
   @Test
@@ -2179,6 +2177,8 @@ class SaiP4E2ETest {
       .toStringUtf8()
 
   companion object {
+    private const val SUBSCRIBE_RESULT_TIMEOUT_MS = 20_000L
+
     // CPU port = 2^9 - 2 = 510 for 9-bit ports (SAI P4 ids.h: SAI_P4_CPU_PORT).
     private const val CPU_PORT = 510
     private const val COPY_TO_CPU_SESSION_ID = 255
@@ -2240,5 +2240,19 @@ class SaiP4E2ETest {
     @Suppress("MagicNumber")
     private val IPV6_2001_DB8 =
       byteArrayOf(0x20, 0x01, 0x0d, 0xb8.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+    private suspend fun CoroutineScope.subscribeAndAwaitActive(
+      stub: DataplaneCoroutineStub
+    ): Pair<Job, Channel<SubscribeResultsResponse>> {
+      val results = Channel<SubscribeResultsResponse>(UNLIMITED)
+      val job = launch {
+        stub.subscribeResults(SubscribeResultsRequest.getDefaultInstance()).collect {
+          results.send(it)
+        }
+      }
+      val first = withTimeout(SUBSCRIBE_RESULT_TIMEOUT_MS) { results.receive() }
+      assertTrue("first message should be SubscriptionActive", first.hasActive())
+      return job to results
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds explicit follow-up coverage after #789:

- byte-compares duplicate binary pipeline outputs from separate `p4c-4ward` invocations
- covers P4Runtime, P4Info, and DeviceConfig binary output determinism
- hardens the SAI PacketOut result subscriber test by waiting through a named integration-test timeout and always cancelling the subscriber job

## Validation

- `./tools/format.sh`
- `bazel test //e2e_tests/pipeline_outputs:PipelineOutputsTest //grpc:SaiP4E2ETest --test_output=errors --cache_test_results=no`
- `./tools/lint.sh`
