### PR TITLE
[codex] Guarantee trace-global event ids

### DIFF
--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -58,8 +58,16 @@ class TraceTreeConsistencyTest(private val testName: String) {
   private fun verifyConsistency(result: ProcessPacketResult) {
     val trace = result.trace
     val leafTrees = collectLeafOutcomes(trace)
+    val eventIdCounts = collectEventIdCounts(trace)
 
     assertTrue("Trace tree for $testName has no leaf outcomes", leafTrees.isNotEmpty())
+    val duplicateIds = eventIdCounts.filterValues { it > 1 }.keys.sorted()
+    assertTrue(
+      "Trace event ids must be unique for $testName; duplicate ids: $duplicateIds.\n" +
+        "Trace:\n${TextFormat.printer().printToString(trace)}",
+      duplicateIds.isEmpty(),
+    )
+    assertCausesResolveOnce(trace, eventIdCounts)
 
     // Verify possibleOutcomes is consistent with the trace tree: flattening all worlds
     // should produce the same outputs as collecting all leaf outputs from the tree.
@@ -94,4 +102,58 @@ class TraceTreeConsistencyTest(private val testName: String) {
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,
       null -> emptyList()
     }
+
+  /** Recursively counts all [TraceEvent.id] values from a trace tree. */
+  private fun collectEventIdCounts(tree: TraceTree): Map<Long, Int> {
+    val counts = mutableMapOf<Long, Int>()
+    fun collect(node: TraceTree) {
+      for (event in node.eventsList) counts[event.id] = counts.getOrDefault(event.id, 0) + 1
+      when (node.outcomeCase) {
+        TraceTree.OutcomeCase.REPLICATION -> node.replication.branchesList.forEach { collect(it) }
+        TraceTree.OutcomeCase.CHOICE -> node.choice.branchesList.forEach { collect(it) }
+        TraceTree.OutcomeCase.CONTINUATION -> collect(node.continuation.next)
+        TraceTree.OutcomeCase.OUTPUT,
+        TraceTree.OutcomeCase.DROP,
+        TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+        null -> {}
+      }
+    }
+    collect(tree)
+    return counts
+  }
+
+  private fun assertCausesResolveOnce(tree: TraceTree, eventIdCounts: Map<Long, Int>) {
+    val cause =
+      when (tree.outcomeCase) {
+        TraceTree.OutcomeCase.REPLICATION ->
+          if (tree.replication.hasCause()) tree.replication.cause else null
+        TraceTree.OutcomeCase.CHOICE -> if (tree.choice.hasCause()) tree.choice.cause else null
+        TraceTree.OutcomeCase.DROP -> if (tree.drop.hasCause()) tree.drop.cause else null
+        TraceTree.OutcomeCase.CONTINUATION,
+        TraceTree.OutcomeCase.OUTPUT,
+        TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+        null -> null
+      }
+    if (cause != null) {
+      assertEquals(
+        "Trace outcome cause $cause must resolve to exactly one event for $testName.\n" +
+          "Trace:\n${TextFormat.printer().printToString(tree)}",
+        1,
+        eventIdCounts[cause] ?: 0,
+      )
+    }
+
+    when (tree.outcomeCase) {
+      TraceTree.OutcomeCase.REPLICATION ->
+        tree.replication.branchesList.forEach { assertCausesResolveOnce(it, eventIdCounts) }
+      TraceTree.OutcomeCase.CHOICE ->
+        tree.choice.branchesList.forEach { assertCausesResolveOnce(it, eventIdCounts) }
+      TraceTree.OutcomeCase.CONTINUATION ->
+        assertCausesResolveOnce(tree.continuation.next, eventIdCounts)
+      TraceTree.OutcomeCase.OUTPUT,
+      TraceTree.OutcomeCase.DROP,
+      TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+      null -> {}
+    }
+  }
 }

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -101,7 +101,7 @@ choice {
           value: "\000\001"
         }
       }
-      id: 1
+      id: 9
       source_info {
         file: "e2e_tests/trace_tree/action_selector_3.p4"
         line: 49
@@ -113,7 +113,7 @@ choice {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 2
+      id: 10
       source_info {
         file: "e2e_tests/trace_tree/action_selector_3.p4"
         line: 34
@@ -132,7 +132,7 @@ choice {
         stage_kind: CONTROL
         direction: EXIT
       }
-      id: 3
+      id: 11
     }
     events {
       pipeline_stage {
@@ -141,7 +141,7 @@ choice {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 4
+      id: 12
     }
     events {
       pipeline_stage {
@@ -150,7 +150,7 @@ choice {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 5
+      id: 13
     }
     events {
       pipeline_stage {
@@ -159,7 +159,7 @@ choice {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 6
+      id: 14
     }
     events {
       pipeline_stage {
@@ -168,7 +168,7 @@ choice {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 7
+      id: 15
     }
     events {
       pipeline_stage {
@@ -176,14 +176,14 @@ choice {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 8
+      id: 16
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 9
+      id: 17
     }
     events {
       pipeline_stage {
@@ -191,7 +191,7 @@ choice {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 10
+      id: 18
     }
     output {
       dataplane_egress_port: 1
@@ -207,7 +207,7 @@ choice {
           value: "\000\002"
         }
       }
-      id: 1
+      id: 19
       source_info {
         file: "e2e_tests/trace_tree/action_selector_3.p4"
         line: 49
@@ -219,7 +219,7 @@ choice {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 2
+      id: 20
       source_info {
         file: "e2e_tests/trace_tree/action_selector_3.p4"
         line: 34
@@ -238,7 +238,7 @@ choice {
         stage_kind: CONTROL
         direction: EXIT
       }
-      id: 3
+      id: 21
     }
     events {
       pipeline_stage {
@@ -247,7 +247,7 @@ choice {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 4
+      id: 22
     }
     events {
       pipeline_stage {
@@ -256,7 +256,7 @@ choice {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 5
+      id: 23
     }
     events {
       pipeline_stage {
@@ -265,7 +265,7 @@ choice {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 6
+      id: 24
     }
     events {
       pipeline_stage {
@@ -274,7 +274,7 @@ choice {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 7
+      id: 25
     }
     events {
       pipeline_stage {
@@ -282,14 +282,14 @@ choice {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 8
+      id: 26
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 9
+      id: 27
     }
     events {
       pipeline_stage {
@@ -297,7 +297,7 @@ choice {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 10
+      id: 28
     }
     output {
       dataplane_egress_port: 2
@@ -313,7 +313,7 @@ choice {
           value: "\000\003"
         }
       }
-      id: 1
+      id: 29
       source_info {
         file: "e2e_tests/trace_tree/action_selector_3.p4"
         line: 49
@@ -325,7 +325,7 @@ choice {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 2
+      id: 30
       source_info {
         file: "e2e_tests/trace_tree/action_selector_3.p4"
         line: 34
@@ -344,7 +344,7 @@ choice {
         stage_kind: CONTROL
         direction: EXIT
       }
-      id: 3
+      id: 31
     }
     events {
       pipeline_stage {
@@ -353,7 +353,7 @@ choice {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 4
+      id: 32
     }
     events {
       pipeline_stage {
@@ -362,7 +362,7 @@ choice {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 5
+      id: 33
     }
     events {
       pipeline_stage {
@@ -371,7 +371,7 @@ choice {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 6
+      id: 34
     }
     events {
       pipeline_stage {
@@ -380,7 +380,7 @@ choice {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 7
+      id: 35
     }
     events {
       pipeline_stage {
@@ -388,14 +388,14 @@ choice {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 8
+      id: 36
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 9
+      id: 37
     }
     events {
       pipeline_stage {
@@ -403,7 +403,7 @@ choice {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 10
+      id: 38
     }
     output {
       dataplane_egress_port: 3

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -101,7 +101,7 @@ choice {
           value: "\001"
         }
       }
-      id: 1
+      id: 9
       source_info {
         file: "e2e_tests/trace_tree/action_selector_nested.p4"
         line: 62
@@ -113,7 +113,7 @@ choice {
       assignment {
         target: "meta.tag"
       }
-      id: 2
+      id: 10
       source_info {
         file: "e2e_tests/trace_tree/action_selector_nested.p4"
         line: 35
@@ -144,7 +144,7 @@ choice {
         }
         action_name: "set_port"
       }
-      id: 3
+      id: 11
       source_info {
         file: "e2e_tests/trace_tree/action_selector_nested.p4"
         line: 63
@@ -157,7 +157,7 @@ choice {
       }
     }
     choice {
-      cause: 3
+      cause: 11
       branches {
         events {
           action_execution {
@@ -167,7 +167,7 @@ choice {
               value: "\000\001"
             }
           }
-          id: 1
+          id: 12
           source_info {
             file: "e2e_tests/trace_tree/action_selector_nested.p4"
             line: 63
@@ -179,7 +179,7 @@ choice {
           assignment {
             target: "smeta.egress_spec"
           }
-          id: 2
+          id: 13
           source_info {
             file: "e2e_tests/trace_tree/action_selector_nested.p4"
             line: 34
@@ -198,7 +198,7 @@ choice {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 3
+          id: 14
         }
         events {
           pipeline_stage {
@@ -207,7 +207,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 4
+          id: 15
         }
         events {
           pipeline_stage {
@@ -216,7 +216,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 5
+          id: 16
         }
         events {
           pipeline_stage {
@@ -225,7 +225,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 6
+          id: 17
         }
         events {
           pipeline_stage {
@@ -234,7 +234,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 7
+          id: 18
         }
         events {
           pipeline_stage {
@@ -242,14 +242,14 @@ choice {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 8
+          id: 19
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 9
+          id: 20
         }
         events {
           pipeline_stage {
@@ -257,7 +257,7 @@ choice {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 10
+          id: 21
         }
         output {
           dataplane_egress_port: 1
@@ -273,7 +273,7 @@ choice {
               value: "\000\002"
             }
           }
-          id: 1
+          id: 22
           source_info {
             file: "e2e_tests/trace_tree/action_selector_nested.p4"
             line: 63
@@ -285,7 +285,7 @@ choice {
           assignment {
             target: "smeta.egress_spec"
           }
-          id: 2
+          id: 23
           source_info {
             file: "e2e_tests/trace_tree/action_selector_nested.p4"
             line: 34
@@ -304,7 +304,7 @@ choice {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 3
+          id: 24
         }
         events {
           pipeline_stage {
@@ -313,7 +313,7 @@ choice {
             direction: ENTER
             dataplane_port: 2
           }
-          id: 4
+          id: 25
         }
         events {
           pipeline_stage {
@@ -322,7 +322,7 @@ choice {
             direction: EXIT
             dataplane_port: 2
           }
-          id: 5
+          id: 26
         }
         events {
           pipeline_stage {
@@ -331,7 +331,7 @@ choice {
             direction: ENTER
             dataplane_port: 2
           }
-          id: 6
+          id: 27
         }
         events {
           pipeline_stage {
@@ -340,7 +340,7 @@ choice {
             direction: EXIT
             dataplane_port: 2
           }
-          id: 7
+          id: 28
         }
         events {
           pipeline_stage {
@@ -348,14 +348,14 @@ choice {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 8
+          id: 29
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 9
+          id: 30
         }
         events {
           pipeline_stage {
@@ -363,7 +363,7 @@ choice {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 10
+          id: 31
         }
         output {
           dataplane_egress_port: 2
@@ -381,7 +381,7 @@ choice {
           value: "\002"
         }
       }
-      id: 1
+      id: 32
       source_info {
         file: "e2e_tests/trace_tree/action_selector_nested.p4"
         line: 62
@@ -393,7 +393,7 @@ choice {
       assignment {
         target: "meta.tag"
       }
-      id: 2
+      id: 33
       source_info {
         file: "e2e_tests/trace_tree/action_selector_nested.p4"
         line: 35
@@ -424,7 +424,7 @@ choice {
         }
         action_name: "set_port"
       }
-      id: 3
+      id: 34
       source_info {
         file: "e2e_tests/trace_tree/action_selector_nested.p4"
         line: 63
@@ -437,7 +437,7 @@ choice {
       }
     }
     choice {
-      cause: 3
+      cause: 34
       branches {
         events {
           action_execution {
@@ -447,7 +447,7 @@ choice {
               value: "\000\001"
             }
           }
-          id: 1
+          id: 35
           source_info {
             file: "e2e_tests/trace_tree/action_selector_nested.p4"
             line: 63
@@ -459,7 +459,7 @@ choice {
           assignment {
             target: "smeta.egress_spec"
           }
-          id: 2
+          id: 36
           source_info {
             file: "e2e_tests/trace_tree/action_selector_nested.p4"
             line: 34
@@ -478,7 +478,7 @@ choice {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 3
+          id: 37
         }
         events {
           pipeline_stage {
@@ -487,7 +487,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 4
+          id: 38
         }
         events {
           pipeline_stage {
@@ -496,7 +496,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 5
+          id: 39
         }
         events {
           pipeline_stage {
@@ -505,7 +505,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 6
+          id: 40
         }
         events {
           pipeline_stage {
@@ -514,7 +514,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 7
+          id: 41
         }
         events {
           pipeline_stage {
@@ -522,14 +522,14 @@ choice {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 8
+          id: 42
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 9
+          id: 43
         }
         events {
           pipeline_stage {
@@ -537,7 +537,7 @@ choice {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 10
+          id: 44
         }
         output {
           dataplane_egress_port: 1
@@ -553,7 +553,7 @@ choice {
               value: "\000\002"
             }
           }
-          id: 1
+          id: 45
           source_info {
             file: "e2e_tests/trace_tree/action_selector_nested.p4"
             line: 63
@@ -565,7 +565,7 @@ choice {
           assignment {
             target: "smeta.egress_spec"
           }
-          id: 2
+          id: 46
           source_info {
             file: "e2e_tests/trace_tree/action_selector_nested.p4"
             line: 34
@@ -584,7 +584,7 @@ choice {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 3
+          id: 47
         }
         events {
           pipeline_stage {
@@ -593,7 +593,7 @@ choice {
             direction: ENTER
             dataplane_port: 2
           }
-          id: 4
+          id: 48
         }
         events {
           pipeline_stage {
@@ -602,7 +602,7 @@ choice {
             direction: EXIT
             dataplane_port: 2
           }
-          id: 5
+          id: 49
         }
         events {
           pipeline_stage {
@@ -611,7 +611,7 @@ choice {
             direction: ENTER
             dataplane_port: 2
           }
-          id: 6
+          id: 50
         }
         events {
           pipeline_stage {
@@ -620,7 +620,7 @@ choice {
             direction: EXIT
             dataplane_port: 2
           }
-          id: 7
+          id: 51
         }
         events {
           pipeline_stage {
@@ -628,14 +628,14 @@ choice {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 8
+          id: 52
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 9
+          id: 53
         }
         events {
           pipeline_stage {
@@ -643,7 +643,7 @@ choice {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 10
+          id: 54
         }
         output {
           dataplane_egress_port: 2

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -112,10 +112,10 @@ replication {
         group_found: true
         replica_count: 2
       }
-      id: 1
+      id: 12
     }
     replication {
-      cause: 1
+      cause: 12
       branches {
         events {
           pipeline_stage {
@@ -124,7 +124,7 @@ replication {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 1
+          id: 13
         }
         events {
           pipeline_stage {
@@ -133,7 +133,7 @@ replication {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 2
+          id: 14
         }
         events {
           pipeline_stage {
@@ -142,7 +142,7 @@ replication {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 3
+          id: 15
         }
         events {
           pipeline_stage {
@@ -151,7 +151,7 @@ replication {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 4
+          id: 16
         }
         events {
           pipeline_stage {
@@ -159,14 +159,14 @@ replication {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 5
+          id: 17
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 6
+          id: 18
         }
         events {
           pipeline_stage {
@@ -174,7 +174,7 @@ replication {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 7
+          id: 19
         }
         output {
           dataplane_egress_port: 1
@@ -189,7 +189,7 @@ replication {
             direction: ENTER
             dataplane_port: 2
           }
-          id: 1
+          id: 20
         }
         events {
           pipeline_stage {
@@ -198,7 +198,7 @@ replication {
             direction: EXIT
             dataplane_port: 2
           }
-          id: 2
+          id: 21
         }
         events {
           pipeline_stage {
@@ -207,7 +207,7 @@ replication {
             direction: ENTER
             dataplane_port: 2
           }
-          id: 3
+          id: 22
         }
         events {
           pipeline_stage {
@@ -216,7 +216,7 @@ replication {
             direction: EXIT
             dataplane_port: 2
           }
-          id: 4
+          id: 23
         }
         events {
           pipeline_stage {
@@ -224,14 +224,14 @@ replication {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 5
+          id: 24
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 6
+          id: 25
         }
         events {
           pipeline_stage {
@@ -239,7 +239,7 @@ replication {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 7
+          id: 26
         }
         output {
           dataplane_egress_port: 2
@@ -256,7 +256,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 1
+      id: 27
     }
     events {
       pipeline_stage {
@@ -265,7 +265,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 2
+      id: 28
     }
     events {
       pipeline_stage {
@@ -274,7 +274,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 3
+      id: 29
     }
     events {
       pipeline_stage {
@@ -283,7 +283,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 4
+      id: 30
     }
     events {
       pipeline_stage {
@@ -291,14 +291,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 5
+      id: 31
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 6
+      id: 32
     }
     events {
       pipeline_stage {
@@ -306,7 +306,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 7
+      id: 33
     }
     output {
       dataplane_egress_port: 3

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -113,7 +113,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 1
+      id: 12
     }
     events {
       pipeline_stage {
@@ -122,7 +122,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 2
+      id: 13
     }
     events {
       pipeline_stage {
@@ -131,7 +131,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 3
+      id: 14
     }
     events {
       pipeline_stage {
@@ -140,7 +140,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 4
+      id: 15
     }
     events {
       pipeline_stage {
@@ -148,14 +148,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 5
+      id: 16
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 6
+      id: 17
     }
     events {
       pipeline_stage {
@@ -163,7 +163,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 7
+      id: 18
     }
     output {
       dataplane_egress_port: 1
@@ -178,7 +178,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 1
+      id: 19
     }
     events {
       pipeline_stage {
@@ -187,7 +187,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 2
+      id: 20
     }
     events {
       pipeline_stage {
@@ -196,7 +196,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 3
+      id: 21
     }
     events {
       pipeline_stage {
@@ -205,7 +205,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 4
+      id: 22
     }
     events {
       pipeline_stage {
@@ -213,14 +213,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 5
+      id: 23
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 6
+      id: 24
     }
     events {
       pipeline_stage {
@@ -228,7 +228,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 7
+      id: 25
     }
     output {
       dataplane_egress_port: 1

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -125,7 +125,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 1
+      id: 13
     }
     events {
       pipeline_stage {
@@ -134,7 +134,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 2
+      id: 14
     }
     events {
       pipeline_stage {
@@ -143,7 +143,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 3
+      id: 15
     }
     events {
       pipeline_stage {
@@ -152,7 +152,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 4
+      id: 16
     }
     events {
       pipeline_stage {
@@ -160,14 +160,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 5
+      id: 17
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 6
+      id: 18
     }
     events {
       pipeline_stage {
@@ -175,7 +175,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 7
+      id: 19
     }
     output {
       dataplane_egress_port: 3
@@ -190,7 +190,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 1
+      id: 20
     }
     events {
       pipeline_stage {
@@ -199,7 +199,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 2
+      id: 21
     }
     events {
       pipeline_stage {
@@ -208,7 +208,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 3
+      id: 22
     }
     events {
       pipeline_stage {
@@ -217,7 +217,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 4
+      id: 23
     }
     events {
       pipeline_stage {
@@ -225,14 +225,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 5
+      id: 24
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 6
+      id: 25
     }
     events {
       pipeline_stage {
@@ -240,7 +240,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 7
+      id: 26
     }
     output {
       dataplane_egress_port: 1

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -113,7 +113,7 @@ choice {
           value: "\000\001"
         }
       }
-      id: 1
+      id: 10
       source_info {
         file: "e2e_tests/trace_tree/clone_plus_selector.p4"
         line: 52
@@ -125,7 +125,7 @@ choice {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 2
+      id: 11
       source_info {
         file: "e2e_tests/trace_tree/clone_plus_selector.p4"
         line: 35
@@ -144,7 +144,7 @@ choice {
         stage_kind: CONTROL
         direction: EXIT
       }
-      id: 3
+      id: 12
     }
     events {
       clone_session_lookup {
@@ -153,10 +153,10 @@ choice {
         dataplane_egress_port: 1
         replica_count: 1
       }
-      id: 4
+      id: 13
     }
     replication {
-      cause: 4
+      cause: 13
       branches {
         events {
           pipeline_stage {
@@ -165,7 +165,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 1
+          id: 14
         }
         events {
           pipeline_stage {
@@ -174,7 +174,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 2
+          id: 15
         }
         events {
           pipeline_stage {
@@ -183,7 +183,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 3
+          id: 16
         }
         events {
           pipeline_stage {
@@ -192,7 +192,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 4
+          id: 17
         }
         events {
           pipeline_stage {
@@ -200,14 +200,14 @@ choice {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 5
+          id: 18
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 6
+          id: 19
         }
         events {
           pipeline_stage {
@@ -215,7 +215,7 @@ choice {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 7
+          id: 20
         }
         output {
           dataplane_egress_port: 1
@@ -230,7 +230,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 1
+          id: 21
         }
         events {
           pipeline_stage {
@@ -239,7 +239,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 2
+          id: 22
         }
         events {
           pipeline_stage {
@@ -248,7 +248,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 3
+          id: 23
         }
         events {
           pipeline_stage {
@@ -257,7 +257,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 4
+          id: 24
         }
         events {
           pipeline_stage {
@@ -265,14 +265,14 @@ choice {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 5
+          id: 25
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 6
+          id: 26
         }
         events {
           pipeline_stage {
@@ -280,7 +280,7 @@ choice {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 7
+          id: 27
         }
         output {
           dataplane_egress_port: 1
@@ -298,7 +298,7 @@ choice {
           value: "\000\002"
         }
       }
-      id: 1
+      id: 28
       source_info {
         file: "e2e_tests/trace_tree/clone_plus_selector.p4"
         line: 52
@@ -310,7 +310,7 @@ choice {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 2
+      id: 29
       source_info {
         file: "e2e_tests/trace_tree/clone_plus_selector.p4"
         line: 35
@@ -329,7 +329,7 @@ choice {
         stage_kind: CONTROL
         direction: EXIT
       }
-      id: 3
+      id: 30
     }
     events {
       clone_session_lookup {
@@ -338,10 +338,10 @@ choice {
         dataplane_egress_port: 1
         replica_count: 1
       }
-      id: 4
+      id: 31
     }
     replication {
-      cause: 4
+      cause: 31
       branches {
         events {
           pipeline_stage {
@@ -350,7 +350,7 @@ choice {
             direction: ENTER
             dataplane_port: 2
           }
-          id: 1
+          id: 32
         }
         events {
           pipeline_stage {
@@ -359,7 +359,7 @@ choice {
             direction: EXIT
             dataplane_port: 2
           }
-          id: 2
+          id: 33
         }
         events {
           pipeline_stage {
@@ -368,7 +368,7 @@ choice {
             direction: ENTER
             dataplane_port: 2
           }
-          id: 3
+          id: 34
         }
         events {
           pipeline_stage {
@@ -377,7 +377,7 @@ choice {
             direction: EXIT
             dataplane_port: 2
           }
-          id: 4
+          id: 35
         }
         events {
           pipeline_stage {
@@ -385,14 +385,14 @@ choice {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 5
+          id: 36
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 6
+          id: 37
         }
         events {
           pipeline_stage {
@@ -400,7 +400,7 @@ choice {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 7
+          id: 38
         }
         output {
           dataplane_egress_port: 2
@@ -415,7 +415,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 1
+          id: 39
         }
         events {
           pipeline_stage {
@@ -424,7 +424,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 2
+          id: 40
         }
         events {
           pipeline_stage {
@@ -433,7 +433,7 @@ choice {
             direction: ENTER
             dataplane_port: 1
           }
-          id: 3
+          id: 41
         }
         events {
           pipeline_stage {
@@ -442,7 +442,7 @@ choice {
             direction: EXIT
             dataplane_port: 1
           }
-          id: 4
+          id: 42
         }
         events {
           pipeline_stage {
@@ -450,14 +450,14 @@ choice {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 5
+          id: 43
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 6
+          id: 44
         }
         events {
           pipeline_stage {
@@ -465,7 +465,7 @@ choice {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 7
+          id: 45
         }
         output {
           dataplane_egress_port: 1

--- a/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
@@ -139,14 +139,14 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 1
+      id: 14
     }
     events {
       branch {
         control_name: "MyEgress"
         taken: false
       }
-      id: 2
+      id: 15
       source_info {
         file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
         line: 55
@@ -166,7 +166,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 3
+      id: 16
     }
     events {
       pipeline_stage {
@@ -175,7 +175,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 4
+      id: 17
     }
     events {
       pipeline_stage {
@@ -184,7 +184,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 5
+      id: 18
     }
     events {
       pipeline_stage {
@@ -192,14 +192,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 6
+      id: 19
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 7
+      id: 20
     }
     events {
       pipeline_stage {
@@ -207,7 +207,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 8
+      id: 21
     }
     output {
       dataplane_egress_port: 1
@@ -222,14 +222,14 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 1
+      id: 22
     }
     events {
       branch {
         control_name: "MyEgress"
         taken: true
       }
-      id: 2
+      id: 23
       source_info {
         file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
         line: 55
@@ -246,7 +246,7 @@ replication {
       assignment {
         target: "hdr.ethernet.etherType"
       }
-      id: 3
+      id: 24
       source_info {
         file: "e2e_tests/trace_tree/clone_preserve_meta.p4"
         line: 57
@@ -266,7 +266,7 @@ replication {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 4
+      id: 25
     }
     events {
       pipeline_stage {
@@ -275,7 +275,7 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 5
+      id: 26
     }
     events {
       pipeline_stage {
@@ -284,7 +284,7 @@ replication {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 6
+      id: 27
     }
     events {
       pipeline_stage {
@@ -292,14 +292,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 7
+      id: 28
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 8
+      id: 29
     }
     events {
       pipeline_stage {
@@ -307,7 +307,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 9
+      id: 30
     }
     output {
       dataplane_egress_port: 2

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -113,7 +113,7 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 1
+      id: 12
     }
     events {
       table_lookup {
@@ -136,7 +136,7 @@ replication {
         }
         action_name: "tag_original"
       }
-      id: 2
+      id: 13
       source_info {
         file: "e2e_tests/trace_tree/clone_with_egress.p4"
         line: 55
@@ -152,7 +152,7 @@ replication {
       action_execution {
         action_name: "tag_original"
       }
-      id: 3
+      id: 14
       source_info {
         file: "e2e_tests/trace_tree/clone_with_egress.p4"
         line: 55
@@ -164,7 +164,7 @@ replication {
       assignment {
         target: "hdr.ethernet.dstAddr"
       }
-      id: 4
+      id: 15
       source_info {
         file: "e2e_tests/trace_tree/clone_with_egress.p4"
         line: 43
@@ -180,7 +180,7 @@ replication {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 5
+      id: 16
     }
     events {
       pipeline_stage {
@@ -189,7 +189,7 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 6
+      id: 17
     }
     events {
       pipeline_stage {
@@ -198,7 +198,7 @@ replication {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 7
+      id: 18
     }
     events {
       pipeline_stage {
@@ -206,14 +206,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 8
+      id: 19
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 9
+      id: 20
     }
     events {
       pipeline_stage {
@@ -221,7 +221,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 10
+      id: 21
     }
     output {
       dataplane_egress_port: 2
@@ -236,7 +236,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 1
+      id: 22
     }
     events {
       table_lookup {
@@ -259,7 +259,7 @@ replication {
         }
         action_name: "tag_clone"
       }
-      id: 2
+      id: 23
       source_info {
         file: "e2e_tests/trace_tree/clone_with_egress.p4"
         line: 55
@@ -275,7 +275,7 @@ replication {
       action_execution {
         action_name: "tag_clone"
       }
-      id: 3
+      id: 24
       source_info {
         file: "e2e_tests/trace_tree/clone_with_egress.p4"
         line: 55
@@ -287,7 +287,7 @@ replication {
       assignment {
         target: "hdr.ethernet.srcAddr"
       }
-      id: 4
+      id: 25
       source_info {
         file: "e2e_tests/trace_tree/clone_with_egress.p4"
         line: 44
@@ -303,7 +303,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 5
+      id: 26
     }
     events {
       pipeline_stage {
@@ -312,7 +312,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 6
+      id: 27
     }
     events {
       pipeline_stage {
@@ -321,7 +321,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 7
+      id: 28
     }
     events {
       pipeline_stage {
@@ -329,14 +329,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 8
+      id: 29
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 9
+      id: 30
     }
     events {
       pipeline_stage {
@@ -344,7 +344,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 10
+      id: 31
     }
     output {
       dataplane_egress_port: 3

--- a/e2e_tests/trace_tree/e2e_clone.golden.txtpb
+++ b/e2e_tests/trace_tree/e2e_clone.golden.txtpb
@@ -224,14 +224,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 1
+      id: 20
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 2
+      id: 21
     }
     events {
       pipeline_stage {
@@ -239,7 +239,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 3
+      id: 22
     }
     output {
       dataplane_egress_port: 2
@@ -254,14 +254,14 @@ replication {
         direction: ENTER
         dataplane_port: 5
       }
-      id: 1
+      id: 23
     }
     events {
       branch {
         control_name: "MyEgress"
         taken: false
       }
-      id: 2
+      id: 24
       source_info {
         file: "e2e_tests/trace_tree/e2e_clone.p4"
         line: 53
@@ -295,7 +295,7 @@ replication {
         }
         action_name: "tag_clone"
       }
-      id: 3
+      id: 25
       source_info {
         file: "e2e_tests/trace_tree/e2e_clone.p4"
         line: 56
@@ -311,7 +311,7 @@ replication {
       action_execution {
         action_name: "tag_clone"
       }
-      id: 4
+      id: 26
       source_info {
         file: "e2e_tests/trace_tree/e2e_clone.p4"
         line: 56
@@ -323,7 +323,7 @@ replication {
       assignment {
         target: "hdr.ethernet.srcAddr"
       }
-      id: 5
+      id: 27
       source_info {
         file: "e2e_tests/trace_tree/e2e_clone.p4"
         line: 40
@@ -339,7 +339,7 @@ replication {
         direction: EXIT
         dataplane_port: 5
       }
-      id: 6
+      id: 28
     }
     events {
       pipeline_stage {
@@ -348,7 +348,7 @@ replication {
         direction: ENTER
         dataplane_port: 5
       }
-      id: 7
+      id: 29
     }
     events {
       pipeline_stage {
@@ -357,7 +357,7 @@ replication {
         direction: EXIT
         dataplane_port: 5
       }
-      id: 8
+      id: 30
     }
     events {
       pipeline_stage {
@@ -365,14 +365,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 9
+      id: 31
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 10
+      id: 32
     }
     events {
       pipeline_stage {
@@ -380,7 +380,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 11
+      id: 33
     }
     output {
       dataplane_egress_port: 5

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -100,7 +100,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 1
+      id: 11
     }
     events {
       pipeline_stage {
@@ -109,7 +109,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 2
+      id: 12
     }
     events {
       pipeline_stage {
@@ -118,7 +118,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 3
+      id: 13
     }
     events {
       pipeline_stage {
@@ -127,7 +127,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 4
+      id: 14
     }
     events {
       pipeline_stage {
@@ -135,14 +135,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 5
+      id: 15
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 6
+      id: 16
     }
     events {
       pipeline_stage {
@@ -150,7 +150,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 7
+      id: 17
     }
     output {
       dataplane_egress_port: 1
@@ -165,7 +165,7 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 1
+      id: 18
     }
     events {
       pipeline_stage {
@@ -174,7 +174,7 @@ replication {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 2
+      id: 19
     }
     events {
       pipeline_stage {
@@ -183,7 +183,7 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 3
+      id: 20
     }
     events {
       pipeline_stage {
@@ -192,7 +192,7 @@ replication {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 4
+      id: 21
     }
     events {
       pipeline_stage {
@@ -200,14 +200,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 5
+      id: 22
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 6
+      id: 23
     }
     events {
       pipeline_stage {
@@ -215,7 +215,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 7
+      id: 24
     }
     output {
       dataplane_egress_port: 2
@@ -230,7 +230,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 1
+      id: 25
     }
     events {
       pipeline_stage {
@@ -239,7 +239,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 2
+      id: 26
     }
     events {
       pipeline_stage {
@@ -248,7 +248,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 3
+      id: 27
     }
     events {
       pipeline_stage {
@@ -257,7 +257,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 4
+      id: 28
     }
     events {
       pipeline_stage {
@@ -265,14 +265,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 5
+      id: 29
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 6
+      id: 30
     }
     events {
       pipeline_stage {
@@ -280,7 +280,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 7
+      id: 31
     }
     output {
       dataplane_egress_port: 3

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -100,14 +100,14 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 1
+      id: 11
     }
     events {
       branch {
         control_name: "MyEgress"
         taken: false
       }
-      id: 2
+      id: 12
       source_info {
         file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
         line: 41
@@ -127,7 +127,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 3
+      id: 13
     }
     events {
       pipeline_stage {
@@ -136,7 +136,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 4
+      id: 14
     }
     events {
       pipeline_stage {
@@ -145,7 +145,7 @@ replication {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 5
+      id: 15
     }
     events {
       pipeline_stage {
@@ -153,14 +153,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 6
+      id: 16
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 7
+      id: 17
     }
     events {
       pipeline_stage {
@@ -168,7 +168,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 8
+      id: 18
     }
     output {
       dataplane_egress_port: 1
@@ -183,14 +183,14 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 1
+      id: 19
     }
     events {
       branch {
         control_name: "MyEgress"
         taken: true
       }
-      id: 2
+      id: 20
       source_info {
         file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
         line: 41
@@ -206,7 +206,7 @@ replication {
     events {
       mark_to_drop {
       }
-      id: 3
+      id: 21
       source_info {
         file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
         line: 42
@@ -221,7 +221,7 @@ replication {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 4
+      id: 22
     }
     events {
       pipeline_stage {
@@ -230,7 +230,7 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 5
+      id: 23
     }
     events {
       pipeline_stage {
@@ -239,10 +239,10 @@ replication {
         direction: EXIT
         dataplane_port: 2
       }
-      id: 6
+      id: 24
     }
     drop {
-      cause: 3
+      cause: 21
     }
   }
   branches {
@@ -253,14 +253,14 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 1
+      id: 25
     }
     events {
       branch {
         control_name: "MyEgress"
         taken: false
       }
-      id: 2
+      id: 26
       source_info {
         file: "e2e_tests/trace_tree/multicast_drop_replica.p4"
         line: 41
@@ -280,7 +280,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 3
+      id: 27
     }
     events {
       pipeline_stage {
@@ -289,7 +289,7 @@ replication {
         direction: ENTER
         dataplane_port: 3
       }
-      id: 4
+      id: 28
     }
     events {
       pipeline_stage {
@@ -298,7 +298,7 @@ replication {
         direction: EXIT
         dataplane_port: 3
       }
-      id: 5
+      id: 29
     }
     events {
       pipeline_stage {
@@ -306,14 +306,14 @@ replication {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 6
+      id: 30
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 7
+      id: 31
     }
     events {
       pipeline_stage {
@@ -321,7 +321,7 @@ replication {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 8
+      id: 32
     }
     output {
       dataplane_egress_port: 3

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -100,7 +100,7 @@ replication {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 1
+      id: 11
     }
     events {
       table_lookup {
@@ -120,7 +120,7 @@ replication {
         }
         action_name: "tag_a"
       }
-      id: 2
+      id: 12
       source_info {
         file: "e2e_tests/trace_tree/multicast_selector.p4"
         line: 58
@@ -133,13 +133,13 @@ replication {
       }
     }
     choice {
-      cause: 2
+      cause: 12
       branches {
         events {
           action_execution {
             action_name: "tag_a"
           }
-          id: 1
+          id: 13
           source_info {
             file: "e2e_tests/trace_tree/multicast_selector.p4"
             line: 58
@@ -151,7 +151,7 @@ replication {
           assignment {
             target: "hdr.ethernet.dstAddr"
           }
-          id: 2
+          id: 14
           source_info {
             file: "e2e_tests/trace_tree/multicast_selector.p4"
             line: 42
@@ -166,7 +166,7 @@ replication {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 3
+          id: 15
         }
         events {
           pipeline_stage {
@@ -174,7 +174,7 @@ replication {
             stage_kind: CONTROL
             direction: ENTER
           }
-          id: 4
+          id: 16
         }
         events {
           pipeline_stage {
@@ -182,7 +182,7 @@ replication {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 5
+          id: 17
         }
         events {
           pipeline_stage {
@@ -190,14 +190,14 @@ replication {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 6
+          id: 18
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 7
+          id: 19
         }
         events {
           pipeline_stage {
@@ -205,7 +205,7 @@ replication {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 8
+          id: 20
         }
         output {
           dataplane_egress_port: 1
@@ -217,7 +217,7 @@ replication {
           action_execution {
             action_name: "tag_b"
           }
-          id: 1
+          id: 21
           source_info {
             file: "e2e_tests/trace_tree/multicast_selector.p4"
             line: 58
@@ -229,7 +229,7 @@ replication {
           assignment {
             target: "hdr.ethernet.dstAddr"
           }
-          id: 2
+          id: 22
           source_info {
             file: "e2e_tests/trace_tree/multicast_selector.p4"
             line: 43
@@ -244,7 +244,7 @@ replication {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 3
+          id: 23
         }
         events {
           pipeline_stage {
@@ -252,7 +252,7 @@ replication {
             stage_kind: CONTROL
             direction: ENTER
           }
-          id: 4
+          id: 24
         }
         events {
           pipeline_stage {
@@ -260,7 +260,7 @@ replication {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 5
+          id: 25
         }
         events {
           pipeline_stage {
@@ -268,14 +268,14 @@ replication {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 6
+          id: 26
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 7
+          id: 27
         }
         events {
           pipeline_stage {
@@ -283,7 +283,7 @@ replication {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 8
+          id: 28
         }
         output {
           dataplane_egress_port: 1
@@ -300,7 +300,7 @@ replication {
         direction: ENTER
         dataplane_port: 2
       }
-      id: 1
+      id: 29
     }
     events {
       table_lookup {
@@ -320,7 +320,7 @@ replication {
         }
         action_name: "tag_a"
       }
-      id: 2
+      id: 30
       source_info {
         file: "e2e_tests/trace_tree/multicast_selector.p4"
         line: 58
@@ -333,13 +333,13 @@ replication {
       }
     }
     choice {
-      cause: 2
+      cause: 30
       branches {
         events {
           action_execution {
             action_name: "tag_a"
           }
-          id: 1
+          id: 31
           source_info {
             file: "e2e_tests/trace_tree/multicast_selector.p4"
             line: 58
@@ -351,7 +351,7 @@ replication {
           assignment {
             target: "hdr.ethernet.dstAddr"
           }
-          id: 2
+          id: 32
           source_info {
             file: "e2e_tests/trace_tree/multicast_selector.p4"
             line: 42
@@ -366,7 +366,7 @@ replication {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 3
+          id: 33
         }
         events {
           pipeline_stage {
@@ -374,7 +374,7 @@ replication {
             stage_kind: CONTROL
             direction: ENTER
           }
-          id: 4
+          id: 34
         }
         events {
           pipeline_stage {
@@ -382,7 +382,7 @@ replication {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 5
+          id: 35
         }
         events {
           pipeline_stage {
@@ -390,14 +390,14 @@ replication {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 6
+          id: 36
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 7
+          id: 37
         }
         events {
           pipeline_stage {
@@ -405,7 +405,7 @@ replication {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 8
+          id: 38
         }
         output {
           dataplane_egress_port: 2
@@ -417,7 +417,7 @@ replication {
           action_execution {
             action_name: "tag_b"
           }
-          id: 1
+          id: 39
           source_info {
             file: "e2e_tests/trace_tree/multicast_selector.p4"
             line: 58
@@ -429,7 +429,7 @@ replication {
           assignment {
             target: "hdr.ethernet.dstAddr"
           }
-          id: 2
+          id: 40
           source_info {
             file: "e2e_tests/trace_tree/multicast_selector.p4"
             line: 43
@@ -444,7 +444,7 @@ replication {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 3
+          id: 41
         }
         events {
           pipeline_stage {
@@ -452,7 +452,7 @@ replication {
             stage_kind: CONTROL
             direction: ENTER
           }
-          id: 4
+          id: 42
         }
         events {
           pipeline_stage {
@@ -460,7 +460,7 @@ replication {
             stage_kind: CONTROL
             direction: EXIT
           }
-          id: 5
+          id: 43
         }
         events {
           pipeline_stage {
@@ -468,14 +468,14 @@ replication {
             stage_kind: DEPARSER
             direction: ENTER
           }
-          id: 6
+          id: 44
         }
         events {
           deparser_emit {
             header_type: "ethernet_t"
             byte_length: 14
           }
-          id: 7
+          id: 45
         }
         events {
           pipeline_stage {
@@ -483,7 +483,7 @@ replication {
             stage_kind: DEPARSER
             direction: EXIT
           }
-          id: 8
+          id: 46
         }
         output {
           dataplane_egress_port: 2

--- a/e2e_tests/trace_tree/recirculate.golden.txtpb
+++ b/e2e_tests/trace_tree/recirculate.golden.txtpb
@@ -165,7 +165,7 @@ continuation {
     events {
       packet_ingress {
       }
-      id: 1
+      id: 18
     }
     events {
       pipeline_stage {
@@ -173,7 +173,7 @@ continuation {
         stage_kind: PARSER
         direction: ENTER
       }
-      id: 2
+      id: 19
     }
     events {
       parser_transition {
@@ -181,7 +181,7 @@ continuation {
         from_state: "start"
         to_state: "accept"
       }
-      id: 3
+      id: 20
       source_info {
         file: "e2e_tests/trace_tree/recirculate.p4"
         line: 22
@@ -195,7 +195,7 @@ continuation {
         stage_kind: PARSER
         direction: EXIT
       }
-      id: 4
+      id: 21
     }
     events {
       pipeline_stage {
@@ -204,7 +204,7 @@ continuation {
         direction: ENTER
         dataplane_port: 0
       }
-      id: 5
+      id: 22
     }
     events {
       pipeline_stage {
@@ -213,7 +213,7 @@ continuation {
         direction: EXIT
         dataplane_port: 0
       }
-      id: 6
+      id: 23
     }
     events {
       pipeline_stage {
@@ -222,13 +222,13 @@ continuation {
         direction: ENTER
         dataplane_port: 0
       }
-      id: 7
+      id: 24
     }
     events {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 8
+      id: 25
       source_info {
         file: "e2e_tests/trace_tree/recirculate.p4"
         line: 33
@@ -244,7 +244,7 @@ continuation {
         direction: EXIT
         dataplane_port: 0
       }
-      id: 9
+      id: 26
     }
     events {
       pipeline_stage {
@@ -253,14 +253,14 @@ continuation {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 10
+      id: 27
     }
     events {
       branch {
         control_name: "MyEgress"
         taken: false
       }
-      id: 11
+      id: 28
       source_info {
         file: "e2e_tests/trace_tree/recirculate.p4"
         line: 39
@@ -280,7 +280,7 @@ continuation {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 12
+      id: 29
     }
     events {
       pipeline_stage {
@@ -289,7 +289,7 @@ continuation {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 13
+      id: 30
     }
     events {
       pipeline_stage {
@@ -298,7 +298,7 @@ continuation {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 14
+      id: 31
     }
     events {
       pipeline_stage {
@@ -306,14 +306,14 @@ continuation {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 15
+      id: 32
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 16
+      id: 33
     }
     events {
       pipeline_stage {
@@ -321,7 +321,7 @@ continuation {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 17
+      id: 34
     }
     output {
       dataplane_egress_port: 1

--- a/e2e_tests/trace_tree/resubmit.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit.golden.txtpb
@@ -106,7 +106,7 @@ continuation {
     events {
       packet_ingress {
       }
-      id: 1
+      id: 11
     }
     events {
       pipeline_stage {
@@ -114,7 +114,7 @@ continuation {
         stage_kind: PARSER
         direction: ENTER
       }
-      id: 2
+      id: 12
     }
     events {
       parser_transition {
@@ -122,7 +122,7 @@ continuation {
         from_state: "start"
         to_state: "accept"
       }
-      id: 3
+      id: 13
       source_info {
         file: "e2e_tests/trace_tree/resubmit.p4"
         line: 22
@@ -136,7 +136,7 @@ continuation {
         stage_kind: PARSER
         direction: EXIT
       }
-      id: 4
+      id: 14
     }
     events {
       pipeline_stage {
@@ -145,7 +145,7 @@ continuation {
         direction: ENTER
         dataplane_port: 0
       }
-      id: 5
+      id: 15
     }
     events {
       pipeline_stage {
@@ -154,7 +154,7 @@ continuation {
         direction: EXIT
         dataplane_port: 0
       }
-      id: 6
+      id: 16
     }
     events {
       pipeline_stage {
@@ -163,13 +163,13 @@ continuation {
         direction: ENTER
         dataplane_port: 0
       }
-      id: 7
+      id: 17
     }
     events {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 8
+      id: 18
       source_info {
         file: "e2e_tests/trace_tree/resubmit.p4"
         line: 34
@@ -183,7 +183,7 @@ continuation {
         control_name: "MyIngress"
         taken: false
       }
-      id: 9
+      id: 19
       source_info {
         file: "e2e_tests/trace_tree/resubmit.p4"
         line: 35
@@ -203,7 +203,7 @@ continuation {
         direction: EXIT
         dataplane_port: 0
       }
-      id: 10
+      id: 20
     }
     events {
       pipeline_stage {
@@ -212,7 +212,7 @@ continuation {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 11
+      id: 21
     }
     events {
       pipeline_stage {
@@ -221,7 +221,7 @@ continuation {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 12
+      id: 22
     }
     events {
       pipeline_stage {
@@ -230,7 +230,7 @@ continuation {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 13
+      id: 23
     }
     events {
       pipeline_stage {
@@ -239,7 +239,7 @@ continuation {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 14
+      id: 24
     }
     events {
       pipeline_stage {
@@ -247,14 +247,14 @@ continuation {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 15
+      id: 25
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 16
+      id: 26
     }
     events {
       pipeline_stage {
@@ -262,7 +262,7 @@ continuation {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 17
+      id: 27
     }
     output {
       dataplane_egress_port: 1

--- a/e2e_tests/trace_tree/resubmit_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/resubmit_preserve_meta.golden.txtpb
@@ -119,7 +119,7 @@ continuation {
     events {
       packet_ingress {
       }
-      id: 1
+      id: 12
     }
     events {
       pipeline_stage {
@@ -127,7 +127,7 @@ continuation {
         stage_kind: PARSER
         direction: ENTER
       }
-      id: 2
+      id: 13
     }
     events {
       parser_transition {
@@ -135,7 +135,7 @@ continuation {
         from_state: "start"
         to_state: "accept"
       }
-      id: 3
+      id: 14
       source_info {
         file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
         line: 29
@@ -149,7 +149,7 @@ continuation {
         stage_kind: PARSER
         direction: EXIT
       }
-      id: 4
+      id: 15
     }
     events {
       pipeline_stage {
@@ -158,7 +158,7 @@ continuation {
         direction: ENTER
         dataplane_port: 0
       }
-      id: 5
+      id: 16
     }
     events {
       pipeline_stage {
@@ -167,7 +167,7 @@ continuation {
         direction: EXIT
         dataplane_port: 0
       }
-      id: 6
+      id: 17
     }
     events {
       pipeline_stage {
@@ -176,13 +176,13 @@ continuation {
         direction: ENTER
         dataplane_port: 0
       }
-      id: 7
+      id: 18
     }
     events {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 8
+      id: 19
       source_info {
         file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
         line: 41
@@ -196,7 +196,7 @@ continuation {
         control_name: "MyIngress"
         taken: false
       }
-      id: 9
+      id: 20
       source_info {
         file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
         line: 42
@@ -213,7 +213,7 @@ continuation {
       assignment {
         target: "hdr.ethernet.etherType"
       }
-      id: 10
+      id: 21
       source_info {
         file: "e2e_tests/trace_tree/resubmit_preserve_meta.p4"
         line: 47
@@ -233,7 +233,7 @@ continuation {
         direction: EXIT
         dataplane_port: 0
       }
-      id: 11
+      id: 22
     }
     events {
       pipeline_stage {
@@ -242,7 +242,7 @@ continuation {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 12
+      id: 23
     }
     events {
       pipeline_stage {
@@ -251,7 +251,7 @@ continuation {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 13
+      id: 24
     }
     events {
       pipeline_stage {
@@ -260,7 +260,7 @@ continuation {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 14
+      id: 25
     }
     events {
       pipeline_stage {
@@ -269,7 +269,7 @@ continuation {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 15
+      id: 26
     }
     events {
       pipeline_stage {
@@ -277,14 +277,14 @@ continuation {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 16
+      id: 27
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 17
+      id: 28
     }
     events {
       pipeline_stage {
@@ -292,7 +292,7 @@ continuation {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 18
+      id: 29
     }
     output {
       dataplane_egress_port: 1

--- a/e2e_tests/trace_tree/selector_exit.golden.txtpb
+++ b/e2e_tests/trace_tree/selector_exit.golden.txtpb
@@ -101,7 +101,7 @@ choice {
           value: "\000\001"
         }
       }
-      id: 1
+      id: 9
       source_info {
         file: "e2e_tests/trace_tree/selector_exit.p4"
         line: 60
@@ -113,7 +113,7 @@ choice {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 2
+      id: 10
       source_info {
         file: "e2e_tests/trace_tree/selector_exit.p4"
         line: 36
@@ -147,7 +147,7 @@ choice {
         }
         action_name: "overwrite"
       }
-      id: 3
+      id: 11
       source_info {
         file: "e2e_tests/trace_tree/selector_exit.p4"
         line: 61
@@ -163,7 +163,7 @@ choice {
       action_execution {
         action_name: "overwrite"
       }
-      id: 4
+      id: 12
       source_info {
         file: "e2e_tests/trace_tree/selector_exit.p4"
         line: 61
@@ -175,7 +175,7 @@ choice {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 5
+      id: 13
       source_info {
         file: "e2e_tests/trace_tree/selector_exit.p4"
         line: 52
@@ -190,7 +190,7 @@ choice {
         stage_kind: CONTROL
         direction: EXIT
       }
-      id: 6
+      id: 14
     }
     events {
       pipeline_stage {
@@ -199,7 +199,7 @@ choice {
         direction: ENTER
         dataplane_port: 9
       }
-      id: 7
+      id: 15
     }
     events {
       pipeline_stage {
@@ -208,7 +208,7 @@ choice {
         direction: EXIT
         dataplane_port: 9
       }
-      id: 8
+      id: 16
     }
     events {
       pipeline_stage {
@@ -217,7 +217,7 @@ choice {
         direction: ENTER
         dataplane_port: 9
       }
-      id: 9
+      id: 17
     }
     events {
       pipeline_stage {
@@ -226,7 +226,7 @@ choice {
         direction: EXIT
         dataplane_port: 9
       }
-      id: 10
+      id: 18
     }
     events {
       pipeline_stage {
@@ -234,14 +234,14 @@ choice {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 11
+      id: 19
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 12
+      id: 20
     }
     events {
       pipeline_stage {
@@ -249,7 +249,7 @@ choice {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 13
+      id: 21
     }
     output {
       dataplane_egress_port: 9
@@ -265,7 +265,7 @@ choice {
           value: "\000\001"
         }
       }
-      id: 1
+      id: 22
       source_info {
         file: "e2e_tests/trace_tree/selector_exit.p4"
         line: 60
@@ -277,7 +277,7 @@ choice {
       assignment {
         target: "smeta.egress_spec"
       }
-      id: 2
+      id: 23
       source_info {
         file: "e2e_tests/trace_tree/selector_exit.p4"
         line: 37
@@ -296,7 +296,7 @@ choice {
         stage_kind: CONTROL
         direction: EXIT
       }
-      id: 3
+      id: 24
     }
     events {
       pipeline_stage {
@@ -305,7 +305,7 @@ choice {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 4
+      id: 25
     }
     events {
       pipeline_stage {
@@ -314,7 +314,7 @@ choice {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 5
+      id: 26
     }
     events {
       pipeline_stage {
@@ -323,7 +323,7 @@ choice {
         direction: ENTER
         dataplane_port: 1
       }
-      id: 6
+      id: 27
     }
     events {
       pipeline_stage {
@@ -332,7 +332,7 @@ choice {
         direction: EXIT
         dataplane_port: 1
       }
-      id: 7
+      id: 28
     }
     events {
       pipeline_stage {
@@ -340,14 +340,14 @@ choice {
         stage_kind: DEPARSER
         direction: ENTER
       }
-      id: 8
+      id: 29
     }
     events {
       deparser_emit {
         header_type: "ethernet_t"
         byte_length: 14
       }
-      id: 9
+      id: 30
     }
     events {
       pipeline_stage {
@@ -355,7 +355,7 @@ choice {
         stage_kind: DEPARSER
         direction: EXIT
       }
-      id: 10
+      id: 31
     }
     output {
       dataplane_egress_port: 1

--- a/simulator/Architecture.kt
+++ b/simulator/Architecture.kt
@@ -47,7 +47,10 @@ interface Architecture {
  * The [trace] tree carries the complete execution trace. Leaf nodes are [Output] or [Drop];
  * interior nodes ([Replication], [Choice], [Continuation]) represent branching and looping.
  */
-data class PipelineResult(val trace: TraceTree) {
+class PipelineResult(trace: TraceTree) {
+  /** Public traces always use ids that are unique across the full recursive tree. */
+  val trace: TraceTree = normalizeTraceEventIds(trace)
+
   /** All possible outcome sets, derived from the trace tree's fork structure. */
   val possibleOutcomes: List<List<OutputPacket>> by lazy { collectPossibleOutcomes(trace) }
 }

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -106,6 +106,71 @@ internal fun TraceTree.withEvents(events: List<TraceEvent>): TraceTree {
 internal fun prependEvents(tree: TraceTree, prefix: List<TraceEvent>): TraceTree =
   if (prefix.isEmpty()) tree else tree.withEvents(prefix + tree.eventsList)
 
+/**
+ * Assigns trace-global event ids and rewrites outcome causes to the new ids.
+ *
+ * Fork branches and continuations are often built from fresh [PacketContext]s, so their events can
+ * legitimately start with branch-local ids while the architecture is assembling the tree. This is
+ * the boundary where the simulator turns that internal representation into the public trace
+ * contract: every [TraceEvent.id] is unique across the recursive [TraceTree], and every cause still
+ * points to the event in the same node that originally triggered the outcome.
+ */
+internal fun normalizeTraceEventIds(tree: TraceTree): TraceTree =
+  TraceEventIdNormalizer().normalize(tree)
+
+private class TraceEventIdNormalizer {
+  private var nextEventId = 1L
+
+  fun normalize(tree: TraceTree): TraceTree = normalizeNode(tree)
+
+  private fun normalizeNode(node: TraceTree): TraceTree {
+    val eventIdMap = mutableMapOf<Long, Long>()
+    val normalized = TraceTree.newBuilder()
+    for (event in node.eventsList) {
+      val newId = nextEventId++
+      eventIdMap[event.id] = newId
+      normalized.addEvents(event.toBuilder().setId(newId))
+    }
+
+    // Outcome causes are node-local by construction: Replication/Choice/Drop cause references an
+    // event in the node's own events list, not an event in a child subtree.
+    fun remapCause(cause: Long): Long =
+      checkNotNull(eventIdMap[cause]) { "trace outcome cause $cause does not reference this node" }
+
+    when (node.outcomeCase) {
+      TraceTree.OutcomeCase.REPLICATION -> {
+        val replication = node.replication.toBuilder().clearBranches()
+        if (node.replication.hasCause()) replication.setCause(remapCause(node.replication.cause))
+        for (branch in node.replication.branchesList) {
+          replication.addBranches(normalizeNode(branch))
+        }
+        normalized.setReplication(replication)
+      }
+      TraceTree.OutcomeCase.CHOICE -> {
+        val choice = node.choice.toBuilder().clearBranches()
+        if (node.choice.hasCause()) choice.setCause(remapCause(node.choice.cause))
+        for (branch in node.choice.branchesList) {
+          choice.addBranches(normalizeNode(branch))
+        }
+        normalized.setChoice(choice)
+      }
+      TraceTree.OutcomeCase.CONTINUATION ->
+        normalized.setContinuation(
+          node.continuation.toBuilder().setNext(normalizeNode(node.continuation.next))
+        )
+      TraceTree.OutcomeCase.OUTPUT -> normalized.setOutput(node.output)
+      TraceTree.OutcomeCase.DROP -> {
+        val drop = node.drop.toBuilder()
+        if (node.drop.hasCause()) drop.setCause(remapCause(node.drop.cause))
+        normalized.setDrop(drop)
+      }
+      TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+      null -> {}
+    }
+    return normalized.build()
+  }
+}
+
 /** Creates a [TraceEvent] recording the packet's ingress port. */
 internal fun packetIngressEvent(ingressPort: DataplanePort): TraceEvent =
   TraceEvent.newBuilder()


### PR DESCRIPTION
## Summary

Fixes #796.

Trace event ids are documented as trace-global and are used by `Replication.cause`, `Choice.cause`, and `Drop.cause`. Fork branches and continuations can build their trace subtrees from fresh `PacketContext`s, so branch-local numbering can collide in the final recursive trace.

This PR normalizes a completed `TraceTree` at the `PipelineResult` boundary:

- assigns event ids in deterministic recursive traversal order
- rewrites each node's outcome `cause` through that node's old-to-new event-id mapping
- fails loudly if an outcome cause does not reference an event in its own node

It also extends `TraceTreeConsistencyTest` to assert that ids are unique across the full recursive tree and every cause resolves to exactly one event. The existing `clone_plus_selector` trace now covers the concrete nested fork case from #796.

## Validation

- `bazel test //e2e_tests/trace_tree:trace_tree_consistency_test //e2e_tests/trace_tree:golden_trace_tree_test //simulator:all --test_output=errors`
- `./tools/lint.sh`
