### PR TITLE
[codex] Implement network-wide simulation

### DIFF
--- a/designs/network_simulation.md
+++ b/designs/network_simulation.md
@@ -1,6 +1,6 @@
 # Network-Wide Simulation
 
-**Status: proposed**
+**Status: implemented**
 
 ## Problem
 
@@ -158,10 +158,10 @@ message InjectNetworkPacketRequest {
 
 message InjectNetworkPacketResponse {
   NetworkTrace trace = 1;
-  repeated NetworkPacketSet possible_outcomes = 2;
+  repeated NetworkOutcome possible_outcomes = 2;
 }
 
-message NetworkPacketSet {
+message NetworkOutcome {
   repeated NetworkEgressPacket packets = 1;
 }
 ```
@@ -204,9 +204,8 @@ message LinkTraversal {
 }
 
 message NetworkEgressPacket {
-  uint64 device_id = 1;
-  NetworkPort egress = 2;
-  bytes payload = 3;
+  NetworkPort egress = 1;
+  bytes payload = 2;
 }
 
 message HopLimitExceeded {
@@ -234,7 +233,7 @@ The network layer follows only terminal `Output` leaves:
 | `Output` without a matching configured link | Record a network egress packet. |
 | `Output` with multiple matching configured links | Fail with an ambiguous-topology error. |
 | `Replication` | Follow every output leaf in every branch. |
-| `Choice` | Preserve each branch as a possible world; do not combine downstream paths across alternatives. |
+| `Choice` | Preserve each branch as a possible outcome; do not combine downstream paths across alternatives. |
 | `Continuation` | Continue walking the nested trace until terminal leaves are reached. |
 
 The response mirrors the existing Dataplane API: `trace` is the structured
@@ -245,15 +244,16 @@ only need final packets leaving the modeled network.
 
 `possible_outcomes` is derived from the network trace:
 
-- `Replication` combines packets in the same possible world.
-- `Choice` creates alternative possible worlds.
+- `Replication` combines packets in the same possible outcome.
+- `Choice` creates alternative possible outcomes.
 - Downstream `Choice` nodes multiply with upstream choices.
-- Only packets that leave the modeled topology appear in the final packet sets.
+- Only packets that leave the modeled topology appear in the final outcomes.
 
 This matches the existing Dataplane meaning, lifted from one switch to the
-whole network.
+whole network: the outer collection is a set of distinct outcomes, while each
+outcome is a multiset of packets.
 
-Possible worlds can converge. For example, two upstream choice branches may
+Possible outcomes can converge. For example, two upstream choice branches may
 emit the same packet into the same downstream endpoint, producing the same
 network suffix. The first design intentionally does not memoize those suffixes.
 Memoization is only correct if the suffix is pure with respect to the topology,
@@ -329,6 +329,7 @@ simulation reuses the same dataplane behavior as `InjectPacket`.
 | endpoint already linked | `ALREADY_EXISTS` |
 | removing an absent link | `NOT_FOUND` |
 | malformed asymmetric remove request | `INVALID_ARGUMENT` |
+| duplicate endpoint in a bulk add/remove request | `INVALID_ARGUMENT` |
 | missing pipeline or port translation during injection | `FAILED_PRECONDITION` |
 | output matches both a dataplane-port link and a P4Runtime-port link | `FAILED_PRECONDITION` |
 | `max_hops = 0` in request | `INVALID_ARGUMENT` |
@@ -368,7 +369,8 @@ Tests should prove the contracts that are easy to break:
 - outputs matching both a dataplane-port link and a P4Runtime-port link fail
   loudly
 - multicast/clone output follows all linked output leaves
-- action-selector `Choice` preserves separate possible worlds
+- action-selector `Choice` preserves separate possible outcomes, and identical
+  outcomes collapse
 - hop limit stops loops deterministically
 - missing P4Runtime port translation produces an actionable error
 - existing Dataplane and P4Runtime single-device tests remain unchanged

--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -34,6 +34,8 @@ cc_library(
         "//grpc:dataplane_cc_proto",
         "//grpc:management_cc_grpc",
         "//grpc:management_cc_proto",
+        "//grpc:network_cc_grpc",
+        "//grpc:network_cc_proto",
         "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/status",
@@ -78,6 +80,23 @@ cc_library(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/synchronization",
+        "@abseil-cpp//absl/time",
+        "@grpc//:grpc++",
+    ],
+)
+
+cc_library(
+    name = "network_client",
+    srcs = ["network_client.cc"],
+    hdrs = ["network_client.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":fourward_server",
+        "//grpc:network_cc_grpc",
+        "//grpc:network_cc_proto",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
         "@grpc//:grpc++",
     ],
@@ -160,6 +179,30 @@ cc_test(
         "@abseil-cpp//absl/time",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "network_client_test",
+    srcs = ["network_client_test.cc"],
+    data = ["//e2e_tests/passthrough:passthrough_p4runtime"],
+    local_defines = [
+        'PASSTHROUGH_PIPELINE_RLOCATION=\\"$(rlocationpath //e2e_tests/passthrough:passthrough_p4runtime)\\"',
+    ],
+    deps = [
+        ":fourward_server",
+        ":management_client",
+        ":network_client",
+        "//grpc:network_cc_proto",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@grpc//:grpc++",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
     ],
 )
 

--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -7,6 +7,16 @@ package(
 )
 
 cc_library(
+    name = "grpc_util",
+    hdrs = ["grpc_util.h"],
+    deps = [
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/time",
+        "@grpc//:grpc++",
+    ],
+)
+
+cc_library(
     name = "output_capture",
     srcs = ["output_capture.cc"],
     hdrs = ["output_capture.h"],
@@ -43,10 +53,10 @@ cc_library(
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/time",
-        "@bazel_tools//tools/cpp/runfiles",
         "@grpc//:grpc++",
         "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
         "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+        "@rules_cc//cc/runfiles",
     ],
 )
 
@@ -57,6 +67,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":fourward_server",
+        ":grpc_util",
         "//grpc:management_cc_grpc",
         "//grpc:management_cc_proto",
         "@abseil-cpp//absl/status",
@@ -73,6 +84,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":fourward_server",
+        ":grpc_util",
         "//grpc:dataplane_cc_grpc",
         "//grpc:dataplane_cc_proto",
         "@abseil-cpp//absl/base:core_headers",
@@ -92,6 +104,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":fourward_server",
+        ":grpc_util",
         "//grpc:network_cc_grpc",
         "//grpc:network_cc_proto",
         "@abseil-cpp//absl/status",
@@ -99,6 +112,23 @@ cc_library(
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
         "@grpc//:grpc++",
+    ],
+)
+
+cc_library(
+    name = "test_util",
+    testonly = True,
+    hdrs = ["test_util.h"],
+    deps = [
+        ":fourward_server",
+        ":grpc_util",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@grpc//:grpc++",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+        "@rules_cc//cc/runfiles",
     ],
 )
 
@@ -193,15 +223,12 @@ cc_test(
         ":fourward_server",
         ":management_client",
         ":network_client",
+        ":test_util",
         "//grpc:network_cc_proto",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
-        "@abseil-cpp//absl/strings",
-        "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
-        "@grpc//:grpc++",
-        "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
         "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
     ],
 )
@@ -222,12 +249,11 @@ cc_test(
         ":dataplane_matchers",
         ":fourward_server",
         ":management_client",
+        ":test_util",
         "//grpc:dataplane_cc_proto",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
-        "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
-        "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@grpc//:grpc++",
@@ -261,11 +287,11 @@ cc_test(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
-        "@bazel_tools//tools/cpp/runfiles",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@grpc//:grpc++",
         "@p4runtime//proto/p4/v1:p4runtime_cc_grpc",
         "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+        "@rules_cc//cc/runfiles",
     ],
 )

--- a/fourward_cc/dataplane_client.cc
+++ b/fourward_cc/dataplane_client.cc
@@ -3,7 +3,6 @@
 
 #include "fourward_cc/dataplane_client.h"
 
-#include <chrono>
 #include <deque>
 #include <memory>
 #include <optional>
@@ -19,6 +18,7 @@
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "fourward_cc/fourward_server.h"
+#include "fourward_cc/grpc_util.h"
 #include "grpc/dataplane.grpc.pb.h"
 #include "grpc/dataplane.pb.h"
 #include "grpcpp/client_context.h"
@@ -27,19 +27,6 @@
 
 namespace fourward {
 namespace {
-
-absl::Status ToAbsl(const grpc::Status &s) {
-  if (s.ok()) return absl::OkStatus();
-  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
-                      s.error_message());
-}
-
-std::chrono::system_clock::time_point AbsoluteDeadline(
-    absl::Duration relative) {
-  // time_point_cast: macOS system_clock uses microseconds, not nanoseconds.
-  return std::chrono::time_point_cast<std::chrono::system_clock::duration>(
-      std::chrono::system_clock::now() + absl::ToChronoNanoseconds(relative));
-}
 
 InjectPacketRequest MakeRequest(uint64_t device_id, DataplanePort ingress_port,
                                 std::string_view payload, Tag tag) {

--- a/fourward_cc/dataplane_client_e2e_test.cc
+++ b/fourward_cc/dataplane_client_e2e_test.cc
@@ -9,8 +9,6 @@
 #include "fourward_cc/dataplane_client.h"
 
 #include <cstdint>
-#include <fstream>
-#include <iterator>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -18,18 +16,17 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
 #include "fourward_cc/dataplane_matchers.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "grpc/dataplane.pb.h"
-#include "grpcpp/client_context.h"
-#include "p4/v1/p4runtime.grpc.pb.h"
-#include "p4/v1/p4runtime.pb.h"
 #include "fourward_cc/fourward_server.h"
 #include "fourward_cc/management_client.h"
-#include "tools/cpp/runfiles/runfiles.h"
+#include "fourward_cc/test_util.h"
+#include "gmock/gmock.h"
+#include "grpc/dataplane.pb.h"
+#include "grpcpp/client_context.h"
+#include "gtest/gtest.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "p4/v1/p4runtime.pb.h"
 
 #ifndef PASSTHROUGH_PIPELINE_RLOCATION
 #error "PASSTHROUGH_PIPELINE_RLOCATION must be set by the BUILD rule"
@@ -41,82 +38,6 @@
 
 namespace fourward {
 namespace {
-
-using ::bazel::tools::cpp::runfiles::Runfiles;
-
-using P4RuntimeStream =
-    grpc::ClientReaderWriter<p4::v1::StreamMessageRequest,
-                             p4::v1::StreamMessageResponse>;
-
-absl::Status ToAbsl(const grpc::Status& s) {
-  if (s.ok()) return absl::OkStatus();
-  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
-                      s.error_message());
-}
-
-absl::StatusOr<std::string> ReadRunfile(const std::string& rlocation) {
-  std::string error;
-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", &error));
-  if (runfiles == nullptr) {
-    return absl::InternalError(absl::StrCat("runfiles: ", error));
-  }
-  std::string path = runfiles->Rlocation(rlocation);
-  if (path.empty()) {
-    return absl::NotFoundError(
-        absl::StrCat("not found in runfiles: ", rlocation));
-  }
-  std::ifstream file(path, std::ios::binary);
-  if (!file) {
-    return absl::NotFoundError(absl::StrCat("cannot open: ", path));
-  }
-  return std::string(std::istreambuf_iterator<char>(file),
-                     std::istreambuf_iterator<char>());
-}
-
-absl::Status EstablishMasterArbitration(uint64_t device_id,
-                                        P4RuntimeStream* stream) {
-  p4::v1::StreamMessageRequest arbitration;
-  arbitration.mutable_arbitration()->set_device_id(device_id);
-  arbitration.mutable_arbitration()->mutable_election_id()->set_low(1);
-  if (!stream->Write(arbitration)) {
-    return absl::InternalError("failed to write arbitration request");
-  }
-
-  p4::v1::StreamMessageResponse response;
-  if (!stream->Read(&response)) {
-    return absl::InternalError("failed to read arbitration response");
-  }
-  return absl::OkStatus();
-}
-
-// Pushes a ForwardingPipelineConfig to the server via the P4Runtime API.
-// Handles the arbitration handshake.
-absl::Status PushPipeline(const FourwardServer& server,
-                          const p4::v1::ForwardingPipelineConfig& config,
-                          uint64_t device_id) {
-  auto stub = server.NewP4RuntimeStub();
-
-  grpc::ClientContext stream_ctx;
-  auto stream = stub->StreamChannel(&stream_ctx);
-  absl::Status arbitration = EstablishMasterArbitration(device_id, stream.get());
-  if (!arbitration.ok()) return arbitration;
-
-  // Push pipeline.
-  grpc::ClientContext set_ctx;
-  p4::v1::SetForwardingPipelineConfigRequest req;
-  req.set_device_id(device_id);
-  req.mutable_election_id()->set_low(1);
-  req.set_action(
-      p4::v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT);
-  *req.mutable_config() = config;
-  p4::v1::SetForwardingPipelineConfigResponse resp;
-  grpc::Status status =
-      stub->SetForwardingPipelineConfig(&set_ctx, req, &resp);
-  if (!status.ok()) return ToAbsl(status);
-
-  stream_ctx.TryCancel();
-  return absl::OkStatus();
-}
 
 absl::Status PushPipeline(const FourwardServer& server,
                           const p4::v1::ForwardingPipelineConfig& config) {
@@ -313,7 +234,7 @@ class DataplaneClientE2ETest : public ::testing::Test {
 
     // Load the passthrough pipeline.
     absl::StatusOr<std::string> binpb =
-        ReadRunfile(PASSTHROUGH_PIPELINE_RLOCATION);
+        ReadRunfileForTest(PASSTHROUGH_PIPELINE_RLOCATION);
     ASSERT_TRUE(binpb.ok()) << binpb.status();
     p4::v1::ForwardingPipelineConfig config;
     ASSERT_TRUE(config.ParseFromString(*binpb))
@@ -402,7 +323,7 @@ TEST_F(DataplaneClientE2ETest, ExplicitDeviceIdScopesStreamingDataplaneRpc) {
       management.CreateDevices({.first_device_id = kSecondDeviceId, .count = 1}).ok());
 
   absl::StatusOr<std::string> binpb =
-      ReadRunfile(PASSTHROUGH_PIPELINE_RLOCATION);
+      ReadRunfileForTest(PASSTHROUGH_PIPELINE_RLOCATION);
   ASSERT_TRUE(binpb.ok()) << binpb.status();
   p4::v1::ForwardingPipelineConfig config;
   ASSERT_TRUE(config.ParseFromString(*binpb))
@@ -447,7 +368,8 @@ class SaiPacketIoE2ETest : public ::testing::Test {
     ASSERT_TRUE(s.ok()) << s.status();
     server_ = std::make_unique<FourwardServer>(*std::move(s));
 
-    absl::StatusOr<std::string> binpb = ReadRunfile(SAI_PIPELINE_RLOCATION);
+    absl::StatusOr<std::string> binpb =
+        ReadRunfileForTest(SAI_PIPELINE_RLOCATION);
     ASSERT_TRUE(binpb.ok()) << binpb.status();
     ASSERT_TRUE(config_.ParseFromString(*binpb))
         << "failed to parse ForwardingPipelineConfig";

--- a/fourward_cc/fourward_server.cc
+++ b/fourward_cc/fourward_server.cc
@@ -36,7 +36,7 @@
 #include "grpcpp/create_channel.h"
 #include "grpcpp/security/credentials.h"
 #include "grpcpp/support/channel_arguments.h"
-#include "tools/cpp/runfiles/runfiles.h"
+#include "rules_cc/cc/runfiles/runfiles.h"
 
 #ifndef FOURWARD_SERVER_RLOCATION
 #error "FOURWARD_SERVER_RLOCATION must be set by the BUILD rule"
@@ -47,7 +47,7 @@ extern char** environ;
 namespace fourward {
 namespace {
 
-using ::bazel::tools::cpp::runfiles::Runfiles;
+using ::rules_cc::cc::runfiles::Runfiles;
 
 // Runfile path of the server binary, baked in from BUILD via
 // `$(rlocationpath //grpc:fourward_server)`. Has the canonical repo

--- a/fourward_cc/fourward_server.h
+++ b/fourward_cc/fourward_server.h
@@ -41,6 +41,7 @@
 #include "absl/time/time.h"
 #include "grpc/dataplane.grpc.pb.h"
 #include "grpc/management.grpc.pb.h"
+#include "grpc/network.grpc.pb.h"
 #include "grpcpp/channel.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 
@@ -163,6 +164,9 @@ class FourwardServer {
   std::unique_ptr<fourward::FourwardManagement::Stub> NewManagementStub()
       const {
     return fourward::FourwardManagement::NewStub(channel_);
+  }
+  std::unique_ptr<fourward::Network::Stub> NewNetworkStub() const {
+    return fourward::Network::NewStub(channel_);
   }
 
   // Address suitable for grpc::CreateChannel, e.g. "localhost:42517".

--- a/fourward_cc/fourward_server_test.cc
+++ b/fourward_cc/fourward_server_test.cc
@@ -26,7 +26,7 @@
 #include "gtest/gtest.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
-#include "tools/cpp/runfiles/runfiles.h"
+#include "rules_cc/cc/runfiles/runfiles.h"
 
 #ifndef PASSTHROUGH_PIPELINE_RLOCATION
 #error "PASSTHROUGH_PIPELINE_RLOCATION must be set by the BUILD rule"
@@ -35,7 +35,7 @@
 namespace fourward {
 namespace {
 
-using ::bazel::tools::cpp::runfiles::Runfiles;
+using ::rules_cc::cc::runfiles::Runfiles;
 
 // Issues a Capabilities RPC and asserts it succeeds. This proves the server
 // is not just TCP-listening but actually serving gRPC. Capabilities is used
@@ -336,7 +336,7 @@ TEST(FourwardServerTest, LargeResponseSucceedsUnderDefaultLimits) {
   // gRPC's default 4MB receive limit. This verifies the client channel is
   // correctly configured with an unlimited receive message size.
   std::string error;
-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", &error));
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(&error));
   ASSERT_NE(runfiles, nullptr) << error;
   std::string path =
       runfiles->Rlocation(PASSTHROUGH_PIPELINE_RLOCATION);

--- a/fourward_cc/grpc_util.h
+++ b/fourward_cc/grpc_util.h
@@ -1,0 +1,29 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FOURWARD_CC_GRPC_UTIL_H_
+#define FOURWARD_CC_GRPC_UTIL_H_
+
+#include <chrono>
+
+#include "absl/status/status.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "grpcpp/support/status.h"
+
+namespace fourward {
+
+inline absl::Status ToAbsl(const grpc::Status& s) {
+  if (s.ok()) return absl::OkStatus();
+  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
+                      s.error_message());
+}
+
+inline std::chrono::system_clock::time_point AbsoluteDeadline(
+    absl::Duration relative) {
+  return absl::ToChronoTime(absl::Now() + relative);
+}
+
+}  // namespace fourward
+
+#endif  // FOURWARD_CC_GRPC_UTIL_H_

--- a/fourward_cc/management_client.cc
+++ b/fourward_cc/management_client.cc
@@ -3,7 +3,6 @@
 
 #include "fourward_cc/management_client.h"
 
-#include <chrono>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -11,26 +10,12 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
+#include "fourward_cc/grpc_util.h"
 #include "grpc/management.pb.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/support/status.h"
 
 namespace fourward {
-namespace {
-
-absl::Status ToAbsl(const grpc::Status& s) {
-  if (s.ok()) return absl::OkStatus();
-  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
-                      s.error_message());
-}
-
-std::chrono::system_clock::time_point AbsoluteDeadline(
-    absl::Duration relative) {
-  return std::chrono::time_point_cast<std::chrono::system_clock::duration>(
-      std::chrono::system_clock::now() + absl::ToChronoNanoseconds(relative));
-}
-
-}  // namespace
 
 ManagementClient::ManagementClient(const FourwardServer& server,
                                    absl::Duration default_timeout)

--- a/fourward_cc/network_client.cc
+++ b/fourward_cc/network_client.cc
@@ -1,0 +1,157 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fourward_cc/network_client.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/time/time.h"
+#include "grpc/network.grpc.pb.h"
+#include "grpc/network.pb.h"
+#include "grpcpp/client_context.h"
+#include "grpcpp/support/status.h"
+
+namespace fourward {
+namespace {
+
+absl::Status ToAbsl(const grpc::Status& s) {
+  if (s.ok()) return absl::OkStatus();
+  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
+                      s.error_message());
+}
+
+std::chrono::system_clock::time_point AbsoluteDeadline(
+    absl::Duration relative) {
+  return std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+      std::chrono::system_clock::now() + absl::ToChronoNanoseconds(relative));
+}
+
+NetworkPort ToProto(const NetworkEndpoint& endpoint) {
+  NetworkPort proto;
+  proto.set_device_id(endpoint.device_id);
+  switch (endpoint.port_kind) {
+    case NetworkEndpoint::PortKind::kDataplane:
+      proto.set_dataplane_port(endpoint.dataplane_port);
+      return proto;
+    case NetworkEndpoint::PortKind::kP4Runtime:
+      proto.set_p4rt_port(endpoint.p4rt_port);
+      return proto;
+  }
+}
+
+Link ToProto(const NetworkLink& link) {
+  Link proto;
+  *proto.mutable_a() = ToProto(link.a);
+  *proto.mutable_b() = ToProto(link.b);
+  return proto;
+}
+
+absl::StatusOr<NetworkEndpoint> FromProto(const NetworkPort& proto) {
+  switch (proto.port_case()) {
+    case NetworkPort::kDataplanePort:
+      return NetworkEndpoint::Dataplane(proto.device_id(),
+                                        proto.dataplane_port());
+    case NetworkPort::kP4RtPort:
+      return NetworkEndpoint::P4Runtime(proto.device_id(), proto.p4rt_port());
+    case NetworkPort::PORT_NOT_SET:
+      return absl::InvalidArgumentError(absl::StrCat(
+          "network endpoint for device ", proto.device_id(), " has no port"));
+  }
+}
+
+absl::StatusOr<NetworkLink> FromProto(const Link& proto) {
+  absl::StatusOr<NetworkEndpoint> a = FromProto(proto.a());
+  if (!a.ok()) return a.status();
+  absl::StatusOr<NetworkEndpoint> b = FromProto(proto.b());
+  if (!b.ok()) return b.status();
+  return NetworkLink{.a = std::move(*a), .b = std::move(*b)};
+}
+
+}  // namespace
+
+NetworkEndpoint NetworkEndpoint::Dataplane(uint64_t device_id, uint32_t port) {
+  return NetworkEndpoint{.device_id = device_id,
+                         .port_kind = PortKind::kDataplane,
+                         .dataplane_port = port};
+}
+
+NetworkEndpoint NetworkEndpoint::P4Runtime(uint64_t device_id,
+                                           std::string port) {
+  return NetworkEndpoint{.device_id = device_id,
+                         .port_kind = PortKind::kP4Runtime,
+                         .p4rt_port = std::move(port)};
+}
+
+NetworkClient::NetworkClient(const FourwardServer& server,
+                             absl::Duration default_timeout)
+    : NetworkClient(server.NewNetworkStub(), default_timeout) {}
+
+NetworkClient::NetworkClient(std::unique_ptr<Network::Stub> stub,
+                             absl::Duration default_timeout)
+    : stub_(std::move(stub)), default_timeout_(default_timeout) {}
+
+absl::Status NetworkClient::AddLinks(const std::vector<NetworkLink>& links) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  AddLinksRequest req;
+  for (const NetworkLink& link : links) {
+    *req.add_links() = ToProto(link);
+  }
+  AddLinksResponse resp;
+  return ToAbsl(stub_->AddLinks(&ctx, req, &resp));
+}
+
+absl::Status NetworkClient::RemoveLinks(const std::vector<NetworkLink>& links) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  RemoveLinksRequest req;
+  for (const NetworkLink& link : links) {
+    *req.add_links() = ToProto(link);
+  }
+  RemoveLinksResponse resp;
+  return ToAbsl(stub_->RemoveLinks(&ctx, req, &resp));
+}
+
+absl::StatusOr<std::vector<NetworkLink>> NetworkClient::ListLinks() {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  ListLinksRequest req;
+  ListLinksResponse resp;
+  grpc::Status status = stub_->ListLinks(&ctx, req, &resp);
+  if (!status.ok()) return ToAbsl(status);
+
+  std::vector<NetworkLink> links;
+  links.reserve(resp.links_size());
+  for (const Link& link : resp.links()) {
+    absl::StatusOr<NetworkLink> parsed = FromProto(link);
+    if (!parsed.ok()) return parsed.status();
+    links.push_back(std::move(*parsed));
+  }
+  return links;
+}
+
+absl::StatusOr<InjectNetworkPacketResponse> NetworkClient::InjectPacket(
+    InjectNetworkPacketArgs args) {
+  grpc::ClientContext ctx;
+  ctx.set_deadline(AbsoluteDeadline(default_timeout_));
+  InjectNetworkPacketRequest req;
+  *req.mutable_ingress() = ToProto(args.ingress);
+  req.set_payload(args.payload.data(), args.payload.size());
+  req.set_max_hops(args.max_hops);
+  req.set_tag(args.tag);
+
+  InjectNetworkPacketResponse resp;
+  grpc::Status status = stub_->InjectPacket(&ctx, req, &resp);
+  if (!status.ok()) return ToAbsl(status);
+  return resp;
+}
+
+}  // namespace fourward

--- a/fourward_cc/network_client.cc
+++ b/fourward_cc/network_client.cc
@@ -3,7 +3,6 @@
 
 #include "fourward_cc/network_client.h"
 
-#include <chrono>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -14,6 +13,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
+#include "fourward_cc/grpc_util.h"
 #include "grpc/network.grpc.pb.h"
 #include "grpc/network.pb.h"
 #include "grpcpp/client_context.h"
@@ -21,18 +21,6 @@
 
 namespace fourward {
 namespace {
-
-absl::Status ToAbsl(const grpc::Status& s) {
-  if (s.ok()) return absl::OkStatus();
-  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
-                      s.error_message());
-}
-
-std::chrono::system_clock::time_point AbsoluteDeadline(
-    absl::Duration relative) {
-  return std::chrono::time_point_cast<std::chrono::system_clock::duration>(
-      std::chrono::system_clock::now() + absl::ToChronoNanoseconds(relative));
-}
 
 NetworkPort ToProto(const NetworkEndpoint& endpoint) {
   NetworkPort proto;

--- a/fourward_cc/network_client.h
+++ b/fourward_cc/network_client.h
@@ -1,0 +1,74 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FOURWARD_CC_NETWORK_CLIENT_H_
+#define FOURWARD_CC_NETWORK_CLIENT_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "fourward_cc/fourward_server.h"
+#include "grpc/network.grpc.pb.h"
+#include "grpc/network.pb.h"
+
+namespace fourward {
+
+struct NetworkEndpoint {
+  enum class PortKind {
+    kDataplane,
+    kP4Runtime,
+  };
+
+  static NetworkEndpoint Dataplane(uint64_t device_id, uint32_t port);
+  static NetworkEndpoint P4Runtime(uint64_t device_id, std::string port);
+
+  uint64_t device_id = 0;
+  PortKind port_kind = PortKind::kDataplane;
+  uint32_t dataplane_port = 0;
+  std::string p4rt_port;
+};
+
+struct NetworkLink {
+  NetworkEndpoint a;
+  NetworkEndpoint b;
+};
+
+struct InjectNetworkPacketArgs {
+  NetworkEndpoint ingress;
+  std::string_view payload;
+  uint32_t max_hops = 64;
+  int64_t tag = 0;
+};
+
+// C++ wrapper for the 4ward Network gRPC service.
+//
+// Use this when one 4ward server hosts multiple independent logical switches
+// and a test needs packet traces across links between them. Single-switch tests
+// should continue to use DataplaneClient directly.
+class NetworkClient {
+ public:
+  explicit NetworkClient(const FourwardServer& server,
+                         absl::Duration default_timeout = absl::Seconds(10));
+  explicit NetworkClient(std::unique_ptr<Network::Stub> stub,
+                         absl::Duration default_timeout = absl::Seconds(10));
+
+  absl::Status AddLinks(const std::vector<NetworkLink>& links);
+  absl::Status RemoveLinks(const std::vector<NetworkLink>& links);
+  absl::StatusOr<std::vector<NetworkLink>> ListLinks();
+  absl::StatusOr<InjectNetworkPacketResponse> InjectPacket(
+      InjectNetworkPacketArgs args);
+
+ private:
+  std::unique_ptr<Network::Stub> stub_;
+  absl::Duration default_timeout_;
+};
+
+}  // namespace fourward
+
+#endif  // FOURWARD_CC_NETWORK_CLIENT_H_

--- a/fourward_cc/network_client_test.cc
+++ b/fourward_cc/network_client_test.cc
@@ -4,8 +4,6 @@
 #include "fourward_cc/network_client.h"
 
 #include <cstdint>
-#include <fstream>
-#include <iterator>
 #include <memory>
 #include <string>
 #include <utility>
@@ -13,15 +11,12 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/str_cat.h"
 #include "fourward_cc/fourward_server.h"
 #include "fourward_cc/management_client.h"
+#include "fourward_cc/test_util.h"
 #include "gmock/gmock.h"
-#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
-#include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
-#include "tools/cpp/runfiles/runfiles.h"
 
 #ifndef PASSTHROUGH_PIPELINE_RLOCATION
 #error "PASSTHROUGH_PIPELINE_RLOCATION must be set by the BUILD rule"
@@ -29,72 +24,6 @@
 
 namespace fourward {
 namespace {
-
-using ::bazel::tools::cpp::runfiles::Runfiles;
-using P4RuntimeStream = grpc::ClientReaderWriter<p4::v1::StreamMessageRequest,
-                                                 p4::v1::StreamMessageResponse>;
-
-absl::Status ToAbsl(const grpc::Status& s) {
-  if (s.ok()) return absl::OkStatus();
-  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
-                      s.error_message());
-}
-
-absl::StatusOr<std::string> ReadRunfile(const std::string& rlocation) {
-  std::string error;
-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", &error));
-  if (runfiles == nullptr) {
-    return absl::InternalError(absl::StrCat("runfiles: ", error));
-  }
-  std::string path = runfiles->Rlocation(rlocation);
-  if (path.empty()) {
-    return absl::NotFoundError(
-        absl::StrCat("not found in runfiles: ", rlocation));
-  }
-  std::ifstream file(path, std::ios::binary);
-  if (!file) return absl::NotFoundError(absl::StrCat("cannot open: ", path));
-  return std::string(std::istreambuf_iterator<char>(file),
-                     std::istreambuf_iterator<char>());
-}
-
-absl::Status EstablishMasterArbitration(uint64_t device_id,
-                                        P4RuntimeStream* stream) {
-  p4::v1::StreamMessageRequest arbitration;
-  arbitration.mutable_arbitration()->set_device_id(device_id);
-  arbitration.mutable_arbitration()->mutable_election_id()->set_low(1);
-  if (!stream->Write(arbitration)) {
-    return absl::InternalError("failed to write arbitration request");
-  }
-
-  p4::v1::StreamMessageResponse response;
-  if (!stream->Read(&response)) {
-    return absl::InternalError("failed to read arbitration response");
-  }
-  return absl::OkStatus();
-}
-
-absl::Status PushPipeline(const FourwardServer& server,
-                          const p4::v1::ForwardingPipelineConfig& config,
-                          uint64_t device_id) {
-  auto stub = server.NewP4RuntimeStub();
-
-  grpc::ClientContext stream_ctx;
-  auto stream = stub->StreamChannel(&stream_ctx);
-  absl::Status arbitration =
-      EstablishMasterArbitration(device_id, stream.get());
-  if (!arbitration.ok()) return arbitration;
-
-  grpc::ClientContext set_ctx;
-  p4::v1::SetForwardingPipelineConfigRequest req;
-  req.set_device_id(device_id);
-  req.mutable_election_id()->set_low(1);
-  req.set_action(p4::v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT);
-  *req.mutable_config() = config;
-  p4::v1::SetForwardingPipelineConfigResponse resp;
-  grpc::Status status = stub->SetForwardingPipelineConfig(&set_ctx, req, &resp);
-  stream_ctx.TryCancel();
-  return ToAbsl(status);
-}
 
 std::string MakeEthernetFrame() {
   std::string frame(64, '\0');
@@ -147,7 +76,7 @@ TEST_F(NetworkClientTest, InjectPacketTraversesTwoLogicalSwitches) {
       management.CreateDevices({.first_device_id = 2, .count = 1}).ok());
 
   absl::StatusOr<std::string> binpb =
-      ReadRunfile(PASSTHROUGH_PIPELINE_RLOCATION);
+      ReadRunfileForTest(PASSTHROUGH_PIPELINE_RLOCATION);
   ASSERT_TRUE(binpb.ok()) << binpb.status();
   p4::v1::ForwardingPipelineConfig config;
   ASSERT_TRUE(config.ParseFromString(*binpb));

--- a/fourward_cc/network_client_test.cc
+++ b/fourward_cc/network_client_test.cc
@@ -1,0 +1,183 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fourward_cc/network_client.h"
+
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "fourward_cc/fourward_server.h"
+#include "fourward_cc/management_client.h"
+#include "gmock/gmock.h"
+#include "grpcpp/client_context.h"
+#include "gtest/gtest.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+#ifndef PASSTHROUGH_PIPELINE_RLOCATION
+#error "PASSTHROUGH_PIPELINE_RLOCATION must be set by the BUILD rule"
+#endif
+
+namespace fourward {
+namespace {
+
+using ::bazel::tools::cpp::runfiles::Runfiles;
+using P4RuntimeStream = grpc::ClientReaderWriter<p4::v1::StreamMessageRequest,
+                                                 p4::v1::StreamMessageResponse>;
+
+absl::Status ToAbsl(const grpc::Status& s) {
+  if (s.ok()) return absl::OkStatus();
+  return absl::Status(static_cast<absl::StatusCode>(s.error_code()),
+                      s.error_message());
+}
+
+absl::StatusOr<std::string> ReadRunfile(const std::string& rlocation) {
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", &error));
+  if (runfiles == nullptr) {
+    return absl::InternalError(absl::StrCat("runfiles: ", error));
+  }
+  std::string path = runfiles->Rlocation(rlocation);
+  if (path.empty()) {
+    return absl::NotFoundError(
+        absl::StrCat("not found in runfiles: ", rlocation));
+  }
+  std::ifstream file(path, std::ios::binary);
+  if (!file) return absl::NotFoundError(absl::StrCat("cannot open: ", path));
+  return std::string(std::istreambuf_iterator<char>(file),
+                     std::istreambuf_iterator<char>());
+}
+
+absl::Status EstablishMasterArbitration(uint64_t device_id,
+                                        P4RuntimeStream* stream) {
+  p4::v1::StreamMessageRequest arbitration;
+  arbitration.mutable_arbitration()->set_device_id(device_id);
+  arbitration.mutable_arbitration()->mutable_election_id()->set_low(1);
+  if (!stream->Write(arbitration)) {
+    return absl::InternalError("failed to write arbitration request");
+  }
+
+  p4::v1::StreamMessageResponse response;
+  if (!stream->Read(&response)) {
+    return absl::InternalError("failed to read arbitration response");
+  }
+  return absl::OkStatus();
+}
+
+absl::Status PushPipeline(const FourwardServer& server,
+                          const p4::v1::ForwardingPipelineConfig& config,
+                          uint64_t device_id) {
+  auto stub = server.NewP4RuntimeStub();
+
+  grpc::ClientContext stream_ctx;
+  auto stream = stub->StreamChannel(&stream_ctx);
+  absl::Status arbitration =
+      EstablishMasterArbitration(device_id, stream.get());
+  if (!arbitration.ok()) return arbitration;
+
+  grpc::ClientContext set_ctx;
+  p4::v1::SetForwardingPipelineConfigRequest req;
+  req.set_device_id(device_id);
+  req.mutable_election_id()->set_low(1);
+  req.set_action(p4::v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT);
+  *req.mutable_config() = config;
+  p4::v1::SetForwardingPipelineConfigResponse resp;
+  grpc::Status status = stub->SetForwardingPipelineConfig(&set_ctx, req, &resp);
+  stream_ctx.TryCancel();
+  return ToAbsl(status);
+}
+
+std::string MakeEthernetFrame() {
+  std::string frame(64, '\0');
+  frame[5] = 0x01;
+  frame[11] = 0x02;
+  frame[12] = 0x08;
+  return frame;
+}
+
+class NetworkClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    absl::StatusOr<FourwardServer> s = FourwardServer::Start();
+    ASSERT_TRUE(s.ok()) << s.status();
+    server_ = std::make_unique<FourwardServer>(*std::move(s));
+  }
+
+  std::unique_ptr<FourwardServer> server_;
+};
+
+TEST_F(NetworkClientTest, AddsListsAndRemovesLinks) {
+  ManagementClient management(*server_);
+  ASSERT_TRUE(
+      management.CreateDevices({.first_device_id = 2, .count = 1}).ok());
+
+  NetworkClient network(*server_);
+  std::vector<NetworkLink> links = {
+      {.a = NetworkEndpoint::Dataplane(1, 1),
+       .b = NetworkEndpoint::Dataplane(2, 0)},
+  };
+  ASSERT_TRUE(network.AddLinks(links).ok());
+
+  absl::StatusOr<std::vector<NetworkLink>> listed = network.ListLinks();
+  ASSERT_TRUE(listed.ok()) << listed.status();
+  ASSERT_EQ(listed->size(), 1);
+  EXPECT_EQ((*listed)[0].a.device_id, 1);
+  EXPECT_EQ((*listed)[0].a.dataplane_port, 1);
+  EXPECT_EQ((*listed)[0].b.device_id, 2);
+  EXPECT_EQ((*listed)[0].b.dataplane_port, 0);
+
+  ASSERT_TRUE(network.RemoveLinks(links).ok());
+  absl::StatusOr<std::vector<NetworkLink>> empty = network.ListLinks();
+  ASSERT_TRUE(empty.ok()) << empty.status();
+  EXPECT_TRUE(empty->empty());
+}
+
+TEST_F(NetworkClientTest, InjectPacketTraversesTwoLogicalSwitches) {
+  ManagementClient management(*server_);
+  ASSERT_TRUE(
+      management.CreateDevices({.first_device_id = 2, .count = 1}).ok());
+
+  absl::StatusOr<std::string> binpb =
+      ReadRunfile(PASSTHROUGH_PIPELINE_RLOCATION);
+  ASSERT_TRUE(binpb.ok()) << binpb.status();
+  p4::v1::ForwardingPipelineConfig config;
+  ASSERT_TRUE(config.ParseFromString(*binpb));
+  ASSERT_TRUE(PushPipeline(*server_, config, 1).ok());
+  ASSERT_TRUE(PushPipeline(*server_, config, 2).ok());
+
+  NetworkClient network(*server_);
+  ASSERT_TRUE(network
+                  .AddLinks({{.a = NetworkEndpoint::Dataplane(1, 1),
+                              .b = NetworkEndpoint::Dataplane(2, 0)}})
+                  .ok());
+
+  absl::StatusOr<InjectNetworkPacketResponse> response = network.InjectPacket({
+      .ingress = NetworkEndpoint::Dataplane(1, 0),
+      .payload = MakeEthernetFrame(),
+      .max_hops = 3,
+  });
+  ASSERT_TRUE(response.ok()) << response.status();
+
+  ASSERT_EQ(response->possible_outcomes_size(), 1);
+  ASSERT_EQ(response->possible_outcomes(0).packets_size(), 1);
+  const NetworkEgressPacket& packet = response->possible_outcomes(0).packets(0);
+  EXPECT_EQ(packet.egress().device_id(), 2);
+  EXPECT_EQ(packet.egress().dataplane_port(), 1);
+
+  ASSERT_EQ(response->trace().root().device_id(), 1);
+  ASSERT_EQ(response->trace().root().traversals_size(), 1);
+  ASSERT_TRUE(response->trace().root().traversals(0).has_next_hop());
+  EXPECT_EQ(response->trace().root().traversals(0).next_hop().device_id(), 2);
+}
+
+}  // namespace
+}  // namespace fourward

--- a/fourward_cc/test_util.h
+++ b/fourward_cc/test_util.h
@@ -1,0 +1,92 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FOURWARD_CC_TEST_UTIL_H_
+#define FOURWARD_CC_TEST_UTIL_H_
+
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "fourward_cc/fourward_server.h"
+#include "fourward_cc/grpc_util.h"
+#include "grpcpp/client_context.h"
+#include "p4/v1/p4runtime.grpc.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "rules_cc/cc/runfiles/runfiles.h"
+
+namespace fourward {
+
+using P4RuntimeStream = grpc::ClientReaderWriter<p4::v1::StreamMessageRequest,
+                                                 p4::v1::StreamMessageResponse>;
+
+// Reads a test data dependency whose path was injected by BUILD with
+// `$(rlocationpath ...)`. Do not pass handwritten `_main/...` or apparent-repo
+// paths here; those are not portable across GitHub, BCR consumers, and google3.
+inline absl::StatusOr<std::string> ReadRunfileForTest(
+    const std::string& rlocation) {
+  std::string error;
+  std::unique_ptr<rules_cc::cc::runfiles::Runfiles> runfiles(
+      rules_cc::cc::runfiles::Runfiles::CreateForTest(&error));
+  if (runfiles == nullptr) {
+    return absl::InternalError(absl::StrCat("runfiles: ", error));
+  }
+  std::string path = runfiles->Rlocation(rlocation);
+  if (path.empty()) {
+    return absl::NotFoundError(
+        absl::StrCat("not found in runfiles: ", rlocation));
+  }
+  std::ifstream file(path, std::ios::binary);
+  if (!file) return absl::NotFoundError(absl::StrCat("cannot open: ", path));
+  return std::string(std::istreambuf_iterator<char>(file),
+                     std::istreambuf_iterator<char>());
+}
+
+inline absl::Status EstablishMasterArbitration(uint64_t device_id,
+                                               P4RuntimeStream* stream) {
+  p4::v1::StreamMessageRequest arbitration;
+  arbitration.mutable_arbitration()->set_device_id(device_id);
+  arbitration.mutable_arbitration()->mutable_election_id()->set_low(1);
+  if (!stream->Write(arbitration)) {
+    return absl::InternalError("failed to write arbitration request");
+  }
+  p4::v1::StreamMessageResponse response;
+  if (!stream->Read(&response)) {
+    return absl::InternalError("failed to read arbitration response");
+  }
+  return absl::OkStatus();
+}
+
+// Pushes a ForwardingPipelineConfig to the server via the P4Runtime API.
+// Handles the arbitration handshake.
+inline absl::Status PushPipeline(const FourwardServer& server,
+                                 const p4::v1::ForwardingPipelineConfig& config,
+                                 uint64_t device_id) {
+  auto stub = server.NewP4RuntimeStub();
+
+  grpc::ClientContext stream_ctx;
+  auto stream = stub->StreamChannel(&stream_ctx);
+  absl::Status arbitration =
+      EstablishMasterArbitration(device_id, stream.get());
+  if (!arbitration.ok()) return arbitration;
+
+  grpc::ClientContext set_ctx;
+  p4::v1::SetForwardingPipelineConfigRequest req;
+  req.set_device_id(device_id);
+  req.mutable_election_id()->set_low(1);
+  req.set_action(p4::v1::SetForwardingPipelineConfigRequest::VERIFY_AND_COMMIT);
+  *req.mutable_config() = config;
+  p4::v1::SetForwardingPipelineConfigResponse resp;
+  grpc::Status status = stub->SetForwardingPipelineConfig(&set_ctx, req, &resp);
+  stream_ctx.TryCancel();
+  return ToAbsl(status);
+}
+
+}  // namespace fourward
+
+#endif  // FOURWARD_CC_TEST_UTIL_H_

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -114,6 +114,52 @@ kt_jvm_grpc_library(
 )
 
 # =============================================================================
+# Network-wide simulation gRPC service
+# =============================================================================
+
+proto_library(
+    name = "network_proto",
+    srcs = ["network.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//simulator:simulator_proto"],
+)
+
+java_proto_library(
+    name = "network_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":network_proto"],
+)
+
+cc_proto_library(
+    name = "network_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":network_proto"],
+)
+
+cc_grpc_library(
+    name = "network_cc_grpc",
+    srcs = [":network_proto"],
+    features = ["-layering_check"],
+    grpc_only = True,
+    visibility = ["//visibility:public"],
+    deps = [":network_cc_proto"],
+)
+
+java_grpc_library(
+    name = "network_java_grpc",
+    srcs = [":network_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":network_java_proto"],
+)
+
+kt_jvm_grpc_library(
+    name = "network_kt_grpc",
+    srcs = [":network_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":network_java_proto"],
+)
+
+# =============================================================================
 # P4Runtime gRPC stubs (Kotlin)
 # =============================================================================
 
@@ -155,6 +201,8 @@ kt_jvm_library(
         ":dataplane_kt_grpc",
         ":management_java_proto",
         ":management_kt_grpc",
+        ":network_java_proto",
+        ":network_kt_grpc",
         ":p4runtime_kt_grpc",
         "//simulator",
         "//simulator:ir_java_proto",
@@ -673,6 +721,44 @@ kt_jvm_test(
         ":dataplane_java_proto",
         ":dataplane_kt_grpc",
         ":grpc",
+        ":p4runtime_kt_grpc",
+        "//bazel:runfiles",
+        "//simulator",
+        "//simulator:ir_java_proto",
+        "//simulator:p4data_java_proto",
+        "//simulator:p4info_java_proto",
+        "//simulator:p4runtime_java_proto",
+        "//simulator:simulator_java_proto",
+        "@fourward_maven//:com_google_protobuf_protobuf_java",
+        "@fourward_maven//:io_grpc_grpc_api",
+        "@fourward_maven//:io_grpc_grpc_inprocess",
+        "@fourward_maven//:junit_junit",
+        "@fourward_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@googleapis//google/rpc:rpc_java_proto",
+    ],
+)
+
+kt_jvm_test(
+    name = "NetworkServiceTest",
+    srcs = [
+        "FourwardTestHarness.kt",
+        "NetworkServiceTest.kt",
+    ],
+    data = [
+        "//e2e_tests/passthrough",
+        "//e2e_tests/trace_tree:action_selector_3",
+        "//e2e_tests/trace_tree:multicast",
+        "//e2e_tests/translated_port",
+    ],
+    test_class = "fourward.grpc.NetworkServiceTest",
+    deps = [
+        ":dataplane_java_proto",
+        ":dataplane_kt_grpc",
+        ":grpc",
+        ":management_java_proto",
+        ":management_kt_grpc",
+        ":network_java_proto",
+        ":network_kt_grpc",
         ":p4runtime_kt_grpc",
         "//bazel:runfiles",
         "//simulator",

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -53,6 +53,9 @@ class DataplaneService(
     val packetHeaderCodec: PacketHeaderCodec?,
   )
 
+  internal suspend fun processForNetwork(request: InjectPacketRequest): ProcessPacketResultProto =
+    processAndEnrich(request, "Network.InjectPacket").first.proto
+
   override suspend fun injectPacket(request: InjectPacketRequest): InjectPacketResponse {
     val (enrichedResult, _) = processAndEnrich(request, "InjectPacket")
     return InjectPacketResponse.newBuilder()

--- a/grpc/FourwardServer.kt
+++ b/grpc/FourwardServer.kt
@@ -43,6 +43,7 @@ class FourwardServer(
   private val p4RuntimeService = MultiDeviceP4RuntimeService(registry)
   private val dataplaneService = MultiDeviceDataplaneService(registry, defaultDeviceId = deviceId)
   private val managementService = ManagementService(registry)
+  private val networkService = NetworkService(registry)
 
   private lateinit var server: Server
 
@@ -63,6 +64,7 @@ class FourwardServer(
         .addService(p4RuntimeService)
         .addService(dataplaneService)
         .addService(managementService)
+        .addService(networkService)
         .build()
         .start()
     Runtime.getRuntime().addShutdownHook(Thread { stop() })

--- a/grpc/NetworkService.kt
+++ b/grpc/NetworkService.kt
@@ -1,0 +1,215 @@
+package fourward.grpc
+
+import com.google.protobuf.ByteString
+import fourward.AddLinksRequest
+import fourward.AddLinksResponse
+import fourward.HopLimitExceeded
+import fourward.InjectNetworkPacketRequest
+import fourward.InjectNetworkPacketResponse
+import fourward.InjectPacketRequest
+import fourward.LinkTraversal
+import fourward.ListLinksRequest
+import fourward.ListLinksResponse
+import fourward.NetworkEgressPacket
+import fourward.NetworkGrpcKt
+import fourward.NetworkHop
+import fourward.NetworkOutcome
+import fourward.NetworkPort
+import fourward.NetworkTrace
+import fourward.OutputPacket
+import fourward.RemoveLinksRequest
+import fourward.RemoveLinksResponse
+import fourward.TraceTree
+import io.grpc.Status
+
+class NetworkService(
+  private val registry: DeviceRegistry,
+  private val topology: NetworkTopology = NetworkTopology(registry),
+) : NetworkGrpcKt.NetworkCoroutineImplBase() {
+
+  override suspend fun addLinks(request: AddLinksRequest): AddLinksResponse {
+    topology.addLinks(request.linksList)
+    return AddLinksResponse.getDefaultInstance()
+  }
+
+  override suspend fun removeLinks(request: RemoveLinksRequest): RemoveLinksResponse {
+    topology.removeLinks(request.linksList)
+    return RemoveLinksResponse.getDefaultInstance()
+  }
+
+  override suspend fun listLinks(request: ListLinksRequest): ListLinksResponse =
+    ListLinksResponse.newBuilder().addAllLinks(topology.listLinks()).build()
+
+  override suspend fun injectPacket(
+    request: InjectNetworkPacketRequest
+  ): InjectNetworkPacketResponse {
+    if (request.maxHops == 0) {
+      throw Status.INVALID_ARGUMENT.withDescription("max_hops must be positive").asException()
+    }
+    val ingress = Endpoint.fromProto(request.ingress)
+    val snapshot = topology.snapshot()
+    val root = simulate(ingress, request.payload, request.maxHops, request.tag, snapshot)
+    return InjectNetworkPacketResponse.newBuilder()
+      .setTrace(NetworkTrace.newBuilder().setRoot(root.hop))
+      .addAllPossibleOutcomes(
+        root.possibleOutcomes.map { NetworkOutcome.newBuilder().addAllPackets(it).build() }
+      )
+      .build()
+  }
+
+  private suspend fun simulate(
+    ingress: Endpoint,
+    payload: ByteString,
+    remainingHops: Int,
+    tag: Long,
+    topology: TopologySnapshot,
+  ): SimulatedHop {
+    val device = registry.get(ingress.deviceId)
+    val packetResult =
+      device.dataplaneService.processForNetwork(injectRequest(ingress, payload, tag))
+    val trace = analyzeTrace(packetResult.trace)
+    val hop =
+      NetworkHop.newBuilder()
+        .setDeviceId(ingress.deviceId)
+        .setIngress(ingress.toProto())
+        .setSwitchTrace(packetResult.trace)
+    val outcomesByOutputId = mutableMapOf<Long, List<List<NetworkEgressPacket>>>()
+    for (leaf in trace.leaves) {
+      val result = traversal(ingress.deviceId, leaf, remainingHops, topology)
+      hop.addTraversals(result.traversal)
+      outcomesByOutputId[leaf.id] = result.possibleOutcomes
+    }
+    val possibleOutcomes =
+      trace.outcomes.flatMap { outputIds ->
+        combine(outputIds.map { id -> outcomesByOutputId.getValue(id) })
+      }
+    return SimulatedHop(hop.build(), possibleOutcomes.distinctBy { it.outcomeIdentity() })
+  }
+
+  private suspend fun traversal(
+    deviceId: Long,
+    leaf: OutputLeaf,
+    remainingHops: Int,
+    topology: TopologySnapshot,
+  ): TraversalResult {
+    val matches = matchingPeers(deviceId, leaf.output, topology)
+    val builder = LinkTraversal.newBuilder().setSourceOutputId(leaf.id).setSourceOutput(leaf.output)
+    return when (matches.size) {
+      0 -> {
+        val egress =
+          NetworkEgressPacket.newBuilder()
+            .setEgress(networkEgressPort(deviceId, leaf.output))
+            .setPayload(leaf.output.payload)
+            .build()
+        TraversalResult(
+          builder.setNetworkEgress(egress).build(),
+          possibleOutcomes = listOf(listOf(egress)),
+        )
+      }
+      1 -> {
+        val next = matches.single()
+        if (remainingHops <= 1) {
+          TraversalResult(
+            builder
+              .setHopLimitExceeded(HopLimitExceeded.newBuilder().setNextIngress(next.toProto()))
+              .build(),
+            possibleOutcomes = listOf(emptyList()),
+          )
+        } else {
+          val nextHop = simulate(next, leaf.output.payload, remainingHops - 1, 0, topology)
+          TraversalResult(
+            builder.setNextHop(nextHop.hop).build(),
+            possibleOutcomes = nextHop.possibleOutcomes,
+          )
+        }
+      }
+      else -> {
+        val details = matches.joinToString { it.describe() }
+        throw Status.FAILED_PRECONDITION.withDescription(
+            "output from device_id $deviceId matches multiple configured links: $details"
+          )
+          .asException()
+      }
+    }
+  }
+
+  private fun injectRequest(
+    ingress: Endpoint,
+    payload: ByteString,
+    tag: Long,
+  ): InjectPacketRequest {
+    val builder = InjectPacketRequest.newBuilder().setPayload(payload).setTag(tag)
+    when (val port = ingress.port) {
+      is PortKey.Dataplane -> builder.setDataplaneIngressPort(port.value)
+      is PortKey.P4Runtime -> builder.setP4RtIngressPort(port.value)
+    }
+    return builder.build()
+  }
+
+  private fun matchingPeers(
+    deviceId: Long,
+    output: OutputPacket,
+    topology: TopologySnapshot,
+  ): List<Endpoint> {
+    val candidates = buildList {
+      add(Endpoint(deviceId, PortKey.Dataplane(output.dataplaneEgressPort)))
+      if (!output.p4RtEgressPort.isEmpty) {
+        add(Endpoint(deviceId, PortKey.P4Runtime(output.p4RtEgressPort)))
+      }
+    }
+    return candidates.mapNotNull(topology::peer)
+  }
+
+  private fun networkEgressPort(deviceId: Long, output: OutputPacket): NetworkPort =
+    if (output.p4RtEgressPort.isEmpty) {
+      Endpoint(deviceId, PortKey.Dataplane(output.dataplaneEgressPort)).toProto()
+    } else {
+      Endpoint(deviceId, PortKey.P4Runtime(output.p4RtEgressPort)).toProto()
+    }
+}
+
+private data class SimulatedHop(
+  val hop: NetworkHop,
+  val possibleOutcomes: List<List<NetworkEgressPacket>>,
+)
+
+private data class TraversalResult(
+  val traversal: LinkTraversal,
+  val possibleOutcomes: List<List<NetworkEgressPacket>>,
+)
+
+private data class TraceAnalysis(val leaves: List<OutputLeaf>, val outcomes: List<List<Long>>)
+
+private data class OutputLeaf(val id: Long, val output: OutputPacket)
+
+private fun analyzeTrace(trace: TraceTree): TraceAnalysis {
+  val leaves = mutableListOf<OutputLeaf>()
+  var nextId = 1L
+  fun collect(tree: TraceTree): List<List<Long>> =
+    when (tree.outcomeCase) {
+      TraceTree.OutcomeCase.OUTPUT -> {
+        val id = nextId++
+        leaves.add(OutputLeaf(id, tree.output))
+        listOf(listOf(id))
+      }
+      TraceTree.OutcomeCase.DROP,
+      TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+      null -> listOf(emptyList())
+      TraceTree.OutcomeCase.CONTINUATION -> collect(tree.continuation.next)
+      TraceTree.OutcomeCase.CHOICE -> tree.choice.branchesList.flatMap(::collect)
+      TraceTree.OutcomeCase.REPLICATION ->
+        combine(tree.replication.branchesList.map { branch -> collect(branch) })
+    }
+  return TraceAnalysis(leaves, collect(trace))
+}
+
+private fun <T> combine(parts: List<List<List<T>>>): List<List<T>> {
+  var outcomes = listOf(emptyList<T>())
+  for (part in parts) {
+    outcomes = outcomes.flatMap { prefix -> part.map { suffix -> prefix + suffix } }
+  }
+  return outcomes
+}
+
+private fun List<NetworkEgressPacket>.outcomeIdentity(): Map<Pair<NetworkPort, ByteString>, Int> =
+  groupingBy { it.egress to it.payload }.eachCount()

--- a/grpc/NetworkServiceTest.kt
+++ b/grpc/NetworkServiceTest.kt
@@ -1,0 +1,516 @@
+@file:Suppress("UnusedPrivateProperty")
+
+package fourward.grpc
+
+import com.google.protobuf.ByteString
+import fourward.AddLinksRequest
+import fourward.CreateDevicesRequest
+import fourward.FourwardManagementGrpcKt.FourwardManagementCoroutineStub
+import fourward.InjectNetworkPacketRequest
+import fourward.Link
+import fourward.ListLinksRequest
+import fourward.NetworkGrpcKt.NetworkCoroutineStub
+import fourward.NetworkPort
+import fourward.PipelineConfig
+import fourward.RemoveLinksRequest
+import fourward.grpc.FourwardTestHarness.Companion.assertGrpcError
+import fourward.grpc.FourwardTestHarness.Companion.buildEthernetFrame
+import fourward.grpc.FourwardTestHarness.Companion.buildMulticastGroup
+import fourward.grpc.FourwardTestHarness.Companion.findAction
+import fourward.grpc.FourwardTestHarness.Companion.findTable
+import fourward.grpc.FourwardTestHarness.Companion.loadConfig
+import fourward.grpc.FourwardTestHarness.Companion.longToBytes
+import io.grpc.ManagedChannel
+import io.grpc.Status
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import java.io.Closeable
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import p4.config.v1.P4InfoOuterClass.P4Info
+import p4.v1.P4RuntimeGrpcKt.P4RuntimeCoroutineStub
+import p4.v1.P4RuntimeOuterClass.Action
+import p4.v1.P4RuntimeOuterClass.ActionProfileGroup
+import p4.v1.P4RuntimeOuterClass.ActionProfileMember
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.ForwardingPipelineConfig
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
+import p4.v1.P4RuntimeOuterClass.TableAction
+import p4.v1.P4RuntimeOuterClass.TableEntry
+import p4.v1.P4RuntimeOuterClass.Update
+import p4.v1.P4RuntimeOuterClass.WriteRequest
+
+class NetworkServiceTest {
+  private lateinit var harness: Harness
+
+  @Before
+  fun setUp() {
+    harness = Harness()
+  }
+
+  @After
+  fun tearDown() {
+    harness.close()
+  }
+
+  @Test
+  fun `AddLinks RemoveLinks and ListLinks are atomic and strict`() = runBlocking {
+    harness.createDevices(2, 1)
+    val link = link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 0))
+
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "appears more than once in request") {
+      harness.addLinks(
+        link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 0)),
+        link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 1)),
+      )
+    }
+
+    harness.addLinks(link)
+    assertEquals(listOf(link), harness.listLinks())
+
+    assertGrpcError(Status.Code.ALREADY_EXISTS, "already linked") { harness.addLinks(link) }
+    assertEquals("duplicate add leaves topology unchanged", listOf(link), harness.listLinks())
+
+    val unlinkedEndpoint = link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 7))
+    assertGrpcError(Status.Code.NOT_FOUND, "is not linked") {
+      harness.removeLinks(unlinkedEndpoint)
+    }
+    assertEquals("failed remove leaves topology unchanged", listOf(link), harness.listLinks())
+
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "appears more than once in request") {
+      harness.removeLinks(link, link)
+    }
+    assertEquals("duplicate remove leaves topology unchanged", listOf(link), harness.listLinks())
+
+    val mismatchedPeer = link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 1))
+    harness.addLinks(link(dp(deviceId = 2, port = 1), dp(deviceId = 1, port = 0)))
+    assertGrpcError(Status.Code.INVALID_ARGUMENT, "does not match configured topology") {
+      harness.removeLinks(mismatchedPeer)
+    }
+    assertEquals("failed remove leaves topology unchanged", 2, harness.listLinks().size)
+
+    harness.removeLinks(link)
+    harness.removeLinks(link(dp(deviceId = 2, port = 1), dp(deviceId = 1, port = 0)))
+    assertEquals(emptyList<Link>(), harness.listLinks())
+  }
+
+  @Test
+  fun `dataplane link traverses two switches and returns a network trace`() = runBlocking {
+    harness.createDevices(2, 1)
+    harness.addLinks(link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 0)))
+    harness.loadPipeline(1, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.loadPipeline(2, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+
+    val response = harness.inject(dp(deviceId = 1, port = 0), maxHops = 3)
+
+    assertEquals(1L, response.trace.root.deviceId)
+    val firstTraversal = response.trace.root.traversalsList.single()
+    assertTrue(firstTraversal.hasNextHop())
+    assertEquals(2L, firstTraversal.nextHop.deviceId)
+    val secondTraversal = firstTraversal.nextHop.traversalsList.single()
+    assertTrue(secondTraversal.hasNetworkEgress())
+    assertEquals(dp(deviceId = 2, port = 1), secondTraversal.networkEgress.egress)
+    assertEquals(
+      listOf(2L),
+      response.possibleOutcomesList.single().packetsList.map { it.egress.deviceId },
+    )
+  }
+
+  @Test
+  fun `output without a matching link becomes network egress`() = runBlocking {
+    harness.loadPipeline(1, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+
+    val response = harness.inject(dp(deviceId = 1, port = 0), maxHops = 2)
+
+    val traversal = response.trace.root.traversalsList.single()
+    assertTrue(traversal.hasNetworkEgress())
+    assertEquals(dp(deviceId = 1, port = 1), traversal.networkEgress.egress)
+    assertEquals(
+      listOf(dp(deviceId = 1, port = 1)),
+      response.possibleOutcomesList.single().packetsList.map { it.egress },
+    )
+  }
+
+  @Test
+  fun `P4Runtime link uses translated ports`() = runBlocking {
+    harness.createDevices(2, 1)
+    val config = loadConfig("e2e_tests/translated_port/translated_port.txtpb")
+    harness.loadPipeline(1, config)
+    harness.loadPipeline(2, config)
+    harness.write(1, translatedForwardingEntry(config, portName = "Ethernet1"))
+    harness.write(2, translatedForwardingEntry(config, portName = "Ethernet1"))
+    harness.addLinks(
+      link(p4rt(deviceId = 1, port = "Ethernet1"), p4rt(deviceId = 2, port = "Ethernet0"))
+    )
+
+    val response = harness.inject(p4rt(deviceId = 1, port = "Ethernet0"), maxHops = 3)
+
+    val egress = response.possibleOutcomesList.single().packetsList.single().egress
+    assertEquals(p4rt(deviceId = 2, port = "Ethernet1"), egress)
+  }
+
+  @Test
+  fun `P4Runtime topology can be configured before pipelines are loaded`() = runBlocking {
+    harness.createDevices(2, 1)
+    val link = link(p4rt(deviceId = 1, port = "Ethernet1"), p4rt(deviceId = 2, port = "Ethernet0"))
+
+    harness.addLinks(link)
+    assertEquals(listOf(link), harness.listLinks())
+
+    assertGrpcError(Status.Code.FAILED_PRECONDITION, "no pipeline is loaded") {
+      harness.inject(p4rt(deviceId = 1, port = "Ethernet0"), maxHops = 2)
+    }
+  }
+
+  @Test
+  fun `output matching dataplane and P4Runtime links fails loudly`() = runBlocking {
+    harness.createDevices(2, 2)
+    val config = loadConfig("e2e_tests/translated_port/translated_port.txtpb")
+    harness.loadPipeline(1, config)
+    harness.loadPipeline(2, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.loadPipeline(3, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.write(1, translatedForwardingEntry(config, portName = "Ethernet1"))
+    harness.addLinks(
+      link(dp(deviceId = 1, port = 0), dp(deviceId = 2, port = 0)),
+      link(p4rt(deviceId = 1, port = "Ethernet1"), dp(deviceId = 3, port = 0)),
+    )
+
+    assertGrpcError(Status.Code.FAILED_PRECONDITION, "matches multiple configured links") {
+      harness.inject(p4rt(deviceId = 1, port = "Ethernet0"), maxHops = 2)
+    }
+  }
+
+  @Test
+  fun `hop limit stops traversal deterministically`() = runBlocking {
+    harness.createDevices(2, 1)
+    harness.loadPipeline(1, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.loadPipeline(2, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.addLinks(link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 0)))
+
+    val response = harness.inject(dp(deviceId = 1, port = 0), maxHops = 1)
+
+    val traversal = response.trace.root.traversalsList.single()
+    assertTrue(traversal.hasHopLimitExceeded())
+    assertEquals(dp(deviceId = 2, port = 0), traversal.hopLimitExceeded.nextIngress)
+    assertTrue(response.possibleOutcomesList.single().packetsList.isEmpty())
+  }
+
+  @Test
+  fun `replication follows all output leaves in one possible outcome`() = runBlocking {
+    harness.createDevices(2, 2)
+    harness.loadPipeline(1, loadConfig("e2e_tests/trace_tree/multicast.txtpb"))
+    harness.loadPipeline(2, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.loadPipeline(3, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.write(1, buildMulticastGroup(groupId = 1, ports = listOf(1, 2)))
+    harness.addLinks(
+      link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 0)),
+      link(dp(deviceId = 1, port = 2), dp(deviceId = 3, port = 0)),
+    )
+
+    val response = harness.inject(dp(deviceId = 1, port = 0), maxHops = 3)
+
+    assertEquals("replication is one possible outcome", 1, response.possibleOutcomesCount)
+    assertEquals(
+      listOf(2L, 3L),
+      response.possibleOutcomesList.single().packetsList.map { it.egress.deviceId }.sorted(),
+    )
+  }
+
+  @Test
+  fun `replication records distinct traversals over the same link`() = runBlocking {
+    harness.createDevices(2, 1)
+    harness.loadPipeline(1, loadConfig("e2e_tests/trace_tree/multicast.txtpb"))
+    harness.loadPipeline(2, loadConfig("e2e_tests/passthrough/passthrough.txtpb"))
+    harness.write(1, buildMulticastGroup(groupId = 1, ports = listOf(1, 1)))
+    harness.addLinks(link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 0)))
+
+    val response = harness.inject(dp(deviceId = 1, port = 0), maxHops = 3)
+
+    assertEquals(2, response.trace.root.traversalsCount)
+    assertEquals(listOf(1L, 2L), response.trace.root.traversalsList.map { it.sourceOutputId })
+    assertEquals(listOf(2L, 2L), response.trace.root.traversalsList.map { it.nextHop.deviceId })
+    assertEquals("replication is still one possible outcome", 1, response.possibleOutcomesCount)
+    assertEquals(2, response.possibleOutcomesList.single().packetsCount)
+    assertEquals(
+      listOf(dp(deviceId = 2, port = 1), dp(deviceId = 2, port = 1)),
+      response.possibleOutcomesList.single().packetsList.map { it.egress },
+    )
+  }
+
+  @Test
+  fun `choice branches remain separate possible outcomes`() = runBlocking {
+    harness.createDevices(2, 2)
+    val selector = loadConfig("e2e_tests/trace_tree/action_selector_3.txtpb")
+    val passthrough = loadConfig("e2e_tests/passthrough/passthrough.txtpb")
+    harness.loadPipeline(1, selector)
+    harness.loadPipeline(2, passthrough)
+    harness.loadPipeline(3, passthrough)
+    harness.installSelectorGroup(deviceId = 1, config = selector, memberPorts = listOf(1, 2))
+    harness.addLinks(
+      link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 0)),
+      link(dp(deviceId = 1, port = 2), dp(deviceId = 3, port = 0)),
+    )
+
+    val response = harness.inject(dp(deviceId = 1, port = 0), maxHops = 3)
+
+    assertEquals(
+      "each selector member is a separate possible outcome",
+      2,
+      response.possibleOutcomesCount,
+    )
+    assertEquals(
+      listOf(listOf(2L), listOf(3L)),
+      response.possibleOutcomesList.map { outcome ->
+        outcome.packetsList.map { it.egress.deviceId }
+      },
+    )
+  }
+
+  @Test
+  fun `choice branches with identical network egress collapse to one possible outcome`() =
+    runBlocking {
+      harness.createDevices(2, 1)
+      val selector = loadConfig("e2e_tests/trace_tree/action_selector_3.txtpb")
+      val passthrough = loadConfig("e2e_tests/passthrough/passthrough.txtpb")
+      harness.loadPipeline(1, selector)
+      harness.loadPipeline(2, passthrough)
+      harness.installSelectorGroup(deviceId = 1, config = selector, memberPorts = listOf(1, 1))
+      harness.addLinks(link(dp(deviceId = 1, port = 1), dp(deviceId = 2, port = 0)))
+
+      val response = harness.inject(dp(deviceId = 1, port = 0), maxHops = 3)
+
+      assertEquals("trace preserves both selector branches", 2, response.trace.root.traversalsCount)
+      assertEquals("identical network outcomes collapse", 1, response.possibleOutcomesCount)
+      assertEquals(
+        listOf(dp(deviceId = 2, port = 1)),
+        response.possibleOutcomesList.single().packetsList.map { it.egress },
+      )
+    }
+
+  private class Harness : Closeable {
+    private val registry = DeviceRegistry(DeviceSettings())
+    private val serverName = InProcessServerBuilder.generateName()
+    private val executor = java.util.concurrent.Executors.newCachedThreadPool()
+    private val server =
+      InProcessServerBuilder.forName(serverName)
+        .executor(executor)
+        .addService(MultiDeviceP4RuntimeService(registry))
+        .addService(MultiDeviceDataplaneService(registry))
+        .addService(ManagementService(registry))
+        .addService(NetworkService(registry))
+        .build()
+        .start()
+
+    private val channel: ManagedChannel = InProcessChannelBuilder.forName(serverName).build()
+    private val p4rt = P4RuntimeCoroutineStub(channel)
+    private val management = FourwardManagementCoroutineStub(channel)
+    private val network = NetworkCoroutineStub(channel)
+
+    suspend fun createDevices(firstDeviceId: Long, count: Int) {
+      management.createDevices(
+        CreateDevicesRequest.newBuilder().setFirstDeviceId(firstDeviceId).setCount(count).build()
+      )
+    }
+
+    suspend fun loadPipeline(deviceId: Long, config: PipelineConfig) {
+      val unused =
+        p4rt.setForwardingPipelineConfig(
+          SetForwardingPipelineConfigRequest.newBuilder()
+            .setDeviceId(deviceId)
+            .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+            .setConfig(
+              ForwardingPipelineConfig.newBuilder()
+                .setP4Info(config.p4Info)
+                .setP4DeviceConfig(config.device.toByteString())
+            )
+            .build()
+        )
+    }
+
+    suspend fun write(deviceId: Long, entity: Entity) {
+      val unused =
+        p4rt.write(
+          WriteRequest.newBuilder()
+            .setDeviceId(deviceId)
+            .addUpdates(Update.newBuilder().setType(Update.Type.INSERT).setEntity(entity))
+            .build()
+        )
+    }
+
+    suspend fun addLinks(vararg links: Link) {
+      network.addLinks(AddLinksRequest.newBuilder().addAllLinks(links.asList()).build())
+    }
+
+    suspend fun removeLinks(vararg links: Link) {
+      network.removeLinks(RemoveLinksRequest.newBuilder().addAllLinks(links.asList()).build())
+    }
+
+    suspend fun listLinks(): List<Link> =
+      network.listLinks(ListLinksRequest.getDefaultInstance()).linksList
+
+    suspend fun inject(
+      ingress: NetworkPort,
+      maxHops: Int,
+      payload: ByteArray = buildEthernetFrame(etherType = 0x0800),
+    ) =
+      network.injectPacket(
+        InjectNetworkPacketRequest.newBuilder()
+          .setIngress(ingress)
+          .setPayload(ByteString.copyFrom(payload))
+          .setMaxHops(maxHops)
+          .build()
+      )
+
+    suspend fun installSelectorGroup(
+      deviceId: Long,
+      config: PipelineConfig,
+      memberPorts: List<Int>,
+    ) {
+      val schema = SelectorSchema.discover(config.p4Info)
+      for ((index, port) in memberPorts.withIndex()) {
+        write(deviceId, selectorMember(schema, memberId = index + 1, port = port))
+      }
+      write(
+        deviceId,
+        selectorGroup(schema, groupId = 1, memberIds = (1..memberPorts.size).toList()),
+      )
+      write(deviceId, selectorTableEntry(schema, groupId = 1))
+    }
+
+    override fun close() {
+      channel.shutdownNow()
+      server.shutdownNow()
+      executor.shutdownNow()
+      registry.close()
+    }
+  }
+
+  private data class SelectorSchema(
+    val tableId: Int,
+    val matchFieldId: Int,
+    val profileId: Int,
+    val setPortActionId: Int,
+    val setPortParamId: Int,
+  ) {
+    companion object {
+      fun discover(p4Info: P4Info): SelectorSchema {
+        val profile = p4Info.actionProfilesList.single()
+        val table = p4Info.tablesList.single { it.implementationId == profile.preamble.id }
+        val exactField =
+          table.matchFieldsList.single {
+            it.matchType == p4.config.v1.P4InfoOuterClass.MatchField.MatchType.EXACT
+          }
+        val actionsById = p4Info.actionsList.associateBy { it.preamble.id }
+        val setPort =
+          table.actionRefsList.mapNotNull { actionsById[it.id] }.single { it.paramsCount == 1 }
+        return SelectorSchema(
+          tableId = table.preamble.id,
+          matchFieldId = exactField.id,
+          profileId = profile.preamble.id,
+          setPortActionId = setPort.preamble.id,
+          setPortParamId = setPort.paramsList.first().id,
+        )
+      }
+    }
+  }
+
+  companion object {
+    private fun dp(deviceId: Long, port: Int): NetworkPort =
+      NetworkPort.newBuilder().setDeviceId(deviceId).setDataplanePort(port).build()
+
+    private fun p4rt(deviceId: Long, port: String): NetworkPort =
+      NetworkPort.newBuilder()
+        .setDeviceId(deviceId)
+        .setP4RtPort(ByteString.copyFromUtf8(port))
+        .build()
+
+    private fun link(a: NetworkPort, b: NetworkPort): Link =
+      Link.newBuilder().setA(a).setB(b).build()
+
+    private fun translatedForwardingEntry(config: PipelineConfig, portName: String): Entity {
+      val table = findTable(config, "forwarding")
+      val action = findAction(config, "forward")
+      return Entity.newBuilder()
+        .setTableEntry(
+          TableEntry.newBuilder()
+            .setTableId(table.preamble.id)
+            .addMatch(
+              FieldMatch.newBuilder()
+                .setFieldId(FourwardTestHarness.matchFieldId(table, "hdr.ethernet.ether_type"))
+                .setExact(
+                  FieldMatch.Exact.newBuilder()
+                    .setValue(ByteString.copyFrom(longToBytes(0x0800, 2)))
+                )
+            )
+            .setAction(
+              TableAction.newBuilder()
+                .setAction(
+                  Action.newBuilder()
+                    .setActionId(action.preamble.id)
+                    .addParams(
+                      Action.Param.newBuilder()
+                        .setParamId(FourwardTestHarness.paramId(action, "port"))
+                        .setValue(ByteString.copyFromUtf8(portName))
+                    )
+                )
+            )
+        )
+        .build()
+    }
+
+    private fun selectorMember(schema: SelectorSchema, memberId: Int, port: Int): Entity =
+      Entity.newBuilder()
+        .setActionProfileMember(
+          ActionProfileMember.newBuilder()
+            .setActionProfileId(schema.profileId)
+            .setMemberId(memberId)
+            .setAction(
+              Action.newBuilder()
+                .setActionId(schema.setPortActionId)
+                .addParams(
+                  Action.Param.newBuilder()
+                    .setParamId(schema.setPortParamId)
+                    .setValue(ByteString.copyFrom(byteArrayOf(0, port.toByte())))
+                )
+            )
+        )
+        .build()
+
+    private fun selectorGroup(schema: SelectorSchema, groupId: Int, memberIds: List<Int>): Entity =
+      Entity.newBuilder()
+        .setActionProfileGroup(
+          ActionProfileGroup.newBuilder()
+            .setActionProfileId(schema.profileId)
+            .setGroupId(groupId)
+            .setMaxSize(memberIds.size)
+            .addAllMembers(
+              memberIds.map { memberId ->
+                ActionProfileGroup.Member.newBuilder().setMemberId(memberId).setWeight(1).build()
+              }
+            )
+        )
+        .build()
+
+    private fun selectorTableEntry(schema: SelectorSchema, groupId: Int): Entity =
+      Entity.newBuilder()
+        .setTableEntry(
+          TableEntry.newBuilder()
+            .setTableId(schema.tableId)
+            .addMatch(
+              FieldMatch.newBuilder()
+                .setFieldId(schema.matchFieldId)
+                .setExact(
+                  FieldMatch.Exact.newBuilder()
+                    .setValue(ByteString.copyFrom(ByteArray(6) { 0xff.toByte() }))
+                )
+            )
+            .setAction(TableAction.newBuilder().setActionProfileGroupId(groupId))
+        )
+        .build()
+  }
+}

--- a/grpc/NetworkTopology.kt
+++ b/grpc/NetworkTopology.kt
@@ -1,0 +1,147 @@
+package fourward.grpc
+
+import com.google.protobuf.ByteString
+import fourward.Link
+import fourward.NetworkPort
+import io.grpc.Status
+
+class NetworkTopology(private val registry: DeviceRegistry) {
+  private val peers = mutableMapOf<Endpoint, Endpoint>()
+
+  @Synchronized
+  internal fun addLinks(links: List<Link>) {
+    val additions = links.map(::validatedLink)
+    val newEndpoints = mutableSetOf<Endpoint>()
+    for ((a, b) in additions) {
+      if (!newEndpoints.add(a)) duplicateEndpoint(a)
+      if (!newEndpoints.add(b)) duplicateEndpoint(b)
+      if (peers.containsKey(a)) alreadyLinked(a)
+      if (peers.containsKey(b)) alreadyLinked(b)
+    }
+    for ((a, b) in additions) {
+      peers[a] = b
+      peers[b] = a
+    }
+  }
+
+  @Synchronized
+  internal fun removeLinks(links: List<Link>) {
+    val removals = links.map(::validatedLink)
+    val removedEndpoints = mutableSetOf<Endpoint>()
+    for ((a, b) in removals) {
+      if (!removedEndpoints.add(a)) duplicateEndpoint(a)
+      if (!removedEndpoints.add(b)) duplicateEndpoint(b)
+      val actualA = peers[a] ?: throw notFound(a)
+      val actualB = peers[b] ?: throw notFound(b)
+      if (actualA != b || actualB != a) {
+        throw Status.INVALID_ARGUMENT.withDescription(
+            "link ${a.describe()} <-> ${b.describe()} does not match configured topology"
+          )
+          .asException()
+      }
+    }
+    for ((a, b) in removals) {
+      peers.remove(a)
+      peers.remove(b)
+    }
+  }
+
+  @Synchronized
+  internal fun listLinks(): List<Link> {
+    val seen = mutableSetOf<Endpoint>()
+    val links = mutableListOf<Link>()
+    for ((a, b) in peers) {
+      if (a in seen || b in seen) continue
+      seen.add(a)
+      seen.add(b)
+      links.add(Link.newBuilder().setA(a.toProto()).setB(b.toProto()).build())
+    }
+    return links
+  }
+
+  @Synchronized internal fun snapshot(): TopologySnapshot = TopologySnapshot(peers.toMap())
+
+  private fun validatedLink(link: Link): Pair<Endpoint, Endpoint> {
+    val a = validatedEndpoint(link.a)
+    val b = validatedEndpoint(link.b)
+    if (a == b) {
+      throw Status.INVALID_ARGUMENT.withDescription("link endpoint ${a.describe()} is repeated")
+        .asException()
+    }
+    return a to b
+  }
+
+  private fun validatedEndpoint(port: NetworkPort): Endpoint {
+    val endpoint = Endpoint.fromProto(port)
+    registry.get(endpoint.deviceId)
+    return endpoint
+  }
+
+  private fun alreadyLinked(endpoint: Endpoint): Nothing {
+    throw Status.ALREADY_EXISTS.withDescription("endpoint ${endpoint.describe()} is already linked")
+      .asException()
+  }
+
+  private fun duplicateEndpoint(endpoint: Endpoint): Nothing {
+    throw Status.INVALID_ARGUMENT.withDescription(
+        "endpoint ${endpoint.describe()} appears more than once in request"
+      )
+      .asException()
+  }
+
+  private fun notFound(endpoint: Endpoint) =
+    Status.NOT_FOUND.withDescription("endpoint ${endpoint.describe()} is not linked").asException()
+}
+
+internal class TopologySnapshot internal constructor(private val peers: Map<Endpoint, Endpoint>) {
+  fun peer(endpoint: Endpoint): Endpoint? = peers[endpoint]
+}
+
+internal data class Endpoint(val deviceId: Long, val port: PortKey) {
+  fun toProto(): NetworkPort {
+    val builder = NetworkPort.newBuilder().setDeviceId(deviceId)
+    when (port) {
+      is PortKey.Dataplane -> builder.setDataplanePort(port.value)
+      is PortKey.P4Runtime -> builder.setP4RtPort(port.value)
+    }
+    return builder.build()
+  }
+
+  fun describe(): String =
+    when (port) {
+      is PortKey.Dataplane -> "device_id $deviceId dataplane_port ${port.unsignedValue()}"
+      is PortKey.P4Runtime -> "device_id $deviceId p4rt_port 0x${port.value.toHex()}"
+    }
+
+  companion object {
+    fun fromProto(port: NetworkPort): Endpoint {
+      if (port.deviceId == 0L) {
+        throw Status.INVALID_ARGUMENT.withDescription("device_id must be nonzero").asException()
+      }
+      val key =
+        when (port.portCase) {
+          NetworkPort.PortCase.DATAPLANE_PORT -> PortKey.Dataplane(port.dataplanePort)
+          NetworkPort.PortCase.P4RT_PORT -> {
+            if (port.p4RtPort.isEmpty) {
+              throw Status.INVALID_ARGUMENT.withDescription("p4rt_port must be nonempty")
+                .asException()
+            }
+            PortKey.P4Runtime(port.p4RtPort)
+          }
+          NetworkPort.PortCase.PORT_NOT_SET,
+          null ->
+            throw Status.INVALID_ARGUMENT.withDescription("NetworkPort must set a port")
+              .asException()
+        }
+      return Endpoint(port.deviceId, key)
+    }
+  }
+}
+
+internal sealed interface PortKey {
+  data class Dataplane(val value: Int) : PortKey {
+    fun unsignedValue(): Long = value.toLong() and 0xFFFF_FFFFL
+  }
+
+  data class P4Runtime(val value: ByteString) : PortKey
+}

--- a/grpc/network.proto
+++ b/grpc/network.proto
@@ -1,0 +1,113 @@
+// Network-wide packet simulation across multiple 4ward devices.
+//
+// This is a 4ward-native service. P4Runtime programs individual devices;
+// Network owns only topology and packet traversal between devices.
+
+syntax = "proto3";
+
+package fourward;
+
+import "simulator/simulator.proto";
+
+option java_package = "fourward";
+option java_outer_classname = "NetworkProto";
+option java_multiple_files = true;
+
+service Network {
+  rpc AddLinks(AddLinksRequest) returns (AddLinksResponse);
+  rpc RemoveLinks(RemoveLinksRequest) returns (RemoveLinksResponse);
+  rpc ListLinks(ListLinksRequest) returns (ListLinksResponse);
+  rpc InjectPacket(InjectNetworkPacketRequest)
+      returns (InjectNetworkPacketResponse);
+}
+
+message NetworkPort {
+  // Logical 4ward device ID. Must be nonzero.
+  uint64 device_id = 1;
+
+  oneof port {
+    // P4Runtime port ID bytes. Preferred for controller-facing network tests.
+    bytes p4rt_port = 2;
+
+    // Raw simulator port. Useful for programs without P4Runtime port
+    // translation.
+    uint32 dataplane_port = 3;
+  }
+}
+
+message Link {
+  NetworkPort a = 1;
+  NetworkPort b = 2;
+}
+
+message AddLinksRequest {
+  repeated Link links = 1;
+}
+
+message AddLinksResponse {}
+
+message RemoveLinksRequest {
+  repeated Link links = 1;
+}
+
+message RemoveLinksResponse {}
+
+message ListLinksRequest {}
+
+message ListLinksResponse {
+  repeated Link links = 1;
+}
+
+message InjectNetworkPacketRequest {
+  NetworkPort ingress = 1;
+  bytes payload = 2;
+  // Safety bound for forwarding loops. Must be positive.
+  uint32 max_hops = 3;
+  // Opaque caller-provided tag, copied into the first switch injection.
+  int64 tag = 4;
+}
+
+message InjectNetworkPacketResponse {
+  NetworkTrace trace = 1;
+  // The set of possible network outcomes. Alternative switch executions that
+  // produce identical network egress packets collapse to one entry. Within an
+  // outcome, packet multiplicity is meaningful: multicast/clone can emit the
+  // same packet more than once.
+  repeated NetworkOutcome possible_outcomes = 2;
+}
+
+message NetworkOutcome {
+  repeated NetworkEgressPacket packets = 1;
+}
+
+message NetworkTrace {
+  NetworkHop root = 1;
+}
+
+message NetworkHop {
+  uint64 device_id = 1;
+  NetworkPort ingress = 2;
+  TraceTree switch_trace = 3;
+  repeated LinkTraversal traversals = 4;
+}
+
+message LinkTraversal {
+  // Hop-local ID assigned to terminal Output leaves in deterministic DFS order.
+  uint64 source_output_id = 1;
+  OutputPacket source_output = 2;
+
+  oneof result {
+    NetworkHop next_hop = 3;
+    NetworkEgressPacket network_egress = 4;
+    HopLimitExceeded hop_limit_exceeded = 5;
+  }
+}
+
+message NetworkEgressPacket {
+  NetworkPort egress = 1;
+  bytes payload = 2;
+}
+
+message HopLimitExceeded {
+  NetworkPort next_ingress = 1;
+}


### PR DESCRIPTION
## Summary

Implements the network-wide simulation design as a 4ward-native Network gRPC service, without memoization. The new service owns topology, reuses existing per-device dataplane execution, and returns network-level traces plus final possible outcomes.

Also adds a thin C++ `NetworkClient` wrapper and marks `designs/network_simulation.md` as implemented.

A follow-up commit applied three cleanups:

- `ToAbsl` / `AbsoluteDeadline` were copy-pasted into all three client `.cc` files; extracted into `fourward_cc/grpc_util.h`. `AbsoluteDeadline` now uses `absl::ToChronoTime` instead of the `time_point_cast + ToChronoNanoseconds` two-step.
- The same P4Runtime test helpers (`ReadRunfile`, `EstablishMasterArbitration`, `PushPipeline`) were duplicated across both C++ test files; extracted into `fourward_cc/test_util.h`.
- `OutputWorldCollector` was a class whose only role was holding a mutable counter — collapsed into a local function using the same closure pattern as `outputLeaves`.

## Validation

- `bazel test //grpc:NetworkServiceTest //grpc:MultiDeviceServiceTest //fourward_cc:network_client_test //fourward_cc:fourward_server_test --test_output=errors`
- `./tools/format.sh --check`
- `./tools/lint.sh`
- after rebase: `bazel test //grpc:NetworkServiceTest //fourward_cc:network_client_test --test_output=errors`