### PR TITLE
ci: try protecting the shared Bazel cache from eviction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,14 @@ on:
     # `closed` triggers cancel-closed-pr-runs; the rest are GitHub's defaults.
     types: [opened, synchronize, reopened, closed]
   schedule:
-    # Cache-warming build every 3 days (Mon/Thu 06:00 UTC). BuildBuddy
-    # evicted entries within 6 days of inactivity; GHA caches expire
-    # after 7. Running every 3 days stays well within both windows.
-    - cron: '0 6 * * 1,4'
+    # Daily cache-warming build (06:00 UTC). BuildBuddy evicts entries after
+    # 6 days of inactivity and GHA caches expire after 7; the old Mon/Thu
+    # cadence stayed within those windows on paper, but GitHub delays or
+    # silently drops scheduled runs on public repos under load, so a 3-4 day
+    # gap can stretch past eviction during quiet stretches. Daily warming is
+    # cheap insurance against that — the warm-cache job disables BuildBuddy,
+    # so the extra runs cost zero remote-cache transfer.
+    - cron: '0 6 * * *'
 
 # Cancel any preceding run on the pull request.
 concurrency:
@@ -258,12 +262,19 @@ jobs:
       #   if: always()
       #   run: bazel shutdown && rm -rf $(bazel info repository_cache)
 
-      # Save on main pushes or slow PR builds. Skip on schedule —
-      # the warm-cache job saves a more complete cache (with all
-      # intermediate outputs from a full local build).
+      # Save on main pushes, or on PR builds slow enough (>20 min) that they
+      # were near-cold. The high bar keeps routine PR builds (warm: 1-11 min)
+      # from saving: each ~2.5 GB PR cache counts against the repo's 10 GB
+      # budget, and a PR-scoped cache only helps re-runs of that same PR
+      # (GitHub scopes caches to the branch), so frequent PR saves would
+      # evict the shared main cache that every PR restores from. A build only
+      # exceeds 20 min when the caches are already cold — i.e. when main is
+      # itself rebuilding and there's no warm main cache to evict — so the
+      # save rescues that PR's re-runs without costing the steady state.
+      # Skip on schedule — the warm-cache job saves a more complete cache.
       - name: Save Bazel cache
         uses: actions/cache/save@v5
-        if: always() && github.event_name != 'schedule' && (github.ref_name == 'main' || env.DURATION > 300)
+        if: always() && github.event_name != 'schedule' && (github.ref_name == 'main' || env.DURATION > 1200)
         with:
           path: |
             ${{ env.BAZEL_CACHE }}
@@ -341,12 +352,12 @@ jobs:
         if: always()
         run: echo "DURATION=$(( $(date +%s) - START_TIME ))" >> "$GITHUB_ENV"
 
-      # Mirror build-and-test: save on main (authoritative cache) or
-      # when the build was slow enough (>5 min) that persisting is
-      # worthwhile despite the PR-branch scoping.
+      # Mirror build-and-test: save on main (authoritative cache) or on a
+      # near-cold PR build (>20 min). The high bar keeps routine PR saves from
+      # evicting the shared main cache under the repo's 10 GB budget.
       - name: Save Bazel cache
         uses: actions/cache/save@v5
-        if: always() && (github.ref_name == 'main' || env.DURATION > 300)
+        if: always() && (github.ref_name == 'main' || env.DURATION > 1200)
         with:
           path: ~/.cache/bazel
           key: bazel-bcr-${{ hashFiles('*.bazel*', 'bcr_test_module/*.bazel*') }}-${{ github.run_id }}


### PR DESCRIPTION
## What this is

An **experiment, not a declared fix.** Two cheap, reversible CI knobs aimed at the cache-cold-build slowness — to be kept or reverted based on whether main's cache actually survives over the next week.

## Diagnosis (the solid part)

Recent CI slowness is **cold from-scratch builds, not heavy tests.** Bazel's own logs:

| | Warm build | Cold build |
|---|---|---|
| ubuntu `Build and test` | `12812 action cache hit` → **52 s** | ~2,000 C++ actions recompiled |
| BCR consumer check | ~2 min | `4069/9359 remote hit` (43%) → **59 min** |
| Heavy-test step | **8 s** | (never the bottleneck) |

## The two changes

**1. Raise the PR-cache-save threshold 5 → 20 min.** GitHub scopes Actions caches to the branch, so a PR-saved cache only helps re-runs of that same PR — yet each ~2.5 GB save counts against the repo's **10 GB** budget and can evict the main cache every PR restores from (directly, or by leaving no older main cache for the `restore-keys` prefix to fall back on after a `*.bazel*` hash bump). Routine PR builds (1–11 min) stop saving; a genuinely-cold PR (>20 min, which only happens when caches were already cold) still saves and speeds up its own re-runs.

**2. Warm daily instead of Mon/Thu.** The 6-day BuildBuddy / 7-day GHA eviction windows cover Mon/Thu on paper, but GitHub delays or drops scheduled runs on public repos under load, so a gap can stretch past them. Daily is cheap insurance; the warm-cache job disables BuildBuddy, so the extra runs cost ~zero remote-cache transfer.

## Deliberately dropped

An earlier draft also warmed the **BCR cache on schedule** and made main the **sole cache writer**. Both were cut:
- The BCR cold build that motivated schedule-warming was triggered by a `*.bazel*` **hash-key invalidation**, which daily warming doesn't prevent — so the evidence didn't support it.
- Sole-writer was more drastic than needed; the threshold bump keeps the one case where a PR cache earns its keep.

## How we'll know if it worked

Watch over the next week: do main-scoped `bazel-ubuntu-24.04-*` / `bazel-macos-*` caches survive in the cache list (they were being fully evicted), and do PR `Build and test` jobs stay in the 1–5 min range? If not, revert — it's two `if:` conditions and one cron line.

Separately worth a look (not in this PR): the 43% cold-hit rate may partly be `--remote_timeout=10s` throttling rather than true evictions, in which case BuildBuddy retention/timeout is the real lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)