### PR TITLE
Fix and harden OnPorts: mixed port types + exhaustive matching

### DIFF
--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -92,6 +92,7 @@ cc_library(
         ":dataplane_client",
         "//grpc:dataplane_cc_proto",
         "//simulator:simulator_cc_proto",
+        "@abseil-cpp//absl/algorithm:container",
         "@abseil-cpp//absl/container:btree",
         "@googletest//:gtest",
     ],

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -16,6 +16,7 @@
 #include <variant>
 #include <vector>
 
+#include "absl/algorithm/container.h"
 #include "absl/container/btree_map.h"
 #include "fourward_cc/dataplane_client.h"
 #include "gmock/gmock.h"
@@ -349,7 +350,8 @@ inline auto Drops() { return OutcomeIs(); }
 // OnPorts — group by egress port
 //
 // Expectations may mix DataplanePort and P4RuntimePort; each is matched
-// against the packets on that port in its own port type.
+// against the packets on that port in its own port type. Exhaustive: a
+// packet egressing on a port no expectation lists fails the match.
 // ---------------------------------------------------------------------------
 
 class OnPortsMatcher {
@@ -381,6 +383,22 @@ class OnPortsMatcher {
         return false;
       }
     }
+    // Exhaustive: a packet on a port no expectation lists is a failure, not
+    // silently ignored. A packet is covered if it matches any listed port in
+    // that port's own type, so mixed-type expectations cover it either way.
+    for (const auto& p : packets) {
+      const bool covered =
+          absl::c_any_of(expected_, [&](const PortExpectation& e) {
+            return internal::PacketIsOnPort(p, e.first);
+          });
+      if (!covered) {
+        if (!listener->IsInterested()) return false;
+        *listener << "has an unexpected packet egressing on dataplane port "
+                  << p.dataplane_egress_port() << " (P4Runtime port \""
+                  << p.p4rt_egress_port() << "\")";
+        return false;
+      }
+    }
     return true;
   }
 
@@ -393,6 +411,7 @@ class OnPortsMatcher {
       *os << " ";
       expected_[i].second.DescribeTo(os);
     }
+    *os << ", and no packets on other ports";
   }
   void DescribeNegationTo(std::ostream* os) const {
     *os << "does not match port-grouped expectations";

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -113,29 +113,20 @@ class OutcomesMatcherBase {
   std::string description_;
 };
 
-// Port key for OnPorts grouping.
+// Port key for OnPorts expectations: either a dataplane or a P4Runtime port.
 using PortKey = std::variant<DataplanePort, P4RuntimePort>;
 
-// All entries must use the same port type (DataplanePort or P4RuntimePort).
-// Mixing types in a single OnPorts call groups all packets by the first
-// entry's type, which silently ignores entries of the other type.
-inline PortKey PacketPortKey(const fourward::OutputPacket& pkt,
-                             const PortKey& example_key) {
-  if (std::holds_alternative<P4RuntimePort>(example_key)) {
-    return P4RuntimePort{pkt.p4rt_egress_port()};
+// True if `pkt` egressed on `key`, comparing the packet's egress port in
+// `key`'s own port type. OnPorts evaluates each expectation through this
+// predicate, so a single call can mix DataplanePort and P4RuntimePort
+// expectations freely — each selects packets by its own port type.
+inline bool PacketIsOnPort(const fourward::OutputPacket& pkt,
+                           const PortKey& key) {
+  if (std::holds_alternative<DataplanePort>(key)) {
+    return pkt.dataplane_egress_port() == std::get<DataplanePort>(key).port;
   }
-  return DataplanePort{pkt.dataplane_egress_port()};
+  return pkt.p4rt_egress_port() == std::get<P4RuntimePort>(key).port;
 }
-
-struct PortKeyLess {
-  bool operator()(const PortKey& a, const PortKey& b) const {
-    if (a.index() != b.index()) return a.index() < b.index();
-    if (std::holds_alternative<DataplanePort>(a)) {
-      return std::get<DataplanePort>(a).port < std::get<DataplanePort>(b).port;
-    }
-    return std::get<P4RuntimePort>(a).port < std::get<P4RuntimePort>(b).port;
-  }
-};
 
 inline void PrintPortKey(std::ostream* os, const PortKey& key) {
   if (std::holds_alternative<DataplanePort>(key)) {
@@ -357,7 +348,8 @@ inline auto Drops() { return OutcomeIs(); }
 // ---------------------------------------------------------------------------
 // OnPorts — group by egress port
 //
-// All entries must use the same port type (DataplanePort or P4RuntimePort).
+// Expectations may mix DataplanePort and P4RuntimePort; each is matched
+// against the packets on that port in its own port type.
 // ---------------------------------------------------------------------------
 
 class OnPortsMatcher {
@@ -372,19 +364,14 @@ class OnPortsMatcher {
   template <typename Container>
   bool MatchAndExplain(const Container& packets,
                        ::testing::MatchResultListener* listener) const {
-    absl::btree_map<internal::PortKey, internal::PacketList,
-                    internal::PortKeyLess>
-        groups;
-    // Port type is inferred from the first entry — all entries must use the
-    // same type (DataplanePort or P4RuntimePort).
-    for (const auto& p : packets) {
-      groups[internal::PacketPortKey(p, expected_.front().first)].push_back(p);
-    }
-    static const internal::PacketList kEmpty;
+    // Each expectation is evaluated independently against the full packet
+    // list, selecting packets by its own port type. This lets one OnPorts
+    // call mix DataplanePort and P4RuntimePort expectations.
     for (const auto& [port, matcher] : expected_) {
-      auto it = groups.find(port);
-      const internal::PacketList& group =
-          it != groups.end() ? it->second : kEmpty;
+      internal::PacketList group;
+      for (const auto& p : packets) {
+        if (internal::PacketIsOnPort(p, port)) group.push_back(p);
+      }
       if (!matcher.Matches(group)) {
         if (!listener->IsInterested()) return false;
         *listener << "on port ";

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -266,6 +266,27 @@ TEST(OnPortsTest, MixedPortTypes) {
                         {P4RuntimePort{"6"}, SizeIs(1)},
                         {DataplanePort{510}, SizeIs(2)},
                     })));
+  // The order of mixed expectations must not matter — the original bug keyed
+  // grouping off the first entry's port type, so reversing the order is the
+  // direct regression guard.
+  EXPECT_THAT(resp, OutcomeIs(OnPorts({
+                        {DataplanePort{510}, SizeIs(2)},
+                        {P4RuntimePort{"6"}, SizeIs(1)},
+                    })));
+}
+
+// OnPorts is exhaustive: a packet on a port no expectation lists fails the
+// match rather than being silently ignored.
+TEST(OnPortsTest, RejectsUnlistedPort) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(1);
+  ps->add_packets()->set_dataplane_egress_port(2);
+
+  EXPECT_THAT(resp, Not(OutcomeIs(OnPorts({{DataplanePort{1}, SizeIs(1)}}))));
+  EXPECT_THAT(
+      ExplainMatch(OutcomeIs(OnPorts({{DataplanePort{1}, SizeIs(1)}})), resp),
+      ::testing::HasSubstr("unexpected packet egressing on dataplane port 2"));
 }
 
 TEST(OutcomesAreTest, MixedBareAndOutcome) {

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -247,6 +247,27 @@ TEST(OnPortsTest, P4RuntimePortKeys) {
                     })));
 }
 
+// A single OnPorts call may mix DataplanePort and P4RuntimePort expectations;
+// each is evaluated against its own port type. Here the two CPU packets carry
+// both a dataplane and a P4Runtime egress port, so they are matched either way.
+TEST(OnPortsTest, MixedPortTypes) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* forwarded = ps->add_packets();
+  forwarded->set_dataplane_egress_port(1);
+  forwarded->set_p4rt_egress_port("6");
+  for (int i = 0; i < 2; ++i) {
+    auto* punted = ps->add_packets();
+    punted->set_dataplane_egress_port(510);
+    punted->set_p4rt_egress_port("CPU");
+  }
+
+  EXPECT_THAT(resp, OutcomeIs(OnPorts({
+                        {P4RuntimePort{"6"}, SizeIs(1)},
+                        {DataplanePort{510}, SizeIs(2)},
+                    })));
+}
+
 TEST(OutcomesAreTest, MixedBareAndOutcome) {
   fourward::InjectPacketResponse resp;
   auto* multicast = resp.add_possible_outcomes();

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -141,6 +141,13 @@ EXPECT_THAT(response, OutcomeIs(OnPorts({
     {P4RuntimePort{"Ethernet0"}, SizeIs(1)},
     {P4RuntimePort{"Ethernet1"}, SizeIs(1)},
 })));
+
+// DataplanePort and P4RuntimePort expectations may be mixed in one call;
+// each is matched against the packets on that port in its own port type:
+EXPECT_THAT(response, OutcomeIs(OnPorts({
+    {P4RuntimePort{"Ethernet0"}, SizeIs(1)},
+    {DataplanePort{510}, SizeIs(2)},
+})));
 ```
 
 ## Extracting packets by port

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -109,8 +109,10 @@ EXPECT_THAT(dataplane.InjectPacket({...}), IsOkAndHolds(Forwards()));
 ## Grouping by port
 
 `OnPorts` groups packets by egress port and applies per-group matchers —
-use it when a single `EXPECT_THAT` covers everything you need. When you
-need packets in variables for more involved follow-up, see
+use it when a single `EXPECT_THAT` covers everything you need. It is
+exhaustive: a packet egressing on a port you didn't list fails the
+match, so you can't accidentally overlook stray copies. When you need
+packets in variables for more involved follow-up, see
 [Extracting packets by port](#extracting-packets-by-port) below.
 
 Use `OnPorts` directly inside `OutcomeIs`:


### PR DESCRIPTION
## The win

`OnPorts` was both buggy and quietly permissive. This PR fixes both:

1. **Mixed port types now work.** A single `OnPorts` call can list `DataplanePort` and `P4RuntimePort` expectations together — each is matched against the packets on that port in its own type.
2. **`OnPorts` is now exhaustive.** A packet egressing on a port you didn't list fails the match instead of being silently dropped.

## The bug (#807)

`OnPorts` grouped *all* packets into one map keyed by the **first** expectation's port type. So an assertion like:

```cpp
OnPorts({
    {P4RuntimePort{"6"}, SizeIs(1)},
    {DataplanePort{510}, SizeIs(2)},
})
```

bucketed every packet by its P4Runtime port, then looked up `DataplanePort{510}` — a different `variant` alternative that was never a key — and silently matched it against an empty list. The failure read:

> on port 510: has a size that isn't equal to 2

even though two packets *did* egress on dataplane port 510. The old code even documented this footgun in a comment rather than fixing it.

## The fixes

**Per-expectation matching.** Evaluate each expectation independently against the full packet list, selecting packets by that expectation's own port type. This removes the global grouping map entirely (and its `PortKey` ordering / `PacketPortKey` helpers), replacing it with a small `PacketIsOnPort` predicate.

**Exhaustiveness.** The old behavior silently ignored packets on unlisted ports — undocumented, relied on by no caller (`OnPorts` had no users outside its own test), and at odds with the repo's *never fail silently* invariant. The docs even pitched the extraction path as the way to get "exhaustive, no stray ports" coverage. Now a packet on an unlisted port fails the match with a clear message; with mixed-type expectations a packet counts as covered if it matches any listed port in that port's own type.

New tests: `OnPortsTest.MixedPortTypes` (reproduces the issue) and `OnPortsTest.RejectsUnlistedPort`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)