### PR TITLE
[codex] Avoid matcher crash during quiet OnPorts mismatches

### DIFF
--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -386,6 +386,7 @@ class OnPortsMatcher {
       const internal::PacketList& group =
           it != groups.end() ? it->second : kEmpty;
       if (!matcher.Matches(group)) {
+        if (!listener->IsInterested()) return false;
         *listener << "on port ";
         internal::PrintPortKey(listener->stream(), port);
         *listener << ": ";

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -214,6 +214,27 @@ TEST(OnPortsTest, GroupsByPort) {
               OutcomeIs(OnPorts({{DataplanePort{1}, SizeIs(2)}, {DataplanePort{2}, SizeIs(1)}})));
 }
 
+TEST(OnPortsTest, MatchesDoesNotCrashOnMismatch) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(1);
+
+  ::testing::Matcher<const fourward::InjectPacketResponse&> matcher =
+      OutcomeIs(OnPorts({{DataplanePort{2}, SizeIs(1)}}));
+
+  EXPECT_FALSE(matcher.Matches(resp));
+}
+
+TEST(OnPortsTest, ExplainsMismatchWhenListenerIsInterested) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(1);
+
+  EXPECT_THAT(ExplainMatch(OutcomeIs(OnPorts({{DataplanePort{2}, SizeIs(1)}})),
+                           resp),
+              ::testing::HasSubstr("on port 2"));
+}
+
 TEST(OnPortsTest, P4RuntimePortKeys) {
   fourward::InjectPacketResponse resp;
   auto* ps = resp.add_possible_outcomes();


### PR DESCRIPTION
## What changed

`OnPortsMatcher` now skips failure-message formatting when gMock supplies an uninterested `MatchResultListener`.

## Why

`MatchResultListener*` itself is guaranteed non-null by gMock, but `listener->stream()` may be null. `OnPortsMatcher` passed that null stream to `PrintPortKey()` on a mismatch, which could crash during quiet matcher probes such as `Matcher::Matches(...)` and during some `EXPECT_THAT` internals.

## Impact

Mismatched `OnPorts(...)` checks now return `false` instead of crashing when no explanation stream is available. Interested listeners still get the useful `on port ...` explanation.

## Validation

- Added a reproducer for the quiet mismatch path.
- Added coverage that interested listeners still include the port-specific explanation.
- Ran `bazel test //fourward_cc:dataplane_matchers_test --test_output=errors`.