### PR TITLE
Possible outcomes are a set, not a list

### DIFF
--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.TextFormat
 import fourward.TraceTree
 import fourward.simulator.ProcessPacketResult
 import fourward.simulator.Simulator
+import fourward.simulator.outcomeIdentity
 import fourward.stf.StfFile
 import fourward.stf.installStfEntries
 import fourward.stf.loadPipelineConfig
@@ -87,19 +88,14 @@ class TraceTreeConsistencyTest(private val testName: String) {
       outputsFromTree.toSet(),
     )
 
-    // The set contract holds on real programs, not just hand-built trees: no outcome appears
-    // twice. Identity is the multiset of observable packets — the same key collectPossibleOutcomes
-    // dedupes on. (Only programs that nest an alternative fork inside a parallel one can produce
-    // duplicates pre-dedup, so this bites on exactly the corpus programs that exercise that path.)
-    val outcomeKeys =
-      result.possibleOutcomes.map { outcome ->
-        outcome.groupingBy { it.dataplaneEgressPort to it.payload }.eachCount()
-      }
+    // The set contract holds on real corpus programs, not just hand-built trees: no outcome
+    // repeats (keyed by [outcomeIdentity], the same key collectPossibleOutcomes dedupes on). Only
+    // a program nesting an alternative fork inside a parallel one can produce duplicates here.
     assertEquals(
       "Duplicate possible outcomes for $testName.\n" +
         "Trace:\n${TextFormat.printer().printToString(trace)}",
-      outcomeKeys.size,
-      outcomeKeys.toSet().size,
+      result.possibleOutcomes.size,
+      result.possibleOutcomes.distinctBy { it.outcomeIdentity() }.size,
     )
   }
 

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -77,9 +77,9 @@ class TraceTreeConsistencyTest(private val testName: String) {
     val outputsFromTree =
       leafTrees.filter { it.hasOutput() }.map { it.output.dataplaneEgressPort to it.output.payload }
 
-    // For trees without nested alternative-inside-parallel forks, these match exactly.
-    // For trees with such nesting, possibleOutcomes may have duplicates from the Cartesian
-    // product, so we compare as sets.
+    // possibleOutcomes is a set of distinct outcomes, so flattening it drops the packets of any
+    // folded duplicate outcome — but every distinct output the tree can produce still survives in
+    // some outcome. So we compare as sets of observable outputs rather than as multisets.
     assertEquals(
       "Output packets vs trace tree mismatch for $testName.\n" +
         "Trace:\n${TextFormat.printer().printToString(trace)}",

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -69,7 +69,7 @@ class TraceTreeConsistencyTest(private val testName: String) {
     )
     assertCausesResolveOnce(trace, eventIdCounts)
 
-    // Verify possibleOutcomes is consistent with the trace tree: flattening all worlds
+    // Verify possibleOutcomes is consistent with the trace tree: flattening all outcomes
     // should produce the same outputs as collecting all leaf outputs from the tree.
     val outputsFromPossibleOutcomes =
       result.possibleOutcomes.flatten().map { it.dataplaneEgressPort to it.payload }
@@ -85,6 +85,21 @@ class TraceTreeConsistencyTest(private val testName: String) {
         "Trace:\n${TextFormat.printer().printToString(trace)}",
       outputsFromPossibleOutcomes.toSet(),
       outputsFromTree.toSet(),
+    )
+
+    // The set contract holds on real programs, not just hand-built trees: no outcome appears
+    // twice. Identity is the multiset of observable packets — the same key collectPossibleOutcomes
+    // dedupes on. (Only programs that nest an alternative fork inside a parallel one can produce
+    // duplicates pre-dedup, so this bites on exactly the corpus programs that exercise that path.)
+    val outcomeKeys =
+      result.possibleOutcomes.map { outcome ->
+        outcome.groupingBy { it.dataplaneEgressPort to it.payload }.eachCount()
+      }
+    assertEquals(
+      "Duplicate possible outcomes for $testName.\n" +
+        "Trace:\n${TextFormat.printer().printToString(trace)}",
+      outcomeKeys.size,
+      outcomeKeys.toSet().size,
     )
   }
 

--- a/grpc/BUILD.bazel
+++ b/grpc/BUILD.bazel
@@ -746,6 +746,7 @@ kt_jvm_test(
     data = [
         "//e2e_tests/basic_table",
         "//e2e_tests/passthrough",
+        "//e2e_tests/trace_tree:action_selector_3",
         "//e2e_tests/trace_tree:multicast",
         "//p4c_backend:p4c-4ward",
         "@p4c//p4include",

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -300,9 +300,9 @@ private fun enrichResult(
         .setTag(tag)
     )
     .addAllPossibleOutcomes(
-      possibleOutcomes.map { world ->
+      possibleOutcomes.map { outcome ->
         Outcome.newBuilder()
-          .addAllPackets(world.map { it.toDualEncoded(translator, codec) })
+          .addAllPackets(outcome.map { it.toDualEncoded(translator, codec) })
           .build()
       }
     )

--- a/grpc/DataplaneService.kt
+++ b/grpc/DataplaneService.kt
@@ -6,8 +6,8 @@ import fourward.InjectPacketRequest
 import fourward.InjectPacketResponse
 import fourward.InjectPacketsResponse
 import fourward.InputPacket
+import fourward.Outcome
 import fourward.OutputPacket
-import fourward.PacketSet
 import fourward.PipelineConfig
 import fourward.PrePacketHookInvocation
 import fourward.PrePacketHookResponse
@@ -301,7 +301,7 @@ private fun enrichResult(
     )
     .addAllPossibleOutcomes(
       possibleOutcomes.map { world ->
-        PacketSet.newBuilder()
+        Outcome.newBuilder()
           .addAllPackets(world.map { it.toDualEncoded(translator, codec) })
           .build()
       }

--- a/grpc/DataplaneServiceTest.kt
+++ b/grpc/DataplaneServiceTest.kt
@@ -56,6 +56,12 @@ import p4.config.v1.P4InfoOuterClass.ControllerPacketMetadata
 import p4.config.v1.P4InfoOuterClass.P4Info
 import p4.config.v1.P4InfoOuterClass.Preamble
 import p4.config.v1.P4Types
+import p4.v1.P4RuntimeOuterClass.Action
+import p4.v1.P4RuntimeOuterClass.ActionProfileMember
+import p4.v1.P4RuntimeOuterClass.Entity
+import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.TableAction
+import p4.v1.P4RuntimeOuterClass.TableEntry
 
 class DataplaneServiceTest {
 
@@ -130,6 +136,98 @@ class DataplaneServiceTest {
       response.possibleOutcomesList.single().packetsCount,
     )
   }
+
+  @Test
+  fun `InjectPacket dedupes identical action-selector outcomes on the wire`() {
+    // Set semantics must survive the gRPC boundary, not only the simulator. A group whose two
+    // members forward identically forks the trace into two branches but yields a single possible
+    // outcome — proving the dedup at the single projection (collectPossibleOutcomes) is inherited
+    // by the InjectPacket API end-to-end (enrichment + proto), per the single-source contract.
+    val config = loadConfig("e2e_tests/trace_tree/action_selector_3.txtpb")
+    harness.loadPipeline(config)
+
+    val profileId = config.p4Info.actionProfilesList.first().preamble.id
+    val setPort = FourwardTestHarness.findAction(config, "set_port")
+    val portBytes =
+      ByteString.copyFrom(
+        FourwardTestHarness.longToBytes(1, (setPort.paramsList.first().bitwidth + 7) / 8)
+      )
+
+    // Two members, both set_port(1): identical forwarding, so identical outcomes.
+    for (memberId in listOf(1, 2)) {
+      harness.installEntry(
+        Entity.newBuilder()
+          .setActionProfileMember(
+            ActionProfileMember.newBuilder()
+              .setActionProfileId(profileId)
+              .setMemberId(memberId)
+              .setAction(
+                Action.newBuilder()
+                  .setActionId(setPort.preamble.id)
+                  .addParams(
+                    Action.Param.newBuilder()
+                      .setParamId(FourwardTestHarness.paramId(setPort, "port"))
+                      .setValue(portBytes)
+                  )
+              )
+          )
+          .build()
+      )
+    }
+    harness.installEntry(
+      FourwardTestHarness.buildGroupEntity(profileId, groupId = 1, memberIds = listOf(1, 2))
+    )
+
+    // Table entry: the frame's broadcast dstAddr → action profile group 1.
+    val ecmpTable = config.p4Info.tablesList.first()
+    val dstField = ecmpTable.matchFieldsList.first()
+    harness.installEntry(
+      Entity.newBuilder()
+        .setTableEntry(
+          TableEntry.newBuilder()
+            .setTableId(ecmpTable.preamble.id)
+            .addMatch(
+              FieldMatch.newBuilder()
+                .setFieldId(dstField.id)
+                .setExact(
+                  FieldMatch.Exact.newBuilder()
+                    .setValue(
+                      ByteString.copyFrom(
+                        FourwardTestHarness.longToBytes(
+                          0xFFFFFFFFFFFFL,
+                          (dstField.bitwidth + 7) / 8,
+                        )
+                      )
+                    )
+                )
+            )
+            .setAction(TableAction.newBuilder().setActionProfileGroupId(1))
+        )
+        .build()
+    )
+
+    val response =
+      harness.injectPacket(ingressPort = 0, payload = buildEthernetFrame(etherType = 0x0800))
+
+    // The trace stays lossless (both selector branches), while the outcomes collapse to one.
+    assertEquals("selector forked into 2 branches", 2, choiceBranchCount(response.trace))
+    assertEquals("identical members collapse to one outcome", 1, response.possibleOutcomesCount)
+    assertEquals(1, response.possibleOutcomesList.single().packetsCount)
+    assertEquals(1, response.possibleOutcomesList.single().getPackets(0).dataplaneEgressPort)
+  }
+
+  /** Branch count of the first CHOICE in the trace, through continuation/replication wrappers. */
+  private fun choiceBranchCount(tree: TraceTree): Int? =
+    when (tree.outcomeCase) {
+      TraceTree.OutcomeCase.CHOICE -> tree.choice.branchesCount
+      TraceTree.OutcomeCase.CONTINUATION -> choiceBranchCount(tree.continuation.next)
+      TraceTree.OutcomeCase.REPLICATION ->
+        tree.replication.branchesList.firstNotNullOfOrNull { choiceBranchCount(it) }
+      TraceTree.OutcomeCase.OUTPUT,
+      TraceTree.OutcomeCase.DROP,
+      TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+      null -> null
+    }
 
   // =========================================================================
   // GetReproducer

--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -5,7 +5,7 @@ import com.google.rpc.Status as RpcStatus
 import fourward.DataplaneGrpcKt.DataplaneCoroutineStub
 import fourward.InjectPacketRequest
 import fourward.InjectPacketResponse
-import fourward.PacketSet
+import fourward.Outcome
 import fourward.PipelineConfig
 import fourward.simulator.Simulator
 import fourward.simulator.portToBytes
@@ -201,8 +201,8 @@ class FourwardTestHarness(
       )
     }
 
-  /** Injects a packet and returns the possible outcome sets. */
-  fun simulatePacket(ingressPort: Int, payload: ByteArray): List<PacketSet> =
+  /** Injects a packet and returns the set of possible outcomes. */
+  fun simulatePacket(ingressPort: Int, payload: ByteArray): List<Outcome> =
     injectPacket(ingressPort, payload).possibleOutcomesList
 
   /** Injects multiple packets concurrently via the streaming InjectPackets RPC. */

--- a/grpc/dataplane.proto
+++ b/grpc/dataplane.proto
@@ -84,22 +84,22 @@ message InjectPacketRequest {
   int64 tag = 4;
 }
 
-// A set of output packets from one possible real execution.
-// Programs with only parallel forks (clone, multicast) have exactly one
-// possible outcome.  Programs with alternative forks (action selectors) have
-// one possible outcome per alternative.
-message PacketSet {
+// One possible outcome: the packets emitted by a single real execution.
+// Order is not meaningful; multiplicity is — multicast/clone can emit the same
+// packet more than once, so this is a multiset, not a set, of packets.
+message Outcome {
   repeated OutputPacket packets = 1;
 }
 
 // InjectPacket response. Omits the input (the caller already has it).
 message InjectPacketResponse {
   TraceTree trace = 1;
-  // Each entry is one possible set of output packets from a single real
-  // execution.  Programs with only parallel forks have exactly one entry.
-  // Programs with alternative forks (action selectors) have one entry per
-  // alternative — each representing a "possible world".
-  repeated PacketSet possible_outcomes = 2;
+  // The set of possible outcomes — one entry per *distinct* result a real
+  // execution could produce. Programs with only parallel forks (clone,
+  // multicast) have exactly one entry. Alternative forks (action selectors) add
+  // one entry per distinct alternative; alternatives that emit the same packets
+  // collapse to a single entry.
+  repeated Outcome possible_outcomes = 2;
 }
 
 // Self-contained reproduction case for a packet trace. Load the pipeline,
@@ -123,8 +123,8 @@ message Reproducer {
 message ProcessPacketResult {
   InputPacket input_packet = 1;
   TraceTree trace = 2;
-  // Possible outcome sets (see InjectPacketResponse.possible_outcomes).
-  repeated PacketSet possible_outcomes = 3;
+  // The set of possible outcomes (see InjectPacketResponse.possible_outcomes).
+  repeated Outcome possible_outcomes = 3;
 }
 
 message SubscribeResultsRequest {

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -1479,10 +1479,12 @@ class PSAArchitectureTest {
     assertTrue("expected choice outcome", result.trace.hasChoice())
     assertEquals(2, result.trace.choice.branchesCount)
 
-    // Alternative choice: 2 possible worlds, each with 1 output (send_to_port(1) post-table).
+    // Both members forward identically (no-op action, then post-table send_to_port(1)), so the
+    // trace keeps 2 distinct branches but the outcomes collapse to one: identical outcomes are a
+    // single possibility, not two.
     val outcomes = result.possibleOutcomes
-    assertEquals(2, outcomes.size)
-    assertTrue(outcomes.all { world -> world.size == 1 && world[0].dataplaneEgressPort == 1 })
+    assertEquals(1, outcomes.size)
+    assertTrue(outcomes.all { outcome -> outcome.size == 1 && outcome[0].dataplaneEgressPort == 1 })
   }
 
   @Test
@@ -1511,7 +1513,7 @@ class PSAArchitectureTest {
     assertTrue("expected choice outcome", result.trace.hasChoice())
     assertEquals(1, result.trace.choice.branchesCount)
 
-    // Alternative choice: 1 possible world with 1 output.
+    // Alternative choice: 1 possible outcome with 1 output.
     val outcomes = result.possibleOutcomes
     assertEquals(1, outcomes.size)
     assertEquals(1, outcomes[0].size)
@@ -1534,10 +1536,10 @@ class PSAArchitectureTest {
     assertTrue("expected choice outcome", result.trace.hasChoice())
     assertEquals(2, result.trace.choice.branchesCount)
 
-    // Alternative choice: 2 possible worlds, each with 1 output.
+    // Both members forward identically, so the 2 trace branches collapse to a single outcome.
     val outcomes = result.possibleOutcomes
-    assertEquals(2, outcomes.size)
-    assertTrue(outcomes.all { world -> world.size == 1 && world[0].dataplaneEgressPort == 1 })
+    assertEquals(1, outcomes.size)
+    assertTrue(outcomes.all { outcome -> outcome.size == 1 && outcome[0].dataplaneEgressPort == 1 })
   }
 
   @Test
@@ -1568,10 +1570,11 @@ class PSAArchitectureTest {
     assertTrue("expected choice in clone", cloneBranch.hasChoice())
     assertEquals(2, cloneBranch.choice.branchesCount)
 
-    // Parallel clone × alternative selector: 2 members × 2 members = 4 possible worlds,
-    // each with 2 outputs (one from original, one from clone).
+    // Parallel clone ⊗ alternative selector. Both members forward identically within each branch,
+    // so the 2×2 raw combinations collapse to a single outcome with 2 outputs (one from the
+    // original, one from the clone).
     val outcomes = result.possibleOutcomes
-    assertEquals(4, outcomes.size)
+    assertEquals(1, outcomes.size)
     assertTrue(outcomes.all { it.size == 2 })
   }
 

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -1,5 +1,6 @@
 package fourward.simulator
 
+import com.google.protobuf.ByteString
 import fourward.OutputPacket
 import fourward.PipelineConfig
 import fourward.TraceTree
@@ -14,9 +15,9 @@ import java.util.concurrent.atomic.AtomicReference
  * - **Alternative forks** (action selector): exactly one branch executes at runtime, so each branch
  *   produces a separate possible outcome.
  *
- * Programs with no alternative forks have exactly one possible outcome. Programs with action
- * selectors have one possible outcome per alternative (Cartesian product when nested inside
- * parallel forks).
+ * The outcomes form a *set* of distinct possibilities: alternatives that forward identically (e.g.
+ * action-selector members with the same effect) collapse to one outcome. Programs with no
+ * alternative forks have exactly one possible outcome. See [collectPossibleOutcomes].
  *
  * Decouples the simulator from the gRPC wire format ([fourward.InjectPacketResponse]). Each RPC
  * method builds its own wire proto from this data class.
@@ -326,19 +327,22 @@ fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
   // possible outcome, not two. Distinct fork resolutions can produce the same outcome (a multicast
   // whose replicas land on the same ports, symmetric action-selector members, …), and the forks
   // carry no probability, so the multiplicity of identical outcomes is meaningless — only their
-  // presence is.
-  //
-  // An outcome's identity is the *multiset* of packets it emits: multiplicity within one outcome is
-  // real (multicast/clone can emit a packet twice) and is preserved, while order is not observable.
-  // The key uses the observable packet fields only (egress port, payload); enrichment fields are
-  // never populated at this layer.
+  // presence is. [outcomeIdentity] defines when two outcomes are the same.
   //
   // Deduplicating on every return (rather than building raw and deduplicating once at the top)
   // keeps
   // this a single recursive function and stops the Cartesian product from compounding duplicates
   // across nesting levels. The repeated dedup work is irrelevant here — simplicity over
   // performance.
-  return outcomes.distinctBy { outcome ->
-    outcome.groupingBy { it.dataplaneEgressPort to it.payload }.eachCount()
-  }
+  return outcomes.distinctBy { it.outcomeIdentity() }
 }
+
+/**
+ * The identity of an outcome (the output packets from one real execution): the *multiset* of
+ * packets it emits, keyed by the observable fields (egress port, payload). Two outcomes are the
+ * same iff their identities are equal — order within an outcome is not observable, but multiplicity
+ * is (multicast/clone can emit a packet twice), hence a multiset and not a set. Enrichment fields
+ * are never populated at this layer, so they don't participate.
+ */
+fun List<OutputPacket>.outcomeIdentity(): Map<Pair<Int, ByteString>, Int> =
+  groupingBy { it.dataplaneEgressPort to it.payload }.eachCount()

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -287,36 +287,53 @@ class Simulator : TableDataReader {
 }
 
 /**
- * Collects all possible outcome sets from a trace tree, respecting outcome semantics.
+ * Collects the set of possible outcomes from a trace tree, respecting outcome semantics.
  * - **Replication** (clone, multicast): all branches execute simultaneously — Cartesian product.
  * - **Choice** (action selector): exactly one branch executes — union of branch outcomes.
  * - **Continuation** (resubmit, recirculate): same packet, another pass — delegate to next.
- * - **Output:** one possible world with one packet.
- * - **Drop:** one possible world with no packets.
+ * - **Output:** one possible outcome with one packet.
+ * - **Drop:** one possible outcome with no packets.
  *
- * Returns a non-empty list. Each inner list is one complete set of output packets that could result
- * from a single real execution.
+ * Returns a non-empty, duplicate-free list: each entry is a distinct possible outcome — one
+ * complete multiset of output packets that could result from a single real execution. The entries
+ * form a *set* (no outcome appears twice); *within* an entry, multiplicity is preserved (a packet
+ * emitted twice appears twice) but order is not meaningful.
  */
 fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
-  return when (tree.outcomeCase) {
-    TraceTree.OutcomeCase.OUTPUT -> listOf(listOf(tree.output))
-    TraceTree.OutcomeCase.DROP,
-    TraceTree.OutcomeCase.OUTCOME_NOT_SET,
-    null -> listOf(emptyList())
-    TraceTree.OutcomeCase.REPLICATION -> {
-      // Cartesian product: for each combination of one world per branch, concatenate packets.
-      require(tree.replication.branchesCount > 0) { "Replication must have at least one branch" }
-      tree.replication.branchesList
-        .map { collectPossibleOutcomes(it) }
-        .reduce { acc, next ->
-          acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
-        }
+  val worlds =
+    when (tree.outcomeCase) {
+      TraceTree.OutcomeCase.OUTPUT -> listOf(listOf(tree.output))
+      TraceTree.OutcomeCase.DROP,
+      TraceTree.OutcomeCase.OUTCOME_NOT_SET,
+      null -> listOf(emptyList())
+      TraceTree.OutcomeCase.REPLICATION -> {
+        // Cartesian product: for each combination of one world per branch, concatenate packets.
+        require(tree.replication.branchesCount > 0) { "Replication must have at least one branch" }
+        tree.replication.branchesList
+          .map { collectPossibleOutcomes(it) }
+          .reduce { acc, next ->
+            acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
+          }
+      }
+      TraceTree.OutcomeCase.CHOICE -> {
+        // Each branch is a separate possible world; union their outcomes.
+        require(tree.choice.branchesCount > 0) { "Choice must have at least one branch" }
+        tree.choice.branchesList.flatMap { collectPossibleOutcomes(it) }
+      }
+      TraceTree.OutcomeCase.CONTINUATION -> collectPossibleOutcomes(tree.continuation.next)
     }
-    TraceTree.OutcomeCase.CHOICE -> {
-      // Each branch is a separate possible world; union their outcomes.
-      require(tree.choice.branchesCount > 0) { "Choice must have at least one branch" }
-      tree.choice.branchesList.flatMap { collectPossibleOutcomes(it) }
-    }
-    TraceTree.OutcomeCase.CONTINUATION -> collectPossibleOutcomes(tree.continuation.next)
+  // The possible outcomes are a *set*: two real executions that emit the same packets are one
+  // possible outcome, not two. Distinct fork resolutions can produce the same outcome (a multicast
+  // whose replicas land on the same ports, symmetric action-selector members, …), and the forks
+  // carry no probability, so the multiplicity of identical outcomes is meaningless — only their
+  // presence is. Deduplicating here, at every level of the recursion, makes each subtree likewise
+  // yield a set and stops the Cartesian product from compounding duplicates across nesting levels.
+  //
+  // An outcome's identity is the *multiset* of packets it emits: multiplicity within one outcome is
+  // real (multicast/clone can emit a packet twice) and is preserved, while order is not observable.
+  // The key uses the observable packet fields only (egress port, payload); enrichment fields are
+  // never populated at this layer.
+  return worlds.distinctBy { world ->
+    world.groupingBy { it.dataplaneEgressPort to it.payload }.eachCount()
   }
 }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -156,7 +156,7 @@ class Simulator : TableDataReader {
 
     // Output packets are extracted from trace tree leaves — the tree is the single source
     // of truth for packet outcomes. Parallel forks (clone, multicast) combine outputs within
-    // each world; alternative forks (action selector) produce separate possible worlds.
+    // each outcome; alternative forks (action selector) produce separate outcomes.
     val trace = result.trace
     return ProcessPacketResult(
       trace = trace,
@@ -300,23 +300,23 @@ class Simulator : TableDataReader {
  * emitted twice appears twice) but order is not meaningful.
  */
 fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
-  val worlds =
+  val outcomes =
     when (tree.outcomeCase) {
       TraceTree.OutcomeCase.OUTPUT -> listOf(listOf(tree.output))
       TraceTree.OutcomeCase.DROP,
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,
       null -> listOf(emptyList())
       TraceTree.OutcomeCase.REPLICATION -> {
-        // Cartesian product: for each combination of one world per branch, concatenate packets.
+        // Cartesian product: for each combination of one outcome per branch, concatenate packets.
         require(tree.replication.branchesCount > 0) { "Replication must have at least one branch" }
         tree.replication.branchesList
           .map { collectPossibleOutcomes(it) }
           .reduce { acc, next ->
-            acc.flatMap { world -> next.map { branchWorld -> world + branchWorld } }
+            acc.flatMap { outcome -> next.map { branchOutcome -> outcome + branchOutcome } }
           }
       }
       TraceTree.OutcomeCase.CHOICE -> {
-        // Each branch is a separate possible world; union their outcomes.
+        // Each branch is a separate possible outcome; union them.
         require(tree.choice.branchesCount > 0) { "Choice must have at least one branch" }
         tree.choice.branchesList.flatMap { collectPossibleOutcomes(it) }
       }
@@ -326,14 +326,19 @@ fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
   // possible outcome, not two. Distinct fork resolutions can produce the same outcome (a multicast
   // whose replicas land on the same ports, symmetric action-selector members, …), and the forks
   // carry no probability, so the multiplicity of identical outcomes is meaningless — only their
-  // presence is. Deduplicating here, at every level of the recursion, makes each subtree likewise
-  // yield a set and stops the Cartesian product from compounding duplicates across nesting levels.
+  // presence is.
   //
   // An outcome's identity is the *multiset* of packets it emits: multiplicity within one outcome is
   // real (multicast/clone can emit a packet twice) and is preserved, while order is not observable.
   // The key uses the observable packet fields only (egress port, payload); enrichment fields are
   // never populated at this layer.
-  return worlds.distinctBy { world ->
-    world.groupingBy { it.dataplaneEgressPort to it.payload }.eachCount()
+  //
+  // Deduplicating on every return (rather than building raw and deduplicating once at the top)
+  // keeps
+  // this a single recursive function and stops the Cartesian product from compounding duplicates
+  // across nesting levels. The repeated dedup work is irrelevant here — simplicity over
+  // performance.
+  return outcomes.distinctBy { outcome ->
+    outcome.groupingBy { it.dataplaneEgressPort to it.payload }.eachCount()
   }
 }

--- a/simulator/Simulator.kt
+++ b/simulator/Simulator.kt
@@ -329,11 +329,9 @@ fun collectPossibleOutcomes(tree: TraceTree): List<List<OutputPacket>> {
   // carry no probability, so the multiplicity of identical outcomes is meaningless — only their
   // presence is. [outcomeIdentity] defines when two outcomes are the same.
   //
-  // Deduplicating on every return (rather than building raw and deduplicating once at the top)
-  // keeps
-  // this a single recursive function and stops the Cartesian product from compounding duplicates
-  // across nesting levels. The repeated dedup work is irrelevant here — simplicity over
-  // performance.
+  // Deduplicate on every return (not once at the top) — this keeps one recursive function and
+  // stops the Cartesian product from compounding duplicates across nesting. The repeated work
+  // is irrelevant for a simulator: simplicity over performance.
   return outcomes.distinctBy { it.outcomeIdentity() }
 }
 

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -410,12 +410,12 @@ class SimulatorTest {
 /** Unit tests for [collectPossibleOutcomes] — the outcome type semantics. */
 class CollectPossibleOutcomesTest {
 
-  private fun output(port: Int): fourward.TraceTree =
+  private fun output(port: Int, payload: Int = 0x01): fourward.TraceTree =
     fourward.TraceTree.newBuilder()
       .setOutput(
         fourward.OutputPacket.newBuilder()
           .setDataplaneEgressPort(port)
-          .setPayload(com.google.protobuf.ByteString.copyFrom(byteArrayOf(0x01)))
+          .setPayload(com.google.protobuf.ByteString.copyFrom(byteArrayOf(payload.toByte())))
       )
       .build()
 
@@ -526,5 +526,26 @@ class CollectPossibleOutcomesTest {
     val portMultisets = outcomes.map { outcome -> outcome.map { it.dataplaneEgressPort }.sorted() }
     assertEquals("distinct outcomes only", portMultisets.size, portMultisets.toSet().size)
     assertEquals(setOf(listOf(1, 1), listOf(1, 2), listOf(2, 2)), portMultisets.toSet())
+  }
+
+  @Test
+  fun `outcomes differing only by payload stay distinct`() {
+    // Same egress port, different payload — these are different observable outcomes and must not
+    // collapse. Outcome identity is (port, payload), not port alone. (Without this, a regression
+    // that keyed on port only would still pass every other test, which all use one payload.)
+    val tree = choice(output(1, payload = 0x01), output(1, payload = 0x02))
+    val outcomes = collectPossibleOutcomes(tree)
+    assertEquals(2, outcomes.size)
+  }
+
+  @Test
+  fun `outcomes differing only by packet multiplicity stay distinct`() {
+    // One copy versus two copies of the same packet are different outcomes — multiplicity is part
+    // of an outcome's identity (multicast/clone really can emit a packet twice), so they must not
+    // collapse to one.
+    val tree = choice(output(1), replication(output(1), output(1)))
+    val outcomes = collectPossibleOutcomes(tree)
+    assertEquals("one-copy and two-copy outcomes are distinct", 2, outcomes.size)
+    assertEquals(setOf(1, 2), outcomes.map { it.size }.toSet())
   }
 }

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -433,33 +433,33 @@ class CollectPossibleOutcomesTest {
       .build()
 
   @Test
-  fun `linear trace produces one world with one output`() {
+  fun `linear trace produces one outcome with one output`() {
     val outcomes = collectPossibleOutcomes(output(1))
     assertEquals(listOf(listOf(output(1).output)), outcomes)
   }
 
   @Test
-  fun `drop produces one world with no outputs`() {
+  fun `drop produces one outcome with no outputs`() {
     val outcomes = collectPossibleOutcomes(drop())
     assertEquals(1, outcomes.size)
     assertTrue(outcomes[0].isEmpty())
   }
 
   @Test
-  fun `replication combines outputs within each world`() {
+  fun `replication combines outputs within each outcome`() {
     val tree = replication(output(1), output(2))
     val outcomes = collectPossibleOutcomes(tree)
-    assertEquals("one world", 1, outcomes.size)
+    assertEquals("one outcome", 1, outcomes.size)
     assertEquals("two outputs", 2, outcomes[0].size)
     assertEquals(1, outcomes[0][0].dataplaneEgressPort)
     assertEquals(2, outcomes[0][1].dataplaneEgressPort)
   }
 
   @Test
-  fun `choice produces one world per branch`() {
+  fun `choice produces one outcome per branch`() {
     val tree = choice(output(1), output(2), output(3))
     val outcomes = collectPossibleOutcomes(tree)
-    assertEquals("three worlds", 3, outcomes.size)
+    assertEquals("three outcomes", 3, outcomes.size)
     assertEquals(1, outcomes[0].single().dataplaneEgressPort)
     assertEquals(2, outcomes[1].single().dataplaneEgressPort)
     assertEquals(3, outcomes[2].single().dataplaneEgressPort)
@@ -470,27 +470,28 @@ class CollectPossibleOutcomesTest {
     // Replication with 2 branches, each containing a 2-member choice.
     val tree = replication(choice(output(1), output(2)), choice(output(3), output(4)))
     val outcomes = collectPossibleOutcomes(tree)
-    // 2 × 2 = 4 possible worlds, each with 2 outputs (one per replication branch).
+    // 2 × 2 = 4 possible outcomes, each with 2 outputs (one per replication branch).
     assertEquals("2×2 Cartesian product", 4, outcomes.size)
     assertTrue(outcomes.all { it.size == 2 })
-    val portPairs = outcomes.map { world -> world.map { it.dataplaneEgressPort }.sorted() }.toSet()
+    val portPairs =
+      outcomes.map { outcome -> outcome.map { it.dataplaneEgressPort }.sorted() }.toSet()
     assertEquals(setOf(listOf(1, 3), listOf(1, 4), listOf(2, 3), listOf(2, 4)), portPairs)
   }
 
   @Test
-  fun `choice with drop produces world with empty output`() {
+  fun `choice with drop produces outcome with empty output`() {
     val tree = choice(output(1), drop())
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals(2, outcomes.size)
     assertEquals(1, outcomes[0].size)
-    assertTrue("drop world is empty", outcomes[1].isEmpty())
+    assertTrue("drop outcome is empty", outcomes[1].isEmpty())
   }
 
   @Test
   fun `multicast replication combines all outputs`() {
     val tree = replication(output(1), output(2), output(3))
     val outcomes = collectPossibleOutcomes(tree)
-    assertEquals("one world", 1, outcomes.size)
+    assertEquals("one outcome", 1, outcomes.size)
     assertEquals("three outputs", 3, outcomes[0].size)
   }
 
@@ -498,7 +499,7 @@ class CollectPossibleOutcomesTest {
   fun `identical choice branches collapse to one outcome`() {
     // An action selector whose members all forward identically: the result is certain, so there
     // is exactly one possible outcome — not one per member. The outer collection is a set of
-    // distinct outcomes; duplicate worlds carry no information (forks are unweighted).
+    // distinct outcomes; duplicate outcomes carry no information (forks are unweighted).
     val tree = choice(output(1), output(1))
     val outcomes = collectPossibleOutcomes(tree)
     assertEquals(listOf(listOf(output(1).output)), outcomes)
@@ -522,7 +523,7 @@ class CollectPossibleOutcomesTest {
     // raw Cartesian combinations collapse to three distinct outcomes: {1,1}, {1,2}, {2,2}.
     val tree = replication(choice(output(1), output(2)), choice(output(1), output(2)))
     val outcomes = collectPossibleOutcomes(tree)
-    val portMultisets = outcomes.map { world -> world.map { it.dataplaneEgressPort }.sorted() }
+    val portMultisets = outcomes.map { outcome -> outcome.map { it.dataplaneEgressPort }.sorted() }
     assertEquals("distinct outcomes only", portMultisets.size, portMultisets.toSet().size)
     assertEquals(setOf(listOf(1, 1), listOf(1, 2), listOf(2, 2)), portMultisets.toSet())
   }

--- a/simulator/SimulatorTest.kt
+++ b/simulator/SimulatorTest.kt
@@ -493,4 +493,37 @@ class CollectPossibleOutcomesTest {
     assertEquals("one world", 1, outcomes.size)
     assertEquals("three outputs", 3, outcomes[0].size)
   }
+
+  @Test
+  fun `identical choice branches collapse to one outcome`() {
+    // An action selector whose members all forward identically: the result is certain, so there
+    // is exactly one possible outcome — not one per member. The outer collection is a set of
+    // distinct outcomes; duplicate worlds carry no information (forks are unweighted).
+    val tree = choice(output(1), output(1))
+    val outcomes = collectPossibleOutcomes(tree)
+    assertEquals(listOf(listOf(output(1).output)), outcomes)
+  }
+
+  @Test
+  fun `replication keeps duplicate packets within an outcome`() {
+    // Multicast/clone can emit the same packet to the same port more than once, and every copy
+    // is physically real. Multiplicity *within* a single outcome is meaningful and must never be
+    // deduplicated — only duplicate *outcomes* collapse, not duplicate packets.
+    val tree = replication(output(1), output(1))
+    val outcomes = collectPossibleOutcomes(tree)
+    assertEquals("one outcome", 1, outcomes.size)
+    assertEquals("two real copies, not collapsed", 2, outcomes[0].size)
+  }
+
+  @Test
+  fun `symmetric choices fold duplicate outcomes`() {
+    // Both replication branches choose between the same two ports. Choosing (port1, port2) and
+    // (port2, port1) emit the same multiset of packets — one possible outcome, not two. The four
+    // raw Cartesian combinations collapse to three distinct outcomes: {1,1}, {1,2}, {2,2}.
+    val tree = replication(choice(output(1), output(2)), choice(output(1), output(2)))
+    val outcomes = collectPossibleOutcomes(tree)
+    val portMultisets = outcomes.map { world -> world.map { it.dataplaneEgressPort }.sorted() }
+    assertEquals("distinct outcomes only", portMultisets.size, portMultisets.toSet().size)
+    assertEquals(setOf(listOf(1, 1), listOf(1, 2), listOf(2, 2)), portMultisets.toSet())
+  }
 }

--- a/stf/Runner.kt
+++ b/stf/Runner.kt
@@ -76,29 +76,30 @@ class StfRunner(private val pipelineConfigPath: Path, private val dropPortOverri
 }
 
 /**
- * Appends the best-matching possible world's outputs to [outputQueue].
+ * Appends the best-matching outcome's outputs to [outputQueue].
  *
- * For each world in [possibleOutcomes], scores how well it satisfies [expects] when combined with
- * already-accumulated outputs, and picks the world with the fewest failures. For the common case of
- * a single possible world (no alternative forks), skips scoring entirely.
+ * For each outcome in [possibleOutcomes], scores how well it satisfies [expects] when combined with
+ * already-accumulated outputs, and picks the outcome with the fewest failures. For the common case
+ * of a single possible outcome (no alternative forks), skips scoring entirely.
  */
 fun appendBestOutcome(
   possibleOutcomes: List<List<fourward.OutputPacket>>,
   expects: List<StfExpectedOutput>,
   outputQueue: MutableList<ReceivedPacket>,
 ) {
-  val bestWorld =
+  val bestOutcome =
     if (possibleOutcomes.size == 1) {
       possibleOutcomes[0]
     } else {
-      possibleOutcomes.minBy { world ->
+      possibleOutcomes.minBy { outcome ->
         val candidate =
           outputQueue +
-            world.map { ReceivedPacket(it.dataplaneEgressPort, it.payload.toByteArray()) }
+            outcome.map { ReceivedPacket(it.dataplaneEgressPort, it.payload.toByteArray()) }
         matchOutputAgainstExpects(expects, candidate).size
       }
     }
-  outputQueue += bestWorld.map { ReceivedPacket(it.dataplaneEgressPort, it.payload.toByteArray()) }
+  outputQueue +=
+    bestOutcome.map { ReceivedPacket(it.dataplaneEgressPort, it.payload.toByteArray()) }
 }
 
 /**

--- a/userdocs/reference/dataplane-matchers.md
+++ b/userdocs/reference/dataplane-matchers.md
@@ -196,7 +196,7 @@ vector.
 ## Handling multiple outcomes
 
 P4 programs with action selectors can produce multiple possible outcomes
-— each representing one "possible world."
+— each representing one distinct possible execution.
 
 **`OutcomesAre`** pins the exact set of outcomes (order-independent).
 Each argument is a packet matcher for a single-packet outcome; use

--- a/userdocs/reference/grpc.md
+++ b/userdocs/reference/grpc.md
@@ -89,20 +89,21 @@ The `p4rt_ingress_port` variant requires a loaded pipeline with
 
 ```protobuf
 message InjectPacketResponse {
-  repeated PacketSet possible_outcomes = 3;   // one entry per possible real execution
-  TraceTree trace = 2;                        // P4RT-enriched when translation is available
+  repeated Outcome possible_outcomes = 3;   // one entry per distinct possible execution
+  TraceTree trace = 2;                      // P4RT-enriched when translation is available
 }
 
-message PacketSet {
+message Outcome {
   repeated OutputPacket packets = 1;
 }
 ```
 
 The `possible_outcomes` field captures the distinction between
 [parallel and alternative forks](../concepts/traces.md#forks).
-Each `PacketSet` is one possible set of output packets from a single real
-execution. Programs with only parallel forks (clone, multicast) have exactly
-one entry. Programs with action selectors have one entry per alternative.
+Each `Outcome` is the packets emitted by a single real execution. The entries
+form a set: programs with only parallel forks (clone, multicast) have exactly
+one entry, action selectors add one entry per alternative, and alternatives that
+emit the same packets collapse to a single entry.
 
 ### `InjectPackets`
 

--- a/web/WebServer.kt
+++ b/web/WebServer.kt
@@ -226,8 +226,8 @@ class WebServer(
     val result = simulator.processPacket(ingressPort, payload)
 
     val outcomesJson =
-      result.possibleOutcomes.joinToString(",") { world ->
-        "[${world.joinToString(",") { jsonPrinter.print(it) }}]"
+      result.possibleOutcomes.joinToString(",") { outcome ->
+        "[${outcome.joinToString(",") { jsonPrinter.print(it) }}]"
       }
     val traceJson = jsonPrinter.print(result.trace)
     val traceProto = textPrinter.printToString(result.trace)


### PR DESCRIPTION
## The win

`possibleOutcomes` answers an existential question — *what can this packet do?* — so the right answer is a **set of distinct outcomes**. Before this change it was a raw list: nesting an alternative fork (action selector) inside a parallel fork (multicast/clone) made the Cartesian product emit the **same outcome more than once**. The forks carry no probability, so that multiplicity was pure noise — an artifact of trace-tree shape — yet it leaked into every outcome-returning API: `InjectPacket`, `SubscribeResults`, `GetReproducer`, P4Runtime `PacketIn`, the STF runner, the web UI, and the C++ matchers.

This deduplicates **once, at the single projection** from trace tree to outcomes (`collectPossibleOutcomes`), so every consumer inherits set semantics from one source of truth.

## The contract

The two nesting levels have deliberately **opposite** semantics:

- **Outer collection → a set.** Two real executions that emit the same packets are *one* possibility. Identical outcomes collapse.
- **Each outcome → a multiset.** Multicast/clone can genuinely emit the same packet to the same port twice; both copies are real, so multiplicity *within* an outcome is preserved. (A naive "just make it a `Set`" would have been a correctness bug here.)

Outcome identity is the multiset of **observable** packet fields — egress port and payload — captured once in `List<OutputPacket>.outcomeIdentity()`, the single key the dedup and the tests both use. Order within an outcome is not observable, so it doesn't participate.

## Why here, and not deeper

The **trace tree stays lossless**: two action-selector members that forward identically remain *distinct* branches, because the tree records control flow, not just observable output (and reproduction relies on that). Dedup belongs at the projection step, not in the tree — and `collectPossibleOutcomes` is the only projection, so it's the deepest correct place. Deduping recursively at every level also keeps the Cartesian product from compounding duplicates across nesting; that placement is spelled out in a comment.

## Also

- Renamed the `PacketSet` proto message to `Outcome`. It was never a set (it preserves duplicate packets), and the thing that genuinely *is* a set is the outer `possible_outcomes` collection — so the old name pointed at exactly the wrong level.
- Standardized terminology on "outcome" across the simulator, gRPC, STF, web, tests, and docs; the code previously said "world" internally while the contract said "outcome".

## Tests

- **Unit** (`collectPossibleOutcomes`): identical branches collapse; replication keeps duplicate packets within an outcome; symmetric choice-in-replication folds 4→3; and — closing a real hole where every test shared one payload — outcomes differing only by **payload**, and only by packet **multiplicity**, stay distinct.
- **Architecture** (`PSAArchitectureTest`): real action-selector programs whose members forward identically now collapse to one outcome while the trace keeps its branches — the lossless-tree-vs-set distinction, end to end through the simulator.
- **Corpus** (`TraceTreeConsistencyTest`): asserts the set invariant (no duplicate outcome) on every trace-tree corpus program, using the same `outcomeIdentity` key as the implementation.
- **Wire** (`DataplaneServiceTest`): an `InjectPacket` with an identical-member selector group returns a single outcome over gRPC — proving the dedup survives enrichment and the proto boundary, not just the simulator layer.

Independently adversarially reviewed (key equality, order-insensitivity, edge cases, per-level vs top-level dedup equivalence, enrichment-layer correctness) — no defects. Full `bazel test //...` (90/90, incl. heavy), `format.sh`, and `lint.sh` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)