### PR TITLE
golden_test_main: initialize golden test flag before gtest

### DIFF
--- a/bazel/golden_test_main.cc
+++ b/bazel/golden_test_main.cc
@@ -7,10 +7,10 @@
 #include "gtest/gtest.h"
 
 int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
   // Must run before ParseCommandLine: it sets the --update_golden default that a
   // command-line --update_golden=... then overrides.
   fourward::bazel::internal::InitializeGoldenTestMain();
+  testing::InitGoogleTest(&argc, argv);
   absl::ParseCommandLine(argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Swaps the order of `InitializeGoldenTestMain` and `InitGoogleTest` so the
code reads in the same order the comment describes: set the `--update_golden`
default, clean up argv, parse flags. The two calls are independent, so this
is a readability-only change.