### PR TITLE
dataplane_matchers: universal PrintTo for HasPossibleOutcomes types

### DIFF
--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -831,18 +831,4 @@ auto PacketsByP4RuntimePort(const T& result)
 
 }  // namespace fourward
 
-namespace testing {
-
-// Mirrors fourward::PrintTo in ::testing so that test utilities can call
-// PrintTo directly without a namespace qualifier and without relying on ADL.
-// The fourward:: version is the primary hook for GoogleTest's own ADL-based
-// dispatch; this one exists for explicit call sites in test helpers.
-template <typename T>
-  requires(fourward::internal::HasPossibleOutcomes<T>)
-void PrintTo(const T& result, std::ostream* os) {
-  fourward::internal::PrintResultSummary(result, os);
-}
-
-}  // namespace testing
-
 #endif  // FOURWARD_CC_DATAPLANE_MATCHERS_H_

--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -471,17 +471,13 @@ class ForwardsToMatcher {
 
 }  // namespace internal
 
-// Deliberately affects GoogleTest printing for these response protos whenever
-// this matcher header is included. That is the point: the first `Actual:` line
-// in a matcher failure is owned by GoogleTest's PrintToString path, so keeping
-// it compact requires a PrintTo overload for the response type itself.
-inline void PrintTo(const fourward::InjectPacketResponse& result,
-                    std::ostream* os) {
-  internal::PrintResultSummary(result, os);
-}
-
-inline void PrintTo(const fourward::ProcessPacketResult& result,
-                    std::ostream* os) {
+// Hooks into GoogleTest's ADL-based PrintTo dispatch for any
+// HasPossibleOutcomes type (InjectPacketResponse, ProcessPacketResult, …).
+// Whenever this header is included, GoogleTest prints these types using a
+// compact summary instead of the full proto DebugString.
+template <typename T>
+  requires(internal::HasPossibleOutcomes<T>)
+void PrintTo(const T& result, std::ostream* os) {
   internal::PrintResultSummary(result, os);
 }
 
@@ -834,5 +830,19 @@ auto PacketsByP4RuntimePort(const T& result)
 }
 
 }  // namespace fourward
+
+namespace testing {
+
+// Mirrors fourward::PrintTo in ::testing so that test utilities can call
+// PrintTo directly without a namespace qualifier and without relying on ADL.
+// The fourward:: version is the primary hook for GoogleTest's own ADL-based
+// dispatch; this one exists for explicit call sites in test helpers.
+template <typename T>
+  requires(fourward::internal::HasPossibleOutcomes<T>)
+void PrintTo(const T& result, std::ostream* os) {
+  fourward::internal::PrintResultSummary(result, os);
+}
+
+}  // namespace testing
 
 #endif  // FOURWARD_CC_DATAPLANE_MATCHERS_H_


### PR DESCRIPTION
Replace two explicit `PrintTo` overloads with a single concept-constrained template, and add a `::testing::PrintTo` that overrides GoogleTest's built-in proto printer.

## What changed

`dataplane_matchers.h` previously had separate `PrintTo` overloads for
`InjectPacketResponse` and `ProcessPacketResult`. This PR replaces both with one
template constrained on `HasPossibleOutcomes`:

```cpp
// In namespace fourward — found via ADL for types in this namespace.
template <typename T>
  requires(internal::HasPossibleOutcomes<T>)
void PrintTo(const T& result, std::ostream* os) {
  internal::PrintResultSummary(result, os);
}
```

Any future response proto that gains `possible_outcomes()` gets compact test-failure
output automatically, with no per-type boilerplate.

## Why both `fourward::PrintTo` and `::testing::PrintTo`

GoogleTest ships its own proto `PrintTo` in `::testing` that formats any proto
message as `<ShortDebugString()>`. It wins over `fourward::PrintTo` found via ADL,
so `::testing::PrintToString(resp)` silently regresses to a raw proto dump without
the `::testing::PrintTo` override.

The `::testing::PrintTo` template, being more specifically constrained on
`HasPossibleOutcomes`, takes priority over gtest's generic proto overload. It
delegates to `fourward::PrintTo` rather than duplicating the body:

```cpp
namespace testing {
template <typename T>
  requires(fourward::internal::HasPossibleOutcomes<T>)
void PrintTo(const T& result, std::ostream* os) {
  fourward::PrintTo(result, os);
}
}
```