### PR TITLE
dataplane_matchers: restore testing::PrintTo as a thin delegate

### DIFF
--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -831,4 +831,19 @@ auto PacketsByP4RuntimePort(const T& result)
 
 }  // namespace fourward
 
+namespace testing {
+
+// GoogleTest has a built-in proto PrintTo in ::testing that produces
+// "<ShortDebugString()>" for any proto message. It wins over fourward::PrintTo
+// found via ADL. This overload, being more specifically constrained on
+// HasPossibleOutcomes, takes priority and replaces the generic proto output
+// with our compact summary.
+template <typename T>
+  requires(fourward::internal::HasPossibleOutcomes<T>)
+void PrintTo(const T& result, std::ostream* os) {
+  fourward::PrintTo(result, os);
+}
+
+}  // namespace testing
+
 #endif  // FOURWARD_CC_DATAPLANE_MATCHERS_H_


### PR DESCRIPTION
Fixes a regression introduced by #815.

## What happened

#815 added a `::testing::PrintTo` template to override GoogleTest's built-in proto
printer (which formats any proto as `<ShortDebugString()>`). A `/simplify` pass
then removed it on the grounds that `fourward::PrintTo` was reachable via ADL —
but that reasoning was wrong: gtest's proto overload lives in `::testing` and wins
over ADL, so `::testing::PrintToString(resp)` was silently regressing to the raw
proto dump.

## What this PR does

Restores `::testing::PrintTo`, now as a thin delegate rather than a body
duplicate:

```cpp
namespace testing {
template <typename T>
  requires(fourward::internal::HasPossibleOutcomes<T>)
void PrintTo(const T& result, std::ostream* os) {
  fourward::PrintTo(result, os);
}
}
```

Being constrained on `HasPossibleOutcomes`, it takes priority over gtest's
unconstrained proto overload while staying in sync with `fourward::PrintTo`
automatically.