### PR TITLE
Follow-up fixes from typed trace tree outcomes review

### DIFF
--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -53,16 +53,16 @@ object TraceFormatter {
         )
       }
       TraceTree.OutcomeCase.DROP -> {
+        val cause =
+          if (tree.drop.hasCause()) tree.eventsList.firstOrNull { it.id == tree.drop.cause }
+          else null
         val suffix =
-          if (tree.drop.hasCause()) {
-            val cause = tree.eventsList.firstOrNull { it.id == tree.drop.cause }
-            when {
-              cause?.hasMarkToDrop() == true -> " (mark_to_drop)"
-              cause?.hasAssertion() == true -> " (assertion failed)"
-              cause?.hasMulticastGroupLookup() == true -> " (multicast group not found)"
-              else -> ""
-            }
-          } else ""
+          when (cause?.eventCase) {
+            TraceEvent.EventCase.MARK_TO_DROP -> " (mark_to_drop)"
+            TraceEvent.EventCase.ASSERTION -> " (assertion failed)"
+            TraceEvent.EventCase.MULTICAST_GROUP_LOOKUP -> " (multicast group not found)"
+            else -> ""
+          }
         appendLine("${pad(indent)}drop$suffix")
       }
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,

--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -34,7 +34,8 @@ object TraceFormatter {
             Continuation.Kind.RECIRCULATE -> "recirculate"
             Continuation.Kind.KIND_UNSPECIFIED,
             Continuation.Kind.UNRECOGNIZED,
-            null -> error("unexpected continuation kind: ${cont.kind}")
+            null ->
+              error("unexpected continuation kind ${cont.kind}: expected RESUBMIT or RECIRCULATE")
           }
         if (cont.preservedFieldsCount > 0) {
           val fields =
@@ -51,7 +52,19 @@ object TraceFormatter {
           "${pad(indent)}output port ${out.dataplaneEgressPort}, ${out.payload.size()} bytes"
         )
       }
-      TraceTree.OutcomeCase.DROP -> appendLine("${pad(indent)}drop")
+      TraceTree.OutcomeCase.DROP -> {
+        val suffix =
+          if (tree.drop.hasCause()) {
+            val cause = tree.eventsList.firstOrNull { it.id == tree.drop.cause }
+            when {
+              cause?.hasMarkToDrop() == true -> " (mark_to_drop)"
+              cause?.hasAssertion() == true -> " (assertion failed)"
+              cause?.hasMulticastGroupLookup() == true -> " (multicast group not found)"
+              else -> ""
+            }
+          } else ""
+        appendLine("${pad(indent)}drop$suffix")
+      }
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,
       null -> {}
     }

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -94,19 +94,27 @@ class TraceFormatterTest {
   fun dropWithMarkToDrop() {
     val tree =
       TraceTree.newBuilder()
-        .addEvents(TraceEvent.newBuilder().setMarkToDrop(MarkToDropEvent.newBuilder()))
-        .setDrop(Drop.getDefaultInstance())
+        .addEvents(TraceEvent.newBuilder().setMarkToDrop(MarkToDropEvent.newBuilder()).setId(1))
+        .setDrop(Drop.newBuilder().setCause(1))
         .build()
 
     val output = TraceFormatter.format(tree)
     assertEquals(
       """
       |mark_to_drop()
-      |drop
+      |drop (mark_to_drop)
       |"""
         .trimMargin(),
       output,
     )
+  }
+
+  @Test
+  fun dropWithNoCause() {
+    // Parser-reject and execution-limit drops have no cause event.
+    val tree = TraceTree.newBuilder().setDrop(Drop.getDefaultInstance()).build()
+
+    assertEquals("drop\n", TraceFormatter.format(tree))
   }
 
   @Test
@@ -195,15 +203,17 @@ class TraceFormatterTest {
     val tree =
       TraceTree.newBuilder()
         .addEvents(
-          TraceEvent.newBuilder().setAssertion(AssertionEvent.newBuilder().setPassed(false))
+          TraceEvent.newBuilder()
+            .setAssertion(AssertionEvent.newBuilder().setPassed(false))
+            .setId(1)
         )
-        .setDrop(Drop.getDefaultInstance())
+        .setDrop(Drop.newBuilder().setCause(1))
         .build()
 
     assertEquals(
       """
       |assert: FAILED
-      |drop
+      |drop (assertion failed)
       |"""
         .trimMargin(),
       TraceFormatter.format(tree),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,11 +203,11 @@ See [TESTING_STRATEGY.md](TESTING_STRATEGY.md).
 ## Trace trees
 
 4ward's output format is a **trace tree** (`TraceTree` in `simulator.proto`) —
-a recursive structure where each node contains a sequence of events and an
-optional fork. At non-deterministic choice points (action selectors, clone,
+a recursive structure where each node contains a sequence of events and one
+outcome. At non-deterministic choice points (action selectors, clone,
 multicast), execution forks into branches, one per possible outcome. A program
-with no non-determinism produces a zero-fork tree that is structurally
-equivalent to a flat trace — there is no separate "flat trace" format.
+with no non-determinism produces a linear tree: the root has events followed by
+a terminal `Output` or `Drop` outcome. There is no separate "flat trace" format.
 
 The key insight: even when choices like action selector hashing are technically
 deterministic, it's often more useful to reason about them as

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,7 +217,8 @@ happens with this specific hash seed?"
 ### Parallel vs alternative forks
 
 Not all forks are created equal. The simulator distinguishes two kinds of
-nondeterminism (see `ForkMode` and `forkModeOf` in `TraceHelpers.kt`):
+nondeterminism, represented by the `Replication` and `Choice` outcomes in
+`TraceTree` (`simulator.proto`):
 
 - **Parallel forks** (clone, multicast, resubmit, recirculate) — all branches
   execute simultaneously in a single real execution. The output packets are the

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -28,7 +28,7 @@ Legend:
 | Action selectors | Supported | Supported | N/A | PSA selector hits produce `Choice` trace tree nodes; PNA does not use the same selector model. |
 | Clone/mirror | Supported | Supported | Supported | PNA `mirror_packet` emits the deparsed current packet state, matching DPDK SoftNIC behavior. |
 | Multicast | Supported | Supported | N/A | v1model forks one branch per configured PRE replica and sets `egress_port`/`egress_rid`. |
-| Resubmit | Supported | Supported | N/A | Produces trace tree forks where applicable. |
+| Resubmit | Supported | Supported | N/A | Produces `Continuation` trace tree outcomes where applicable. |
 | Recirculate | Supported | Supported | Supported | PNA recirculate tracks pass count. |
 | Registers | Supported | Supported | Supported | Reproducers seed the packet-start register values read by the trace. |
 | Counters | Supported | Supported | Supported | Direct counters increment on table hits; PSA/PNA `Counter.count()` updates P4Runtime-readable counter state. |

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -25,7 +25,7 @@ Legend:
 | Pipeline execution | Supported | Supported | Supported | v1model, PSA, and PNA all have corpus coverage. |
 | Parser select ranges/masks | Supported | Supported | Supported | Covered by parser/interpreter and corpus tests. |
 | Table match kinds | Supported | Supported | Supported | Exact, LPM, ternary, optional, and range are supported in the simulator/P4Runtime layers. UI coverage is listed separately below. |
-| Action selectors | Supported | Supported | N/A | PSA selector hits produce fork-based trace trees; PNA does not use the same selector model. |
+| Action selectors | Supported | Supported | N/A | PSA selector hits produce `Choice` trace tree nodes; PNA does not use the same selector model. |
 | Clone/mirror | Supported | Supported | Supported | PNA `mirror_packet` emits the deparsed current packet state, matching DPDK SoftNIC behavior. |
 | Multicast | Supported | Supported | N/A | v1model forks one branch per configured PRE replica and sets `egress_port`/`egress_rid`. |
 | Resubmit | Supported | Supported | N/A | Produces trace tree forks where applicable. |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -20,7 +20,7 @@ guilt — just write it down so someone can find it later.
   bare fields, 1-arg and 3-arg forms), `Meter.execute` (stub GREEN),
   `Random.read()`, `InternetChecksum` (clear/add/subtract/get/get_state/set_state),
   `Digest.pack` (stub no-op), counters (indirect + direct), action profiles,
-  action selectors (including fork-based trace trees for group hits), parser
+  action selectors (including `Choice`-based trace trees for group hits), parser
   `value_set`, header stacks, and top-level assignments. 73 additional PSA
   programs (BMv2 + DPDK targets) are verified to compile. TNA is not
   implemented.
@@ -94,14 +94,14 @@ traffic rates, or asynchronous controller queues.
 
 ## Simulator
 
-- **Fork-point resume is v1model only.** When the trace tree forks (action
-  selectors, clone, multicast), v1model continues each branch from the fork
-  point instead of replaying the pipeline. PSA and PNA still use the
+- **Branch-point resume is v1model only.** When the trace tree branches
+  (`Choice` for action selectors, `Replication` for clone/multicast), v1model
+  continues each branch from the branch point instead of replaying the pipeline. PSA and PNA still use the
   replay-based approach (`handleActionSelectorFork` in `ArchitectureHelpers.kt`).
   Other v1model-specific optimizations (Long-backed `BitVector`, `CompactFieldMap`,
   proto builder pooling) benefit all architectures.
 - **Multicast: basic replication only.** Multicast group replication works
-  for the trace tree (forking per replica). PRE entries are installed via
+  for the trace tree (one `Replication` branch per replica). PRE entries are installed via
   P4Runtime `PacketReplicationEngineEntry`.
 
 ## Web playground

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -58,7 +58,7 @@ ternary ACL entries.
 - **Sequential** = `InjectPacket` (one packet at a time, wait for result).
   Intra-packet parallelism (fork branches) is enabled.
 - **Batch** = `InjectPackets` (1000 packets streamed concurrently).
-  Parallelizes across packets and within trace tree forks.
+  Parallelizes across packets and within trace tree branches.
 
 Reproducing:
 ```sh
@@ -80,7 +80,7 @@ with the same table entries: 10k LPM routes + 500 ternary ACL entries.
 BMv2 is faster on single-core sequential throughput — it's a mature C++
 codebase compiled with `-O2` and doesn't build trace trees. 4ward's
 concurrent mode (`InjectPackets`) pulls ahead by parallelizing across
-packets and within trace tree forks.
+packets and within trace tree branches.
 
 WCMP ×16 sequential is additionally lower because the two simulators do
 different amounts of work: BMv2 hashes to one action selector member per

--- a/e2e_tests/trace_tree/action_selector_miss.p4
+++ b/e2e_tests/trace_tree/action_selector_miss.p4
@@ -2,7 +2,7 @@
  *
  * When the lookup misses, the default action runs without forking.
  * When it hits a group entry, the simulator forks into N branches.
- * This test verifies that misses produce a zero-fork subtree.
+ * This test verifies that misses produce a linear subtree.
  */
 
 #include <core.p4>

--- a/e2e_tests/trace_tree/no_fork.p4
+++ b/e2e_tests/trace_tree/no_fork.p4
@@ -1,8 +1,8 @@
 /* no_fork.p4 — simplest trace tree test: no non-determinism.
  *
  * Parses an Ethernet header, applies an exact-match table to set the egress
- * port, and re-emits.  The resulting trace tree should be a zero-fork tree
- * (no ForkNode) with parser + table lookup + action execution events.
+ * port, and re-emits.  The resulting trace tree should be a linear tree
+ * with parser + table lookup + action execution events.
  */
 
 #include <core.p4>

--- a/examples/tutorial.t
+++ b/examples/tutorial.t
@@ -97,7 +97,7 @@ an IPv4 frame that matches, and an ARP frame that doesn't.
     table port_table: miss -> drop
     action drop
     mark_to_drop()
-    drop
+    drop (mark_to_drop)
   PASS
 
 Now the trace tells a much richer story. The first packet (etherType

--- a/simulator/Environment.kt
+++ b/simulator/Environment.kt
@@ -152,8 +152,10 @@ class PacketContext(packet: PacketBits, initialBitOffset: Int = 0, firstEventId:
   private val traceEvents: MutableList<TraceEvent> = mutableListOf()
   private var nextEventId: Long = firstEventId
 
-  fun addTraceEvent(event: TraceEvent) {
-    traceEvents.add(event.toBuilder().setId(nextEventId++).build())
+  fun addTraceEvent(event: TraceEvent): Long {
+    val id = nextEventId++
+    traceEvents.add(event.toBuilder().setId(id).build())
+    return id
   }
 
   fun getEvents(): List<TraceEvent> = traceEvents.toList()

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -329,19 +329,20 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     selectorMembers: Map<String, Int> = emptyMap(),
     firstEventId: Long = 1L,
   ): TraceTree {
+    // Use a PacketContext so the multicast lookup event is id-stamped the same way as all other
+    // trace events, rather than being set by hand.
+    val ctx = PacketContext(PacketBits.ofBytes(byteArrayOf()), firstEventId = firstEventId)
     val group = egressState.pipeline.tableStore.getMulticastGroup(multicastGroup)
     if (group == null) {
-      // Multicast to unconfigured group — the lookup miss is the trigger for the drop.
-      val missEvent =
-        multicastGroupMissEvent(multicastGroup).toBuilder().setId(firstEventId).build()
-      return buildDropTrace(listOf(missEvent), causeId = firstEventId)
+      ctx.addTraceEvent(multicastGroupMissEvent(multicastGroup))
+      return buildDropTrace(
+        ctx.getEvents(),
+        causeId = ctx.lastEventIdWhere { it.hasMulticastGroupLookup() },
+      )
     }
 
-    val hitEvent =
-      multicastGroupLookupEvent(multicastGroup, group.replicasCount)
-        .toBuilder()
-        .setId(firstEventId)
-        .build()
+    ctx.addTraceEvent(multicastGroupLookupEvent(multicastGroup, group.replicasCount))
+    val causeId = ctx.lastEventIdWhere { it.hasMulticastGroupLookup() }
     val branches =
       group.replicasList.map { replica ->
         val port = replicaPort(replica)
@@ -356,7 +357,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
           selectorMembers,
         )
       }
-    return buildReplicationTree(listOf(hitEvent), branches, cause = firstEventId)
+    return buildReplicationTree(ctx.getEvents(), branches, cause = causeId)
   }
 
   // ---------------------------------------------------------------------------

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -331,7 +331,7 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
   ): TraceTree {
     // Use a PacketContext so the multicast lookup event is id-stamped the same way as all other
     // trace events, rather than being set by hand.
-    val ctx = PacketContext(PacketBits.ofBytes(byteArrayOf()), firstEventId = firstEventId)
+    val ctx = PacketContext(PacketBits.EMPTY, firstEventId = firstEventId)
     val group = egressState.pipeline.tableStore.getMulticastGroup(multicastGroup)
     if (group == null) {
       ctx.addTraceEvent(multicastGroupMissEvent(multicastGroup))

--- a/simulator/PSAArchitecture.kt
+++ b/simulator/PSAArchitecture.kt
@@ -334,15 +334,11 @@ class PSAArchitecture(private val config: BehavioralConfig) : Architecture {
     val ctx = PacketContext(PacketBits.EMPTY, firstEventId = firstEventId)
     val group = egressState.pipeline.tableStore.getMulticastGroup(multicastGroup)
     if (group == null) {
-      ctx.addTraceEvent(multicastGroupMissEvent(multicastGroup))
-      return buildDropTrace(
-        ctx.getEvents(),
-        causeId = ctx.lastEventIdWhere { it.hasMulticastGroupLookup() },
-      )
+      val causeId = ctx.addTraceEvent(multicastGroupMissEvent(multicastGroup))
+      return buildDropTrace(ctx.getEvents(), causeId = causeId)
     }
 
-    ctx.addTraceEvent(multicastGroupLookupEvent(multicastGroup, group.replicasCount))
-    val causeId = ctx.lastEventIdWhere { it.hasMulticastGroupLookup() }
+    val causeId = ctx.addTraceEvent(multicastGroupLookupEvent(multicastGroup, group.replicasCount))
     val branches =
       group.replicasList.map { replica ->
         val port = replicaPort(replica)

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -491,7 +491,7 @@ class PSAArchitectureTest {
   }
 
   @Test
-  fun `multicast trace has fork node with MULTICAST reason`() {
+  fun `multicast trace has replication outcome`() {
     val config = psaConfig(ingressStmts = listOf(multicast(1)))
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 1 to 3))

--- a/simulator/PacketBits.kt
+++ b/simulator/PacketBits.kt
@@ -63,6 +63,8 @@ class PacketBits private constructor(private val paddedBytes: ByteArray, val val
       "validBitLength=$validBitLength)"
 
   companion object {
+    val EMPTY: PacketBits = PacketBits(byteArrayOf(), 0)
+
     fun ofBytes(bytes: ByteArray): PacketBits = PacketBits(bytes, bytes.size * Byte.SIZE_BITS)
 
     /**

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -303,18 +303,20 @@ fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
     TraceTree.OutcomeCase.DROP,
     TraceTree.OutcomeCase.OUTCOME_NOT_SET,
     null -> listOf(emptyList())
-    TraceTree.OutcomeCase.REPLICATION ->
+    TraceTree.OutcomeCase.REPLICATION -> {
       // Cartesian product: for each combination of one world per branch, concatenate packets.
+      require(tree.replication.branchesCount > 0) { "Replication must have at least one branch" }
       tree.replication.branchesList
         .map { collectPossibleOutcomes(it) }
-        .reduceOrNull { acc, next ->
+        .reduce { acc, next ->
           acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
-        } ?: listOf(emptyList())
-    TraceTree.OutcomeCase.CHOICE ->
+        }
+    }
+    TraceTree.OutcomeCase.CHOICE -> {
       // Each branch is a separate possible world; union their outcomes.
-      tree.choice.branchesList
-        .flatMap { collectPossibleOutcomes(it) }
-        .ifEmpty { listOf(emptyList()) }
+      require(tree.choice.branchesCount > 0) { "Choice must have at least one branch" }
+      tree.choice.branchesList.flatMap { collectPossibleOutcomes(it) }
+    }
     TraceTree.OutcomeCase.CONTINUATION -> collectPossibleOutcomes(tree.continuation.next)
   }
 }

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -710,7 +710,7 @@ class V1ModelArchitectureTest {
   }
 
   @Test
-  fun `multicast fork trace tree has fork node`() {
+  fun `multicast trace has replication outcome`() {
     val config = v1modelConfig(assignField("sm", "mcast_grp", 1, 16))
     val tableStore = TableStore()
     writeMulticastGroup(tableStore, groupId = 1, replicas = listOf(0 to 2, 0 to 3))

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -224,7 +224,7 @@ message ExternCallEvent {
 }
 
 // Fired when mark_to_drop() is called. Records the call site, not the packet
-// fate — the actual drop is represented by Drop in PacketOutcome.
+// fate — the actual drop is represented by the Drop TraceTree outcome.
 message MarkToDropEvent {}
 
 // Fired when the P4 program calls clone().

--- a/userdocs/concepts/architectures.md
+++ b/userdocs/concepts/architectures.md
@@ -67,7 +67,7 @@ present). Both can be overridden via `--drop-port` and `--cpu-port` flags.
     for a thorough writeup.
 
 Multiple calls use last-writer-wins semantics. All of these produce
-[trace tree forks](traces.md#forks).
+[trace tree branches](traces.md#forks).
 
 **Checksums:**
 

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -21,15 +21,18 @@ A trace tree is a recursive structure:
 
 ```
 TraceTree
-├── events[]          — chronologically ordered
-└── outcome
-    ├── PacketOutcome — terminal: output on a port, or drop
-    └── Fork          — non-terminal: branches into subtrees
+├── events[]      — chronologically ordered
+└── outcome (one of)
+    ├── Output        — terminal: packet transmitted on a port
+    ├── Drop          — terminal: packet discarded
+    ├── Replication   — parallel branches (clone, multicast)
+    ├── Choice        — alternative branches (action selector)
+    └── Continuation  — same packet, another pass (resubmit, recirculate)
 ```
 
 Events at the parent level are **shared** across all branches. Per-branch
-events live in the fork's subtrees. A program with no non-determinism produces
-a zero-fork tree — structurally equivalent to a flat trace.
+events live in the subtrees. A program with no non-determinism produces a
+linear trace — a `TraceTree` with a single `Output` or `Drop` outcome.
 
 ## A simple trace
 
@@ -189,15 +192,13 @@ source fragment) linking back to the P4 source.
 
 ## Packet outcomes
 
-Every trace path terminates with a **PacketOutcome**:
+Every trace path terminates with one of two outcomes:
 
 - **Output** — packet transmitted: `dataplane_egress_port` + `payload`.
-- **Drop** — packet dropped, with a reason:
-    - `MARK_TO_DROP` — explicit `mark_to_drop()` call.
-    - `PARSER_REJECT` — parser transitioned to the reject state.
-    - `PIPELINE_EXECUTION_LIMIT_REACHED` — too many fork branches
-      (exponential blowup guard).
-    - `ASSERTION_FAILURE` — `assert()` or `assume()` failed.
+- **Drop** — packet discarded. When there is a triggering event (e.g.
+  `mark_to_drop()`, a failed assertion, a missing multicast group), the
+  `Drop.cause` field points to its id in the same node's `events` list.
+  Parser-reject drops have no cause.
 
 ## P4RT enrichment
 

--- a/userdocs/concepts/traces.md
+++ b/userdocs/concepts/traces.md
@@ -69,9 +69,7 @@ events { action_execution {
   params { key: "port" value: "\001" }
 } }
 events { deparser_emit { header_type: "ethernet_t" byte_length: 14 } }
-packet_outcome {
-  output { dataplane_egress_port: 1 payload: "..." }
-}
+output { dataplane_egress_port: 1 payload: "..." }
 ```
 
 ## Forks
@@ -225,10 +223,10 @@ events { table_lookup {
     # P4Runtime: action param value "Ethernet1"
   }
 } }
-packet_outcome { output {
+output {
   dataplane_egress_port: 0
   p4rt_egress_port: "Ethernet1"
-} }
+}
 ```
 
 Enrichment only applies to the DataplaneService gRPC path. The CLI and web

--- a/userdocs/getting-started/grpc.md
+++ b/userdocs/getting-started/grpc.md
@@ -78,7 +78,7 @@ The response contains possible outcomes (output packet sets) and a full trace tr
 ```protobuf
 InjectPacketResponse {
   possible_outcomes { packets { dataplane_egress_port: 1  payload: <...> } }
-  trace { events { ... } packet_outcome { ... } }
+  trace { events { ... } output { ... } }
 }
 ```
 


### PR DESCRIPTION
Three follow-ups from the typed trace tree review:

**1. Tighten `collectPossibleOutcomes` invariants** (`Simulator.kt`)

`reduceOrNull ?: fallback` and `ifEmpty { fallback }` silently tolerated
empty `Replication`/`Choice` nodes — malformed proto that the proto comment
explicitly says cannot happen. Replace with `require` + `reduce`/`flatMap`
so malformed input fails loudly rather than producing a plausible-but-wrong
answer, in keeping with the project's "never fail silently" invariant.

**2. `PacketBits.EMPTY`** (`PacketBits.kt`, `PSAArchitecture.kt`)

`multicastEgressTree` created a throwaway `PacketContext` with
`PacketBits.ofBytes(byteArrayOf())` to stamp the multicast lookup event
with a sequential id. Add a `PacketBits.EMPTY` constant and use it —
the intent (no packet bytes, just event stamping) is now self-evident.

**3. Update stale doc references** (`ARCHITECTURE.md`, `LIMITATIONS.md`,
`COMPATIBILITY.md`, `userdocs/concepts/traces.md`)

PR #766 removed `ForkMode`, `forkModeOf`, `PacketOutcome`, and `Fork` —
a handful of docs still named them. Updated to use the actual `TraceTree`
outcome types (`Replication`, `Choice`, `Continuation`, `Output`, `Drop`).
Historical docs (STATUS.md, ROADMAP.md) are left unchanged.