### PR TITLE
Index @refers_to validation lookups

### DIFF
--- a/grpc/MultiDeviceScaleBenchmark.kt
+++ b/grpc/MultiDeviceScaleBenchmark.kt
@@ -27,11 +27,16 @@ import p4.v1.P4RuntimeOuterClass.WriteRequest
  *
  * The benchmark loads SAI middleblock on every device. `entriesPerDevice` installs that many IPv6
  * route entries per device, plus the four prerequisite SAI objects needed by `@refers_to`.
+ *
+ * Use `-Dfourward.multidevice.mode=refersTo` to stress `@refers_to` validation directly. Each
+ * logical route gets distinct VRF, router-interface, neighbor, nexthop, and IPv6-route entries,
+ * covering match-field references and action parameters with multiple references.
  */
 @Suppress("FunctionNaming", "MagicNumber")
 class MultiDeviceScaleBenchmark {
   @Test
   fun `multi-device scale benchmark`() = runBlocking {
+    val mode = benchmarkMode()
     val deviceCount = intProperty("fourward.multidevice.devices", default = 100)
     val entriesPerDevice = intProperty("fourward.multidevice.entriesPerDevice", default = 0)
     val writeBatchSize = intProperty("fourward.multidevice.writeBatchSize", default = 1_000)
@@ -39,6 +44,11 @@ class MultiDeviceScaleBenchmark {
     require(entriesPerDevice >= 0) { "fourward.multidevice.entriesPerDevice must be non-negative" }
     require(entriesPerDevice <= MAX_IPV6_ROUTES_PER_DEVICE) {
       "entriesPerDevice must be <= $MAX_IPV6_ROUTES_PER_DEVICE for unique IPv6 /128 routes"
+    }
+    require(
+      mode != BenchmarkMode.REFERS_TO || entriesPerDevice <= MAX_REFERS_TO_CHAINS_PER_DEVICE
+    ) {
+      "entriesPerDevice must be <= $MAX_REFERS_TO_CHAINS_PER_DEVICE in refersTo mode"
     }
     require(writeBatchSize > 0) { "fourward.multidevice.writeBatchSize must be positive" }
 
@@ -64,7 +74,8 @@ class MultiDeviceScaleBenchmark {
           .setP4Info(config.p4Info)
           .setP4DeviceConfig(config.device.toByteString())
           .build()
-      val entryBatches = saiEntries(config, entriesPerDevice).chunked(writeBatchSize)
+      val entryPlan = saiEntries(config, entriesPerDevice, mode)
+      val entryBatches = entryPlan.entities.chunked(writeBatchSize)
 
       val populateMs = elapsedMillis {
         for (deviceId in 1L..deviceCount.toLong()) {
@@ -85,8 +96,10 @@ class MultiDeviceScaleBenchmark {
       println()
       println("Multi-device scale benchmark")
       println("pipeline: sai_middleblock")
+      println("mode: ${mode.propertyValue}")
       println("devices: $deviceCount")
       println("ipv6_routes/device: $entriesPerDevice")
+      println("referenced_objects/device: ${entryPlan.referencedObjectCount}")
       println("total_table_entries/device: ${entryBatches.sumOf { it.size }}")
       println("create_ms: $createMs")
       println("populate_ms: $populateMs")
@@ -112,6 +125,15 @@ class MultiDeviceScaleBenchmark {
   private fun intProperty(name: String, default: Int): Int =
     System.getProperty(name)?.toIntOrNull() ?: default
 
+  private fun benchmarkMode(): BenchmarkMode {
+    val value = System.getProperty("fourward.multidevice.mode", BenchmarkMode.ROUTES.propertyValue)
+    return BenchmarkMode.entries.find { it.propertyValue == value }
+      ?: error(
+        "fourward.multidevice.mode must be one of " +
+          BenchmarkMode.entries.joinToString(", ") { it.propertyValue }
+      )
+  }
+
   private suspend fun elapsedMillis(block: suspend () -> Unit): Long {
     val start = System.nanoTime()
     block()
@@ -129,32 +151,84 @@ class MultiDeviceScaleBenchmark {
 
   private fun bytesToMiB(bytes: Long): Long = bytes / (1024 * 1024)
 
-  private fun saiEntries(config: PipelineConfig, routeCount: Int): List<Entity> {
-    if (routeCount == 0) return emptyList()
-    return buildList {
-      add(buildVrfEntry(config))
+  private fun saiEntries(config: PipelineConfig, routeCount: Int, mode: BenchmarkMode): EntryPlan =
+    when (mode) {
+      BenchmarkMode.ROUTES -> saiRouteEntries(config, routeCount)
+      BenchmarkMode.REFERS_TO -> saiRefersToEntries(config, routeCount)
+    }
+
+  private fun saiRouteEntries(config: PipelineConfig, routeCount: Int): EntryPlan {
+    if (routeCount == 0) return EntryPlan(emptyList(), referencedObjectCount = 0)
+    val entities = buildList {
+      add(buildVrfEntry(config, VRF_ID))
       add(buildRouterInterfaceEntry(config))
       add(buildNeighborEntry(config))
       add(buildNexthopEntry(config))
       for (index in 0 until routeCount) {
-        add(buildIpv6RouteEntry(config, index))
+        add(buildIpv6RouteEntry(config, index, VRF_ID))
       }
     }
+    return EntryPlan(entities, referencedObjectCount = 4)
   }
 
-  private fun buildVrfEntry(config: PipelineConfig): Entity {
+  private fun saiRefersToEntries(config: PipelineConfig, routeCount: Int): EntryPlan {
+    if (routeCount == 0) return EntryPlan(emptyList(), referencedObjectCount = 0)
+    val vrfCount = minOf(routeCount, SAI_VRF_TABLE_SIZE)
+    val entities = buildList {
+      for (index in 0 until routeCount) {
+        add(buildRouterInterfaceEntry(config, benchmarkRouterInterfaceId(index)))
+      }
+      for (index in 0 until routeCount) {
+        add(
+          buildNeighborEntry(config, benchmarkRouterInterfaceId(index), benchmarkNeighborId(index))
+        )
+      }
+      for (index in 0 until routeCount) {
+        add(
+          buildNexthopEntry(
+            config,
+            benchmarkNexthopId(index),
+            benchmarkRouterInterfaceId(index),
+            benchmarkNeighborId(index),
+          )
+        )
+      }
+      for (index in 0 until vrfCount) {
+        add(buildVrfEntry(config, benchmarkVrfId(index)))
+      }
+      for (index in 0 until routeCount) {
+        add(
+          buildIpv6RouteEntry(
+            config,
+            index,
+            benchmarkVrfId(index % vrfCount),
+            benchmarkNexthopId(index),
+          )
+        )
+      }
+    }
+    return EntryPlan(
+      entities,
+      referencedObjectCount = routeCount * REFERENCED_OBJECTS_PER_CHAIN + vrfCount,
+    )
+  }
+
+  private fun buildVrfEntry(config: PipelineConfig, vrfId: String): Entity {
     val table = findTable(config, "vrf_table")
     val action = findAction(config, "no_action")
-    return buildEntry(table, action, matches = listOf(exactMatch(table, "vrf_id", VRF_ID)))
+    return buildEntry(table, action, matches = listOf(exactMatch(table, "vrf_id", vrfId)))
   }
 
-  private fun buildRouterInterfaceEntry(config: PipelineConfig): Entity {
+  private fun buildRouterInterfaceEntry(
+    config: PipelineConfig,
+    routerInterfaceId: String = ROUTER_INTERFACE_ID,
+  ): Entity {
     val table = findTable(config, "router_interface_table")
     val action = findAction(config, "set_port_and_src_mac")
     return buildEntry(
       table,
       action,
-      matches = listOf(exactMatch(table, "router_interface_id", ROUTER_INTERFACE_ID)),
+      matches = listOf(exactMatch(table, "router_interface_id", routerInterfaceId)),
       params =
         listOf(
           stringParam(action, "port", PORT_ID),
@@ -163,7 +237,11 @@ class MultiDeviceScaleBenchmark {
     )
   }
 
-  private fun buildNeighborEntry(config: PipelineConfig): Entity {
+  private fun buildNeighborEntry(
+    config: PipelineConfig,
+    routerInterfaceId: String = ROUTER_INTERFACE_ID,
+    neighborId: ByteArray = NEIGHBOR_ID,
+  ): Entity {
     val table = findTable(config, "neighbor_table")
     val action = findAction(config, "set_dst_mac")
     return buildEntry(
@@ -171,8 +249,8 @@ class MultiDeviceScaleBenchmark {
       action,
       matches =
         listOf(
-          exactMatch(table, "router_interface_id", ROUTER_INTERFACE_ID),
-          exactMatch(table, "neighbor_id", NEIGHBOR_ID),
+          exactMatch(table, "router_interface_id", routerInterfaceId),
+          exactMatch(table, "neighbor_id", neighborId),
         ),
       params =
         listOf(
@@ -192,22 +270,32 @@ class MultiDeviceScaleBenchmark {
     )
   }
 
-  private fun buildNexthopEntry(config: PipelineConfig): Entity {
+  private fun buildNexthopEntry(
+    config: PipelineConfig,
+    nexthopId: String = NEXTHOP_ID,
+    routerInterfaceId: String = ROUTER_INTERFACE_ID,
+    neighborId: ByteArray = NEIGHBOR_ID,
+  ): Entity {
     val table = findTable(config, "nexthop_table")
     val action = findAction(config, "set_ip_nexthop")
     return buildEntry(
       table,
       action,
-      matches = listOf(exactMatch(table, "nexthop_id", NEXTHOP_ID)),
+      matches = listOf(exactMatch(table, "nexthop_id", nexthopId)),
       params =
         listOf(
-          stringParam(action, "router_interface_id", ROUTER_INTERFACE_ID),
-          bytesParam(action, "neighbor_id", NEIGHBOR_ID),
+          stringParam(action, "router_interface_id", routerInterfaceId),
+          bytesParam(action, "neighbor_id", neighborId),
         ),
     )
   }
 
-  private fun buildIpv6RouteEntry(config: PipelineConfig, index: Int): Entity {
+  private fun buildIpv6RouteEntry(
+    config: PipelineConfig,
+    index: Int,
+    vrfId: String,
+    nexthopId: String = NEXTHOP_ID,
+  ): Entity {
     val table = findTable(config, "ipv6_table")
     val action = findAction(config, "set_nexthop_id")
     return buildEntry(
@@ -215,10 +303,10 @@ class MultiDeviceScaleBenchmark {
       action,
       matches =
         listOf(
-          exactMatch(table, "vrf_id", VRF_ID),
+          exactMatch(table, "vrf_id", vrfId),
           lpmMatch(table, "ipv6_dst", ipv6Address(index), prefixLen = 128),
         ),
-      params = listOf(stringParam(action, "nexthop_id", NEXTHOP_ID)),
+      params = listOf(stringParam(action, "nexthop_id", nexthopId)),
     )
   }
 
@@ -329,8 +417,29 @@ class MultiDeviceScaleBenchmark {
       (index and 0xFF).toByte(),
     )
 
+  private fun benchmarkVrfId(index: Int): String = "benchmark-vrf-$index"
+
+  private fun benchmarkRouterInterfaceId(index: Int): String = "benchmark-rif-$index"
+
+  private fun benchmarkNexthopId(index: Int): String = "benchmark-nhop-$index"
+
+  private fun benchmarkNeighborId(index: Int): ByteArray =
+    ByteArray(16) { byteIndex ->
+      if (byteIndex >= 12) (index ushr ((15 - byteIndex) * 8)).toByte() else 0
+    }
+
+  private enum class BenchmarkMode(val propertyValue: String) {
+    ROUTES("routes"),
+    REFERS_TO("refersTo"),
+  }
+
+  private data class EntryPlan(val entities: List<Entity>, val referencedObjectCount: Int)
+
   companion object {
     private const val MAX_IPV6_ROUTES_PER_DEVICE = 1 shl 24
+    private const val REFERENCED_OBJECTS_PER_CHAIN = 3
+    private const val MAX_REFERS_TO_CHAINS_PER_DEVICE = 4_096
+    private const val SAI_VRF_TABLE_SIZE = 64
     private const val VRF_ID = "benchmark-vrf"
     private const val ROUTER_INTERFACE_ID = "benchmark-rif"
     private const val NEXTHOP_ID = "benchmark-nhop"

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -53,6 +53,8 @@ private data class ResolvedTableWrite(
   val storedEntry: TableEntry,
 )
 
+private data class ReferencedFieldValue(val fieldId: Int, val value: ByteString)
+
 private fun applyInlineDirectResources(
   rawEntry: TableEntry,
   storedEntry: TableEntry,
@@ -355,6 +357,8 @@ class TableStore : TableDataReader {
     private val tableEntriesByName: MutableMap<String, MutableList<TableEntry>> = mutableMapOf()
     private val tableEntryIndexes: MutableMap<String, MutableMap<TableEntryKey, Int>> =
       mutableMapOf()
+    private val tableFieldValueCounts: MutableMap<String, MutableMap<ReferencedFieldValue, Int>> =
+      mutableMapOf()
     internal val directMeterData: MutableMap<TableEntry, P4RuntimeOuterClass.MeterConfig> =
       mutableMapOf()
     internal val defaultActions: MutableMap<String, DefaultAction> = mutableMapOf()
@@ -403,21 +407,32 @@ class TableStore : TableDataReader {
     internal fun tableEntryAt(tableName: String, index: Int): TableEntry? =
       tableEntriesByName[tableName]?.getOrNull(index)
 
+    internal fun hasEntryWithFieldValue(
+      tableName: String,
+      fieldId: Int,
+      value: ByteString,
+    ): Boolean =
+      tableFieldValueCounts[tableName]?.containsKey(ReferencedFieldValue(fieldId, value)) ?: false
+
     internal fun setTableEntries(tableName: String, entries: List<TableEntry>) {
       tableEntriesByName[tableName] = entries.toMutableList()
       rebuildTableEntryIndex(tableName)
+      rebuildTableFieldValueIndex(tableName)
     }
 
     internal fun addTableEntry(tableName: String, entry: TableEntry) {
       val entries = tableEntriesByName.getOrPut(tableName) { mutableListOf() }
       entries.add(entry)
       tableEntryIndexes.getOrPut(tableName) { mutableMapOf() }[entry.key()] = entries.lastIndex
+      addFieldValues(tableName, entry)
     }
 
     internal fun replaceTableEntry(tableName: String, index: Int, entry: TableEntry) {
       val entries = tableEntriesByName[tableName] ?: error("unknown table '$tableName'")
       val old = entries[index]
       entries[index] = entry
+      removeFieldValues(tableName, old)
+      addFieldValues(tableName, entry)
       tableEntryIndexes
         .getOrPut(tableName) { mutableMapOf() }
         .let { indexByKey ->
@@ -429,6 +444,7 @@ class TableStore : TableDataReader {
     internal fun removeTableEntry(tableName: String, index: Int): TableEntry {
       val entries = tableEntriesByName[tableName] ?: error("unknown table '$tableName'")
       val removed = entries.removeAt(index)
+      removeFieldValues(tableName, removed)
       rebuildTableEntryIndex(tableName)
       return removed
     }
@@ -438,6 +454,42 @@ class TableStore : TableDataReader {
       tableEntryIndexes[tableName] =
         entries.withIndex().associateTo(mutableMapOf()) { (index, entry) -> entry.key() to index }
     }
+
+    private fun rebuildTableFieldValueIndex(tableName: String) {
+      tableFieldValueCounts.remove(tableName)
+      tableEntriesByName[tableName]?.forEach { addFieldValues(tableName, it) }
+    }
+
+    private fun addFieldValues(tableName: String, entry: TableEntry) {
+      for (fieldValue in referencedFieldValues(entry)) {
+        tableFieldValueCounts.getOrPut(tableName) { mutableMapOf() }.merge(fieldValue, 1, Int::plus)
+      }
+    }
+
+    private fun removeFieldValues(tableName: String, entry: TableEntry) {
+      val counts = tableFieldValueCounts[tableName] ?: return
+      for (fieldValue in referencedFieldValues(entry)) {
+        val remaining = (counts[fieldValue] ?: error("missing field-value index entry")) - 1
+        if (remaining == 0) counts.remove(fieldValue) else counts[fieldValue] = remaining
+      }
+      if (counts.isEmpty()) tableFieldValueCounts.remove(tableName)
+    }
+
+    private fun referencedFieldValues(entry: TableEntry): Sequence<ReferencedFieldValue> =
+      entry.matchList.asSequence().mapNotNull { match ->
+        when (match.fieldMatchTypeCase) {
+          P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT ->
+            ReferencedFieldValue(match.fieldId, match.exact.value)
+          P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
+            ReferencedFieldValue(match.fieldId, match.optional.value)
+          P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY,
+          P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM,
+          P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE,
+          P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
+          P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
+          null -> null
+        }
+      }
 
     /** Creates a structural copy. Protobuf entries are shared; only containers are copied. */
     fun deepCopy(): ForwardingSnapshot =
@@ -2072,21 +2124,7 @@ class TableStore : TableDataReader {
    */
   fun hasEntryWithFieldValue(tableId: Int, fieldId: Int, value: ByteString): Boolean {
     val tableName = tableNameById[tableId] ?: return false
-    return writeState.tableEntries(tableName).any { entry ->
-      entry.matchList.any { fm ->
-        fm.fieldId == fieldId &&
-          when (fm.fieldMatchTypeCase) {
-            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.EXACT -> fm.exact.value == value
-            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL -> fm.optional.value == value
-            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY,
-            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM,
-            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE,
-            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OTHER,
-            P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.FIELDMATCHTYPE_NOT_SET,
-            null -> false
-          }
-      }
-    }
+    return writeState.hasEntryWithFieldValue(tableName, fieldId, value)
   }
 
   // -------------------------------------------------------------------------

--- a/simulator/TableStore.kt
+++ b/simulator/TableStore.kt
@@ -461,8 +461,9 @@ class TableStore : TableDataReader {
     }
 
     private fun addFieldValues(tableName: String, entry: TableEntry) {
+      val counts = tableFieldValueCounts.getOrPut(tableName) { mutableMapOf() }
       for (fieldValue in referencedFieldValues(entry)) {
-        tableFieldValueCounts.getOrPut(tableName) { mutableMapOf() }.merge(fieldValue, 1, Int::plus)
+        counts.merge(fieldValue, 1, Int::plus)
       }
     }
 
@@ -482,6 +483,8 @@ class TableStore : TableDataReader {
             ReferencedFieldValue(match.fieldId, match.exact.value)
           P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.OPTIONAL ->
             ReferencedFieldValue(match.fieldId, match.optional.value)
+          // @refers_to applies only to point values; range-like match types cannot be used as
+          // reference targets, so they don't participate in the field-value index.
           P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.TERNARY,
           P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.LPM,
           P4RuntimeOuterClass.FieldMatch.FieldMatchTypeCase.RANGE,

--- a/simulator/TableStoreTest.kt
+++ b/simulator/TableStoreTest.kt
@@ -110,6 +110,28 @@ class TableStoreTest {
       .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId)))
       .build()
 
+  private fun exactEntry(
+    firstFieldId: Int,
+    firstValue: ByteArray,
+    secondFieldId: Int,
+    secondValue: ByteArray,
+    actionId: Int,
+  ): TableEntry =
+    TableEntry.newBuilder()
+      .setTableId(TABLE_ID)
+      .addMatch(
+        FieldMatch.newBuilder()
+          .setFieldId(firstFieldId)
+          .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(firstValue)))
+      )
+      .addMatch(
+        FieldMatch.newBuilder()
+          .setFieldId(secondFieldId)
+          .setExact(FieldMatch.Exact.newBuilder().setValue(ByteString.copyFrom(secondValue)))
+      )
+      .setAction(TableAction.newBuilder().setAction(Action.newBuilder().setActionId(actionId)))
+      .build()
+
   private fun lpmEntry(fieldId: Int, value: ByteArray, prefixLen: Int, actionId: Int): TableEntry =
     TableEntry.newBuilder()
       .setTableId(TABLE_ID)
@@ -548,6 +570,55 @@ class TableStoreTest {
     val thirdResult = store.lookup(TABLE_NAME, listOf("1" to BitVal(3, 8)))
     assertTrue(thirdResult.hit)
     assertEquals("action99", thirdResult.actionName)
+  }
+
+  @Test
+  fun `hasEntryWithFieldValue sees uncommitted exact match writes`() {
+    val value = byteArrayOf(0x0A)
+
+    assertEquals(WriteResult.Success, store.write(insertUpdate(exactEntry(1, value, 10))))
+
+    assertTrue(store.hasEntryWithFieldValue(TABLE_ID, fieldId = 1, ByteString.copyFrom(value)))
+  }
+
+  @Test
+  fun `hasEntryWithFieldValue tracks optional match writes`() {
+    val value = byteArrayOf(0x0B)
+
+    assertEquals(WriteResult.Success, store.write(insertUpdate(optionalEntry(1, value, 10))))
+
+    assertTrue(store.hasEntryWithFieldValue(TABLE_ID, fieldId = 1, ByteString.copyFrom(value)))
+  }
+
+  @Test
+  fun `hasEntryWithFieldValue ignores non-exact match kinds`() {
+    val value = byteArrayOf(0x0C)
+
+    assertEquals(
+      WriteResult.Success,
+      store.write(insertUpdate(lpmEntry(1, value, prefixLen = 8, actionId = 10))),
+    )
+
+    assertFalse(store.hasEntryWithFieldValue(TABLE_ID, fieldId = 1, ByteString.copyFrom(value)))
+  }
+
+  @Test
+  fun `hasEntryWithFieldValue removes value only after last matching entry is deleted`() {
+    val referencedValue = byteArrayOf(0x0D)
+    val first = exactEntry(1, referencedValue, 2, byteArrayOf(0x01), actionId = 10)
+    val second = exactEntry(1, referencedValue, 2, byteArrayOf(0x02), actionId = 20)
+    assertEquals(WriteResult.Success, store.write(insertUpdate(first)))
+    assertEquals(WriteResult.Success, store.write(insertUpdate(second)))
+
+    assertEquals(WriteResult.Success, store.write(deleteUpdate(first)))
+    assertTrue(
+      store.hasEntryWithFieldValue(TABLE_ID, fieldId = 1, ByteString.copyFrom(referencedValue))
+    )
+
+    assertEquals(WriteResult.Success, store.write(deleteUpdate(second)))
+    assertFalse(
+      store.hasEntryWithFieldValue(TABLE_ID, fieldId = 1, ByteString.copyFrom(referencedValue))
+    )
   }
 
   // P4Runtime spec §9.1: INSERT of a duplicate entry must return ALREADY_EXISTS.


### PR DESCRIPTION
## Summary

Adds a SAI-based `refersTo` mode to the multi-device benchmark and uses it to stress `@refers_to` validation directly, including match-field references and action parameters with multiple references. The benchmark showed `TableStore.hasEntryWithFieldValue()` becoming a meaningful cost, so this adds a local field-value count index next to the existing table-entry key index.

Closes #794.

## Results

On this machine with one device and 4096 SAI reference chains, the targeted `@refers_to` stress case improved by about 3.3x:

- Before index: `populate_ms=1130` for `mode=refersTo`
- After index: `populate_ms=342` for `mode=refersTo`
- Common route mode stayed flat: `populate_ms=98` before, `populate_ms=102` after

## Tests

- `bazel test //simulator:TableStoreTest //grpc:ReferenceValidatorTest //grpc:SaiP4E2ETest --test_output=errors`
- `bazel test //grpc:MultiDeviceScaleBenchmark --test_output=streamed --test_tag_filters=heavy --jvmopt=-Dfourward.multidevice.devices=1 --jvmopt=-Dfourward.multidevice.entriesPerDevice=4096 --jvmopt=-Dfourward.multidevice.mode=refersTo`
- `bazel test //grpc:MultiDeviceScaleBenchmark --test_output=streamed --test_tag_filters=heavy --jvmopt=-Dfourward.multidevice.devices=1 --jvmopt=-Dfourward.multidevice.entriesPerDevice=4096 --jvmopt=-Dfourward.multidevice.mode=routes`
- `./tools/format.sh`
- `./tools/lint.sh`