### PR TITLE
grpc: preserve TypeTranslator across RECONCILE_AND_COMMIT (fixes WCMP group selection)

### DIFF
--- a/grpc/FourwardTestHarness.kt
+++ b/grpc/FourwardTestHarness.kt
@@ -132,11 +132,13 @@ class FourwardTestHarness(
   fun loadPipeline(
     config: PipelineConfig,
     cookie: ForwardingPipelineConfig.Cookie = ForwardingPipelineConfig.Cookie.getDefaultInstance(),
+    action: SetForwardingPipelineConfigRequest.Action =
+      SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT,
   ): SetForwardingPipelineConfigResponse = runBlocking {
     stub.setForwardingPipelineConfig(
       SetForwardingPipelineConfigRequest.newBuilder()
         .setDeviceId(1)
-        .setAction(SetForwardingPipelineConfigRequest.Action.VERIFY_AND_COMMIT)
+        .setAction(action)
         .setConfig(buildForwardingPipelineConfig(config, cookie))
         .build()
     )

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -288,28 +288,27 @@ class P4RuntimeService(
    * (counters, registers, meters) is reset; PRE entries and action profiles are preserved.
    */
   private fun reconcileAndCommit(fwdConfig: ForwardingPipelineConfig) {
-    val newState = verifyPipeline(fwdConfig)
+    val verified = verifyPipeline(fwdConfig)
     val oldState = pipeline
     if (oldState == null) {
-      commitPipeline(newState)
+      commitPipeline(verified)
       return
     }
 
+    // TypeTranslator is forwarding state: its auto-allocated IDs are already baked into the
+    // preserved entries. Carry the old translator forward so future writes use the same ID
+    // sequence — verifyPipeline() always produces a fresh one that would restart allocation.
+    //
+    // TODO: if the new pipeline introduces different @p4runtime_translation_mappings for an
+    // existing type, merging T_old and T_new would be required. In practice RECONCILE_AND_COMMIT
+    // is used for backward-compatible updates where translation configs don't change.
+    val newState = verified.copy(typeTranslator = oldState.typeTranslator)
+
     // Identical pipeline: update P4Runtime-layer state (cookie, validators) without touching
     // the simulator. This is the common case for DVaaS-style reloads.
-    //
-    // Crucially, we also preserve the old TypeTranslator. verifyPipeline() always creates a
-    // fresh translator, but the simulator's preserved entries already have match keys and action
-    // params encoded with the old translator's auto-allocated IDs. If we switched to a fresh
-    // translator here, subsequent writes would allocate different IDs for the same P4RT strings,
-    // causing lookups to hit the wrong entries (e.g. the wrong WCMP group).
     if (oldState.config == newState.config) {
       oldState.constraintValidator?.close()
-      pipeline =
-        newState.copy(
-          typeTranslator = oldState.typeTranslator,
-          entityReader = oldState.entityReader,
-        )
+      pipeline = newState.copy(entityReader = oldState.entityReader)
       return
     }
 
@@ -335,14 +334,7 @@ class P4RuntimeService(
       }
     }
 
-    // Preserve the old TypeTranslator for the same reason as the identical-pipeline case above:
-    // existing entries encode their keys/params with the old translator's IDs, so all future
-    // writes must use those same IDs to stay consistent.
-    //
-    // TODO: if the new pipeline introduces different @p4runtime_translation_mappings for an
-    // existing type, merging T_old and T_new would be required. In practice RECONCILE_AND_COMMIT
-    // is used for backward-compatible updates where translation configs don't change.
-    activatePipeline(newState.copy(typeTranslator = oldState.typeTranslator)) {
+    activatePipeline(newState) {
       simulator.loadPipelinePreservingEntries(it, newState.resolvedDropPort)
     }
   }

--- a/grpc/P4RuntimeService.kt
+++ b/grpc/P4RuntimeService.kt
@@ -297,9 +297,19 @@ class P4RuntimeService(
 
     // Identical pipeline: update P4Runtime-layer state (cookie, validators) without touching
     // the simulator. This is the common case for DVaaS-style reloads.
+    //
+    // Crucially, we also preserve the old TypeTranslator. verifyPipeline() always creates a
+    // fresh translator, but the simulator's preserved entries already have match keys and action
+    // params encoded with the old translator's auto-allocated IDs. If we switched to a fresh
+    // translator here, subsequent writes would allocate different IDs for the same P4RT strings,
+    // causing lookups to hit the wrong entries (e.g. the wrong WCMP group).
     if (oldState.config == newState.config) {
       oldState.constraintValidator?.close()
-      pipeline = newState.copy(entityReader = oldState.entityReader)
+      pipeline =
+        newState.copy(
+          typeTranslator = oldState.typeTranslator,
+          entityReader = oldState.entityReader,
+        )
       return
     }
 
@@ -325,7 +335,14 @@ class P4RuntimeService(
       }
     }
 
-    activatePipeline(newState) {
+    // Preserve the old TypeTranslator for the same reason as the identical-pipeline case above:
+    // existing entries encode their keys/params with the old translator's IDs, so all future
+    // writes must use those same IDs to stay consistent.
+    //
+    // TODO: if the new pipeline introduces different @p4runtime_translation_mappings for an
+    // existing type, merging T_old and T_new would be required. In practice RECONCILE_AND_COMMIT
+    // is used for backward-compatible updates where translation configs don't change.
+    activatePipeline(newState.copy(typeTranslator = oldState.typeTranslator)) {
       simulator.loadPipelinePreservingEntries(it, newState.resolvedDropPort)
     }
   }

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -612,6 +612,127 @@ class SaiP4E2ETest {
     }
   }
 
+  @Test
+  @Suppress("MagicNumber")
+  fun `WCMP group selection survives RECONCILE_AND_COMMIT with same pipeline`() {
+    // Regression test for TypeTranslator reset on RECONCILE_AND_COMMIT.
+    //
+    // The bug: RECONCILE_AND_COMMIT preserved simulator entries but created a fresh
+    // TypeTranslator. If WCMP entries were written before the reconcile and the IP route
+    // after, the route's action param used a different (restarted) ID sequence. The result
+    // was that the route resolved to the wrong WCMP group.
+    //
+    // Setup: group-first (2 members → Ethernet1/2) and group-second (3 members → Ethernet3/4/5).
+    // Write WCMP entries first (pre-reconcile), then RECONCILE_AND_COMMIT, then write the
+    // IP route pointing to group-second (post-reconcile). Only Ethernet3/4/5 should appear.
+    harness.installEntry(buildVrfEntry(""))
+    val rifMac1 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x01)
+    val rifMac2 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x02)
+    val rifMac3 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x03)
+    val rifMac4 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x04)
+    val rifMac5 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x05)
+    for (i in 1..5) {
+      harness.installEntry(
+        buildRouterInterfaceEntry(
+          "rif-$i",
+          "Ethernet$i",
+          when (i) {
+            1 -> rifMac1
+            2 -> rifMac2
+            3 -> rifMac3
+            4 -> rifMac4
+            else -> rifMac5
+          },
+        )
+      )
+      harness.installEntry(buildNeighborEntry("rif-$i", NEIGHBOR_ID, NEIGHBOR_MAC))
+      harness.installEntry(buildNexthopEntry(nexthopId = "nhop-$i", routerInterfaceId = "rif-$i"))
+    }
+
+    val setNexthop = findAction("set_nexthop_id")
+    val wcmpTable = findTable("wcmp_group_table")
+
+    fun oneShotWcmpEntry(groupId: String, nexthopIds: List<String>): Entity =
+      Entity.newBuilder()
+        .setTableEntry(
+          TableEntry.newBuilder()
+            .setTableId(wcmpTable.preamble.id)
+            .addMatch(exactMatch(wcmpTable, "wcmp_group_id", groupId))
+            .setAction(
+              P4RuntimeOuterClass.TableAction.newBuilder()
+                .setActionProfileActionSet(
+                  P4RuntimeOuterClass.ActionProfileActionSet.newBuilder().also { set ->
+                    for (nhop in nexthopIds) {
+                      set.addActionProfileActions(
+                        P4RuntimeOuterClass.ActionProfileAction.newBuilder()
+                          .setAction(
+                            P4RuntimeOuterClass.Action.newBuilder()
+                              .setActionId(setNexthop.preamble.id)
+                              .addParams(stringParam(setNexthop, "nexthop_id", nhop))
+                          )
+                          .setWeight(1)
+                      )
+                    }
+                  }
+                )
+            )
+        )
+        .build()
+
+    // Write WCMP entries BEFORE RECONCILE_AND_COMMIT. group-first is seen first by the
+    // TypeTranslator (gets ID 0), group-second second (gets ID 1).
+    harness.installEntry(oneShotWcmpEntry("group-first", listOf("nhop-1", "nhop-2")))
+    harness.installEntry(oneShotWcmpEntry("group-second", listOf("nhop-3", "nhop-4", "nhop-5")))
+
+    // Reload the same pipeline with RECONCILE_AND_COMMIT — simulates a DVaaS-style reload
+    // that preserves forwarding state. Without the fix, a fresh TypeTranslator starts here
+    // and assigns ID 0 to the next string it sees ("group-second"), while group-second's
+    // WCMP entry in the simulator still has match key 1 (from the pre-reconcile translator).
+    runBlocking {
+      harness.stub.setForwardingPipelineConfig(
+        P4RuntimeOuterClass.SetForwardingPipelineConfigRequest.newBuilder()
+          .setDeviceId(1)
+          .setAction(
+            P4RuntimeOuterClass.SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT
+          )
+          .setConfig(harness.buildForwardingPipelineConfig(config))
+          .build()
+      )
+    }
+
+    // Write the IP route AFTER RECONCILE_AND_COMMIT, pointing to group-second.
+    // With a fresh (buggy) TypeTranslator: "group-second" → ID 0, but the WCMP entry has
+    // match key 1 → route resolves to group-first (ID 0) instead → wrong outputs.
+    val ipv4Table = findTable("ipv4_table")
+    val setWcmpGroupId = findAction("set_wcmp_group_id")
+    harness.installEntry(
+      buildEntry(
+        ipv4Table,
+        setWcmpGroupId,
+        matches =
+          listOf(
+            exactMatch(ipv4Table, "vrf_id", ""),
+            lpmMatch(ipv4Table, "ipv4_dst", byteArrayOf(10, 0, 0, 0), prefixLen = 8),
+          ),
+        params = listOf(stringParam(setWcmpGroupId, "wcmp_group_id", "group-second")),
+      )
+    )
+
+    val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
+    val allOutcomes = harness.simulatePacket(ingressPort = 0, payload = packet)
+
+    assertEquals(
+      "routing to group-second should produce 3 outcomes (nhop-3/4/5), not 2 (group-first)",
+      3,
+      allOutcomes.size,
+    )
+    val validPorts = setOf("Ethernet3", "Ethernet4", "Ethernet5")
+    for (outcome in allOutcomes) {
+      val port = outcome.getPackets(0).p4RtEgressPort.toStringUtf8()
+      assertTrue("expected output on Ethernet3/4/5, got $port", port in validPorts)
+    }
+  }
+
   // =========================================================================
   // Port translation: stock v1model has no port newtype
   // =========================================================================

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -457,6 +457,161 @@ class SaiP4E2ETest {
     }
   }
 
+  @Test
+  @Suppress("MagicNumber")
+  fun `one-shot WCMP entry produces outputs from all members`() {
+    // Same routing setup as the ActionProfileGroup WCMP test, but uses one-shot
+    // ActionProfileActionSet (as mandated by @oneshot() on wcmp_group_table).
+    harness.installEntry(buildVrfEntry(""))
+    harness.installEntry(buildRouterInterfaceEntry("rif-a", "Ethernet1", RIF_MAC))
+    harness.installEntry(buildRouterInterfaceEntry("rif-b", "Ethernet2", ALT_RIF_MAC))
+    harness.installEntry(buildNeighborEntry("rif-a", NEIGHBOR_ID, NEIGHBOR_MAC))
+    harness.installEntry(buildNeighborEntry("rif-b", NEIGHBOR_ID, ALT_NEIGHBOR_MAC))
+    harness.installEntry(buildNexthopEntry(nexthopId = "nhop-a", routerInterfaceId = "rif-a"))
+    harness.installEntry(buildNexthopEntry(nexthopId = "nhop-b", routerInterfaceId = "rif-b"))
+
+    val setNexthop = findAction("set_nexthop_id")
+    val wcmpTable = findTable("wcmp_group_table")
+
+    // One-shot entry: wcmp_group_id="group-1" → two inline member actions.
+    harness.installEntry(
+      Entity.newBuilder()
+        .setTableEntry(
+          TableEntry.newBuilder()
+            .setTableId(wcmpTable.preamble.id)
+            .addMatch(exactMatch(wcmpTable, "wcmp_group_id", "group-1"))
+            .setAction(
+              P4RuntimeOuterClass.TableAction.newBuilder()
+                .setActionProfileActionSet(
+                  P4RuntimeOuterClass.ActionProfileActionSet.newBuilder()
+                    .addActionProfileActions(
+                      P4RuntimeOuterClass.ActionProfileAction.newBuilder()
+                        .setAction(
+                          P4RuntimeOuterClass.Action.newBuilder()
+                            .setActionId(setNexthop.preamble.id)
+                            .addParams(stringParam(setNexthop, "nexthop_id", "nhop-a"))
+                        )
+                        .setWeight(1)
+                    )
+                    .addActionProfileActions(
+                      P4RuntimeOuterClass.ActionProfileAction.newBuilder()
+                        .setAction(
+                          P4RuntimeOuterClass.Action.newBuilder()
+                            .setActionId(setNexthop.preamble.id)
+                            .addParams(stringParam(setNexthop, "nexthop_id", "nhop-b"))
+                        )
+                        .setWeight(1)
+                    )
+                )
+            )
+        )
+        .build()
+    )
+
+    val ipv4Table = findTable("ipv4_table")
+    val setWcmpGroupId = findAction("set_wcmp_group_id")
+    harness.installEntry(
+      buildEntry(
+        ipv4Table,
+        setWcmpGroupId,
+        matches =
+          listOf(
+            exactMatch(ipv4Table, "vrf_id", ""),
+            lpmMatch(ipv4Table, "ipv4_dst", byteArrayOf(10, 0, 0, 0), prefixLen = 8),
+          ),
+        params = listOf(stringParam(setWcmpGroupId, "wcmp_group_id", "group-1")),
+      )
+    )
+
+    val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
+    val allOutcomes = harness.simulatePacket(ingressPort = 0, payload = packet)
+
+    assertEquals("one-shot WCMP with 2 members should produce 2 outcomes", 2, allOutcomes.size)
+    val validPorts = setOf("Ethernet1", "Ethernet2")
+    for (outcome in allOutcomes) {
+      assertEquals("each outcome should have exactly one packet", 1, outcome.packetsCount)
+      val port = outcome.getPackets(0).p4RtEgressPort.toStringUtf8()
+      assertTrue("WCMP member should forward to a valid port, got $port", port in validPorts)
+    }
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun `correct WCMP group selected when multiple groups are installed`() {
+    // Install infra: VRF, router interfaces, neighbors, nexthops.
+    // Group A (group-large): 4 nexthops → ports Ethernet1..Ethernet4
+    // Group B (group-small): 2 nexthops → ports Ethernet5 and Ethernet6
+    // The IP route points to group-small; only group-small's ports should appear.
+    harness.installEntry(buildVrfEntry(""))
+    val rifMac1 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x01)
+    val rifMac2 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x02)
+    val rifMac3 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x03)
+    val rifMac4 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x04)
+    val rifMac5 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x05)
+    val rifMac6 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x06)
+    harness.installEntry(buildRouterInterfaceEntry("rif-1", "Ethernet1", rifMac1))
+    harness.installEntry(buildRouterInterfaceEntry("rif-2", "Ethernet2", rifMac2))
+    harness.installEntry(buildRouterInterfaceEntry("rif-3", "Ethernet3", rifMac3))
+    harness.installEntry(buildRouterInterfaceEntry("rif-4", "Ethernet4", rifMac4))
+    harness.installEntry(buildRouterInterfaceEntry("rif-5", "Ethernet5", rifMac5))
+    harness.installEntry(buildRouterInterfaceEntry("rif-6", "Ethernet6", rifMac6))
+    for (i in 1..6) {
+      harness.installEntry(buildNeighborEntry("rif-$i", NEIGHBOR_ID, NEIGHBOR_MAC))
+      harness.installEntry(buildNexthopEntry(nexthopId = "nhop-$i", routerInterfaceId = "rif-$i"))
+    }
+
+    val wcmpSelector =
+      config.p4Info.actionProfilesList.find { it.preamble.alias == "wcmp_group_selector" }!!
+    val profileId = wcmpSelector.preamble.id
+    val setNexthop = findAction("set_nexthop_id")
+    for (i in 1..6) {
+      harness.installEntry(buildActionProfileMember(profileId, memberId = i, setNexthop, "nhop-$i"))
+    }
+
+    // group-large: members 1-4
+    harness.installEntry(buildActionProfileGroup(profileId, groupId = 1, listOf(1, 2, 3, 4)))
+    // group-small: members 5-6
+    harness.installEntry(buildActionProfileGroup(profileId, groupId = 2, listOf(5, 6)))
+
+    // wcmp_group_table: "group-large" → groupId 1, "group-small" → groupId 2
+    harness.installEntry(buildWcmpGroupTableEntry(wcmpGroupId = "group-large", groupId = 1))
+    harness.installEntry(buildWcmpGroupTableEntry(wcmpGroupId = "group-small", groupId = 2))
+
+    // IP route points to "group-small"
+    val ipv4Table = findTable("ipv4_table")
+    val setWcmpGroupId = findAction("set_wcmp_group_id")
+    harness.installEntry(
+      buildEntry(
+        ipv4Table,
+        setWcmpGroupId,
+        matches =
+          listOf(
+            exactMatch(ipv4Table, "vrf_id", ""),
+            lpmMatch(ipv4Table, "ipv4_dst", byteArrayOf(10, 0, 0, 0), prefixLen = 8),
+          ),
+        params = listOf(stringParam(setWcmpGroupId, "wcmp_group_id", "group-small")),
+      )
+    )
+
+    val packet = buildIpv4Packet(dstMac = UNICAST_MAC, srcMac = SRC_MAC, ttl = 64)
+    val allOutcomes = harness.simulatePacket(ingressPort = 0, payload = packet)
+
+    // Must produce exactly 2 outputs (group-small has 2 members), not 4 (group-large).
+    assertEquals(
+      "routing to group-small should produce 2 outcomes, not 4 (group-large)",
+      2,
+      allOutcomes.size,
+    )
+    val validPorts = setOf("Ethernet5", "Ethernet6")
+    for (outcome in allOutcomes) {
+      val port = outcome.getPackets(0).p4RtEgressPort.toStringUtf8()
+      assertTrue(
+        "WCMP member should be from group-small (Ethernet5 or Ethernet6), got $port",
+        port in validPorts,
+      )
+    }
+  }
+
   // =========================================================================
   // Port translation: stock v1model has no port newtype
   // =========================================================================

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -592,7 +592,9 @@ class SaiP4E2ETest {
     // Write WCMP entries BEFORE RECONCILE_AND_COMMIT. group-first is seen first by the
     // TypeTranslator (gets ID 0), group-second second (gets ID 1).
     harness.installEntry(buildOneShotWcmpEntry("group-first", listOf("nhop-1", "nhop-2")))
-    harness.installEntry(buildOneShotWcmpEntry("group-second", listOf("nhop-3", "nhop-4", "nhop-5")))
+    harness.installEntry(
+      buildOneShotWcmpEntry("group-second", listOf("nhop-3", "nhop-4", "nhop-5"))
+    )
 
     // Reload the same pipeline with RECONCILE_AND_COMMIT — simulates a DVaaS-style reload
     // that preserves forwarding state. Without the fix, a fresh TypeTranslator starts here

--- a/grpc/SaiP4E2ETest.kt
+++ b/grpc/SaiP4E2ETest.kt
@@ -29,6 +29,7 @@ import p4.config.v1.P4InfoOuterClass
 import p4.v1.P4RuntimeOuterClass
 import p4.v1.P4RuntimeOuterClass.Entity
 import p4.v1.P4RuntimeOuterClass.FieldMatch
+import p4.v1.P4RuntimeOuterClass.SetForwardingPipelineConfigRequest
 import p4.v1.P4RuntimeOuterClass.TableEntry
 
 /**
@@ -470,43 +471,8 @@ class SaiP4E2ETest {
     harness.installEntry(buildNexthopEntry(nexthopId = "nhop-a", routerInterfaceId = "rif-a"))
     harness.installEntry(buildNexthopEntry(nexthopId = "nhop-b", routerInterfaceId = "rif-b"))
 
-    val setNexthop = findAction("set_nexthop_id")
-    val wcmpTable = findTable("wcmp_group_table")
-
     // One-shot entry: wcmp_group_id="group-1" → two inline member actions.
-    harness.installEntry(
-      Entity.newBuilder()
-        .setTableEntry(
-          TableEntry.newBuilder()
-            .setTableId(wcmpTable.preamble.id)
-            .addMatch(exactMatch(wcmpTable, "wcmp_group_id", "group-1"))
-            .setAction(
-              P4RuntimeOuterClass.TableAction.newBuilder()
-                .setActionProfileActionSet(
-                  P4RuntimeOuterClass.ActionProfileActionSet.newBuilder()
-                    .addActionProfileActions(
-                      P4RuntimeOuterClass.ActionProfileAction.newBuilder()
-                        .setAction(
-                          P4RuntimeOuterClass.Action.newBuilder()
-                            .setActionId(setNexthop.preamble.id)
-                            .addParams(stringParam(setNexthop, "nexthop_id", "nhop-a"))
-                        )
-                        .setWeight(1)
-                    )
-                    .addActionProfileActions(
-                      P4RuntimeOuterClass.ActionProfileAction.newBuilder()
-                        .setAction(
-                          P4RuntimeOuterClass.Action.newBuilder()
-                            .setActionId(setNexthop.preamble.id)
-                            .addParams(stringParam(setNexthop, "nexthop_id", "nhop-b"))
-                        )
-                        .setWeight(1)
-                    )
-                )
-            )
-        )
-        .build()
-    )
+    harness.installEntry(buildOneShotWcmpEntry("group-1", listOf("nhop-a", "nhop-b")))
 
     val ipv4Table = findTable("ipv4_table")
     val setWcmpGroupId = findAction("set_wcmp_group_id")
@@ -543,19 +509,9 @@ class SaiP4E2ETest {
     // Group B (group-small): 2 nexthops → ports Ethernet5 and Ethernet6
     // The IP route points to group-small; only group-small's ports should appear.
     harness.installEntry(buildVrfEntry(""))
-    val rifMac1 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x01)
-    val rifMac2 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x02)
-    val rifMac3 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x03)
-    val rifMac4 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x04)
-    val rifMac5 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x05)
-    val rifMac6 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x06)
-    harness.installEntry(buildRouterInterfaceEntry("rif-1", "Ethernet1", rifMac1))
-    harness.installEntry(buildRouterInterfaceEntry("rif-2", "Ethernet2", rifMac2))
-    harness.installEntry(buildRouterInterfaceEntry("rif-3", "Ethernet3", rifMac3))
-    harness.installEntry(buildRouterInterfaceEntry("rif-4", "Ethernet4", rifMac4))
-    harness.installEntry(buildRouterInterfaceEntry("rif-5", "Ethernet5", rifMac5))
-    harness.installEntry(buildRouterInterfaceEntry("rif-6", "Ethernet6", rifMac6))
     for (i in 1..6) {
+      val mac = byteArrayOf(0x02, 0, 0, 0, 0, i.toByte())
+      harness.installEntry(buildRouterInterfaceEntry("rif-$i", "Ethernet$i", mac))
       harness.installEntry(buildNeighborEntry("rif-$i", NEIGHBOR_ID, NEIGHBOR_MAC))
       harness.installEntry(buildNexthopEntry(nexthopId = "nhop-$i", routerInterfaceId = "rif-$i"))
     }
@@ -626,79 +582,26 @@ class SaiP4E2ETest {
     // Write WCMP entries first (pre-reconcile), then RECONCILE_AND_COMMIT, then write the
     // IP route pointing to group-second (post-reconcile). Only Ethernet3/4/5 should appear.
     harness.installEntry(buildVrfEntry(""))
-    val rifMac1 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x01)
-    val rifMac2 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x02)
-    val rifMac3 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x03)
-    val rifMac4 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x04)
-    val rifMac5 = byteArrayOf(0x02, 0x00, 0x00, 0x00, 0x00, 0x05)
     for (i in 1..5) {
-      harness.installEntry(
-        buildRouterInterfaceEntry(
-          "rif-$i",
-          "Ethernet$i",
-          when (i) {
-            1 -> rifMac1
-            2 -> rifMac2
-            3 -> rifMac3
-            4 -> rifMac4
-            else -> rifMac5
-          },
-        )
-      )
+      val mac = byteArrayOf(0x02, 0, 0, 0, 0, i.toByte())
+      harness.installEntry(buildRouterInterfaceEntry("rif-$i", "Ethernet$i", mac))
       harness.installEntry(buildNeighborEntry("rif-$i", NEIGHBOR_ID, NEIGHBOR_MAC))
       harness.installEntry(buildNexthopEntry(nexthopId = "nhop-$i", routerInterfaceId = "rif-$i"))
     }
 
-    val setNexthop = findAction("set_nexthop_id")
-    val wcmpTable = findTable("wcmp_group_table")
-
-    fun oneShotWcmpEntry(groupId: String, nexthopIds: List<String>): Entity =
-      Entity.newBuilder()
-        .setTableEntry(
-          TableEntry.newBuilder()
-            .setTableId(wcmpTable.preamble.id)
-            .addMatch(exactMatch(wcmpTable, "wcmp_group_id", groupId))
-            .setAction(
-              P4RuntimeOuterClass.TableAction.newBuilder()
-                .setActionProfileActionSet(
-                  P4RuntimeOuterClass.ActionProfileActionSet.newBuilder().also { set ->
-                    for (nhop in nexthopIds) {
-                      set.addActionProfileActions(
-                        P4RuntimeOuterClass.ActionProfileAction.newBuilder()
-                          .setAction(
-                            P4RuntimeOuterClass.Action.newBuilder()
-                              .setActionId(setNexthop.preamble.id)
-                              .addParams(stringParam(setNexthop, "nexthop_id", nhop))
-                          )
-                          .setWeight(1)
-                      )
-                    }
-                  }
-                )
-            )
-        )
-        .build()
-
     // Write WCMP entries BEFORE RECONCILE_AND_COMMIT. group-first is seen first by the
     // TypeTranslator (gets ID 0), group-second second (gets ID 1).
-    harness.installEntry(oneShotWcmpEntry("group-first", listOf("nhop-1", "nhop-2")))
-    harness.installEntry(oneShotWcmpEntry("group-second", listOf("nhop-3", "nhop-4", "nhop-5")))
+    harness.installEntry(buildOneShotWcmpEntry("group-first", listOf("nhop-1", "nhop-2")))
+    harness.installEntry(buildOneShotWcmpEntry("group-second", listOf("nhop-3", "nhop-4", "nhop-5")))
 
     // Reload the same pipeline with RECONCILE_AND_COMMIT — simulates a DVaaS-style reload
     // that preserves forwarding state. Without the fix, a fresh TypeTranslator starts here
     // and assigns ID 0 to the next string it sees ("group-second"), while group-second's
     // WCMP entry in the simulator still has match key 1 (from the pre-reconcile translator).
-    runBlocking {
-      harness.stub.setForwardingPipelineConfig(
-        P4RuntimeOuterClass.SetForwardingPipelineConfigRequest.newBuilder()
-          .setDeviceId(1)
-          .setAction(
-            P4RuntimeOuterClass.SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT
-          )
-          .setConfig(harness.buildForwardingPipelineConfig(config))
-          .build()
-      )
-    }
+    harness.loadPipeline(
+      config,
+      action = SetForwardingPipelineConfigRequest.Action.RECONCILE_AND_COMMIT,
+    )
 
     // Write the IP route AFTER RECONCILE_AND_COMMIT, pointing to group-second.
     // With a fresh (buggy) TypeTranslator: "group-second" → ID 0, but the WCMP entry has
@@ -2540,6 +2443,36 @@ class SaiP4E2ETest {
           )
       )
       .build()
+
+  private fun buildOneShotWcmpEntry(groupId: String, nexthopIds: List<String>): Entity {
+    val wcmpTable = findTable("wcmp_group_table")
+    val setNexthop = findAction("set_nexthop_id")
+    return Entity.newBuilder()
+      .setTableEntry(
+        TableEntry.newBuilder()
+          .setTableId(wcmpTable.preamble.id)
+          .addMatch(exactMatch(wcmpTable, "wcmp_group_id", groupId))
+          .setAction(
+            P4RuntimeOuterClass.TableAction.newBuilder()
+              .setActionProfileActionSet(
+                P4RuntimeOuterClass.ActionProfileActionSet.newBuilder().also { set ->
+                  for (nhop in nexthopIds) {
+                    set.addActionProfileActions(
+                      P4RuntimeOuterClass.ActionProfileAction.newBuilder()
+                        .setAction(
+                          P4RuntimeOuterClass.Action.newBuilder()
+                            .setActionId(setNexthop.preamble.id)
+                            .addParams(stringParam(setNexthop, "nexthop_id", nhop))
+                        )
+                        .setWeight(1)
+                    )
+                  }
+                }
+              )
+          )
+      )
+      .build()
+  }
 
   private fun buildWcmpGroupTableEntry(wcmpGroupId: String, groupId: Int): Entity {
     val table = findTable("wcmp_group_table")


### PR DESCRIPTION
## The bug

`RECONCILE_AND_COMMIT` is meant to reload a pipeline while preserving
forwarding state. Under SAI P4's `@p4runtime_translation("", string)`,
the `TypeTranslator` auto-allocates compact numeric IDs for opaque
string values (nexthop IDs, VRF IDs, WCMP group IDs, …).

The problem: `verifyPipeline()` always creates a **fresh** TypeTranslator.
When `RECONCILE_AND_COMMIT` preserved simulator entries but dropped the
old translator, subsequent writes allocated IDs from scratch — the same
string got a different ID post-reconcile. A packet would look up
`wcmp_group_id = 0` and land on whichever WCMP group happened to be ID 0
in the *old* translator, not the group the IP route intended.

Concretely: with two WCMP groups installed pre-reconcile and an IP route
installed post-reconcile pointing to `"group-second"`, the route would
be forwarded to `"group-first"` instead.

## The fix

`TypeTranslator` is forwarding state, not pipeline state — its
auto-allocated IDs are already baked into the simulator's preserved
entries. `reconcileAndCommit` now carries the old translator forward via
a single `.copy(typeTranslator = oldState.typeTranslator)` call applied
to the freshly-verified pipeline, before branching on whether the
pipeline changed.

```
// Before (buggy): two separate .copy() calls, one per branch
if (oldState.config == newState.config) {
    pipeline = newState.copy(typeTranslator = oldState.typeTranslator, entityReader = oldState.entityReader)
    return
}
...
activatePipeline(newState.copy(typeTranslator = oldState.typeTranslator)) { ... }

// After (fixed): carry forward once, up front
val newState = verified.copy(typeTranslator = oldState.typeTranslator)
if (oldState.config == newState.config) {
    pipeline = newState.copy(entityReader = oldState.entityReader)
    return
}
...
activatePipeline(newState) { ... }
```

> **TODO** (noted in code): if a future pipeline change alters
> `@p4runtime_translation` mappings for an existing type, we'd need to
> merge the old and new translators. In practice `RECONCILE_AND_COMMIT`
> is used for backward-compatible updates, so this is deferred.

## Tests

Three new tests in `SaiP4E2ETest`:

1. **One-shot WCMP entry produces outputs from all members** — basic
   `ActionProfileActionSet` path; verifies packets fan out to both
   nexthop ports.
2. **Correct WCMP group selected when multiple groups are installed** —
   two groups (4-member and 2-member); IP route to the smaller group;
   verifies only the 2-member group's ports appear.
3. **WCMP group selection survives `RECONCILE_AND_COMMIT` with same
   pipeline** — regression test for this exact bug: WCMP entries
   written pre-reconcile, route written post-reconcile, packet must
   reach the correct group.

Test 3 fails without the fix and passes with it (confirmed by reverting).