### PR TITLE
bazel: add alwayslink to golden_test_main

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -77,6 +77,7 @@ cc_library(
         "@abseil-cpp//absl/flags:parse",
         "@googletest//:gtest",
     ],
+    alwayslink = True,
 )
 
 bzl_library(


### PR DESCRIPTION
`cc_library` targets without exported headers have no symbols that dependents
can reference by name, so the linker may silently drop them. `alwayslink`
ensures `golden_test_main` is always included in the final binary.