### PR TITLE
Polish #809: clarity and consistency in matcher trace output

### DIFF
--- a/bazel/golden_test_main.cc
+++ b/bazel/golden_test_main.cc
@@ -8,6 +8,8 @@
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
+  // Must run before ParseCommandLine: it sets the --update_golden default that a
+  // command-line --update_golden=... then overrides.
   fourward::bazel::internal::InitializeGoldenTestMain();
   absl::ParseCommandLine(argc, argv);
   return RUN_ALL_TESTS();

--- a/fourward_cc/dataplane_matchers.cc
+++ b/fourward_cc/dataplane_matchers.cc
@@ -200,6 +200,24 @@ void PrintTraceForMatcher(std::ostream* os, const fourward::TraceTree& trace) {
   }
 }
 
+void PrintActualOutputSummary(std::ostream* os, const PacketList& packets) {
+  if (packets.empty()) {
+    *os << "actual output had no packets";
+    return;
+  }
+  if (packets.size() == 1) {
+    *os << "actual packet egressed on ";
+    PrintPacketEgress(os, packets[0]);
+    return;
+  }
+
+  *os << "actual output had " << packets.size() << " packets";
+  for (size_t i = 0; i < packets.size(); ++i) {
+    *os << (i == 0 ? ": " : ", ");
+    PrintPacketEgress(os, packets[i]);
+  }
+}
+
 void PrintPacketPortGroups(std::ostream* os, const PacketList& packets) {
   ::absl::btree_map<uint32_t, int> dataplane_ports;
   ::absl::btree_map<std::string, int> p4rt_ports;

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -7,7 +7,6 @@
 #ifndef FOURWARD_CC_DATAPLANE_MATCHERS_H_
 #define FOURWARD_CC_DATAPLANE_MATCHERS_H_
 
-#include <algorithm>
 #include <concepts>
 #include <cstdint>
 #include <ostream>
@@ -299,25 +298,6 @@ inline void PrintPacketEgress(std::ostream* os,
   if (!packet.payload().empty()) {
     *os << " with payload ";
     PrintPayloadPreview(os, packet.payload());
-  }
-}
-
-inline void PrintActualOutputSummary(std::ostream* os,
-                                     const PacketList& packets) {
-  if (packets.empty()) {
-    *os << "actual output had no packets";
-    return;
-  }
-  if (packets.size() == 1) {
-    *os << "actual packet egressed on ";
-    PrintPacketEgress(os, packets[0]);
-    return;
-  }
-
-  *os << "actual output had " << packets.size() << " packets";
-  for (size_t i = 0; i < packets.size(); ++i) {
-    *os << (i == 0 ? ": " : ", ");
-    PrintPacketEgress(os, packets[i]);
   }
 }
 

--- a/simulator/trace_summary.cc
+++ b/simulator/trace_summary.cc
@@ -212,17 +212,11 @@ void PrintAssignmentRun(
   *os << "\n";
 }
 
-// Returns the action's params as (name, value) pairs, preferring P4Runtime-encoded values over the
-// dataplane-encoded ones the simulator records — the P4Runtime encoding is what the control plane
-// wrote, so it reads more naturally in a failure summary.
-//
-// The translation is only possible via the matched table entry, which carries the action params in
-// both encodings: `matched_entry` (dataplane) and `p4rt_matched_entry` (P4Runtime), positionally
-// aligned. The event's params, however, are keyed by name, so we recover each one's position by
-// matching its dataplane value against `matched_entry`'s params, then read the P4Runtime value at
-// that position. We fall back to the dataplane values (returning early) whenever that mapping would
-// be ambiguous or unsafe: missing/typed-wrong entries, mismatched param counts, or — the subtle
-// case — duplicate dataplane values, which make value-based position recovery ambiguous.
+// Returns the action's params as (name, value) pairs in the P4Runtime encoding rather than the
+// dataplane encoding the simulator records, since P4Runtime is what the control plane wrote. The
+// matched table entry holds both encodings positionally aligned, so we recover each param's position
+// by matching its dataplane value, then read the P4Runtime value there. Duplicate dataplane values
+// make that position recovery ambiguous, so (as with any shape mismatch) we fall back to raw values.
 std::vector<std::pair<std::string, absl::string_view>> ActionParamValues(
     const fourward::ActionExecutionEvent& action,
     const fourward::TableLookupEvent* table) {

--- a/simulator/trace_summary.cc
+++ b/simulator/trace_summary.cc
@@ -212,6 +212,17 @@ void PrintAssignmentRun(
   *os << "\n";
 }
 
+// Returns the action's params as (name, value) pairs, preferring P4Runtime-encoded values over the
+// dataplane-encoded ones the simulator records — the P4Runtime encoding is what the control plane
+// wrote, so it reads more naturally in a failure summary.
+//
+// The translation is only possible via the matched table entry, which carries the action params in
+// both encodings: `matched_entry` (dataplane) and `p4rt_matched_entry` (P4Runtime), positionally
+// aligned. The event's params, however, are keyed by name, so we recover each one's position by
+// matching its dataplane value against `matched_entry`'s params, then read the P4Runtime value at
+// that position. We fall back to the dataplane values (returning early) whenever that mapping would
+// be ambiguous or unsafe: missing/typed-wrong entries, mismatched param counts, or — the subtle
+// case — duplicate dataplane values, which make value-based position recovery ambiguous.
 std::vector<std::pair<std::string, absl::string_view>> ActionParamValues(
     const fourward::ActionExecutionEvent& action,
     const fourward::TableLookupEvent* table) {


### PR DESCRIPTION
## The win

Small follow-up polish on the just-landed #809 (dataplane matcher failure output). All four changes are **no-op refactors/comments** — the golden tests are unchanged, which is the proof. The aim is clarity and internal consistency, nothing behavioral.

## Changes

- **Document the cryptic bit.** `ActionParamValues` (in `trace_summary.cc`) translates an action's *dataplane-encoded* param values into the *P4Runtime* encoding the control plane actually wrote, by recovering each named param's position from the matched table entry's two encodings. The translation — and especially its early bail-out when dataplane values are duplicated (which makes value-based position recovery ambiguous) — had no explanation. Now it does.

- **Put the odd one back with its siblings.** `PrintActualOutputSummary` was forward-declared like the other non-template formatters (which live in `dataplane_matchers.cc`) but then defined `inline` in the header — the only one that did. Moved its definition into the `.cc`, slimming the header and removing the "why is this one different?" double-take.

- **Drop a dead include.** `dataplane_matchers.h` included `<algorithm>` but uses none of it (its container algorithms come from `absl/algorithm/container.h`).

- **Name a load-bearing order.** In `golden_test_main.cc`, `InitializeGoldenTestMain()` must run *before* `ParseCommandLine` so the `--update_golden` default is set before any command-line override is parsed. A one-line comment so a future reorder doesn't silently break golden updates.

## Scrutinized but deliberately skipped

- A `PrintCountMap` trait to dedupe its two near-identical overloads — two self-contained overloads read more clearly than a trait with overload-resolution subtleties.
- Replacing an O(n²) duplicate-value check with a hash set — simplicity over performance for a handful of action params.
- Restructuring an effectively-dead `PrintEvent` case — the exhaustive switch is intentional and the fallback is defensible.

## Validation

`./tools/format.sh`, `./tools/lint.sh`, `bazel build //...`, and the affected tests (`dataplane_matchers_test`, `dataplane_matchers_flag_test`, `trace_summary_test`) all green; goldens unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)