### PR TITLE
[codex] Clarify agent publishing workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,14 @@
 directly. This keeps the main tree clean and allows parallel work.
 
 ```sh
-git worktree add ../4ward-<branch> -b <branch>    # create
-git worktree remove ../4ward-<branch>              # clean up after merging
-git worktree prune                                 # gc dangling refs
+git fetch origin main
+git worktree add ../4ward-<branch> -b <branch> origin/main  # create from latest main
+git worktree remove ../4ward-<branch>                       # clean up after merging
+git worktree prune                                          # gc dangling refs
 ```
+
+For completed changes, do not stop at local edits. Commit, push, and open a
+draft PR unless the user explicitly asks not to.
 
 ## Philosophy
 


### PR DESCRIPTION
Clarifies the agent workflow so work starts from the latest `origin/main` and does not stop at local edits.

This updates the top-level worktree instructions to fetch `origin/main`, create new worktrees from `origin/main`, and explicitly commit, push, and open a draft PR for completed changes unless the user asks otherwise.

Validation: docs-only change; no tests run.