### PR TITLE
[codex] Improve dataplane matcher failure output

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,6 +1,7 @@
 # Build rules and patches for third-party dependencies.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_kotlinc_options")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
@@ -49,6 +50,32 @@ kt_jvm_test(
     deps = [
         ":runfiles",
         "@fourward_maven//:junit_junit",
+    ],
+)
+
+cc_library(
+    name = "golden_test",
+    testonly = True,
+    srcs = ["golden_test.cc"],
+    hdrs = ["golden_test.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/strings",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "golden_test_main",
+    testonly = True,
+    srcs = ["golden_test_main.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":golden_test",
+        "@abseil-cpp//absl/flags:parse",
+        "@googletest//:gtest",
     ],
 )
 

--- a/bazel/golden_test.cc
+++ b/bazel/golden_test.cc
@@ -1,0 +1,96 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bazel/golden_test.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+ABSL_FLAG(std::optional<bool>, update_golden, std::nullopt,
+          "Update golden files instead of comparing test output to them. Use "
+          "--update_golden=true.");
+
+namespace fourward::bazel {
+namespace {
+
+using ::bazel::tools::cpp::runfiles::Runfiles;
+
+std::string ReadRunfileOrDie(absl::string_view rlocation) {
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", &error));
+  if (runfiles == nullptr) {
+    ADD_FAILURE() << "runfiles: " << error;
+    return "";
+  }
+  std::string path = runfiles->Rlocation(std::string(rlocation));
+  if (path.empty()) {
+    ADD_FAILURE() << "not found in runfiles: " << rlocation;
+    return "";
+  }
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    ADD_FAILURE() << "cannot open: " << path;
+    return "";
+  }
+  return std::string(std::istreambuf_iterator<char>(file),
+                     std::istreambuf_iterator<char>());
+}
+
+std::string SourceGoldenPath(absl::string_view package_dir,
+                             absl::string_view golden_file_name) {
+  const char* workspace = std::getenv("BUILD_WORKSPACE_DIRECTORY");
+  if (workspace == nullptr) {
+    ADD_FAILURE()
+        << "BUILD_WORKSPACE_DIRECTORY is not set. Run via `bazel run`, not "
+           "`bazel test`, to update goldens.";
+    return "";
+  }
+  return absl::StrCat(workspace, "/", package_dir, "/", golden_file_name);
+}
+
+std::optional<bool> UpdateGolden() {
+  return absl::GetFlag(FLAGS_update_golden);
+}
+
+}  // namespace
+
+namespace internal {
+
+void InitializeGoldenTestMain() { absl::SetFlag(&FLAGS_update_golden, false); }
+
+}  // namespace internal
+
+void ExpectMatchesGolden(const GoldenFile& golden, absl::string_view package_dir,
+                         absl::string_view update_target,
+                         absl::string_view actual) {
+  const std::optional<bool> update_golden = UpdateGolden();
+  ASSERT_TRUE(update_golden.has_value())
+      << "Tests using //bazel:golden_test must depend on "
+         "//bazel:golden_test_main instead of @googletest//:gtest_main so "
+         "Abseil flags such as --update_golden are parsed.";
+
+  if (*update_golden) {
+    const std::string path = SourceGoldenPath(package_dir, golden.name);
+    std::ofstream file(path, std::ios::binary);
+    ASSERT_TRUE(file) << "cannot write golden: " << path;
+    file << actual;
+    return;
+  }
+
+  EXPECT_EQ(actual, ReadRunfileOrDie(golden.rlocation))
+      << "Golden file mismatch: " << golden.name
+      << "\nTo update: bazel run " << update_target
+      << " -- --update_golden=true";
+}
+
+}  // namespace fourward::bazel

--- a/bazel/golden_test.h
+++ b/bazel/golden_test.h
@@ -1,0 +1,38 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef BAZEL_GOLDEN_TEST_H_
+#define BAZEL_GOLDEN_TEST_H_
+
+#include <string>
+
+#include "absl/strings/string_view.h"
+
+namespace fourward::bazel {
+
+struct GoldenFile {
+  absl::string_view name;
+  absl::string_view rlocation;
+};
+
+// Compares `actual` to a BUILD-provided runfile. Pass `--update_golden=true`
+// to write the actual text back to the source tree:
+//
+//   bazel run <update_target> -- --update_golden=true
+void ExpectMatchesGolden(const GoldenFile& golden,
+                         absl::string_view package_dir,
+                         absl::string_view update_target,
+                         absl::string_view actual);
+
+namespace internal {
+
+// Called by //bazel:golden_test_main before tests run. This sets the default
+// value for --update_golden and lets ExpectMatchesGolden detect tests that
+// accidentally link @googletest//:gtest_main instead.
+void InitializeGoldenTestMain();
+
+}  // namespace internal
+
+}  // namespace fourward::bazel
+
+#endif  // BAZEL_GOLDEN_TEST_H_

--- a/bazel/golden_test_main.cc
+++ b/bazel/golden_test_main.cc
@@ -1,0 +1,14 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bazel/golden_test.h"
+
+#include "absl/flags/parse.h"
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  fourward::bazel::internal::InitializeGoldenTestMain();
+  absl::ParseCommandLine(argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fourward_cc/BUILD.bazel
+++ b/fourward_cc/BUILD.bazel
@@ -86,14 +86,19 @@ cc_library(
 cc_library(
     name = "dataplane_matchers",
     testonly = True,
+    srcs = ["dataplane_matchers.cc"],
     hdrs = ["dataplane_matchers.h"],
     visibility = ["//visibility:public"],
     deps = [
         ":dataplane_client",
         "//grpc:dataplane_cc_proto",
         "//simulator:simulator_cc_proto",
+        "//simulator:trace_summary",
         "@abseil-cpp//absl/algorithm:container",
+        "@abseil-cpp//absl/base",
         "@abseil-cpp//absl/container:btree",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/strings",
         "@googletest//:gtest",
     ],
 )
@@ -101,9 +106,29 @@ cc_library(
 cc_test(
     name = "dataplane_matchers_test",
     srcs = ["dataplane_matchers_test.cc"],
+    data = glob(["golden_matcher_failures/*.golden.txt"]),
+    local_defines = [
+        'COMPACT_TRACE_GOLDEN_RLOCATION=\\"$(rlocationpath //fourward_cc:golden_matcher_failures/compact_trace.golden.txt)\\"',
+        'ON_PORTS_CPU_NAME_MISMATCH_GOLDEN_RLOCATION=\\"$(rlocationpath //fourward_cc:golden_matcher_failures/on_ports_cpu_name_mismatch.golden.txt)\\"',
+        'PAYLOAD_MISMATCH_GOLDEN_RLOCATION=\\"$(rlocationpath //fourward_cc:golden_matcher_failures/payload_mismatch.golden.txt)\\"',
+        'WRONG_PORT_GOLDEN_RLOCATION=\\"$(rlocationpath //fourward_cc:golden_matcher_failures/wrong_port.golden.txt)\\"',
+    ],
     deps = [
         ":dataplane_matchers",
+        "//bazel:golden_test",
+        "//bazel:golden_test_main",
         "//grpc:dataplane_cc_proto",
+        "@abseil-cpp//absl/strings",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "dataplane_matchers_flag_test",
+    srcs = ["dataplane_matchers_flag_test.cc"],
+    args = ["--fourward_matcher_trace=full"],
+    deps = [
+        ":dataplane_matchers",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/fourward_cc/dataplane_matchers.cc
+++ b/fourward_cc/dataplane_matchers.cc
@@ -1,0 +1,248 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fourward_cc/dataplane_matchers.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#ifdef __APPLE__
+#include <crt_externs.h>
+#endif
+
+#include "absl/base/call_once.h"
+#include "absl/container/btree_map.h"
+#include "absl/flags/flag.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
+
+namespace fourward {
+namespace internal {
+
+bool AbslParseFlag(::absl::string_view text, MatcherTraceMode* mode,
+                   std::string* error) {
+  const std::string normalized = ::absl::AsciiStrToLower(text);
+  if (normalized == "none") {
+    *mode = MatcherTraceMode::kNone;
+    return true;
+  }
+  if (normalized == "summary") {
+    *mode = MatcherTraceMode::kSummary;
+    return true;
+  }
+  if (normalized == "full") {
+    *mode = MatcherTraceMode::kFull;
+    return true;
+  }
+  *error = "expected one of: none, summary, full";
+  return false;
+}
+
+std::string AbslUnparseFlag(MatcherTraceMode mode) {
+  switch (mode) {
+    case MatcherTraceMode::kNone:
+      return "none";
+    case MatcherTraceMode::kSummary:
+      return "summary";
+    case MatcherTraceMode::kFull:
+      return "full";
+  }
+  return "unknown";
+}
+
+}  // namespace internal
+}  // namespace fourward
+
+ABSL_FLAG(::fourward::internal::MatcherTraceMode, fourward_matcher_trace,
+          ::fourward::internal::MatcherTraceMode::kSummary,
+          "Trace output in dataplane matcher failures: none, summary, full.");
+
+namespace fourward {
+namespace internal {
+
+namespace {
+
+std::vector<std::string> ReadProcessArgv() {
+  std::vector<std::string> args;
+#ifdef __linux__
+  // Stock gtest_main leaves non-gtest flags unparsed, but Bazel's --test_arg
+  // is still visible in the process command line. Import only this matcher flag
+  // so users do not have to replace their test main to get useful diagnostics.
+  std::ifstream cmdline("/proc/self/cmdline", std::ios::binary);
+  std::string arg;
+  while (std::getline(cmdline, arg, '\0')) {
+    args.push_back(arg);
+  }
+#elif defined(__APPLE__)
+  // Same issue as above, but macOS exposes argv through libSystem instead of
+  // procfs.
+  char** argv = *_NSGetArgv();
+  const int argc = *_NSGetArgc();
+  for (int i = 0; i < argc; ++i) {
+    args.push_back(argv[i]);
+  }
+#endif
+  return args;
+}
+
+std::optional<std::string> FindMatcherTraceFlagValue(
+    const std::vector<std::string>& args) {
+  constexpr absl::string_view kFlag = "--fourward_matcher_trace";
+  std::optional<std::string> value;
+  for (size_t i = 1; i < args.size(); ++i) {
+    if (args[i] == "--") return value;
+
+    absl::string_view arg = args[i];
+    if (arg == kFlag) {
+      if (i + 1 == args.size()) {
+        std::cerr << kFlag << " needs a value; using the default trace mode\n";
+        return std::nullopt;
+      }
+      value = args[++i];
+      continue;
+    }
+    if (absl::ConsumePrefix(&arg, "--fourward_matcher_trace=")) {
+      value = std::string(arg);
+    }
+  }
+  return value;
+}
+
+void ImportMatcherTraceFlagFromUnparsedArgv() {
+  std::optional<std::string> value = FindMatcherTraceFlagValue(ReadProcessArgv());
+  if (!value.has_value()) return;
+
+  MatcherTraceMode mode;
+  std::string error;
+  if (!AbslParseFlag(*value, &mode, &error)) {
+    std::cerr << "Invalid --fourward_matcher_trace=" << *value << ": " << error
+              << "; using the default trace mode\n";
+    return;
+  }
+  absl::SetFlag(&::FLAGS_fourward_matcher_trace, mode);
+}
+
+}  // namespace
+
+MatcherTraceMode GetMatcherTraceMode() {
+  static absl::once_flag import_once;
+  absl::call_once(import_once, ImportMatcherTraceFlagFromUnparsedArgv);
+  return ::absl::GetFlag(::FLAGS_fourward_matcher_trace);
+}
+
+void SetMatcherTraceModeForTest(MatcherTraceMode mode) {
+  ::absl::SetFlag(&::FLAGS_fourward_matcher_trace, mode);
+}
+
+namespace {
+
+template <typename Key, typename Value>
+void PrintCountMap(std::ostream* os, const ::absl::btree_map<Key, Value>& map) {
+  *os << "{";
+  bool first = true;
+  for (const auto& [key, value] : map) {
+    if (!first) *os << ", ";
+    first = false;
+    *os << key << ": " << value;
+  }
+  *os << "}";
+}
+
+template <typename Value>
+void PrintCountMap(std::ostream* os,
+                   const ::absl::btree_map<std::string, Value>& map) {
+  *os << "{";
+  bool first = true;
+  for (const auto& [key, value] : map) {
+    if (!first) *os << ", ";
+    first = false;
+    *os << "\"" << key << "\": " << value;
+  }
+  *os << "}";
+}
+
+void PrintTraceHint(std::ostream* os) {
+  switch (GetMatcherTraceMode()) {
+    case MatcherTraceMode::kNone:
+      *os << "trace omitted; rerun with --fourward_matcher_trace=summary or "
+             "--fourward_matcher_trace=full";
+      return;
+    case MatcherTraceMode::kSummary:
+      *os << "full trace omitted; rerun with --fourward_matcher_trace=full";
+      return;
+    case MatcherTraceMode::kFull:
+      return;
+  }
+}
+
+}  // namespace
+
+void PrintTraceForMatcher(std::ostream* os, const fourward::TraceTree& trace) {
+  switch (GetMatcherTraceMode()) {
+    case MatcherTraceMode::kNone:
+      *os << "trace omitted\n";
+      PrintTraceHint(os);
+      return;
+    case MatcherTraceMode::kSummary:
+      PrintHumanTraceSummary(os, trace);
+      PrintTraceHint(os);
+      return;
+    case MatcherTraceMode::kFull:
+      *os << "trace proto:\n" << trace.DebugString();
+      return;
+  }
+}
+
+void PrintPacketPortGroups(std::ostream* os, const PacketList& packets) {
+  ::absl::btree_map<uint32_t, int> dataplane_ports;
+  ::absl::btree_map<std::string, int> p4rt_ports;
+  for (const auto& packet : packets) {
+    ++dataplane_ports[packet.dataplane_egress_port()];
+    if (!packet.p4rt_egress_port().empty()) {
+      ++p4rt_ports[packet.p4rt_egress_port()];
+    }
+  }
+  *os << "dataplane ports ";
+  PrintCountMap(os, dataplane_ports);
+  if (!p4rt_ports.empty()) {
+    *os << ", P4Runtime ports ";
+    PrintCountMap(os, p4rt_ports);
+  }
+}
+
+void PrintPacketList(std::ostream* os, const PacketList& packets,
+                     bool include_braces) {
+  if (include_braces) *os << "{";
+  *os << packets.size() << " packet"
+      << (packets.size() == 1 ? "" : "s") << ", ";
+  PrintPacketPortGroups(os, packets);
+  if (include_braces) *os << "}";
+}
+
+void PrintPacketListSummary(std::ostream* os, const PacketList& packets) {
+  PrintPacketList(os, packets, true);
+}
+
+void PrintPacketListDetails(std::ostream* os, const PacketList& packets) {
+  PrintPacketList(os, packets, false);
+}
+
+void PrintOutcomesSummary(std::ostream* os,
+                          const std::vector<PacketList>& outcomes) {
+  *os << "[";
+  for (size_t i = 0; i < outcomes.size(); ++i) {
+    if (i > 0) *os << ", ";
+    PrintPacketListSummary(os, outcomes[i]);
+  }
+  *os << "]";
+}
+
+}  // namespace internal
+}  // namespace fourward

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -7,9 +7,11 @@
 #ifndef FOURWARD_CC_DATAPLANE_MATCHERS_H_
 #define FOURWARD_CC_DATAPLANE_MATCHERS_H_
 
+#include <algorithm>
 #include <concepts>
 #include <cstdint>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -18,15 +20,30 @@
 
 #include "absl/algorithm/container.h"
 #include "absl/container/btree_map.h"
+#include "absl/strings/escaping.h"
+#include "absl/strings/string_view.h"
 #include "fourward_cc/dataplane_client.h"
 #include "gmock/gmock.h"
 #include "grpc/dataplane.pb.h"
 #include "simulator/simulator.pb.h"
+#include "simulator/trace_summary.h"
 
 namespace fourward {
 namespace internal {
 
 using PacketList = std::vector<fourward::OutputPacket>;
+
+enum class MatcherTraceMode {
+  kNone,
+  kSummary,
+  kFull,
+};
+
+bool AbslParseFlag(::absl::string_view text, MatcherTraceMode* mode,
+                   std::string* error);
+std::string AbslUnparseFlag(MatcherTraceMode mode);
+MatcherTraceMode GetMatcherTraceMode();
+void SetMatcherTraceModeForTest(MatcherTraceMode mode);
 
 // Satisfied by InjectPacketResponse and ProcessPacketResult.
 template <typename T>
@@ -42,6 +59,44 @@ std::vector<PacketList> ExtractOutcomes(const T& result) {
     outcomes.emplace_back(ps.packets().begin(), ps.packets().end());
   }
   return outcomes;
+}
+
+void PrintTraceForMatcher(std::ostream* os, const fourward::TraceTree& trace);
+void PrintActualOutputSummary(std::ostream* os, const PacketList& packets);
+void PrintPacketPortGroups(std::ostream* os, const PacketList& packets);
+void PrintPacketListSummary(std::ostream* os, const PacketList& packets);
+void PrintPacketListDetails(std::ostream* os, const PacketList& packets);
+void PrintOutcomesSummary(std::ostream* os,
+                          const std::vector<PacketList>& outcomes);
+
+template <typename T>
+  requires(HasPossibleOutcomes<T>)
+void PrintResultSummary(const T& result, std::ostream* os) {
+  auto outcomes = ExtractOutcomes(result);
+  if (outcomes.size() == 1) {
+    *os << "1 outcome: ";
+    PrintPacketListSummary(os, outcomes[0]);
+    return;
+  }
+  *os << outcomes.size() << " possible outcomes: ";
+  PrintOutcomesSummary(os, outcomes);
+}
+
+template <typename T>
+  requires(HasPossibleOutcomes<T>)
+void PrintResultFailureDetails(const T& result,
+                               const std::vector<PacketList>& outcomes,
+                               ::testing::MatchResultListener* listener,
+                               bool include_outcomes = true) {
+  if (!listener->IsInterested()) return;
+  if (include_outcomes) {
+    *listener << "\nactual outcomes: ";
+    PrintOutcomesSummary(listener->stream(), outcomes);
+  }
+  if (result.has_trace()) {
+    *listener << "\n";
+    PrintTraceForMatcher(listener->stream(), result.trace());
+  }
 }
 
 // Tag types for disambiguation.
@@ -86,9 +141,7 @@ class OutcomesMatcherBase {
                        ::testing::MatchResultListener* listener) const {
     auto outcomes = ExtractOutcomes(result);
     if (inner_.MatchAndExplain(outcomes, listener)) return true;
-    if (result.has_trace()) {
-      *listener << "\nfull trace:\n" << result.trace().DebugString();
-    }
+    PrintResultFailureDetails(result, outcomes, listener);
     return false;
   }
 
@@ -114,6 +167,66 @@ class OutcomesMatcherBase {
   std::string description_;
 };
 
+class SingleOutcomePacketsMatcher {
+ public:
+  SingleOutcomePacketsMatcher(
+      ::testing::Matcher<const PacketList&> packet_matcher,
+      std::string description, bool include_packet_explanation = false)
+      : packet_matcher_(std::move(packet_matcher)),
+        description_(std::move(description)),
+        include_packet_explanation_(include_packet_explanation) {}
+
+  template <typename T>
+    requires(HasPossibleOutcomes<T>)
+  bool MatchAndExplain(const T& result,
+                       ::testing::MatchResultListener* listener) const {
+    auto outcomes = ExtractOutcomes(result);
+    ::testing::StringMatchResultListener inner_listener;
+    if (outcomes.size() == 1 &&
+        packet_matcher_.MatchAndExplain(outcomes[0], &inner_listener)) {
+      return true;
+    }
+    if (listener->IsInterested()) {
+      *listener << "expected one outcome whose packets match; ";
+      if (outcomes.size() == 1) {
+        PrintActualOutputSummary(listener->stream(), outcomes[0]);
+      } else {
+        *listener << "actual result had " << outcomes.size()
+                  << " possible outcomes";
+      }
+      const std::string packet_explanation = inner_listener.str();
+      if (include_packet_explanation_ && !packet_explanation.empty()) {
+        *listener << "\n" << packet_explanation;
+      }
+    }
+    PrintResultFailureDetails(result, outcomes, listener,
+                              /*include_outcomes=*/outcomes.size() != 1);
+    return false;
+  }
+
+  void DescribeTo(std::ostream* os) const {
+    if (description_.empty()) {
+      *os << "has exactly one outcome and that outcome ";
+      packet_matcher_.DescribeTo(os);
+    } else {
+      *os << description_;
+    }
+  }
+  void DescribeNegationTo(std::ostream* os) const {
+    if (description_.empty()) {
+      *os << "does not have exactly one outcome whose packets ";
+      packet_matcher_.DescribeTo(os);
+    } else {
+      *os << "does not " << description_;
+    }
+  }
+
+ private:
+  ::testing::Matcher<const PacketList&> packet_matcher_;
+  std::string description_;
+  bool include_packet_explanation_;
+};
+
 // Port key for OnPorts expectations: either a dataplane or a P4Runtime port.
 using PortKey = std::variant<DataplanePort, P4RuntimePort>;
 
@@ -137,6 +250,77 @@ inline void PrintPortKey(std::ostream* os, const PortKey& key) {
   }
 }
 
+inline void PrintTypedPortKey(std::ostream* os, const PortKey& key) {
+  if (std::holds_alternative<DataplanePort>(key)) {
+    *os << "dataplane port " << std::get<DataplanePort>(key).port;
+  } else {
+    *os << "P4Runtime port \"" << std::get<P4RuntimePort>(key).port << "\"";
+  }
+}
+
+inline void PrintPayloadPreview(std::ostream* os, std::string_view payload) {
+  constexpr size_t kMaxPayloadPreviewBytes = 24;
+  const std::string_view preview = payload.substr(0, kMaxPayloadPreviewBytes);
+  *os << "0x" << absl::BytesToHexString(preview);
+  if (payload.size() > kMaxPayloadPreviewBytes) *os << "...";
+}
+
+inline PortKey ToPortKey(DataplanePort port) { return PortKey{port}; }
+inline PortKey ToPortKey(P4RuntimePort port) {
+  return PortKey{std::move(port)};
+}
+inline PortKey ToPortKey(uint32_t port) { return PortKey{DataplanePort{port}}; }
+inline PortKey ToPortKey(const std::string& port) {
+  return PortKey{P4RuntimePort{port}};
+}
+inline PortKey ToPortKey(std::string_view port) {
+  return PortKey{P4RuntimePort{std::string(port)}};
+}
+inline PortKey ToPortKey(const char* port) {
+  return PortKey{P4RuntimePort{port}};
+}
+
+inline std::string ForwardDescription(const std::vector<PortKey>& ports) {
+  std::ostringstream description;
+  description << (ports.size() == 1 ? "forward to " : "forward to ports ");
+  for (size_t i = 0; i < ports.size(); ++i) {
+    if (i > 0) description << ", ";
+    PrintTypedPortKey(&description, ports[i]);
+  }
+  return description.str();
+}
+
+inline void PrintPacketEgress(std::ostream* os,
+                              const fourward::OutputPacket& packet) {
+  *os << "dataplane port " << packet.dataplane_egress_port();
+  if (!packet.p4rt_egress_port().empty()) {
+    *os << " / P4Runtime port \"" << packet.p4rt_egress_port() << "\"";
+  }
+  if (!packet.payload().empty()) {
+    *os << " with payload ";
+    PrintPayloadPreview(os, packet.payload());
+  }
+}
+
+inline void PrintActualOutputSummary(std::ostream* os,
+                                     const PacketList& packets) {
+  if (packets.empty()) {
+    *os << "actual output had no packets";
+    return;
+  }
+  if (packets.size() == 1) {
+    *os << "actual packet egressed on ";
+    PrintPacketEgress(os, packets[0]);
+    return;
+  }
+
+  *os << "actual output had " << packets.size() << " packets";
+  for (size_t i = 0; i < packets.size(); ++i) {
+    *os << (i == 0 ? ": " : ", ");
+    PrintPacketEgress(os, packets[i]);
+  }
+}
+
 template <typename T>
   requires(HasPossibleOutcomes<T>)
 PacketList DeterministicPackets(const T& result) {
@@ -148,23 +332,190 @@ PacketList DeterministicPackets(const T& result) {
   return std::move(outcomes[0]);
 }
 
+class OnPortMatcher {
+ public:
+  explicit OnPortMatcher(PortKey expected) : expected_(std::move(expected)) {}
+
+  bool MatchAndExplain(const fourward::OutputPacket& packet,
+                       ::testing::MatchResultListener* listener) const {
+    if (PacketIsOnPort(packet, expected_)) return true;
+
+    if (std::holds_alternative<DataplanePort>(expected_)) {
+      *listener << "egressed on dataplane port "
+                << packet.dataplane_egress_port();
+    } else {
+      *listener << "egressed on P4Runtime port \"" << packet.p4rt_egress_port()
+                << "\"";
+    }
+    return false;
+  }
+
+  void DescribeTo(std::ostream* os) const {
+    *os << "is on ";
+    PrintTypedPortKey(os, expected_);
+  }
+
+  void DescribeNegationTo(std::ostream* os) const {
+    *os << "is not on ";
+    PrintTypedPortKey(os, expected_);
+  }
+
+ private:
+  PortKey expected_;
+};
+
+class HasPayloadMatcher {
+ public:
+  explicit HasPayloadMatcher(::testing::Matcher<const std::string&> expected)
+      : expected_(std::move(expected)) {}
+
+  bool MatchAndExplain(const fourward::OutputPacket& packet,
+                       ::testing::MatchResultListener* listener) const {
+    ::testing::StringMatchResultListener inner_listener;
+    if (expected_.MatchAndExplain(packet.payload(), &inner_listener)) {
+      return true;
+    }
+
+    *listener << "has payload " << ::testing::PrintToString(packet.payload());
+    const std::string inner_explanation = inner_listener.str();
+    if (!inner_explanation.empty()) {
+      *listener << ", " << inner_explanation;
+    }
+    return false;
+  }
+
+  void DescribeTo(std::ostream* os) const {
+    *os << "has payload that ";
+    expected_.DescribeTo(os);
+  }
+
+  void DescribeNegationTo(std::ostream* os) const {
+    *os << "has payload that ";
+    expected_.DescribeNegationTo(os);
+  }
+
+ private:
+  ::testing::Matcher<const std::string&> expected_;
+};
+
+class DropMatcher {
+ public:
+  DropMatcher() : inner_(::testing::ElementsAre(::testing::IsEmpty())) {}
+
+  template <typename T>
+    requires(HasPossibleOutcomes<T>)
+  bool MatchAndExplain(const T& result,
+                       ::testing::MatchResultListener* listener) const {
+    auto outcomes = ExtractOutcomes(result);
+    ::testing::StringMatchResultListener inner_listener;
+    if (inner_.MatchAndExplain(outcomes, &inner_listener)) return true;
+
+    if (listener->IsInterested()) {
+      if (outcomes.size() == 1) {
+        *listener << "expected drop; ";
+        PrintActualOutputSummary(listener->stream(), outcomes[0]);
+      } else {
+        *listener << "expected drop; actual result had " << outcomes.size()
+                  << " possible outcomes";
+      }
+      PrintResultFailureDetails(result, outcomes, listener,
+                                /*include_outcomes=*/outcomes.size() != 1);
+    }
+    return false;
+  }
+
+  void DescribeTo(std::ostream* os) const { *os << "drop the packet"; }
+  void DescribeNegationTo(std::ostream* os) const {
+    *os << "does not drop the packet";
+  }
+
+ private:
+  ::testing::Matcher<const std::vector<PacketList>&> inner_;
+};
+
+class ForwardsToMatcher {
+ public:
+  ForwardsToMatcher(::testing::Matcher<const std::vector<PacketList>&> inner,
+                    std::vector<PortKey> expected)
+      : inner_(std::move(inner)), expected_(std::move(expected)) {}
+
+  template <typename T>
+    requires(HasPossibleOutcomes<T>)
+  bool MatchAndExplain(const T& result,
+                       ::testing::MatchResultListener* listener) const {
+    auto outcomes = ExtractOutcomes(result);
+    ::testing::StringMatchResultListener inner_listener;
+    if (inner_.MatchAndExplain(outcomes, &inner_listener)) return true;
+
+    if (listener->IsInterested()) {
+      *listener << "expected ";
+      PrintExpectedOutput(listener->stream());
+      *listener << "; ";
+      if (outcomes.size() == 1) {
+        PrintActualOutputSummary(listener->stream(), outcomes[0]);
+      } else {
+        *listener << "actual result had " << outcomes.size()
+                  << " possible outcomes";
+      }
+      PrintResultFailureDetails(result, outcomes, listener,
+                                /*include_outcomes=*/outcomes.size() != 1);
+    }
+    return false;
+  }
+
+  void DescribeTo(std::ostream* os) const {
+    *os << ForwardDescription(expected_);
+  }
+  void DescribeNegationTo(std::ostream* os) const {
+    *os << "does not " << ForwardDescription(expected_);
+  }
+
+ private:
+  void PrintExpectedOutput(std::ostream* os) const {
+    if (expected_.size() == 1) {
+      *os << "one packet on ";
+      PrintTypedPortKey(os, expected_[0]);
+      return;
+    }
+
+    *os << expected_.size() << " packets on ";
+    for (size_t i = 0; i < expected_.size(); ++i) {
+      if (i > 0) *os << ", ";
+      PrintTypedPortKey(os, expected_[i]);
+    }
+  }
+
+  ::testing::Matcher<const std::vector<PacketList>&> inner_;
+  std::vector<PortKey> expected_;
+};
+
 }  // namespace internal
+
+// Deliberately affects GoogleTest printing for these response protos whenever
+// this matcher header is included. That is the point: the first `Actual:` line
+// in a matcher failure is owned by GoogleTest's PrintToString path, so keeping
+// it compact requires a PrintTo overload for the response type itself.
+inline void PrintTo(const fourward::InjectPacketResponse& result,
+                    std::ostream* os) {
+  internal::PrintResultSummary(result, os);
+}
+
+inline void PrintTo(const fourward::ProcessPacketResult& result,
+                    std::ostream* os) {
+  internal::PrintResultSummary(result, os);
+}
 
 // ---------------------------------------------------------------------------
 // Packet-level matchers (match on OutputPacket)
 // ---------------------------------------------------------------------------
 
 inline auto OnPort(DataplanePort expected) {
-  return ::testing::ResultOf(
-      [](const fourward::OutputPacket& p) { return p.dataplane_egress_port(); },
-      ::testing::Eq(expected.port));
+  return ::testing::MakePolymorphicMatcher(
+      internal::OnPortMatcher(internal::PortKey{expected}));
 }
 inline auto OnPort(P4RuntimePort expected) {
-  return ::testing::ResultOf(
-      [](const fourward::OutputPacket& p) -> const std::string& {
-        return p.p4rt_egress_port();
-      },
-      ::testing::Eq(expected.port));
+  return ::testing::MakePolymorphicMatcher(
+      internal::OnPortMatcher(internal::PortKey{std::move(expected)}));
 }
 inline auto OnPort(uint32_t port) { return OnPort(DataplanePort{port}); }
 inline auto OnPort(std::string port) {
@@ -175,11 +526,8 @@ inline auto OnPort(std::string_view port) {
 }
 
 inline auto HasPayload(::testing::Matcher<const std::string&> m) {
-  return ::testing::ResultOf(
-      [](const fourward::OutputPacket& p) -> const std::string& {
-        return p.payload();
-      },
-      std::move(m));
+  return ::testing::MakePolymorphicMatcher(
+      internal::HasPayloadMatcher(std::move(m)));
 }
 
 // OnPort with payload: "a packet on this port with this payload."
@@ -213,21 +561,55 @@ auto Outcome(Ms... ms) {
 // ---------------------------------------------------------------------------
 
 inline auto OutcomeIs() {
-  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
-      ::testing::ElementsAre(::testing::IsEmpty()), "drop the packet"));
+  return ::testing::MakePolymorphicMatcher(internal::DropMatcher());
+}
+
+namespace internal {
+
+template <typename M>
+std::string DescribePacketMatcher(const M& matcher_like) {
+  ::testing::Matcher<const fourward::OutputPacket&> matcher = matcher_like;
+  std::ostringstream description;
+  matcher.DescribeTo(&description);
+  return description.str();
 }
 
 template <typename... Ms>
+std::string SingleOutcomeDescription(const Ms&... matchers) {
+  std::vector<std::string> descriptions;
+  (descriptions.push_back(DescribePacketMatcher(matchers)), ...);
+
+  std::ostringstream description;
+  description << "has exactly one outcome with ";
+  if (descriptions.size() == 1) {
+    description << "one packet that " << descriptions[0];
+    return description.str();
+  }
+
+  description << descriptions.size() << " packets matching: ";
+  for (size_t i = 0; i < descriptions.size(); ++i) {
+    if (i > 0) description << ", ";
+    description << descriptions[i];
+  }
+  return description.str();
+}
+
+}  // namespace internal
+
+template <typename... Ms>
 auto OutcomeIs(Ms... ms) {
-  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
-      ::testing::ElementsAre(::testing::UnorderedElementsAre(std::move(ms)...)),
-      ""));
+  return ::testing::MakePolymorphicMatcher(
+      internal::SingleOutcomePacketsMatcher(
+          ::testing::UnorderedElementsAre(std::move(ms)...),
+          internal::SingleOutcomeDescription(ms...)));
 }
 
 template <typename M>
 auto OutcomeIs(internal::PacketsTag<M> tagged) {
-  return ::testing::MakePolymorphicMatcher(internal::OutcomesMatcherBase(
-      ::testing::ElementsAre(std::move(tagged.matcher)), ""));
+  return ::testing::MakePolymorphicMatcher(
+      internal::SingleOutcomePacketsMatcher(
+          std::move(tagged.matcher), "",
+          /*include_packet_explanation=*/true));
 }
 
 // ---------------------------------------------------------------------------
@@ -335,7 +717,9 @@ inline auto HasIngress(std::string_view port) {
 
 template <typename... Ports>
 auto ForwardsTo(Ports... ports) {
-  return OutcomeIs(OnPort(std::move(ports))...);
+  return ::testing::MakePolymorphicMatcher(internal::ForwardsToMatcher(
+      ::testing::ElementsAre(::testing::UnorderedElementsAre(OnPort(ports)...)),
+      {internal::ToPortKey(ports)...}));
 }
 
 inline auto Forwards() {
@@ -374,12 +758,22 @@ class OnPortsMatcher {
       for (const auto& p : packets) {
         if (internal::PacketIsOnPort(p, port)) group.push_back(p);
       }
-      if (!matcher.Matches(group)) {
+      ::testing::StringMatchResultListener inner_listener;
+      if (!matcher.MatchAndExplain(group, &inner_listener)) {
         if (!listener->IsInterested()) return false;
-        *listener << "on port ";
-        internal::PrintPortKey(listener->stream(), port);
-        *listener << ": ";
-        matcher.DescribeNegationTo(listener->stream());
+        *listener << "on ";
+        internal::PrintTypedPortKey(listener->stream(), port);
+        *listener << ": found " << group.size() << " packet"
+                  << (group.size() == 1 ? "" : "s") << "; expected: ";
+        matcher.DescribeTo(listener->stream());
+        const std::string inner_explanation = inner_listener.str();
+        if (!inner_explanation.empty()) {
+          *listener << "\n" << inner_explanation;
+        }
+        *listener << "\nactual port groups: ";
+        internal::PrintPacketPortGroups(
+            listener->stream(),
+            internal::PacketList(packets.begin(), packets.end()));
         return false;
       }
     }
@@ -406,8 +800,7 @@ class OnPortsMatcher {
     *os << "has packets grouped by port matching: ";
     for (size_t i = 0; i < expected_.size(); ++i) {
       if (i > 0) *os << ", ";
-      *os << "port ";
-      internal::PrintPortKey(os, expected_[i].first);
+      internal::PrintTypedPortKey(os, expected_[i].first);
       *os << " ";
       expected_[i].second.DescribeTo(os);
     }
@@ -438,9 +831,9 @@ inline auto OnPorts(
 
 template <typename T>
   requires(internal::HasPossibleOutcomes<T>)
-absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>>
-PacketsByDataplanePort(const T& result) {
-  absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>> groups;
+auto PacketsByDataplanePort(const T& result)
+    -> ::absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>> {
+  ::absl::btree_map<uint32_t, std::vector<fourward::OutputPacket>> groups;
   auto packets = internal::DeterministicPackets(result);
   for (auto& pkt : packets) {
     groups[pkt.dataplane_egress_port()].push_back(std::move(pkt));
@@ -450,9 +843,9 @@ PacketsByDataplanePort(const T& result) {
 
 template <typename T>
   requires(internal::HasPossibleOutcomes<T>)
-absl::btree_map<std::string, std::vector<fourward::OutputPacket>>
-PacketsByP4RuntimePort(const T& result) {
-  absl::btree_map<std::string, std::vector<fourward::OutputPacket>> groups;
+auto PacketsByP4RuntimePort(const T& result)
+    -> ::absl::btree_map<std::string, std::vector<fourward::OutputPacket>> {
+  ::absl::btree_map<std::string, std::vector<fourward::OutputPacket>> groups;
   auto packets = internal::DeterministicPackets(result);
   for (auto& pkt : packets) {
     groups[pkt.p4rt_egress_port()].push_back(std::move(pkt));

--- a/fourward_cc/dataplane_matchers_flag_test.cc
+++ b/fourward_cc/dataplane_matchers_flag_test.cc
@@ -1,0 +1,16 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fourward_cc/dataplane_matchers.h"
+
+#include "gtest/gtest.h"
+
+namespace fourward {
+namespace {
+
+TEST(DataplaneMatchersFlagTest, GtestMainHonorsMatcherTraceFlag) {
+  EXPECT_EQ(internal::GetMatcherTraceMode(), internal::MatcherTraceMode::kFull);
+}
+
+}  // namespace
+}  // namespace fourward

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -3,13 +3,29 @@
 
 #include "fourward_cc/dataplane_matchers.h"
 
+#include <cctype>
 #include <sstream>
 #include <string>
 #include <string_view>
 
+#include "absl/strings/str_cat.h"
+#include "bazel/golden_test.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "grpc/dataplane.pb.h"
+
+#ifndef COMPACT_TRACE_GOLDEN_RLOCATION
+#error "COMPACT_TRACE_GOLDEN_RLOCATION must be set by BUILD.bazel"
+#endif
+#ifndef ON_PORTS_CPU_NAME_MISMATCH_GOLDEN_RLOCATION
+#error "ON_PORTS_CPU_NAME_MISMATCH_GOLDEN_RLOCATION must be set by BUILD.bazel"
+#endif
+#ifndef PAYLOAD_MISMATCH_GOLDEN_RLOCATION
+#error "PAYLOAD_MISMATCH_GOLDEN_RLOCATION must be set by BUILD.bazel"
+#endif
+#ifndef WRONG_PORT_GOLDEN_RLOCATION
+#error "WRONG_PORT_GOLDEN_RLOCATION must be set by BUILD.bazel"
+#endif
 
 namespace fourward {
 namespace {
@@ -67,6 +83,81 @@ std::string ExplainMatch(M polymorphic_matcher, const T& value) {
   matcher.MatchAndExplain(value, &listener);
   return listener.str();
 }
+
+template <typename M, typename T>
+std::string FailureReport(M polymorphic_matcher, const T& value) {
+  ::testing::Matcher<const T&> matcher = polymorphic_matcher;
+  std::ostringstream description;
+  matcher.DescribeTo(&description);
+  std::string explanation = ExplainMatch(polymorphic_matcher, value);
+  while (!explanation.empty() && explanation.front() == '\n') {
+    explanation.erase(explanation.begin());
+  }
+  return absl::StrCat("Expected: ", description.str(), "\n",
+                      "Actual: ", ::testing::PrintToString(value), "\n",
+                      explanation, "\n");
+}
+
+fourward::bazel::GoldenFile GoldenFileFor(
+    const std::string& golden_file_name) {
+  if (golden_file_name == "compact_trace.golden.txt") {
+    return {golden_file_name, COMPACT_TRACE_GOLDEN_RLOCATION};
+  }
+  if (golden_file_name == "on_ports_cpu_name_mismatch.golden.txt") {
+    return {golden_file_name, ON_PORTS_CPU_NAME_MISMATCH_GOLDEN_RLOCATION};
+  }
+  if (golden_file_name == "payload_mismatch.golden.txt") {
+    return {golden_file_name, PAYLOAD_MISMATCH_GOLDEN_RLOCATION};
+  }
+  if (golden_file_name == "wrong_port.golden.txt") {
+    return {golden_file_name, WRONG_PORT_GOLDEN_RLOCATION};
+  }
+  ADD_FAILURE() << "unknown golden: " << golden_file_name;
+  return {golden_file_name, ""};
+}
+
+std::string NormalizeGoldenOutput(std::string text) {
+  constexpr std::string_view kDebugMarker = "goo.gle/debug";
+  size_t pos = 0;
+  while ((pos = text.find(kDebugMarker, pos)) != std::string::npos) {
+    size_t end = pos + kDebugMarker.size();
+    while (end < text.size() &&
+           std::isalnum(static_cast<unsigned char>(text[end]))) {
+      ++end;
+    }
+    while (end < text.size() && text[end] == ' ') {
+      ++end;
+    }
+    const std::string replacement =
+        end < text.size() && text[end] != '\n' ? "goo.gle/debug "
+                                               : "goo.gle/debug";
+    text.replace(pos, end - pos, replacement);
+    pos += replacement.size();
+  }
+  return text;
+}
+
+void ExpectMatchesGolden(const std::string& golden_file_name,
+                         const std::string& actual) {
+  const std::string normalized_actual = NormalizeGoldenOutput(actual);
+  fourward::bazel::ExpectMatchesGolden(
+      GoldenFileFor(golden_file_name), "fourward_cc/golden_matcher_failures",
+      "//fourward_cc:dataplane_matchers_test", normalized_actual);
+}
+
+class MatcherTraceFlagScope {
+ public:
+  explicit MatcherTraceFlagScope(internal::MatcherTraceMode mode)
+      : previous_(internal::GetMatcherTraceMode()) {
+    internal::SetMatcherTraceModeForTest(mode);
+  }
+  ~MatcherTraceFlagScope() {
+    internal::SetMatcherTraceModeForTest(previous_);
+  }
+
+ private:
+  internal::MatcherTraceMode previous_;
+};
 
 // --- ForwardsTo ---
 
@@ -232,7 +323,7 @@ TEST(OnPortsTest, ExplainsMismatchWhenListenerIsInterested) {
 
   EXPECT_THAT(ExplainMatch(OutcomeIs(OnPorts({{DataplanePort{2}, SizeIs(1)}})),
                            resp),
-              ::testing::HasSubstr("on port 2"));
+              ::testing::HasSubstr("on dataplane port 2"));
 }
 
 TEST(OnPortsTest, P4RuntimePortKeys) {
@@ -400,7 +491,7 @@ TEST(ErrorMessageTest, ForwardsToDescribes) {
       ForwardsTo(1);
   std::ostringstream os;
   m.DescribeTo(&os);
-  EXPECT_THAT(os.str(), ::testing::HasSubstr("outcomes"));
+  EXPECT_EQ(os.str(), "forward to dataplane port 1");
 }
 
 TEST(ErrorMessageTest, ForwardsDescribes) {
@@ -432,17 +523,90 @@ TEST(ErrorMessageTest, FailureIncludesTrace) {
   resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
   resp.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
       "my_table");
-  EXPECT_THAT(ExplainMatch(Drops(), resp),
-              ::testing::HasSubstr("my_table"));
+  const std::string explanation = ExplainMatch(Drops(), resp);
+  if (internal::GetMatcherTraceMode() == internal::MatcherTraceMode::kFull) {
+    EXPECT_THAT(explanation,
+                AllOf(::testing::HasSubstr("trace proto:"),
+                      ::testing::HasSubstr("table_name: \"my_table\""),
+                      Not(::testing::HasSubstr("trace:\n"))));
+  } else {
+    EXPECT_THAT(explanation,
+                AllOf(::testing::HasSubstr("trace:\n"),
+                      ::testing::HasSubstr("table my_table: miss")));
+  }
 }
 
 TEST(ErrorMessageTest, FailureIncludesTraceOnProcessPacketResult) {
+  MatcherTraceFlagScope flag(internal::MatcherTraceMode::kSummary);
   fourward::ProcessPacketResult result;
   result.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
   result.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
       "ingress_table");
   EXPECT_THAT(ExplainMatch(Drops(), result),
-              ::testing::HasSubstr("ingress_table"));
+              AllOf(::testing::HasSubstr("trace:\n"),
+                    ::testing::HasSubstr("table ingress_table: miss")));
+}
+
+TEST(ErrorMessageTest, CommandLineTraceFlagCanRequestFullTrace) {
+  if (internal::GetMatcherTraceMode() != internal::MatcherTraceMode::kFull) {
+    GTEST_SKIP() << "run with --fourward_matcher_trace=full";
+  }
+  fourward::InjectPacketResponse resp;
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  resp.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
+      "my_table");
+
+  EXPECT_THAT(ExplainMatch(Drops(), resp),
+              AllOf(::testing::HasSubstr("trace proto:"),
+                    ::testing::HasSubstr("table_name: \"my_table\""),
+                    Not(::testing::HasSubstr("trace:\n"))));
+}
+
+TEST(ErrorMessageTest, TraceFlagNoneOmitsTraceWithRerunHint) {
+  MatcherTraceFlagScope flag(internal::MatcherTraceMode::kNone);
+  fourward::InjectPacketResponse resp;
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  resp.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
+      "my_table");
+
+  EXPECT_THAT(ExplainMatch(Drops(), resp),
+              AllOf(::testing::HasSubstr("trace omitted"),
+                    ::testing::HasSubstr("--fourward_matcher_trace=full"),
+                    Not(::testing::HasSubstr("table my_table"))));
+}
+
+TEST(ErrorMessageTest, TraceFlagFullIncludesRawTrace) {
+  MatcherTraceFlagScope flag(internal::MatcherTraceMode::kFull);
+  fourward::InjectPacketResponse resp;
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  resp.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
+      "my_table");
+
+  EXPECT_THAT(ExplainMatch(Drops(), resp),
+              AllOf(::testing::HasSubstr("trace proto:"),
+                    ::testing::HasSubstr("table_name: \"my_table\"")));
+}
+
+TEST(ErrorMessageTest, TraceOutputPayloadHexPreviewIsBounded) {
+  MatcherTraceFlagScope flag(internal::MatcherTraceMode::kSummary);
+  fourward::InjectPacketResponse resp;
+  resp.add_possible_outcomes()->add_packets()->set_dataplane_egress_port(1);
+  auto* output = resp.mutable_trace()->mutable_output();
+  output->set_dataplane_egress_port(1);
+  std::string payload;
+  for (char byte = 0; byte < 32; ++byte) {
+    payload.push_back(byte);
+  }
+  output->set_payload(payload);
+
+  EXPECT_THAT(ExplainMatch(Drops(), resp),
+              AllOf(::testing::HasSubstr(
+                        "output dataplane port 1: "
+                        "0x000102030405060708090a0b0c0d0e0f1011121314151617"
+                        "..."),
+                    Not(::testing::HasSubstr("24 bytes")),
+                    Not(::testing::HasSubstr("more bytes")),
+                    Not(::testing::HasSubstr("18191a1b"))));
 }
 
 TEST(ErrorMessageTest, FailureOmitsTraceWhenAbsent) {
@@ -457,6 +621,211 @@ TEST(ErrorMessageTest, NoTraceWhenMatches) {
       "my_table");
   EXPECT_THAT(ExplainMatch(Drops(), resp),
               Not(::testing::HasSubstr("my_table")));
+}
+
+TEST(ErrorMessageTest, PrintToSummarizesInjectPacketResponse) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(1);
+  auto* cpu = ps->add_packets();
+  cpu->set_dataplane_egress_port(510);
+  cpu->set_p4rt_egress_port("CPU");
+  cpu->set_payload("payload bytes should not be printed");
+  resp.mutable_trace()->add_events()->mutable_table_lookup()->set_table_name(
+      "my_table");
+
+  EXPECT_THAT(
+      ::testing::PrintToString(resp),
+      AllOf(::testing::HasSubstr("1 outcome:"),
+            ::testing::HasSubstr("dataplane ports {1: 1, 510: 1}"),
+            ::testing::HasSubstr("P4Runtime ports {\"CPU\": 1}"),
+            Not(::testing::HasSubstr("trace")),
+            Not(::testing::HasSubstr("payload bytes should not be printed")),
+            Not(::testing::HasSubstr("my_table"))));
+}
+
+TEST(ErrorMessageTest, FailureSummarizesActualOutcomes) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  ps->add_packets()->set_dataplane_egress_port(6);
+  ps->add_packets()->set_dataplane_egress_port(510);
+  ps->add_packets()->set_dataplane_egress_port(510);
+
+  EXPECT_THAT(ExplainMatch(Drops(), resp),
+              ::testing::HasSubstr(
+                  "actual output had 3 packets: dataplane port 6, dataplane "
+                  "port 510, dataplane port 510"));
+}
+
+TEST(ErrorMessageTest, OnPortsFailureShowsActualPortGroups) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* data = ps->add_packets();
+  data->set_dataplane_egress_port(1);
+  data->set_p4rt_egress_port("6");
+  auto* cpu1 = ps->add_packets();
+  cpu1->set_dataplane_egress_port(510);
+  cpu1->set_p4rt_egress_port("CPU");
+  auto* cpu2 = ps->add_packets();
+  cpu2->set_dataplane_egress_port(510);
+  cpu2->set_p4rt_egress_port("CPU");
+
+  EXPECT_THAT(
+      ExplainMatch(OutcomeIs(OnPorts({
+                       {P4RuntimePort{"6"}, SizeIs(1)},
+                       {P4RuntimePort{"510"}, SizeIs(2)},
+                   })),
+                   resp),
+      AllOf(::testing::HasSubstr("on P4Runtime port \"510\""),
+            ::testing::HasSubstr("actual port groups:"),
+            ::testing::HasSubstr("dataplane ports {1: 1, 510: 2}"),
+            ::testing::HasSubstr("P4Runtime ports {\"6\": 1, \"CPU\": 2}")));
+}
+
+TEST(ErrorMessageTest, WrongPortFailureMatchesGolden) {
+  ExpectMatchesGolden("wrong_port.golden.txt",
+                      FailureReport(ForwardsTo(2), Forward(1)));
+}
+
+TEST(ErrorMessageTest, CompactTraceFailureMatchesGolden) {
+  MatcherTraceFlagScope flag(internal::MatcherTraceMode::kSummary);
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* packet = ps->add_packets();
+  packet->set_dataplane_egress_port(6);
+  packet->set_p4rt_egress_port("6");
+  packet->set_payload("abc");
+  auto* cpu_packet = ps->add_packets();
+  cpu_packet->set_dataplane_egress_port(510);
+  cpu_packet->set_p4rt_egress_port("CPU");
+  cpu_packet->set_payload("abcdef");
+
+  auto* ingress = resp.mutable_trace()->add_events()->mutable_packet_ingress();
+  ingress->set_dataplane_ingress_port(2);
+  ingress->set_p4rt_ingress_port("4");
+  auto* parser_start =
+      resp.mutable_trace()->add_events()->mutable_parser_transition();
+  parser_start->set_parser_name("packet_parser");
+  parser_start->set_from_state("start");
+  parser_start->set_to_state("parse_ethernet");
+  auto* parser_ipv4 =
+      resp.mutable_trace()->add_events()->mutable_parser_transition();
+  parser_ipv4->set_parser_name("packet_parser");
+  parser_ipv4->set_from_state("parse_ethernet");
+  parser_ipv4->set_to_state("parse_ipv4");
+  auto* parser_accept =
+      resp.mutable_trace()->add_events()->mutable_parser_transition();
+  parser_accept->set_parser_name("packet_parser");
+  parser_accept->set_from_state("parse_ipv4");
+  parser_accept->set_to_state("accept");
+  auto* assignment_1 = resp.mutable_trace()->add_events();
+  assignment_1->mutable_assignment()->set_target("local_metadata.vrf_id");
+  assignment_1->set_result_value("1");
+  auto* assignment_2 = resp.mutable_trace()->add_events();
+  assignment_2->mutable_assignment()->set_target(
+      "local_metadata.nexthop_id_valid");
+  assignment_2->set_result_value("true");
+  auto* assignment_3 = resp.mutable_trace()->add_events();
+  assignment_3->mutable_assignment()->set_target("local_metadata.nexthop_id");
+  assignment_3->set_result_value("5");
+  auto* assignment_4 = resp.mutable_trace()->add_events();
+  assignment_4->mutable_assignment()->set_target("standard_metadata.egress_spec");
+  assignment_4->set_result_value("6");
+  auto* assignment_5 = resp.mutable_trace()->add_events();
+  assignment_5->mutable_assignment()->set_target(
+      "local_metadata.packet_in_target_egress_port");
+  assignment_5->set_result_value("6");
+  auto* vlan_miss = resp.mutable_trace()->add_events()->mutable_table_lookup();
+  vlan_miss->set_table_name("acl_pre_ingress_vlan_table");
+  vlan_miss->set_hit(false);
+  vlan_miss->set_action_name("NoAction");
+  auto* metadata_miss =
+      resp.mutable_trace()->add_events()->mutable_table_lookup();
+  metadata_miss->set_table_name("acl_pre_ingress_metadata_table");
+  metadata_miss->set_hit(false);
+  metadata_miss->set_action_name("NoAction");
+  auto* acl = resp.mutable_trace()->add_events()->mutable_table_lookup();
+  acl->set_table_name("acl_ingress_table");
+  acl->set_hit(true);
+  acl->set_action_name("acl_copy");
+  auto* route = resp.mutable_trace()->add_events()->mutable_table_lookup();
+  route->set_table_name("ipv4_table");
+  route->set_hit(true);
+  route->set_action_name("set_nexthop_id");
+  route->mutable_p4rt_matched_entry()->set_table_id(33554500);
+  auto* route_match = route->mutable_p4rt_matched_entry()->add_match();
+  route_match->set_field_id(1);
+  route_match->mutable_exact()->set_value("vrf");
+  auto* route_action =
+      route->mutable_p4rt_matched_entry()->mutable_action()->mutable_action();
+  route_action->add_params()->set_param_id(1);
+  route_action->mutable_params(0)->set_value("nexthop(5, vrf)");
+  auto* route_action_execution =
+      resp.mutable_trace()->add_events()->mutable_action_execution();
+  route_action_execution->set_action_name("set_nexthop_id");
+  (*route_action_execution->mutable_params())["nexthop_id"] =
+      "nexthop(5, vrf)";
+  auto* clone_event = resp.mutable_trace()->add_events();
+  clone_event->set_id(265);
+  auto* clone = clone_event->mutable_clone_session_lookup();
+  clone->set_session_id(1);
+  clone->set_session_found(true);
+  clone->set_dataplane_egress_port(510);
+  clone->set_p4rt_egress_port("CPU");
+  clone->set_egress_rid(1);
+  clone->set_replica_count(1);
+  resp.mutable_trace()->add_events()->mutable_clone()->set_session_id(1);
+
+  auto* replication = resp.mutable_trace()->mutable_replication();
+  replication->set_cause(265);
+  auto* egress = replication->add_branches();
+  auto* egress_assignment = egress->add_events();
+  egress_assignment->mutable_assignment()->set_target("headers.ipv4.ttl");
+  egress_assignment->set_result_value("31 (0x1f)");
+  auto* output = egress->mutable_output();
+  output->set_dataplane_egress_port(6);
+  output->set_p4rt_egress_port("6");
+  output->set_payload("abc");
+  auto* cpu = replication->add_branches();
+  auto* cpu_output = cpu->mutable_output();
+  cpu_output->set_dataplane_egress_port(510);
+  cpu_output->set_p4rt_egress_port("CPU");
+  cpu_output->set_payload("abcdef");
+
+  ExpectMatchesGolden("compact_trace.golden.txt",
+                      FailureReport(Drops(), resp));
+}
+
+TEST(ErrorMessageTest, OnPortsFailureMatchesGolden) {
+  fourward::InjectPacketResponse resp;
+  auto* ps = resp.add_possible_outcomes();
+  auto* data = ps->add_packets();
+  data->set_dataplane_egress_port(1);
+  data->set_p4rt_egress_port("6");
+  auto* cpu1 = ps->add_packets();
+  cpu1->set_dataplane_egress_port(510);
+  cpu1->set_p4rt_egress_port("CPU");
+  auto* cpu2 = ps->add_packets();
+  cpu2->set_dataplane_egress_port(510);
+  cpu2->set_p4rt_egress_port("CPU");
+
+  ExpectMatchesGolden(
+      "on_ports_cpu_name_mismatch.golden.txt",
+      FailureReport(OutcomeIs(OnPorts({
+                        {P4RuntimePort{"6"}, SizeIs(1)},
+                        {P4RuntimePort{"510"}, SizeIs(2)},
+                    })),
+                    resp));
+}
+
+TEST(ErrorMessageTest, PayloadMismatchFailureMatchesGolden) {
+  fourward::InjectPacketResponse resp;
+  auto* packet = resp.add_possible_outcomes()->add_packets();
+  packet->set_dataplane_egress_port(1);
+  packet->set_payload("actual");
+
+  ExpectMatchesGolden("payload_mismatch.golden.txt",
+                      FailureReport(OutcomeIs(OnPort(1, "expected")), resp));
 }
 
 // --- Composition ---

--- a/fourward_cc/golden_matcher_failures/compact_trace.golden.txt
+++ b/fourward_cc/golden_matcher_failures/compact_trace.golden.txt
@@ -1,0 +1,19 @@
+Expected: drop the packet
+Actual: 1 outcome: {2 packets, dataplane ports {6: 1, 510: 1}, P4Runtime ports {"6": 1, "CPU": 1}}
+expected drop; actual output had 2 packets: dataplane port 6 / P4Runtime port "6" with payload 0x616263, dataplane port 510 / P4Runtime port "CPU" with payload 0x616263646566
+trace:
+ingress dataplane port 2 / P4Runtime port "4"
+parser path: start -> parse_ethernet -> parse_ipv4 -> accept
+assignments: local_metadata.vrf_id := 1, local_metadata.nexthop_id_valid := true, local_metadata.nexthop_id := 5, standard_metadata.egress_spec := 6, ... (+1 more)
+tables missed: acl_pre_ingress_vlan_table, acl_pre_ingress_metadata_table
+table acl_ingress_table: hit action acl_copy
+table ipv4_table: hit action set_nexthop_id(nexthop_id="nexthop(5, vrf)") (looked up value: "vrf")
+clone session 1: found -> dataplane port 510 / P4Runtime port "CPU", rid 1, replicas 1
+clone session 1
+clone replication with 2 branches
+  branch 1:
+    assignment: headers.ipv4.ttl := 31 (0x1f)
+    output dataplane port 6 / P4Runtime port "6": 0x616263
+  branch 2:
+    output dataplane port 510 / P4Runtime port "CPU": 0x616263646566
+full trace omitted; rerun with --fourward_matcher_trace=full

--- a/fourward_cc/golden_matcher_failures/on_ports_cpu_name_mismatch.golden.txt
+++ b/fourward_cc/golden_matcher_failures/on_ports_cpu_name_mismatch.golden.txt
@@ -1,0 +1,6 @@
+Expected: has exactly one outcome and that outcome has packets grouped by port matching: P4Runtime port "6" has a size that is equal to 1, P4Runtime port "510" has a size that is equal to 2, and no packets on other ports
+Actual: 1 outcome: {3 packets, dataplane ports {1: 1, 510: 2}, P4Runtime ports {"6": 1, "CPU": 2}}
+expected one outcome whose packets match; actual output had 3 packets: dataplane port 1 / P4Runtime port "6", dataplane port 510 / P4Runtime port "CPU", dataplane port 510 / P4Runtime port "CPU"
+on P4Runtime port "510": found 0 packets; expected: has a size that is equal to 2
+whose size 0 doesn't match
+actual port groups: dataplane ports {1: 1, 510: 2}, P4Runtime ports {"6": 1, "CPU": 2}

--- a/fourward_cc/golden_matcher_failures/payload_mismatch.golden.txt
+++ b/fourward_cc/golden_matcher_failures/payload_mismatch.golden.txt
@@ -1,0 +1,3 @@
+Expected: has exactly one outcome with one packet that (is on dataplane port 1) and (has payload that is equal to "expected")
+Actual: 1 outcome: {1 packet, dataplane ports {1: 1}}
+expected one outcome whose packets match; actual packet egressed on dataplane port 1 with payload 0x61637475616c

--- a/fourward_cc/golden_matcher_failures/wrong_port.golden.txt
+++ b/fourward_cc/golden_matcher_failures/wrong_port.golden.txt
@@ -1,0 +1,3 @@
+Expected: forward to dataplane port 2
+Actual: 1 outcome: {1 packet, dataplane ports {1: 1}}
+expected one packet on dataplane port 2; actual packet egressed on dataplane port 1

--- a/simulator/BUILD.bazel
+++ b/simulator/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
 package(
@@ -54,6 +56,19 @@ cc_proto_library(
     name = "simulator_cc_proto",
     visibility = ["//visibility:public"],
     deps = [":simulator_proto"],
+)
+
+cc_library(
+    name = "trace_summary",
+    srcs = ["trace_summary.cc"],
+    hdrs = ["trace_summary.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ir_cc_proto",
+        ":simulator_cc_proto",
+        "@abseil-cpp//absl/strings",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+    ],
 )
 
 # The p4runtime BCR module only ships cc/go/py proto targets; we
@@ -131,6 +146,25 @@ kt_jvm_library(
 # =============================================================================
 # Unit tests (colocated with source per Google convention)
 # =============================================================================
+
+cc_test(
+    name = "trace_summary_test",
+    srcs = ["trace_summary_test.cc"],
+    data = glob(["golden_trace_summaries/*.golden.txt"]),
+    local_defines = [
+        'HUMAN_TRACE_SUMMARY_GOLDEN_RLOCATION=\\"$(rlocationpath //simulator:golden_trace_summaries/human_trace_summary.golden.txt)\\"',
+        'MULTICAST_TRACE_SUMMARY_GOLDEN_RLOCATION=\\"$(rlocationpath //simulator:golden_trace_summaries/multicast_trace_summary.golden.txt)\\"',
+    ],
+    deps = [
+        ":ir_cc_proto",
+        ":simulator_cc_proto",
+        ":trace_summary",
+        "//bazel:golden_test",
+        "//bazel:golden_test_main",
+        "@googletest//:gtest",
+        "@p4runtime//proto/p4/v1:p4runtime_cc_proto",
+    ],
+)
 
 kt_jvm_test(
     name = "HeaderValTest",

--- a/simulator/golden_trace_summaries/human_trace_summary.golden.txt
+++ b/simulator/golden_trace_summaries/human_trace_summary.golden.txt
@@ -1,0 +1,7 @@
+trace:
+ingress dataplane port 2 / P4Runtime port "4"
+parser path: start -> parse_ethernet -> parse_ipv4 -> accept
+assignments: a := 1, b := 2, c := 3, d := 4, ... (+1 more)
+table ipv4: hit action punt(port="6", queue="CPU") (looked up value: "vrf")
+table ambiguous: hit action duplicate_params(a="raw_duplicate", b="raw_duplicate")
+output dataplane port 6 / P4Runtime port "6": 0x000102030405060708090a0b0c0d0e0f1011121314151617...

--- a/simulator/golden_trace_summaries/multicast_trace_summary.golden.txt
+++ b/simulator/golden_trace_summaries/multicast_trace_summary.golden.txt
@@ -1,0 +1,7 @@
+trace:
+multicast group 42: found, replicas 2
+multicast replication with 2 branches
+  branch 1:
+    output dataplane port 1
+  branch 2:
+    output dataplane port 2

--- a/simulator/trace_summary.cc
+++ b/simulator/trace_summary.cc
@@ -1,0 +1,547 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "simulator/trace_summary.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/escaping.h"
+#include "absl/strings/string_view.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "simulator/ir.pb.h"
+#include "simulator/simulator.pb.h"
+
+namespace fourward {
+namespace {
+
+void PrintIndent(std::ostream* os, int indent) {
+  for (int i = 0; i < indent; ++i) *os << "  ";
+}
+
+void PrintPayloadHexPreview(std::ostream* os, absl::string_view payload) {
+  constexpr size_t kMaxBytes = 24;
+  const absl::string_view preview = payload.substr(0, kMaxBytes);
+  *os << "0x" << absl::BytesToHexString(preview);
+  if (payload.size() > kMaxBytes) {
+    *os << "...";
+  }
+}
+
+bool IsPrintableBytes(absl::string_view bytes) {
+  return std::all_of(bytes.begin(), bytes.end(), [](unsigned char c) {
+    return c >= 0x20 && c <= 0x7e && c != '"' && c != '\\';
+  });
+}
+
+void PrintBytesValue(std::ostream* os, absl::string_view bytes) {
+  if (IsPrintableBytes(bytes)) {
+    *os << "\"" << bytes << "\"";
+    return;
+  }
+  PrintPayloadHexPreview(os, bytes);
+}
+
+void PrintOutputPacketSummary(std::ostream* os,
+                              const fourward::OutputPacket& packet) {
+  *os << "output dataplane port " << packet.dataplane_egress_port();
+  if (!packet.p4rt_egress_port().empty()) {
+    *os << " / P4Runtime port \"" << packet.p4rt_egress_port() << "\"";
+  }
+  if (!packet.payload().empty()) {
+    *os << ": ";
+    PrintPayloadHexPreview(os, packet.payload());
+  }
+}
+
+void PrintSourceLocation(std::ostream* os, const fourward::SourceInfo& source) {
+  if (source.file().empty()) return;
+  *os << " at " << source.file();
+  if (source.line() != 0) {
+    *os << ":" << source.line();
+    if (source.column() != 0) *os << ":" << source.column();
+  }
+}
+
+void PrintFieldMatchValue(std::ostream* os, const p4::v1::FieldMatch& match) {
+  switch (match.field_match_type_case()) {
+    case p4::v1::FieldMatch::kExact:
+      PrintBytesValue(os, match.exact().value());
+      return;
+    case p4::v1::FieldMatch::kOptional:
+      PrintBytesValue(os, match.optional().value());
+      return;
+    case p4::v1::FieldMatch::kLpm:
+      PrintBytesValue(os, match.lpm().value());
+      *os << "/" << match.lpm().prefix_len();
+      return;
+    case p4::v1::FieldMatch::kTernary:
+      PrintBytesValue(os, match.ternary().value());
+      *os << " &&& ";
+      PrintBytesValue(os, match.ternary().mask());
+      return;
+    case p4::v1::FieldMatch::kRange:
+      PrintBytesValue(os, match.range().low());
+      *os << "..";
+      PrintBytesValue(os, match.range().high());
+      return;
+    case p4::v1::FieldMatch::kOther:
+      *os << "<other>";
+      return;
+    case p4::v1::FieldMatch::FIELD_MATCH_TYPE_NOT_SET:
+      *os << "<unset>";
+      return;
+  }
+}
+
+void PrintLookedUpValues(std::ostream* os, const p4::v1::TableEntry& entry) {
+  if (entry.match().empty()) return;
+  *os << " (looked up " << (entry.match_size() == 1 ? "value" : "values")
+      << ": ";
+  for (int i = 0; i < entry.match_size(); ++i) {
+    if (i > 0) *os << ", ";
+    PrintFieldMatchValue(os, entry.match(i));
+  }
+  *os << ")";
+}
+
+void PrintTableEntrySummary(std::ostream* os,
+                            const fourward::TableLookupEvent& table) {
+  if (table.has_p4rt_matched_entry()) {
+    PrintLookedUpValues(os, table.p4rt_matched_entry());
+  }
+}
+
+bool IsTableMiss(const fourward::TraceEvent& event) {
+  return event.event_case() == fourward::TraceEvent::kTableLookup &&
+         event.table_lookup().has_hit() && !event.table_lookup().hit();
+}
+
+std::vector<std::string> ParserPath(const fourward::TraceTree& trace) {
+  std::vector<std::string> states;
+  for (const fourward::TraceEvent& event : trace.events()) {
+    if (event.event_case() != fourward::TraceEvent::kParserTransition) {
+      continue;
+    }
+    const fourward::ParserTransitionEvent& transition =
+        event.parser_transition();
+    if (states.empty() && !transition.from_state().empty()) {
+      states.push_back(transition.from_state());
+    }
+    if (!transition.to_state().empty() &&
+        (states.empty() || states.back() != transition.to_state())) {
+      states.push_back(transition.to_state());
+    }
+  }
+  return states;
+}
+
+void PrintParserPath(std::ostream* os, const fourward::TraceTree& trace,
+                     int indent) {
+  const std::vector<std::string> states = ParserPath(trace);
+  if (states.size() < 2) return;
+  PrintIndent(os, indent);
+  *os << "parser path: ";
+  for (size_t i = 0; i < states.size(); ++i) {
+    if (i > 0) *os << " -> ";
+    *os << states[i];
+  }
+  *os << "\n";
+}
+
+bool OmitFromHumanSummary(const fourward::TraceEvent& event) {
+  switch (event.event_case()) {
+    case fourward::TraceEvent::kPacketIngress:
+    case fourward::TraceEvent::kTableLookup:
+    case fourward::TraceEvent::kActionExecution:
+    case fourward::TraceEvent::kAssignment:
+    case fourward::TraceEvent::kExternCall:
+    case fourward::TraceEvent::kLogMessage:
+    case fourward::TraceEvent::kClone:
+    case fourward::TraceEvent::kCloneSessionLookup:
+    case fourward::TraceEvent::kMulticastGroupLookup:
+    case fourward::TraceEvent::kMarkToDrop:
+      return false;
+    case fourward::TraceEvent::kPipelineStage:
+    case fourward::TraceEvent::kParserTransition:
+    case fourward::TraceEvent::kBranch:
+    case fourward::TraceEvent::kDeparserEmit:
+    case fourward::TraceEvent::EVENT_NOT_SET:
+      return true;
+    case fourward::TraceEvent::kAssertion:
+      return event.assertion().passed();
+  }
+}
+
+void PrintTableMissRun(std::ostream* os,
+                       const std::vector<const fourward::TraceEvent*>& events,
+                       int indent) {
+  PrintIndent(os, indent);
+  if (events.size() == 1) {
+    *os << "table " << events[0]->table_lookup().table_name() << ": miss\n";
+    return;
+  }
+  *os << "tables missed: ";
+  for (size_t i = 0; i < events.size(); ++i) {
+    if (i > 0) *os << ", ";
+    *os << events[i]->table_lookup().table_name();
+  }
+  *os << "\n";
+}
+
+void PrintAssignmentRun(
+    std::ostream* os, const std::vector<const fourward::TraceEvent*>& events,
+    int indent) {
+  PrintIndent(os, indent);
+  *os << (events.size() == 1 ? "assignment: " : "assignments: ");
+  constexpr size_t kMaxAssignments = 4;
+  const size_t limit = std::min(events.size(), kMaxAssignments);
+  for (size_t i = 0; i < limit; ++i) {
+    if (i > 0) *os << ", ";
+    const auto& event = *events[i];
+    *os << event.assignment().target() << " := " << event.result_value();
+  }
+  if (events.size() > limit) {
+    *os << ", ... (+" << (events.size() - limit) << " more)";
+  }
+  *os << "\n";
+}
+
+std::vector<std::pair<std::string, absl::string_view>> ActionParamValues(
+    const fourward::ActionExecutionEvent& action,
+    const fourward::TableLookupEvent* table) {
+  std::vector<std::pair<std::string, absl::string_view>> params;
+  params.reserve(action.params().size());
+  for (const auto& [name, value] : action.params()) {
+    params.emplace_back(name, value);
+  }
+
+  if (table == nullptr || !table->has_p4rt_matched_entry()) return params;
+  if (!table->has_matched_entry()) return params;
+
+  const p4::v1::TableAction& raw_table_action = table->matched_entry().action();
+  const p4::v1::TableAction& p4rt_table_action =
+      table->p4rt_matched_entry().action();
+  if (raw_table_action.type_case() != p4::v1::TableAction::kAction ||
+      p4rt_table_action.type_case() != p4::v1::TableAction::kAction) {
+    return params;
+  }
+  const p4::v1::Action& raw_action = raw_table_action.action();
+  const p4::v1::Action& p4rt_action = p4rt_table_action.action();
+  if (raw_action.params_size() != p4rt_action.params_size()) return params;
+  if (p4rt_action.params_size() != static_cast<int>(params.size())) {
+    return params;
+  }
+
+  for (int i = 0; i < raw_action.params_size(); ++i) {
+    for (int j = i + 1; j < raw_action.params_size(); ++j) {
+      if (raw_action.params(i).value() == raw_action.params(j).value()) {
+        return params;
+      }
+    }
+  }
+
+  for (auto& [name, value] : params) {
+    bool found = false;
+    for (int i = 0; i < raw_action.params_size(); ++i) {
+      if (raw_action.params(i).value() != value) continue;
+      value = p4rt_action.params(i).value();
+      found = true;
+      break;
+    }
+    if (!found) return params;
+  }
+  return params;
+}
+
+void PrintActionParams(std::ostream* os,
+                       const fourward::ActionExecutionEvent& action,
+                       const fourward::TableLookupEvent* table = nullptr) {
+  std::vector<std::pair<std::string, absl::string_view>> params =
+      ActionParamValues(action, table);
+  if (params.empty()) return;
+  std::sort(params.begin(), params.end(),
+            [](const auto& lhs, const auto& rhs) {
+              return lhs.first < rhs.first;
+            });
+
+  *os << "(";
+  for (size_t i = 0; i < params.size(); ++i) {
+    if (i > 0) *os << ", ";
+    *os << params[i].first << "=";
+    PrintBytesValue(os, params[i].second);
+  }
+  *os << ")";
+}
+
+void PrintActionExecution(std::ostream* os,
+                          const fourward::ActionExecutionEvent& action,
+                          int indent) {
+  PrintIndent(os, indent);
+  *os << "action " << action.action_name();
+  PrintActionParams(os, action);
+  *os << "\n";
+}
+
+bool IsActionForTableHit(const fourward::TraceEvent& action_event,
+                         const fourward::TableLookupEvent& table) {
+  return action_event.event_case() == fourward::TraceEvent::kActionExecution &&
+         action_event.action_execution().action_name() == table.action_name();
+}
+
+void PrintTableLookup(const fourward::TableLookupEvent& table,
+                      const fourward::ActionExecutionEvent* action,
+                      std::ostream* os, int indent) {
+  PrintIndent(os, indent);
+  *os << "table " << table.table_name() << ": ";
+  if (table.has_hit() && table.hit()) {
+    *os << "hit action " << table.action_name();
+    if (action != nullptr) PrintActionParams(os, *action, &table);
+    PrintTableEntrySummary(os, table);
+  } else {
+    *os << "miss";
+  }
+  *os << "\n";
+}
+
+void PrintEvent(const fourward::TraceEvent& event, std::ostream* os,
+                int indent);
+
+std::string ReplicationCauseName(const fourward::TraceTree& trace,
+                                 const fourward::Replication& replication) {
+  if (!replication.has_cause()) return "replication";
+  for (const auto& event : trace.events()) {
+    if (event.id() != replication.cause()) continue;
+    switch (event.event_case()) {
+      case fourward::TraceEvent::kCloneSessionLookup:
+      case fourward::TraceEvent::kClone:
+        return "clone";
+      case fourward::TraceEvent::kMulticastGroupLookup:
+        return "multicast";
+      case fourward::TraceEvent::kPacketIngress:
+      case fourward::TraceEvent::kPipelineStage:
+      case fourward::TraceEvent::kParserTransition:
+      case fourward::TraceEvent::kTableLookup:
+      case fourward::TraceEvent::kActionExecution:
+      case fourward::TraceEvent::kBranch:
+      case fourward::TraceEvent::kAssignment:
+      case fourward::TraceEvent::kExternCall:
+      case fourward::TraceEvent::kLogMessage:
+      case fourward::TraceEvent::kAssertion:
+      case fourward::TraceEvent::kMarkToDrop:
+      case fourward::TraceEvent::kDeparserEmit:
+      case fourward::TraceEvent::EVENT_NOT_SET:
+        return "replication";
+    }
+  }
+  return "replication";
+}
+
+void PrintHumanTraceSummaryNode(const fourward::TraceTree& trace,
+                                std::ostream* os, int indent) {
+  bool parser_path_printed = false;
+  for (int i = 0; i < trace.events_size();) {
+    if (trace.events(i).event_case() ==
+        fourward::TraceEvent::kParserTransition) {
+      if (!parser_path_printed) {
+        PrintParserPath(os, trace, indent);
+        parser_path_printed = true;
+      }
+      ++i;
+      continue;
+    }
+    if (OmitFromHumanSummary(trace.events(i))) {
+      ++i;
+      continue;
+    }
+    if (trace.events(i).event_case() == fourward::TraceEvent::kAssignment) {
+      std::vector<const fourward::TraceEvent*> assignments;
+      while (i < trace.events_size() &&
+             trace.events(i).event_case() == fourward::TraceEvent::kAssignment) {
+        assignments.push_back(&trace.events(i));
+        ++i;
+      }
+      PrintAssignmentRun(os, assignments, indent);
+      continue;
+    }
+    if (IsTableMiss(trace.events(i))) {
+      std::vector<const fourward::TraceEvent*> misses;
+      while (i < trace.events_size() && IsTableMiss(trace.events(i))) {
+        misses.push_back(&trace.events(i));
+        ++i;
+      }
+      PrintTableMissRun(os, misses, indent);
+      continue;
+    }
+    if (trace.events(i).event_case() == fourward::TraceEvent::kTableLookup) {
+      const fourward::TableLookupEvent& table = trace.events(i).table_lookup();
+      const bool has_following_action =
+          i + 1 < trace.events_size() &&
+          IsActionForTableHit(trace.events(i + 1), table);
+      PrintTableLookup(table,
+                       has_following_action
+                           ? &trace.events(i + 1).action_execution()
+                           : nullptr,
+                       os, indent);
+      i += has_following_action ? 2 : 1;
+      continue;
+    }
+    PrintEvent(trace.events(i), os, indent);
+    ++i;
+  }
+
+  switch (trace.outcome_case()) {
+    case fourward::TraceTree::kOutput:
+      PrintIndent(os, indent);
+      PrintOutputPacketSummary(os, trace.output());
+      *os << "\n";
+      return;
+    case fourward::TraceTree::kDrop:
+      PrintIndent(os, indent);
+      *os << "drop\n";
+      return;
+    case fourward::TraceTree::kReplication: {
+      const auto& replication = trace.replication();
+      PrintIndent(os, indent);
+      *os << ReplicationCauseName(trace, replication) << " replication with "
+          << replication.branches_size() << " branch"
+          << (replication.branches_size() == 1 ? "" : "es") << "\n";
+      for (int i = 0; i < replication.branches_size(); ++i) {
+        PrintIndent(os, indent + 1);
+        *os << "branch " << (i + 1) << ":\n";
+        PrintHumanTraceSummaryNode(replication.branches(i), os, indent + 2);
+      }
+      return;
+    }
+    case fourward::TraceTree::kChoice: {
+      const auto& choice = trace.choice();
+      PrintIndent(os, indent);
+      *os << "choice with " << choice.branches_size() << " branches\n";
+      for (int i = 0; i < choice.branches_size(); ++i) {
+        PrintIndent(os, indent + 1);
+        *os << "branch " << (i + 1) << ":\n";
+        PrintHumanTraceSummaryNode(choice.branches(i), os, indent + 2);
+      }
+      return;
+    }
+    case fourward::TraceTree::kContinuation:
+      PrintIndent(os, indent);
+      *os << "continuation\n";
+      PrintHumanTraceSummaryNode(trace.continuation().next(), os, indent + 1);
+      return;
+    case fourward::TraceTree::OUTCOME_NOT_SET:
+      return;
+  }
+}
+
+void PrintEvent(const fourward::TraceEvent& event, std::ostream* os,
+                int indent) {
+  switch (event.event_case()) {
+    case fourward::TraceEvent::kPacketIngress:
+      PrintIndent(os, indent);
+      *os << "ingress dataplane port "
+          << event.packet_ingress().dataplane_ingress_port();
+      if (!event.packet_ingress().p4rt_ingress_port().empty()) {
+        *os << " / P4Runtime port \""
+            << event.packet_ingress().p4rt_ingress_port() << "\"";
+      }
+      *os << "\n";
+      return;
+    case fourward::TraceEvent::kTableLookup:
+      PrintTableLookup(event.table_lookup(), nullptr, os, indent);
+      return;
+    case fourward::TraceEvent::kActionExecution:
+      PrintActionExecution(os, event.action_execution(), indent);
+      return;
+    case fourward::TraceEvent::kCloneSessionLookup:
+      PrintIndent(os, indent);
+      *os << "clone session " << event.clone_session_lookup().session_id();
+      if (event.clone_session_lookup().session_found()) {
+        *os << ": found -> dataplane port "
+            << event.clone_session_lookup().dataplane_egress_port()
+            << " / P4Runtime port \""
+            << event.clone_session_lookup().p4rt_egress_port() << "\"";
+        if (event.clone_session_lookup().egress_rid() != 0) {
+          *os << ", rid " << event.clone_session_lookup().egress_rid();
+        }
+        if (event.clone_session_lookup().replica_count() != 0) {
+          *os << ", replicas " << event.clone_session_lookup().replica_count();
+        }
+      } else {
+        *os << ": not found";
+      }
+      *os << "\n";
+      return;
+    case fourward::TraceEvent::kMulticastGroupLookup:
+      PrintIndent(os, indent);
+      *os << "multicast group "
+          << event.multicast_group_lookup().multicast_group_id();
+      if (event.multicast_group_lookup().group_found()) {
+        *os << ": found, replicas "
+            << event.multicast_group_lookup().replica_count();
+      } else {
+        *os << ": not found";
+      }
+      *os << "\n";
+      return;
+    case fourward::TraceEvent::kClone:
+      PrintIndent(os, indent);
+      *os << "clone session " << event.clone().session_id() << "\n";
+      return;
+    case fourward::TraceEvent::kMarkToDrop:
+      PrintIndent(os, indent);
+      *os << "mark_to_drop";
+      PrintSourceLocation(os, event.source_info());
+      *os << "\n";
+      return;
+    case fourward::TraceEvent::kPipelineStage:
+    case fourward::TraceEvent::kParserTransition:
+    case fourward::TraceEvent::kBranch:
+      // Omitted from human summaries; keep the cases explicit so new trace
+      // event kinds still stand out in this exhaustive switch.
+      return;
+    case fourward::TraceEvent::kExternCall:
+      PrintIndent(os, indent);
+      *os << "extern " << event.extern_call().extern_instance_name() << "."
+          << event.extern_call().method() << "()\n";
+      return;
+    case fourward::TraceEvent::kLogMessage:
+      PrintIndent(os, indent);
+      *os << "log: " << event.log_message().message() << "\n";
+      return;
+    case fourward::TraceEvent::kAssertion:
+      PrintIndent(os, indent);
+      *os << "assertion "
+          << (event.assertion().passed() ? "passed" : "failed");
+      PrintSourceLocation(os, event.source_info());
+      *os << "\n";
+      return;
+    case fourward::TraceEvent::kDeparserEmit:
+      // Omitted from human summaries; keep the case explicit so new trace
+      // event kinds still stand out in this exhaustive switch.
+      return;
+    case fourward::TraceEvent::kAssignment:
+      PrintIndent(os, indent);
+      *os << "assignment: " << event.assignment().target() << " := "
+          << event.result_value() << "\n";
+      return;
+    case fourward::TraceEvent::EVENT_NOT_SET:
+      PrintIndent(os, indent);
+      *os << "unset event\n";
+      return;
+  }
+}
+
+}  // namespace
+
+void PrintHumanTraceSummary(std::ostream* os, const fourward::TraceTree& trace) {
+  *os << "trace:\n";
+  PrintHumanTraceSummaryNode(trace, os, 0);
+}
+
+}  // namespace fourward

--- a/simulator/trace_summary.h
+++ b/simulator/trace_summary.h
@@ -1,0 +1,20 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SIMULATOR_TRACE_SUMMARY_H_
+#define SIMULATOR_TRACE_SUMMARY_H_
+
+#include <iosfwd>
+
+#include "simulator/simulator.pb.h"
+
+namespace fourward {
+
+// Prints a compact, human-oriented trace. This is intentionally not the same
+// format as TraceTree::DebugString(): callers use it when the full proto would
+// bury the dataplane decisions in low-signal execution detail.
+void PrintHumanTraceSummary(std::ostream* os, const TraceTree& trace);
+
+}  // namespace fourward
+
+#endif  // SIMULATOR_TRACE_SUMMARY_H_

--- a/simulator/trace_summary_test.cc
+++ b/simulator/trace_summary_test.cc
@@ -1,0 +1,168 @@
+// Copyright 2026 The 4ward Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "simulator/trace_summary.h"
+
+#include <sstream>
+#include <string>
+
+#include "bazel/golden_test.h"
+#include "gtest/gtest.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "simulator/ir.pb.h"
+#include "simulator/simulator.pb.h"
+
+#ifndef HUMAN_TRACE_SUMMARY_GOLDEN_RLOCATION
+#error "HUMAN_TRACE_SUMMARY_GOLDEN_RLOCATION must be set by BUILD.bazel"
+#endif
+#ifndef MULTICAST_TRACE_SUMMARY_GOLDEN_RLOCATION
+#error "MULTICAST_TRACE_SUMMARY_GOLDEN_RLOCATION must be set by BUILD.bazel"
+#endif
+
+namespace fourward {
+namespace {
+
+std::string RenderHumanReadableTrace(const TraceTree& trace) {
+  std::ostringstream out;
+  PrintHumanTraceSummary(&out, trace);
+  return out.str();
+}
+
+fourward::bazel::GoldenFile GoldenFileFor(
+    const std::string& golden_file_name) {
+  if (golden_file_name == "human_trace_summary.golden.txt") {
+    return {golden_file_name, HUMAN_TRACE_SUMMARY_GOLDEN_RLOCATION};
+  }
+  if (golden_file_name == "multicast_trace_summary.golden.txt") {
+    return {golden_file_name, MULTICAST_TRACE_SUMMARY_GOLDEN_RLOCATION};
+  }
+  ADD_FAILURE() << "unknown golden: " << golden_file_name;
+  return {golden_file_name, ""};
+}
+
+void ExpectMatchesGolden(const std::string& golden_file_name,
+                         const std::string& actual) {
+  fourward::bazel::ExpectMatchesGolden(
+      GoldenFileFor(golden_file_name), "simulator/golden_trace_summaries",
+      "//simulator:trace_summary_test", actual);
+}
+
+std::string Bytes(int size) {
+  std::string bytes;
+  for (int i = 0; i < size; ++i) {
+    bytes.push_back(static_cast<char>(i));
+  }
+  return bytes;
+}
+
+TEST(TraceSummaryTest, PrintsHumanTraceSummary) {
+  TraceTree trace;
+  auto* ingress = trace.add_events();
+  ingress->mutable_packet_ingress()->set_dataplane_ingress_port(2);
+  ingress->mutable_packet_ingress()->set_p4rt_ingress_port("4");
+
+  auto* stage = trace.add_events();
+  stage->mutable_pipeline_stage()->set_stage_name("ingress");
+  stage->mutable_pipeline_stage()->set_stage_kind(CONTROL);
+  stage->mutable_pipeline_stage()->set_direction(PipelineStageEvent::ENTER);
+
+  auto* branch = trace.add_events();
+  branch->mutable_branch()->set_control_name("ingress");
+  branch->mutable_branch()->set_taken(false);
+
+  auto* parser_start = trace.add_events()->mutable_parser_transition();
+  parser_start->set_from_state("start");
+  parser_start->set_to_state("parse_ethernet");
+  auto* parser_ipv4 = trace.add_events()->mutable_parser_transition();
+  parser_ipv4->set_from_state("parse_ethernet");
+  parser_ipv4->set_to_state("parse_ipv4");
+  auto* parser_accept = trace.add_events()->mutable_parser_transition();
+  parser_accept->set_from_state("parse_ipv4");
+  parser_accept->set_to_state("accept");
+
+  for (int i = 0; i < 5; ++i) {
+    auto* assignment = trace.add_events();
+    assignment->mutable_assignment()->set_target(std::string(1, 'a' + i));
+    assignment->set_result_value(std::to_string(i + 1));
+  }
+
+  auto* table = trace.add_events();
+  table->mutable_table_lookup()->set_table_name("ipv4");
+  table->mutable_table_lookup()->set_hit(true);
+  table->mutable_table_lookup()->set_action_name("punt");
+  auto* raw_action = table->mutable_table_lookup()
+                         ->mutable_matched_entry()
+                         ->mutable_action()
+                         ->mutable_action();
+  raw_action->add_params()->set_value("raw_port");
+  raw_action->add_params()->set_value("raw_queue");
+  auto* match =
+      table->mutable_table_lookup()->mutable_p4rt_matched_entry()->add_match();
+  match->mutable_exact()->set_value("vrf");
+  auto* p4rt_action =
+      table->mutable_table_lookup()
+          ->mutable_p4rt_matched_entry()
+          ->mutable_action()
+          ->mutable_action();
+  p4rt_action->add_params()->set_value("6");
+  p4rt_action->add_params()->set_value("CPU");
+
+  auto* action = trace.add_events();
+  action->mutable_action_execution()->set_action_name("punt");
+  (*action->mutable_action_execution()->mutable_params())["port"] = "raw_port";
+  (*action->mutable_action_execution()->mutable_params())["queue"] =
+      "raw_queue";
+
+  auto* ambiguous_table = trace.add_events();
+  ambiguous_table->mutable_table_lookup()->set_table_name("ambiguous");
+  ambiguous_table->mutable_table_lookup()->set_hit(true);
+  ambiguous_table->mutable_table_lookup()->set_action_name("duplicate_params");
+  auto* ambiguous_raw_action = ambiguous_table->mutable_table_lookup()
+                                   ->mutable_matched_entry()
+                                   ->mutable_action()
+                                   ->mutable_action();
+  ambiguous_raw_action->add_params()->set_value("raw_duplicate");
+  ambiguous_raw_action->add_params()->set_value("raw_duplicate");
+  auto* ambiguous_p4rt_action =
+      ambiguous_table->mutable_table_lookup()
+          ->mutable_p4rt_matched_entry()
+          ->mutable_action()
+          ->mutable_action();
+  ambiguous_p4rt_action->add_params()->set_value("first");
+  ambiguous_p4rt_action->add_params()->set_value("second");
+
+  auto* ambiguous_action = trace.add_events();
+  ambiguous_action->mutable_action_execution()->set_action_name(
+      "duplicate_params");
+  (*ambiguous_action->mutable_action_execution()->mutable_params())["a"] =
+      "raw_duplicate";
+  (*ambiguous_action->mutable_action_execution()->mutable_params())["b"] =
+      "raw_duplicate";
+
+  trace.mutable_output()->set_dataplane_egress_port(6);
+  trace.mutable_output()->set_p4rt_egress_port("6");
+  trace.mutable_output()->set_payload(Bytes(32));
+
+  ExpectMatchesGolden("human_trace_summary.golden.txt",
+                      RenderHumanReadableTrace(trace));
+}
+
+TEST(TraceSummaryTest, PrintsMulticastLookupBeforeReplicationBranches) {
+  TraceTree trace;
+  auto* lookup = trace.add_events();
+  lookup->set_id(7);
+  lookup->mutable_multicast_group_lookup()->set_multicast_group_id(42);
+  lookup->mutable_multicast_group_lookup()->set_group_found(true);
+  lookup->mutable_multicast_group_lookup()->set_replica_count(2);
+
+  auto* replication = trace.mutable_replication();
+  replication->set_cause(7);
+  replication->add_branches()->mutable_output()->set_dataplane_egress_port(1);
+  replication->add_branches()->mutable_output()->set_dataplane_egress_port(2);
+
+  ExpectMatchesGolden("multicast_trace_summary.golden.txt",
+                      RenderHumanReadableTrace(trace));
+}
+
+}  // namespace
+}  // namespace fourward

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -301,26 +301,42 @@ way.
 ## Trace on failure
 
 When an outcome-level matcher fails (`ForwardsTo`, `Forwards`, `Drops`,
-`OutcomeIs`, `OutcomesAre`, `EachOutcome`, `AnyOutcome`), the full
-simulator trace is automatically appended to the failure message — if the
-response carries one. This gives you immediate visibility into how the
-packet was processed without rerunning the test:
+`OutcomeIs`, `OutcomesAre`, `EachOutcome`, `AnyOutcome`), the failure
+message includes the actual outcome summary and, if the response carries a
+trace, a compact trace summary. The summary keeps the high-signal routing
+events visible without dumping every parser assignment and branch value:
 
 ```
 Expected: drop the packet
-  Actual: (has 1 possible outcomes),
-full trace:
-events {
-  table_lookup {
-    table_name: "ingress.acl"
-    hit: true
-    ...
-  }
-}
-...
+Actual: 1 outcome: {1 packet, dataplane ports {1: 1}, P4Runtime ports {"Ethernet1": 1}}
+expected drop; actual packet egressed on dataplane port 1 / P4Runtime port "Ethernet1" with payload 0x000102030405...
+trace:
+ingress dataplane port 0 / P4Runtime port "1"
+assignments: local_metadata.vrf_id := 1, local_metadata.nexthop_id_valid := true, ...
+table ingress.acl: hit action punt_to_cpu(queue="CPU") (looked up value: "vrf")
+clone session 1: found -> dataplane port 510 / P4Runtime port "CPU", rid 1, replicas 1
+clone replication with 1 branch
+  branch 1:
+    output dataplane port 510 / P4Runtime port "CPU": 0x000102030405060708090a0b0c0d0e0f1011121314151617...
+full trace omitted; rerun with --fourward_matcher_trace=full
 ```
 
-No opt-in needed — the trace shows up whenever the response has one.
+The `--fourward_matcher_trace` Abseil flag controls how much trace detail
+matcher failures print:
+
+| Value | Behavior |
+| --- | --- |
+| `summary` | Default. Print the compact trace summary and a full-trace rerun hint. |
+| `none` | Omit trace details and print a rerun hint. |
+| `full` | Print the raw `TraceTree` proto debug string. |
+
+For a Bazel test, pass the flag through with `--test_arg`:
+
+```sh
+bazel test //path/to:my_test --test_arg=--fourward_matcher_trace=full
+```
+
+This also works for tests using the default GoogleTest main.
 
 ## Bazel dependency
 


### PR DESCRIPTION
## What changed

Improves C++ dataplane matcher failures so they front-load the actual packet outcomes and print a compact simulator trace by default instead of dumping the full trace proto.

Highlights:
- adds `--fourward_matcher_trace={none,summary,full}` using Abseil flags
- moves non-template matcher formatting into `dataplane_matchers.cc`
- summarizes ports, outcomes, parser paths, assignments, table hits/misses, action params, replication branches, and bounded packet payload hex
- adds golden tests for representative failure messages
- updates the user-facing matcher docs

## Why

Large simulator traces made matcher failures hard to scan. The compact summary keeps high-signal debugging context in the default failure while preserving a clear rerun path for full trace debugging.

## Validation

- `./tools/format.sh`
- `git diff --check`
- `bazel test //fourward_cc:dataplane_matchers_test //fourward_cc:dataplane_matchers_flag_test //simulator:trace_summary_test --test_output=errors`
- `bazel test //... --test_tag_filters=-heavy --test_output=errors`