### PR TITLE
[codex] Fix cancellable cleanup in SAI test

### DIFF
--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -10,11 +10,13 @@ import fourward.TypeTranslation
 import io.grpc.Status
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -652,7 +654,7 @@ class SaiP4E2ETest {
           assertBytesEqual("dst_ip", DST_IP, actualPayload, DST_IP_OFFSET)
         }
       } finally {
-        job.cancelAndJoin()
+        withContext(NonCancellable) { job.cancelAndJoin() }
       }
     }
 


### PR DESCRIPTION
Fixes #801.

The SAI PacketOut subscription test cancelled and joined its collector job directly inside a `finally` block. Android Lint flags that pattern because `cancelAndJoin()` is cancellable and cleanup in `finally` must be allowed to complete even if the surrounding coroutine is already being cancelled.

This wraps the cleanup in `withContext(NonCancellable)`, matching the existing stream cleanup pattern used by the P4Runtime service.

Validation:
- `./tools/format.sh`
- `bazel test //grpc:SaiP4E2ETest`