### PR TITLE
dataplane_matchers.h: use explicit UniversalPrinter full specializations

### DIFF
--- a/fourward_cc/dataplane_matchers.h
+++ b/fourward_cc/dataplane_matchers.h
@@ -834,11 +834,20 @@ namespace internal {
 
 // UniversalPrinter<T>::Print is called before PrintTo overload resolution, so
 // specializing it here is the most direct hook into GoogleTest printing.
-template <typename T>
-  requires(::fourward::internal::HasPossibleOutcomes<T>)
-class UniversalPrinter<T> {
+template <>
+class UniversalPrinter<::fourward::InjectPacketResponse> {
  public:
-  static void Print(const T& value, ::std::ostream* os) {
+  static void Print(const ::fourward::InjectPacketResponse& value,
+                    ::std::ostream* os) {
+    ::fourward::internal::PrintResultSummary(value, os);
+  }
+};
+
+template <>
+class UniversalPrinter<::fourward::ProcessPacketResult> {
+ public:
+  static void Print(const ::fourward::ProcessPacketResult& value,
+                    ::std::ostream* os) {
     ::fourward::internal::PrintResultSummary(value, os);
   }
 };


### PR DESCRIPTION
Replaces the constrained partial specialization of `testing::internal::UniversalPrinter<T>` (introduced in #821) with two explicit full specializations for `InjectPacketResponse` and `ProcessPacketResult`.

Constrained partial specializations on `UniversalPrinter` are valid C++20 but less battle-tested than explicit full specializations, and the full specializations make the intent unambiguous.