### PR TITLE
simulator: rename cause to cause_id in Replication, Choice, and Drop

### DIFF
--- a/cli/TraceFormatter.kt
+++ b/cli/TraceFormatter.kt
@@ -54,7 +54,7 @@ object TraceFormatter {
       }
       TraceTree.OutcomeCase.DROP -> {
         val cause =
-          if (tree.drop.hasCause()) tree.eventsList.firstOrNull { it.id == tree.drop.cause }
+          if (tree.drop.hasCauseId()) tree.eventsList.firstOrNull { it.id == tree.drop.causeId }
           else null
         val suffix =
           when (cause?.eventCase) {

--- a/cli/TraceFormatterTest.kt
+++ b/cli/TraceFormatterTest.kt
@@ -95,7 +95,7 @@ class TraceFormatterTest {
     val tree =
       TraceTree.newBuilder()
         .addEvents(TraceEvent.newBuilder().setMarkToDrop(MarkToDropEvent.newBuilder()).setId(1))
-        .setDrop(Drop.newBuilder().setCause(1))
+        .setDrop(Drop.newBuilder().setCauseId(1))
         .build()
 
     val output = TraceFormatter.format(tree)
@@ -207,7 +207,7 @@ class TraceFormatterTest {
             .setAssertion(AssertionEvent.newBuilder().setPassed(false))
             .setId(1)
         )
-        .setDrop(Drop.newBuilder().setCause(1))
+        .setDrop(Drop.newBuilder().setCauseId(1))
         .build()
 
     assertEquals(

--- a/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
+++ b/e2e_tests/trace_tree/TraceTreeConsistencyTest.kt
@@ -137,9 +137,9 @@ class TraceTreeConsistencyTest(private val testName: String) {
     val cause =
       when (tree.outcomeCase) {
         TraceTree.OutcomeCase.REPLICATION ->
-          if (tree.replication.hasCause()) tree.replication.cause else null
-        TraceTree.OutcomeCase.CHOICE -> if (tree.choice.hasCause()) tree.choice.cause else null
-        TraceTree.OutcomeCase.DROP -> if (tree.drop.hasCause()) tree.drop.cause else null
+          if (tree.replication.hasCauseId()) tree.replication.causeId else null
+        TraceTree.OutcomeCase.CHOICE -> if (tree.choice.hasCauseId()) tree.choice.causeId else null
+        TraceTree.OutcomeCase.DROP -> if (tree.drop.hasCauseId()) tree.drop.causeId else null
         TraceTree.OutcomeCase.CONTINUATION,
         TraceTree.OutcomeCase.OUTPUT,
         TraceTree.OutcomeCase.OUTCOME_NOT_SET,

--- a/e2e_tests/trace_tree/action_selector_3.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_3.golden.txtpb
@@ -91,7 +91,7 @@ events {
   }
 }
 choice {
-  cause: 8
+  cause_id: 8
   branches {
     events {
       action_execution {

--- a/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_miss.golden.txtpb
@@ -111,5 +111,5 @@ events {
   id: 11
 }
 drop {
-  cause: 10
+  cause_id: 10
 }

--- a/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
+++ b/e2e_tests/trace_tree/action_selector_nested.golden.txtpb
@@ -91,7 +91,7 @@ events {
   }
 }
 choice {
-  cause: 8
+  cause_id: 8
   branches {
     events {
       action_execution {
@@ -157,7 +157,7 @@ choice {
       }
     }
     choice {
-      cause: 11
+      cause_id: 11
       branches {
         events {
           action_execution {
@@ -437,7 +437,7 @@ choice {
       }
     }
     choice {
-      cause: 34
+      cause_id: 34
       branches {
         events {
           action_execution {

--- a/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_and_multicast.golden.txtpb
@@ -104,7 +104,7 @@ events {
   id: 11
 }
 replication {
-  cause: 11
+  cause_id: 11
   branches {
     events {
       multicast_group_lookup {
@@ -115,7 +115,7 @@ replication {
       id: 12
     }
     replication {
-      cause: 12
+      cause_id: 12
       branches {
         events {
           pipeline_stage {

--- a/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_ingress_egress.golden.txtpb
@@ -104,7 +104,7 @@ events {
   id: 11
 }
 replication {
-  cause: 11
+  cause_id: 11
   branches {
     events {
       pipeline_stage {

--- a/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_last_wins.golden.txtpb
@@ -116,7 +116,7 @@ events {
   id: 12
 }
 replication {
-  cause: 12
+  cause_id: 12
   branches {
     events {
       pipeline_stage {

--- a/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_plus_selector.golden.txtpb
@@ -103,7 +103,7 @@ events {
   }
 }
 choice {
-  cause: 9
+  cause_id: 9
   branches {
     events {
       action_execution {
@@ -156,7 +156,7 @@ choice {
       id: 13
     }
     replication {
-      cause: 13
+      cause_id: 13
       branches {
         events {
           pipeline_stage {
@@ -341,7 +341,7 @@ choice {
       id: 31
     }
     replication {
-      cause: 31
+      cause_id: 31
       branches {
         events {
           pipeline_stage {

--- a/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_preserve_meta.golden.txtpb
@@ -130,7 +130,7 @@ events {
   id: 13
 }
 replication {
-  cause: 13
+  cause_id: 13
   branches {
     events {
       pipeline_stage {

--- a/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
+++ b/e2e_tests/trace_tree/clone_with_egress.golden.txtpb
@@ -104,7 +104,7 @@ events {
   id: 11
 }
 replication {
-  cause: 11
+  cause_id: 11
   branches {
     events {
       pipeline_stage {

--- a/e2e_tests/trace_tree/e2e_clone.golden.txtpb
+++ b/e2e_tests/trace_tree/e2e_clone.golden.txtpb
@@ -216,7 +216,7 @@ events {
   id: 19
 }
 replication {
-  cause: 19
+  cause_id: 19
   branches {
     events {
       pipeline_stage {

--- a/e2e_tests/trace_tree/multicast.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast.golden.txtpb
@@ -91,7 +91,7 @@ events {
   id: 10
 }
 replication {
-  cause: 10
+  cause_id: 10
   branches {
     events {
       pipeline_stage {

--- a/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_drop_replica.golden.txtpb
@@ -91,7 +91,7 @@ events {
   id: 10
 }
 replication {
-  cause: 10
+  cause_id: 10
   branches {
     events {
       pipeline_stage {
@@ -242,7 +242,7 @@ replication {
       id: 24
     }
     drop {
-      cause: 21
+      cause_id: 21
     }
   }
   branches {

--- a/e2e_tests/trace_tree/multicast_selector.golden.txtpb
+++ b/e2e_tests/trace_tree/multicast_selector.golden.txtpb
@@ -91,7 +91,7 @@ events {
   id: 10
 }
 replication {
-  cause: 10
+  cause_id: 10
   branches {
     events {
       pipeline_stage {
@@ -133,7 +133,7 @@ replication {
       }
     }
     choice {
-      cause: 12
+      cause_id: 12
       branches {
         events {
           action_execution {
@@ -333,7 +333,7 @@ replication {
       }
     }
     choice {
-      cause: 30
+      cause_id: 30
       branches {
         events {
           action_execution {

--- a/e2e_tests/trace_tree/selector_exit.golden.txtpb
+++ b/e2e_tests/trace_tree/selector_exit.golden.txtpb
@@ -91,7 +91,7 @@ events {
   }
 }
 choice {
-  cause: 8
+  cause_id: 8
   branches {
     events {
       action_execution {

--- a/fourward_cc/dataplane_matchers_test.cc
+++ b/fourward_cc/dataplane_matchers_test.cc
@@ -777,7 +777,7 @@ TEST(ErrorMessageTest, CompactTraceFailureMatchesGolden) {
   resp.mutable_trace()->add_events()->mutable_clone()->set_session_id(1);
 
   auto* replication = resp.mutable_trace()->mutable_replication();
-  replication->set_cause(265);
+  replication->set_cause_id(265);
   auto* egress = replication->add_branches();
   auto* egress_assignment = egress->add_events();
   egress_assignment->mutable_assignment()->set_target("headers.ipv4.ttl");

--- a/simulator/PNAArchitectureTest.kt
+++ b/simulator/PNAArchitectureTest.kt
@@ -577,7 +577,7 @@ class PNAArchitectureTest {
     assertTrue(result.trace.hasReplication())
     assertEquals(2, result.trace.replication.branchesList.size)
     // mirror_packet has no triggering lookup event — cause must be absent.
-    assertFalse(result.trace.replication.hasCause())
+    assertFalse(result.trace.replication.hasCauseId())
   }
 
   @Test

--- a/simulator/PSAArchitectureTest.kt
+++ b/simulator/PSAArchitectureTest.kt
@@ -503,9 +503,9 @@ class PSAArchitectureTest {
     // Branches are in replica order; each outputs to its assigned port.
     assertEquals(2, result.trace.replication.branchesList[0].output.dataplaneEgressPort)
     assertEquals(3, result.trace.replication.branchesList[1].output.dataplaneEgressPort)
-    // Replication.cause should reference the multicast group lookup event by id.
-    val causeId = result.trace.replication.cause
-    assertTrue("Replication.cause should be non-zero", causeId > 0)
+    // Replication.causeId should reference the multicast group lookup event by id.
+    val causeId = result.trace.replication.causeId
+    assertTrue("Replication.causeId should be non-zero", causeId > 0)
     val lookupEvent = result.trace.eventsList.single { it.id == causeId }
     assertTrue(lookupEvent.hasMulticastGroupLookup())
   }

--- a/simulator/TraceHelpers.kt
+++ b/simulator/TraceHelpers.kt
@@ -14,7 +14,7 @@ import fourward.TraceTree
 
 /** Builds a [TraceTree] representing a dropped packet with the given trace events. */
 internal fun buildDropTrace(events: List<TraceEvent>, causeId: Long? = null): TraceTree {
-  val drop = Drop.newBuilder().also { if (causeId != null) it.setCause(causeId) }.build()
+  val drop = Drop.newBuilder().also { if (causeId != null) it.setCauseId(causeId) }.build()
   return TraceTree.newBuilder().addAllEvents(events).setDrop(drop).build()
 }
 
@@ -42,7 +42,7 @@ internal fun buildReplicationTree(
     .addAllEvents(events)
     .setReplication(
       Replication.newBuilder()
-        .also { if (cause != null) it.setCause(cause) }
+        .also { if (cause != null) it.setCauseId(cause) }
         .addAllBranches(branches)
     )
     .build()
@@ -59,7 +59,7 @@ internal fun buildChoiceTree(
   TraceTree.newBuilder()
     .addAllEvents(events)
     .setChoice(
-      Choice.newBuilder().also { if (cause != null) it.setCause(cause) }.addAllBranches(branches)
+      Choice.newBuilder().also { if (cause != null) it.setCauseId(cause) }.addAllBranches(branches)
     )
     .build()
 
@@ -140,7 +140,8 @@ private class TraceEventIdNormalizer {
     when (node.outcomeCase) {
       TraceTree.OutcomeCase.REPLICATION -> {
         val replication = node.replication.toBuilder().clearBranches()
-        if (node.replication.hasCause()) replication.setCause(remapCause(node.replication.cause))
+        if (node.replication.hasCauseId())
+          replication.setCauseId(remapCause(node.replication.causeId))
         for (branch in node.replication.branchesList) {
           replication.addBranches(normalizeNode(branch))
         }
@@ -148,7 +149,7 @@ private class TraceEventIdNormalizer {
       }
       TraceTree.OutcomeCase.CHOICE -> {
         val choice = node.choice.toBuilder().clearBranches()
-        if (node.choice.hasCause()) choice.setCause(remapCause(node.choice.cause))
+        if (node.choice.hasCauseId()) choice.setCauseId(remapCause(node.choice.causeId))
         for (branch in node.choice.branchesList) {
           choice.addBranches(normalizeNode(branch))
         }
@@ -161,7 +162,7 @@ private class TraceEventIdNormalizer {
       TraceTree.OutcomeCase.OUTPUT -> normalized.setOutput(node.output)
       TraceTree.OutcomeCase.DROP -> {
         val drop = node.drop.toBuilder()
-        if (node.drop.hasCause()) drop.setCause(remapCause(node.drop.cause))
+        if (node.drop.hasCauseId()) drop.setCauseId(remapCause(node.drop.causeId))
         normalized.setDrop(drop)
       }
       TraceTree.OutcomeCase.OUTCOME_NOT_SET,

--- a/simulator/V1ModelArchitectureTest.kt
+++ b/simulator/V1ModelArchitectureTest.kt
@@ -559,7 +559,7 @@ class V1ModelArchitectureTest {
     val result = V1ModelArchitecture(config).processPacket(port(0), byteArrayOf(0x01), TableStore())
 
     assertTrue(result.trace.hasDrop())
-    assertFalse(result.trace.drop.hasCause())
+    assertFalse(result.trace.drop.hasCauseId())
   }
 
   @Test

--- a/simulator/simulator.proto
+++ b/simulator/simulator.proto
@@ -83,18 +83,18 @@ message TraceTree {
 
 // All branches execute; their output packets are the union.
 // Used for any mechanism that sends copies to multiple ports (clone, multicast,
-// mirror). `cause` references the lookup event that triggered the copies, if
+// mirror). `cause_id` references the lookup event that triggered the copies, if
 // any.
 message Replication {
-  optional uint64 cause = 1;        // id of the typed event that triggered this
+  optional uint64 cause_id = 1;     // id of the typed event that triggered this
   repeated TraceTree branches = 2;  // ≥ 1 branch
 }
 
 // Exactly one branch executes at runtime.
 // Used for action selector groups (the selected member is unknown statically).
-// `cause` references the TableLookupEvent for the selector table.
+// `cause_id` references the TableLookupEvent for the selector table.
 message Choice {
-  optional uint64 cause = 1;        // id of the typed event that triggered this
+  optional uint64 cause_id = 1;     // id of the typed event that triggered this
   repeated TraceTree branches = 2;  // ≥ 2 branches
 }
 
@@ -115,19 +115,19 @@ message Continuation {
   map<string, string> preserved_fields = 3;
 }
 
-// A packet that was dropped.  `cause` is absent when the packet fell off the
-// end of the pipeline with no forwarding decision (the implicit default).
+// A packet that was dropped.  `cause_id` is absent when the packet fell off
+// the end of the pipeline with no forwarding decision (the implicit default).
 // When present, the referenced event's type identifies the cause:
 //   MarkToDropEvent                            → explicit mark_to_drop() call
 //   AssertionEvent                             → assert()/assume() failure
 //   MulticastGroupLookupEvent(group_found=false) → multicast to empty group
 message Drop {
-  optional uint64 cause = 1;  // id of the event that caused the drop, if any
+  optional uint64 cause_id = 1;  // id of the event that caused the drop, if any
 }
 
 message TraceEvent {
   // Trace-global identifier, assigned by the simulator in emission order.
-  // Referenced by Replication.cause, Choice.cause, and Drop.cause to
+  // Referenced by Replication.cause_id, Choice.cause_id, and Drop.cause_id to
   // identify which event triggered each outcome.
   uint64 id = 16;
 

--- a/simulator/trace_summary.cc
+++ b/simulator/trace_summary.cc
@@ -319,9 +319,9 @@ void PrintEvent(const fourward::TraceEvent& event, std::ostream* os,
 
 std::string ReplicationCauseName(const fourward::TraceTree& trace,
                                  const fourward::Replication& replication) {
-  if (!replication.has_cause()) return "replication";
+  if (!replication.has_cause_id()) return "replication";
   for (const auto& event : trace.events()) {
-    if (event.id() != replication.cause()) continue;
+    if (event.id() != replication.cause_id()) continue;
     switch (event.event_case()) {
       case fourward::TraceEvent::kCloneSessionLookup:
       case fourward::TraceEvent::kClone:

--- a/simulator/trace_summary_test.cc
+++ b/simulator/trace_summary_test.cc
@@ -156,7 +156,7 @@ TEST(TraceSummaryTest, PrintsMulticastLookupBeforeReplicationBranches) {
   lookup->mutable_multicast_group_lookup()->set_replica_count(2);
 
   auto* replication = trace.mutable_replication();
-  replication->set_cause(7);
+  replication->set_cause_id(7);
   replication->add_branches()->mutable_output()->set_dataplane_egress_port(1);
   replication->add_branches()->mutable_output()->set_dataplane_egress_port(2);
 


### PR DESCRIPTION
The field holds a TraceEvent ID, so `cause_id` is more precise than the bare `cause` name. Field numbers are unchanged; this is a name-only rename across `simulator.proto` and all call sites.